### PR TITLE
Move `system.local` and `system.peers` handling into an interface

### DIFF
--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/datastore/InternalDataStore.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/datastore/InternalDataStore.java
@@ -62,7 +62,6 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.stargate.db.Result;
-import io.stargate.db.cassandra.impl.StargateSystemKeyspace;
 import io.stargate.db.cassandra.impl.Conversion;
 import io.stargate.db.datastore.DataStore;
 import io.stargate.db.datastore.ExecutionInfo;
@@ -303,28 +302,22 @@ public class InternalDataStore implements DataStore
             {
                 try
                 {
-                    long queryStartNanoTime = System.nanoTime();
-                    CQLStatement statement = QueryProcessor.parseStatement(unpreparedCql, queryState).statement;
-                    if (!StargateSystemKeyspace.maybeCompleteSystemLocalOrPeersInternal(statement, queryState, queryOptions, queryStartNanoTime, future))
-                    {
-                        ResultMessage resultMessage = QueryProcessor.instance.processStatement(statement, queryState, queryOptions, queryStartNanoTime);
-                        if (resultMessage instanceof ResultMessage.Rows) {
-                            try {
-                                org.apache.cassandra.cql3.ResultSet result = ((ResultMessage.Rows) resultMessage).result;
-                                // Didn't really want to grab this using reflection but the only alternative would be to decode
-                                // the ResultMessage in the same way the driver does which is overkill in order to pull a single
-                                // field. Luckily this is public in both DSE and C* 4.0 so we'll only need this here.
-                                Field f = result.metadata.getClass().getDeclaredField("pagingState");
-                                f.setAccessible(true);
-                                this.pagingState = (PagingState) f.get(result.metadata);
-                            } catch (Exception e)
-                            {
-                                LOG.info("Unable to get paging state", e);
-                            }
+                    ResultMessage resultMessage = QueryProcessor.instance.process(unpreparedCql, queryState, queryOptions, System.nanoTime());
+                    if (resultMessage instanceof ResultMessage.Rows) {
+                        try {
+                            org.apache.cassandra.cql3.ResultSet result = ((ResultMessage.Rows) resultMessage).result;
+                            // Didn't really want to grab this using reflection but the only alternative would be to decode
+                            // the ResultMessage in the same way the driver does which is overkill in order to pull a single
+                            // field. Luckily this is public in both DSE and C* 4.0 so we'll only need this here.
+                            Field f = result.metadata.getClass().getDeclaredField("pagingState");
+                            f.setAccessible(true);
+                            this.pagingState = (PagingState) f.get(result.metadata);
+                        } catch (Exception e)
+                        {
+                            LOG.info("Unable to get paging state", e);
                         }
-
-                        future.complete(resultMessage);
                     }
+                    future.complete(resultMessage);
                 }
                 catch (Throwable t)
                 {
@@ -343,30 +336,26 @@ public class InternalDataStore implements DataStore
             {
                 try
                 {
-                    long queryStartNanoTime = System.nanoTime();
-                    if (!StargateSystemKeyspace.maybeCompleteSystemLocalOrPeersInternal(prepared.statement, queryState, queryOptions, queryStartNanoTime, future))
-                    {
-                        ResultMessage resultMessage = QueryProcessor.instance.processPrepared(prepared.statement, queryState, queryOptions, null, System.nanoTime());
+                    ResultMessage resultMessage = QueryProcessor.instance.processPrepared(prepared.statement, queryState, queryOptions, null, System.nanoTime());
 
-                        if (resultMessage instanceof ResultMessage.Rows) {
-                            try
-                            {
-                                org.apache.cassandra.cql3.ResultSet result = ((ResultMessage.Rows) resultMessage).result;
-                                // Didn't really want to grab this using reflection but the only alternative would be to decode
-                                // the ResultMessage in the same way the driver does which is overkill in order to pull a single
-                                // field. Luckily this is public in both DSE and C* 4.0 so we'll only need this here.
-                                Field f = result.metadata.getClass().getDeclaredField("pagingState");
-                                f.setAccessible(true);
-                                this.pagingState = (PagingState) f.get(result.metadata);
-                            }
-                            catch (Exception e)
-                            {
-                                LOG.info("Unable to get paging state", e);
-                            }
+                    if (resultMessage instanceof ResultMessage.Rows) {
+                        try
+                        {
+                            org.apache.cassandra.cql3.ResultSet result = ((ResultMessage.Rows) resultMessage).result;
+                            // Didn't really want to grab this using reflection but the only alternative would be to decode
+                            // the ResultMessage in the same way the driver does which is overkill in order to pull a single
+                            // field. Luckily this is public in both DSE and C* 4.0 so we'll only need this here.
+                            Field f = result.metadata.getClass().getDeclaredField("pagingState");
+                            f.setAccessible(true);
+                            this.pagingState = (PagingState) f.get(result.metadata);
                         }
-
-                        future.complete(resultMessage);
+                        catch (Exception e)
+                        {
+                            LOG.info("Unable to get paging state", e);
+                        }
                     }
+
+                    future.complete(resultMessage);
                 }
                 catch (Throwable t)
                 {

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
@@ -86,7 +86,12 @@ public class CassandraPersistence implements Persistence<Config, org.apache.cass
     public void initialize(Config config)
     {
         logger.info("Initializing CassandraPersistence");
-        System.setProperty("cassandra.join_ring", "false");
+
+        if (!Boolean.parseBoolean(System.getProperty("stargate.developer_mode")))
+        {
+            System.setProperty("cassandra.join_ring", "false");
+        }
+
         daemon = new CassandraDaemon(true);
 
         DatabaseDescriptor.daemonInitialization(() -> config);

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
@@ -238,10 +238,8 @@ public class CassandraPersistence implements Persistence<Config, org.apache.cass
 
                 CQLStatement statement = QueryProcessor.parseStatement(cql, internalState).statement;
 
-                Result result;
-                if  (interceptor.shouldInterceptQuery(statement, state, options, customPayload, queryStartNanoTime))
-                    result = interceptor.interceptQuery(handler, statement, state, options, customPayload, queryStartNanoTime);
-                else
+                Result result = interceptor.interceptQuery(handler, statement, state, options, customPayload, queryStartNanoTime);
+                if  (result == null)
                 {
                     result = Conversion.toResult(
                             QueryProcessor.instance
@@ -297,10 +295,8 @@ public class CassandraPersistence implements Persistence<Config, org.apache.cass
 
                 CQLStatement statement = prepared.statement;
 
-                Result result;
-                if  (interceptor.shouldInterceptQuery(statement, state, options, customPayload, queryStartNanoTime))
-                    result = interceptor.interceptQuery(handler, statement, state, options, customPayload, queryStartNanoTime);
-                else
+                Result result = interceptor.interceptQuery(handler, statement, state, options, customPayload, queryStartNanoTime);
+                if  (result == null)
                 {
                     result = Conversion.toResult(
                             QueryProcessor.instance

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/StargateSystemKeyspace.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/StargateSystemKeyspace.java
@@ -4,8 +4,8 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
@@ -16,7 +16,6 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.SchemaConstants;
 import org.apache.cassandra.cql3.CQLStatement;
 import org.apache.cassandra.cql3.QueryProcessor;
-import org.apache.cassandra.cql3.ResultSet;
 import org.apache.cassandra.cql3.statements.SelectStatement;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.SystemKeyspace;
@@ -33,16 +32,14 @@ import org.apache.cassandra.schema.Tables;
 import org.apache.cassandra.schema.Types;
 import org.apache.cassandra.schema.Views;
 import org.apache.cassandra.service.MigrationManager;
-import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.thrift.cassandraConstants;
 import org.apache.cassandra.transport.ProtocolVersion;
-import org.apache.cassandra.transport.messages.ResultMessage;
 import org.apache.cassandra.utils.FBUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
-import io.stargate.db.Result;
 
 import static org.apache.cassandra.cql3.QueryProcessor.executeInternal;
 import static org.apache.cassandra.cql3.QueryProcessor.executeOnceInternal;
@@ -52,12 +49,12 @@ public class StargateSystemKeyspace
     private static final Logger logger = LoggerFactory.getLogger(StargateSystemKeyspace.class);
 
     public static final String SYSTEM_KEYSPACE_NAME = "stargate_system";
-    public static final String LOCAL_TABLE_NAME = "stargate_local";
-    public static final String PEERS_TABLE_NAME = "stargate_peers";
+    public static final String LOCAL_TABLE_NAME = "local";
+    public static final String PEERS_TABLE_NAME = "peers";
 
     public static final UUID SCHEMA_VERSION = UUID.fromString("17846767-28a1-4acd-a967-f609ff1375f1");
 
-    private static final CFMetaData Local =
+    public static final CFMetaData Local =
             compile(LOCAL_TABLE_NAME,
                     "information about the local node",
                     "CREATE TABLE %s ("
@@ -152,58 +149,26 @@ public class StargateSystemKeyspace
                 SCHEMA_VERSION);
     }
 
-    private static boolean isSystemLocal(SelectStatement statement)
+    public static boolean isSystemLocal(SelectStatement statement)
     {
         return statement.columnFamily().equals(SystemKeyspace.LOCAL);
     }
 
-    private static boolean isSystemLocalOrPeers(CQLStatement statement)
+    public static boolean isSystemLocalOrPeers(CQLStatement statement)
     {
         if (statement instanceof SelectStatement)
         {
             SelectStatement selectStatement = (SelectStatement) statement;
-            return selectStatement.keyspace().equals(SchemaConstants.SYSTEM_KEYSPACE_NAME) && (isSystemLocal(selectStatement) || selectStatement.columnFamily().equals(SystemKeyspace.PEERS)) ;
+            return selectStatement.keyspace().equals(SchemaConstants.SYSTEM_KEYSPACE_NAME) &&
+                    (isSystemLocal(selectStatement) || selectStatement.columnFamily().equals(SystemKeyspace.PEERS)) ;
         }
         return false;
     }
 
-    private static ResultMessage.Rows interceptSystemLocalOrPeers(CQLStatement statement, org.apache.cassandra.service.QueryState state, org.apache.cassandra.cql3.QueryOptions options, long queryStartNanoTime)
+    public static boolean isStargateNode(EndpointState epState)
     {
-        SelectStatement selectStatement = (SelectStatement) statement;
-        SelectStatement peersSelectStatement =
-                new SelectStatement(isSystemLocal(selectStatement) ? Local : Peers,
-                        selectStatement.getBoundTerms(),
-                        selectStatement.parameters,
-                        selectStatement.getSelection(),
-                        selectStatement.getRestrictions(),
-                        false,
-                        null,
-                        null,
-                        null,
-                        null);
-        ResultMessage.Rows rows = peersSelectStatement.execute(state, options, queryStartNanoTime);
-        return new ResultMessage.Rows(new ResultSet(selectStatement.getResultMetadata(), rows.result.rows));
-    }
-
-
-    public static boolean maybeCompleteSystemLocalOrPeers(CQLStatement statement, org.apache.cassandra.service.QueryState state, org.apache.cassandra.cql3.QueryOptions options, long queryStartNanoTime, CompletableFuture<Result> future)
-    {
-        if (isSystemLocalOrPeers(statement))
-        {
-            future.complete(Conversion.toResult(interceptSystemLocalOrPeers(statement, state, options, queryStartNanoTime), options.getProtocolVersion()));
-            return true;
-        }
-        return false;
-    }
-
-    public static boolean maybeCompleteSystemLocalOrPeersInternal(CQLStatement statement, org.apache.cassandra.service.QueryState state, org.apache.cassandra.cql3.QueryOptions options, long queryStartNanoTime, CompletableFuture<ResultMessage> future)
-    {
-        if (isSystemLocalOrPeers(statement))
-        {
-            future.complete(interceptSystemLocalOrPeers(statement, state, options, queryStartNanoTime));
-            return true;
-        }
-        return false;
+        VersionedValue value = epState.getApplicationState(ApplicationState.X10);
+        return value != null && value.value.equals("stargate");
     }
 
     public static Future<?> updatePeerInfo(final InetAddress ep, final String columnName, final Object value, ExecutorService executorService)
@@ -234,12 +199,19 @@ public class StargateSystemKeyspace
 
     public static class PeersUpdater implements IEndpointStateChangeSubscriber
     {
+        private final Set<InetAddress> liveStargateNodes = Sets.newConcurrentHashSet();
+
         @Override
         public void onJoin(InetAddress endpoint, EndpointState epState)
         {
+            if (!isStargateNode(epState))
+                return;
+
+            updateTokens(endpoint);
+
             for (Map.Entry<ApplicationState, VersionedValue> entry : epState.states())
             {
-                onChange(endpoint, entry.getKey(), entry.getValue());
+                applyState(endpoint, entry.getKey(), entry.getValue(), epState);
             }
         }
 
@@ -263,11 +235,42 @@ public class StargateSystemKeyspace
                 return;
             }
 
-            if (StorageService.instance.getTokenMetadata().isMember(endpoint))  // We only want stargate nodes (no members)
+            // We only want stargate nodes
+            if (FBUtilities.getLocalAddress().equals(endpoint) || !isStargateNode(epState))
             {
                 return;
             }
 
+            if (liveStargateNodes.add(endpoint))
+                onJoin(endpoint, epState);
+            else
+                applyState(endpoint, state, value, epState);
+        }
+
+        @Override
+        public void onAlive(InetAddress endpoint, EndpointState state)
+        {
+        }
+
+        @Override
+        public void onDead(InetAddress endpoint, EndpointState state)
+        {
+        }
+
+        @Override
+        public void onRemove(InetAddress endpoint)
+        {
+            liveStargateNodes.remove(endpoint);
+            removeEndpoint(endpoint);
+        }
+
+        @Override
+        public void onRestart(InetAddress endpoint, EndpointState state)
+        {
+        }
+
+        private void applyState(InetAddress endpoint, ApplicationState state, VersionedValue value, EndpointState epState)
+        {
             final ExecutorService executor = StageManager.getStage(Stage.MUTATION);
             switch (state)
             {
@@ -303,29 +306,12 @@ public class StargateSystemKeyspace
                     updatePeerInfo(endpoint, "host_id", UUID.fromString(value.value), executor);
                     break;
             }
+        }
 
+        private void updateTokens(InetAddress endpoint)
+        {
+            final ExecutorService executor = StageManager.getStage(Stage.MUTATION);
             updatePeerInfo(endpoint, "tokens", Collections.singleton(DatabaseDescriptor.getPartitioner().getMinimumToken().toString()), executor);
-        }
-
-        @Override
-        public void onAlive(InetAddress endpoint, EndpointState state)
-        {
-        }
-
-        @Override
-        public void onDead(InetAddress endpoint, EndpointState state)
-        {
-        }
-
-        @Override
-        public void onRemove(InetAddress endpoint)
-        {
-            removeEndpoint(endpoint);
-        }
-
-        @Override
-        public void onRestart(InetAddress endpoint, EndpointState state)
-        {
         }
     }
 }

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/interceptors/DefaultQueryInterceptor.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/interceptors/DefaultQueryInterceptor.java
@@ -51,18 +51,15 @@ public class DefaultQueryInterceptor implements QueryInterceptor, IEndpointState
     }
 
     @Override
-    public boolean shouldInterceptQuery(CQLStatement statement,
-                                        QueryState state, QueryOptions options,
-                                        Map<String, ByteBuffer> customPayload, long queryStartNanoTime)
-    {
-        return isSystemLocalOrPeers(statement);
-    }
-
-    @Override
     public Result interceptQuery(QueryHandler handler, CQLStatement statement,
                                QueryState state, QueryOptions options,
                                Map<String, ByteBuffer> customPayload, long queryStartNanoTime)
     {
+        if (!isSystemLocalOrPeers(statement))
+        {
+            return null;
+        }
+
         org.apache.cassandra.service.QueryState internalState = Conversion.toInternal(state);
         org.apache.cassandra.cql3.QueryOptions internalOptions = Conversion.toInternal(options);
         return Conversion.toResult(interceptSystemLocalOrPeers(statement, internalState, internalOptions, queryStartNanoTime), internalOptions.getProtocolVersion());

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/interceptors/DefaultQueryInterceptor.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/interceptors/DefaultQueryInterceptor.java
@@ -1,0 +1,159 @@
+package io.stargate.db.cassandra.impl.interceptors;
+
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.apache.cassandra.config.Schema;
+import org.apache.cassandra.cql3.CQLStatement;
+import org.apache.cassandra.cql3.QueryHandler;
+import org.apache.cassandra.cql3.ResultSet;
+import org.apache.cassandra.cql3.statements.SelectStatement;
+import org.apache.cassandra.gms.ApplicationState;
+import org.apache.cassandra.gms.EndpointState;
+import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.gms.IEndpointStateChangeSubscriber;
+import org.apache.cassandra.gms.VersionedValue;
+import org.apache.cassandra.service.IEndpointLifecycleSubscriber;
+import org.apache.cassandra.transport.messages.ResultMessage;
+
+import com.google.common.collect.Sets;
+import io.stargate.db.QueryOptions;
+import io.stargate.db.QueryState;
+import io.stargate.db.Result;
+import io.stargate.db.cassandra.impl.Conversion;
+import io.stargate.db.cassandra.impl.StargateSystemKeyspace;
+
+import static io.stargate.db.cassandra.impl.StargateSystemKeyspace.isStargateNode;
+import static io.stargate.db.cassandra.impl.StargateSystemKeyspace.isSystemLocal;
+import static io.stargate.db.cassandra.impl.StargateSystemKeyspace.isSystemLocalOrPeers;
+
+/**
+ * A default interceptor implementation that returns only stargate nodes for `system.peers` queries, but also
+ * returns only the same, single token for all stargate nodes (they all own the whole ring) for both `system.local`
+ * and `system.peers` tables.
+ */
+public class DefaultQueryInterceptor implements QueryInterceptor, IEndpointStateChangeSubscriber
+{
+    private final List<IEndpointLifecycleSubscriber> subscribers = new CopyOnWriteArrayList<>();
+    private final Set<InetAddress> liveStargateNodes = Sets.newConcurrentHashSet();
+
+    @Override
+    public void initialize()
+    {
+        Schema.instance.load(StargateSystemKeyspace.metadata());
+        Gossiper.instance.register(new StargateSystemKeyspace.PeersUpdater());
+        Gossiper.instance.register(this);
+        StargateSystemKeyspace.persistLocalMetadata();
+    }
+
+    @Override
+    public boolean shouldInterceptQuery(CQLStatement statement,
+                                        QueryState state, QueryOptions options,
+                                        Map<String, ByteBuffer> customPayload, long queryStartNanoTime)
+    {
+        return isSystemLocalOrPeers(statement);
+    }
+
+    @Override
+    public Result interceptQuery(QueryHandler handler, CQLStatement statement,
+                               QueryState state, QueryOptions options,
+                               Map<String, ByteBuffer> customPayload, long queryStartNanoTime)
+    {
+        org.apache.cassandra.service.QueryState internalState = Conversion.toInternal(state);
+        org.apache.cassandra.cql3.QueryOptions internalOptions = Conversion.toInternal(options);
+        return Conversion.toResult(interceptSystemLocalOrPeers(statement, internalState, internalOptions, queryStartNanoTime), internalOptions.getProtocolVersion());
+    }
+
+    @Override
+    public void register(IEndpointLifecycleSubscriber subscriber)
+    {
+        subscribers.add(subscriber);
+    }
+
+    @Override
+    public void onJoin(InetAddress endpoint, EndpointState epState)
+    {
+        addStargateNode(endpoint, epState);
+    }
+
+    @Override
+    public void beforeChange(InetAddress endpoint, EndpointState currentState, ApplicationState newStateKey, VersionedValue newValue)
+    {
+
+    }
+
+    @Override
+    public void onChange(InetAddress endpoint, ApplicationState state, VersionedValue value)
+    {
+        EndpointState epState = Gossiper.instance.getEndpointStateForEndpoint(endpoint);
+        if (epState == null || Gossiper.instance.isDeadState(epState))
+        {
+            return;
+        }
+
+        addStargateNode(endpoint, epState);
+    }
+
+    @Override
+    public void onAlive(InetAddress endpoint, EndpointState state)
+    {
+
+    }
+
+    @Override
+    public void onDead(InetAddress endpoint, EndpointState state)
+    {
+
+    }
+
+    @Override
+    public void onRemove(InetAddress endpoint)
+    {
+        if (!liveStargateNodes.remove(endpoint))
+        {
+            return;
+        }
+
+        for (IEndpointLifecycleSubscriber subscriber : subscribers)
+            subscriber.onLeaveCluster(endpoint);
+    }
+
+    @Override
+    public void onRestart(InetAddress endpoint, EndpointState state)
+    {
+
+    }
+
+    private void addStargateNode(InetAddress endpoint, EndpointState epState)
+    {
+        if (!isStargateNode(epState) || !liveStargateNodes.add(endpoint))
+        {
+            return;
+        }
+
+        for (IEndpointLifecycleSubscriber subscriber : subscribers)
+            subscriber.onJoinCluster(endpoint);
+    }
+
+    private static ResultMessage.Rows interceptSystemLocalOrPeers(CQLStatement statement, org.apache.cassandra.service.QueryState state, org.apache.cassandra.cql3.QueryOptions options, long queryStartNanoTime)
+    {
+        SelectStatement selectStatement = (SelectStatement) statement;
+        SelectStatement interceptStatement =
+                new SelectStatement(isSystemLocal(selectStatement) ? StargateSystemKeyspace.Local : StargateSystemKeyspace.Peers,
+                        selectStatement.getBoundTerms(),
+                        selectStatement.parameters,
+                        selectStatement.getSelection(),
+                        selectStatement.getRestrictions(),
+                        false,
+                        null,
+                        null,
+                        null,
+                        null);
+        ResultMessage.Rows rows = interceptStatement.execute(state, options, queryStartNanoTime);
+        return new ResultMessage.Rows(new ResultSet(selectStatement.getResultMetadata(), rows.result.rows));
+    }
+}

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/interceptors/QueryInterceptor.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/interceptors/QueryInterceptor.java
@@ -19,10 +19,6 @@ public interface QueryInterceptor
 {
     void initialize();
 
-    boolean shouldInterceptQuery(CQLStatement statement,
-                                 QueryState state, QueryOptions options,
-                                 Map<String, ByteBuffer> customPayload, long queryStartNanoTime);
-
     Result interceptQuery(QueryHandler handler, CQLStatement statement,
                           QueryState state, QueryOptions options,
                           Map<String, ByteBuffer> customPayload, long queryStartNanoTime);

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/interceptors/QueryInterceptor.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/interceptors/QueryInterceptor.java
@@ -1,0 +1,31 @@
+package io.stargate.db.cassandra.impl.interceptors;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+import org.apache.cassandra.cql3.CQLStatement;
+import org.apache.cassandra.cql3.QueryHandler;
+import org.apache.cassandra.service.IEndpointLifecycleSubscriber;
+
+import io.stargate.db.QueryOptions;
+import io.stargate.db.QueryState;
+import io.stargate.db.Result;
+
+/**
+ * A interface for intercepting queries and node lifecycle events. It's used to intercept `system.local`
+ * and `system.peers` queries and topology events for stargate nodes.
+ */
+public interface QueryInterceptor
+{
+    void initialize();
+
+    boolean shouldInterceptQuery(CQLStatement statement,
+                                 QueryState state, QueryOptions options,
+                                 Map<String, ByteBuffer> customPayload, long queryStartNanoTime);
+
+    Result interceptQuery(QueryHandler handler, CQLStatement statement,
+                          QueryState state, QueryOptions options,
+                          Map<String, ByteBuffer> customPayload, long queryStartNanoTime);
+
+    void register(IEndpointLifecycleSubscriber subscriber);
+}

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/interceptors/QueryInterceptor.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/interceptors/QueryInterceptor.java
@@ -12,7 +12,7 @@ import io.stargate.db.QueryState;
 import io.stargate.db.Result;
 
 /**
- * A interface for intercepting queries and node lifecycle events. It's used to intercept `system.local`
+ * An interface for intercepting queries and node lifecycle events. It's used to intercept `system.local`
  * and `system.peers` queries and topology events for stargate nodes.
  */
 public interface QueryInterceptor

--- a/testing/src/test/java/io/stargate/it/PersistenceTest.java
+++ b/testing/src/test/java/io/stargate/it/PersistenceTest.java
@@ -132,9 +132,11 @@ public class PersistenceTest extends BaseOsgiIntegrationTest
                 .column("data_center")
                 .from("system", "peers")
                 .future();
+        row = rs.get().one();
 
         logger.info(String.valueOf(row));
-        assertThat(rs.get()).isEmpty(); // Should only contain stargate peers (so it should be empty)
+        assertThat(row).isNotNull();
+        assertThat(row.columns().get(0).name()).isEqualTo("data_center");
     }
 
     @Test


### PR DESCRIPTION
Also, fix cases where non-stargate nodes could end up in `system.peers`