### PR TITLE
Fix schema migration for non-member nodes

### DIFF
--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/StargateSystemKeyspace.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/StargateSystemKeyspace.java
@@ -312,10 +312,6 @@ public class StargateSystemKeyspace
                     // Use a fix schema version for all peers (always in agreement) because stargate waits
                     // for DDL queries to reach agreement before returning.
                     updatePeerInfo(endpoint, "schema_version", SCHEMA_VERSION, executor);
-
-                    // This fix schedules a schema pull for the non-member node and is required because
-                    // `StorageService.onChange()` doesn't do this for non-member nodes.
-                    MigrationManager.instance.scheduleSchemaPull(endpoint, epState);
                     break;
                 case HOST_ID:
                     updatePeerInfo(endpoint, "host_id", UUID.fromString(value.value), executor);


### PR DESCRIPTION
This will likely fix the schema agreement issues we've been
experiencing. Schema needs to be migrated regardless of the node type.
The previous logic was only pulling the schema if the other node was a
stargate (non-member) node. That was incorrect schema should be pulled
regardless of the node type.