### PR TITLE
POST to /v1/auth without any params results in 500 and NPE

### DIFF
--- a/auth-api/src/main/java/io/stargate/auth/api/AuthResource.java
+++ b/auth-api/src/main/java/io/stargate/auth/api/AuthResource.java
@@ -21,7 +21,6 @@ import io.stargate.auth.model.AuthTokenResponse;
 import io.stargate.auth.model.Credentials;
 import io.stargate.auth.model.Error;
 import io.stargate.auth.model.Secret;
-import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -45,7 +44,13 @@ public class AuthResource {
   @Path("/auth/token/generate")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
-  public Response createToken(@Valid Secret body) {
+  public Response createToken(Secret body) {
+    if (body == null) {
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity(new Error("Must provide a body to the request"))
+          .build();
+    }
+
     if (body.getKey() == null || body.getKey().equals("")) {
       return Response.status(Response.Status.BAD_REQUEST)
           .entity(new Error("Must provide key in request"))
@@ -82,7 +87,13 @@ public class AuthResource {
   @Path("/auth")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
-  public Response createToken(@Valid Credentials body) {
+  public Response createToken(Credentials body) {
+    if (body == null) {
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity(new Error("Must provide a body to the request"))
+          .build();
+    }
+
     if (body.getUsername() == null || body.getUsername().equals("")) {
       return Response.status(Response.Status.BAD_REQUEST)
           .entity(new Error("Must provide username in request"))

--- a/testing/src/test/java/io/stargate/it/http/RestApiTest.java
+++ b/testing/src/test/java/io/stargate/it/http/RestApiTest.java
@@ -65,15 +65,15 @@ import org.slf4j.LoggerFactory;
 @RunWith(Parameterized.class)
 @NotThreadSafe
 public class RestApiTest extends BaseOsgiIntegrationTest {
+
   private static final Logger logger = LoggerFactory.getLogger(RestApiTest.class);
-
-  @Rule public TestName name = new TestName();
-
-  private DataStore dataStore;
-  private String keyspace;
+  private static final ObjectMapper objectMapper = new ObjectMapper();
   private static String authToken;
   private static String host = "http://" + stargateHost;
-  private static final ObjectMapper objectMapper = new ObjectMapper();
+  @Rule
+  public TestName name = new TestName();
+  private DataStore dataStore;
+  private String keyspace;
 
   @Before
   public void setup()
@@ -117,11 +117,27 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
   }
 
   @Test
+  public void createTokenBadCreds() throws IOException {
+    RestUtils.post(
+        "",
+        String.format("%s:8081/v1/auth/token/generate", host),
+        objectMapper.writeValueAsString(new Credentials("bad", "real_bad")),
+        HttpStatus.SC_UNAUTHORIZED);
+  }
+
+  @Test
+  public void createTokenEmptyBody() throws IOException {
+    RestUtils.post(
+        "", String.format("%s:8081/v1/auth/token/generate", host), "", HttpStatus.SC_BAD_REQUEST);
+  }
+
+  @Test
   public void getKeyspaces() throws IOException {
     String body =
         RestUtils.get(authToken, String.format("%s:8082/v1/keyspaces", host), HttpStatus.SC_OK);
 
-    List<String> keyspaces = objectMapper.readValue(body, new TypeReference<List<String>>() {});
+    List<String> keyspaces = objectMapper.readValue(body, new TypeReference<List<String>>() {
+    });
     assertThat(keyspaces)
         .containsAnyOf(
             "system", "system_auth", "system_distributed", "system_schema", "system_traces");
@@ -143,7 +159,8 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
         RestUtils.get(
             authToken, String.format("%s:8082/v1/keyspaces/system/tables", host), HttpStatus.SC_OK);
 
-    List<String> keyspaces = objectMapper.readValue(body, new TypeReference<List<String>>() {});
+    List<String> keyspaces = objectMapper.readValue(body, new TypeReference<List<String>>() {
+    });
     assertThat(keyspaces)
         .containsAnyOf(
             "IndexInfo",
@@ -184,7 +201,8 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             String.format("%s:8082/v1/keyspaces/%s/tables/%s", host, keyspace, tableName),
             HttpStatus.SC_OK);
 
-    TableResponse table = objectMapper.readValue(body, new TypeReference<TableResponse>() {});
+    TableResponse table = objectMapper.readValue(body, new TypeReference<TableResponse>() {
+    });
     assertThat(table.getName()).isEqualTo(tableName);
   }
 
@@ -220,7 +238,8 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
 
     String body = getRow(tableName, rowIdentifier);
 
-    RowResponse rowResponse = objectMapper.readValue(body, new TypeReference<RowResponse>() {});
+    RowResponse rowResponse = objectMapper.readValue(body, new TypeReference<RowResponse>() {
+    });
     assertThat(rowResponse.getCount()).isEqualTo(1);
     assertThat(rowResponse.getRows().get(0).get("id")).isEqualTo(rowIdentifier);
     assertThat(rowResponse.getRows().get(0).get("firstName")).isEqualTo("John");
@@ -247,7 +266,8 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
 
     String row = getRow(tableName, rowIdentifier);
 
-    RowResponse rowResponse = objectMapper.readValue(row, new TypeReference<RowResponse>() {});
+    RowResponse rowResponse = objectMapper.readValue(row, new TypeReference<RowResponse>() {
+    });
     assertThat(rowResponse.getCount()).isEqualTo(1);
     assertThat(rowResponse.getRows().get(0).get("id")).isEqualTo(rowIdentifier);
     assertThat(rowResponse.getRows().get(0).get("firstName")).isEqualTo("John");
@@ -272,7 +292,8 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
 
     rowResponse =
         objectMapper.readValue(
-            getRow(tableName, rowIdentifier), new TypeReference<RowResponse>() {});
+            getRow(tableName, rowIdentifier), new TypeReference<RowResponse>() {
+            });
     assertThat(rowResponse.getCount()).isEqualTo(1);
     assertThat(rowResponse.getRows().get(0).get("id")).isEqualTo(rowIdentifier);
     assertThat(rowResponse.getRows().get(0).get("firstName")).isEqualTo("Fred");
@@ -287,7 +308,8 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
                 "%s:8082/v1/keyspaces/%s/tables/%s/rows/%s", host, "system", "local", "local"),
             HttpStatus.SC_OK);
 
-    RowResponse rowResponse = objectMapper.readValue(body, new TypeReference<RowResponse>() {});
+    RowResponse rowResponse = objectMapper.readValue(body, new TypeReference<RowResponse>() {
+    });
     assertThat(rowResponse.getCount()).isEqualTo(1);
     assertThat(rowResponse.getRows().get(0).get("cluster_name")).isEqualTo("Test Cluster");
   }
@@ -348,7 +370,8 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
                 "%s:8082/v1/keyspaces/%s/tables/%s/rows?pageSize=2", host, keyspace, tableName),
             HttpStatus.SC_OK);
 
-    Rows rows = objectMapper.readValue(body, new TypeReference<Rows>() {});
+    Rows rows = objectMapper.readValue(body, new TypeReference<Rows>() {
+    });
     assertThat(rows.getCount()).isEqualTo(2);
     assertThat(rows.getPageState()).isNotNull();
   }
@@ -400,7 +423,8 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             String.format("%s:8082/v1/keyspaces/%s/tables/%s/rows", host, keyspace, tableName),
             HttpStatus.SC_OK);
 
-    Rows rows = objectMapper.readValue(body, new TypeReference<Rows>() {});
+    Rows rows = objectMapper.readValue(body, new TypeReference<Rows>() {
+    });
     assertThat(rows.getCount()).isEqualTo(3);
   }
 
@@ -438,7 +462,8 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             objectMapper.writeValueAsString(rowAdd),
             HttpStatus.SC_CREATED);
 
-    RowsResponse rowsResponse = objectMapper.readValue(body, new TypeReference<RowsResponse>() {});
+    RowsResponse rowsResponse = objectMapper.readValue(body, new TypeReference<RowsResponse>() {
+    });
     assertThat(rowsResponse.getRowsModified()).isEqualTo(1);
     assertThat(rowsResponse.getSuccess()).isTrue();
 
@@ -490,7 +515,8 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             objectMapper.writeValueAsString(query),
             HttpStatus.SC_OK);
 
-    RowResponse rowResponse = objectMapper.readValue(body, new TypeReference<RowResponse>() {});
+    RowResponse rowResponse = objectMapper.readValue(body, new TypeReference<RowResponse>() {
+    });
     assertThat(rowResponse.getCount()).isEqualTo(1);
     assertThat(rowResponse.getRows().get(0).get("id")).isEqualTo(rowIdentifier);
   }
@@ -572,7 +598,8 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             objectMapper.writeValueAsString(query),
             HttpStatus.SC_OK);
 
-    Rows rows = objectMapper.readValue(body, new TypeReference<Rows>() {});
+    Rows rows = objectMapper.readValue(body, new TypeReference<Rows>() {
+    });
     assertThat(rows.getCount()).isEqualTo(1);
     assertThat(rows.getRows().get(0).get("date")).isEqualTo("2020-08-10T18:48:31.020Z");
   }
@@ -589,7 +616,8 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             HttpStatus.SC_OK);
 
     List<ColumnDefinition> columnDefinitions =
-        objectMapper.readValue(body, new TypeReference<List<ColumnDefinition>>() {});
+        objectMapper.readValue(body, new TypeReference<List<ColumnDefinition>>() {
+        });
     assertThat(columnDefinitions.size()).isEqualTo(3);
     columnDefinitions.sort(Comparator.comparing(ColumnDefinition::getName));
     assertThat(columnDefinitions.get(0).getName()).isEqualTo("firstName");
@@ -608,7 +636,8 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             HttpStatus.SC_OK);
 
     ColumnDefinition columnDefinition =
-        objectMapper.readValue(body, new TypeReference<ColumnDefinition>() {});
+        objectMapper.readValue(body, new TypeReference<ColumnDefinition>() {
+        });
     assertThat(columnDefinition.getName()).isEqualTo("firstName");
     assertThat(columnDefinition.getTypeDefinition()).isEqualTo("Varchar");
   }
@@ -673,7 +702,8 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             HttpStatus.SC_CREATED);
 
     SuccessResponse successResponse =
-        objectMapper.readValue(body, new TypeReference<SuccessResponse>() {});
+        objectMapper.readValue(body, new TypeReference<SuccessResponse>() {
+        });
     assertThat(successResponse.getSuccess()).isTrue();
   }
 
@@ -696,7 +726,8 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             objectMapper.writeValueAsString(rowAdd),
             HttpStatus.SC_CREATED);
 
-    RowsResponse rowsResponse = objectMapper.readValue(body, new TypeReference<RowsResponse>() {});
+    RowsResponse rowsResponse = objectMapper.readValue(body, new TypeReference<RowsResponse>() {
+    });
     assertThat(rowsResponse.getRowsModified()).isEqualTo(1);
     assertThat(rowsResponse.getSuccess()).isTrue();
   }
@@ -711,7 +742,8 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             HttpStatus.SC_CREATED);
 
     SuccessResponse successResponse =
-        objectMapper.readValue(body, new TypeReference<SuccessResponse>() {});
+        objectMapper.readValue(body, new TypeReference<SuccessResponse>() {
+        });
     assertThat(successResponse.getSuccess()).isTrue();
   }
 }

--- a/testing/src/test/java/io/stargate/it/http/RestApiTest.java
+++ b/testing/src/test/java/io/stargate/it/http/RestApiTest.java
@@ -70,8 +70,7 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
   private static final ObjectMapper objectMapper = new ObjectMapper();
   private static String authToken;
   private static String host = "http://" + stargateHost;
-  @Rule
-  public TestName name = new TestName();
+  @Rule public TestName name = new TestName();
   private DataStore dataStore;
   private String keyspace;
 
@@ -136,8 +135,7 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
     String body =
         RestUtils.get(authToken, String.format("%s:8082/v1/keyspaces", host), HttpStatus.SC_OK);
 
-    List<String> keyspaces = objectMapper.readValue(body, new TypeReference<List<String>>() {
-    });
+    List<String> keyspaces = objectMapper.readValue(body, new TypeReference<List<String>>() {});
     assertThat(keyspaces)
         .containsAnyOf(
             "system", "system_auth", "system_distributed", "system_schema", "system_traces");
@@ -159,8 +157,7 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
         RestUtils.get(
             authToken, String.format("%s:8082/v1/keyspaces/system/tables", host), HttpStatus.SC_OK);
 
-    List<String> keyspaces = objectMapper.readValue(body, new TypeReference<List<String>>() {
-    });
+    List<String> keyspaces = objectMapper.readValue(body, new TypeReference<List<String>>() {});
     assertThat(keyspaces)
         .containsAnyOf(
             "IndexInfo",
@@ -201,8 +198,7 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             String.format("%s:8082/v1/keyspaces/%s/tables/%s", host, keyspace, tableName),
             HttpStatus.SC_OK);
 
-    TableResponse table = objectMapper.readValue(body, new TypeReference<TableResponse>() {
-    });
+    TableResponse table = objectMapper.readValue(body, new TypeReference<TableResponse>() {});
     assertThat(table.getName()).isEqualTo(tableName);
   }
 
@@ -238,8 +234,7 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
 
     String body = getRow(tableName, rowIdentifier);
 
-    RowResponse rowResponse = objectMapper.readValue(body, new TypeReference<RowResponse>() {
-    });
+    RowResponse rowResponse = objectMapper.readValue(body, new TypeReference<RowResponse>() {});
     assertThat(rowResponse.getCount()).isEqualTo(1);
     assertThat(rowResponse.getRows().get(0).get("id")).isEqualTo(rowIdentifier);
     assertThat(rowResponse.getRows().get(0).get("firstName")).isEqualTo("John");
@@ -266,8 +261,7 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
 
     String row = getRow(tableName, rowIdentifier);
 
-    RowResponse rowResponse = objectMapper.readValue(row, new TypeReference<RowResponse>() {
-    });
+    RowResponse rowResponse = objectMapper.readValue(row, new TypeReference<RowResponse>() {});
     assertThat(rowResponse.getCount()).isEqualTo(1);
     assertThat(rowResponse.getRows().get(0).get("id")).isEqualTo(rowIdentifier);
     assertThat(rowResponse.getRows().get(0).get("firstName")).isEqualTo("John");
@@ -292,8 +286,7 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
 
     rowResponse =
         objectMapper.readValue(
-            getRow(tableName, rowIdentifier), new TypeReference<RowResponse>() {
-            });
+            getRow(tableName, rowIdentifier), new TypeReference<RowResponse>() {});
     assertThat(rowResponse.getCount()).isEqualTo(1);
     assertThat(rowResponse.getRows().get(0).get("id")).isEqualTo(rowIdentifier);
     assertThat(rowResponse.getRows().get(0).get("firstName")).isEqualTo("Fred");
@@ -308,8 +301,7 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
                 "%s:8082/v1/keyspaces/%s/tables/%s/rows/%s", host, "system", "local", "local"),
             HttpStatus.SC_OK);
 
-    RowResponse rowResponse = objectMapper.readValue(body, new TypeReference<RowResponse>() {
-    });
+    RowResponse rowResponse = objectMapper.readValue(body, new TypeReference<RowResponse>() {});
     assertThat(rowResponse.getCount()).isEqualTo(1);
     assertThat(rowResponse.getRows().get(0).get("cluster_name")).isEqualTo("Test Cluster");
   }
@@ -370,8 +362,7 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
                 "%s:8082/v1/keyspaces/%s/tables/%s/rows?pageSize=2", host, keyspace, tableName),
             HttpStatus.SC_OK);
 
-    Rows rows = objectMapper.readValue(body, new TypeReference<Rows>() {
-    });
+    Rows rows = objectMapper.readValue(body, new TypeReference<Rows>() {});
     assertThat(rows.getCount()).isEqualTo(2);
     assertThat(rows.getPageState()).isNotNull();
   }
@@ -423,8 +414,7 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             String.format("%s:8082/v1/keyspaces/%s/tables/%s/rows", host, keyspace, tableName),
             HttpStatus.SC_OK);
 
-    Rows rows = objectMapper.readValue(body, new TypeReference<Rows>() {
-    });
+    Rows rows = objectMapper.readValue(body, new TypeReference<Rows>() {});
     assertThat(rows.getCount()).isEqualTo(3);
   }
 
@@ -462,8 +452,7 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             objectMapper.writeValueAsString(rowAdd),
             HttpStatus.SC_CREATED);
 
-    RowsResponse rowsResponse = objectMapper.readValue(body, new TypeReference<RowsResponse>() {
-    });
+    RowsResponse rowsResponse = objectMapper.readValue(body, new TypeReference<RowsResponse>() {});
     assertThat(rowsResponse.getRowsModified()).isEqualTo(1);
     assertThat(rowsResponse.getSuccess()).isTrue();
 
@@ -515,8 +504,7 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             objectMapper.writeValueAsString(query),
             HttpStatus.SC_OK);
 
-    RowResponse rowResponse = objectMapper.readValue(body, new TypeReference<RowResponse>() {
-    });
+    RowResponse rowResponse = objectMapper.readValue(body, new TypeReference<RowResponse>() {});
     assertThat(rowResponse.getCount()).isEqualTo(1);
     assertThat(rowResponse.getRows().get(0).get("id")).isEqualTo(rowIdentifier);
   }
@@ -598,8 +586,7 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             objectMapper.writeValueAsString(query),
             HttpStatus.SC_OK);
 
-    Rows rows = objectMapper.readValue(body, new TypeReference<Rows>() {
-    });
+    Rows rows = objectMapper.readValue(body, new TypeReference<Rows>() {});
     assertThat(rows.getCount()).isEqualTo(1);
     assertThat(rows.getRows().get(0).get("date")).isEqualTo("2020-08-10T18:48:31.020Z");
   }
@@ -616,8 +603,7 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             HttpStatus.SC_OK);
 
     List<ColumnDefinition> columnDefinitions =
-        objectMapper.readValue(body, new TypeReference<List<ColumnDefinition>>() {
-        });
+        objectMapper.readValue(body, new TypeReference<List<ColumnDefinition>>() {});
     assertThat(columnDefinitions.size()).isEqualTo(3);
     columnDefinitions.sort(Comparator.comparing(ColumnDefinition::getName));
     assertThat(columnDefinitions.get(0).getName()).isEqualTo("firstName");
@@ -636,8 +622,7 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             HttpStatus.SC_OK);
 
     ColumnDefinition columnDefinition =
-        objectMapper.readValue(body, new TypeReference<ColumnDefinition>() {
-        });
+        objectMapper.readValue(body, new TypeReference<ColumnDefinition>() {});
     assertThat(columnDefinition.getName()).isEqualTo("firstName");
     assertThat(columnDefinition.getTypeDefinition()).isEqualTo("Varchar");
   }
@@ -702,8 +687,7 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             HttpStatus.SC_CREATED);
 
     SuccessResponse successResponse =
-        objectMapper.readValue(body, new TypeReference<SuccessResponse>() {
-        });
+        objectMapper.readValue(body, new TypeReference<SuccessResponse>() {});
     assertThat(successResponse.getSuccess()).isTrue();
   }
 
@@ -726,8 +710,7 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             objectMapper.writeValueAsString(rowAdd),
             HttpStatus.SC_CREATED);
 
-    RowsResponse rowsResponse = objectMapper.readValue(body, new TypeReference<RowsResponse>() {
-    });
+    RowsResponse rowsResponse = objectMapper.readValue(body, new TypeReference<RowsResponse>() {});
     assertThat(rowsResponse.getRowsModified()).isEqualTo(1);
     assertThat(rowsResponse.getSuccess()).isTrue();
   }
@@ -742,8 +725,7 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             HttpStatus.SC_CREATED);
 
     SuccessResponse successResponse =
-        objectMapper.readValue(body, new TypeReference<SuccessResponse>() {
-        });
+        objectMapper.readValue(body, new TypeReference<SuccessResponse>() {});
     assertThat(successResponse.getSuccess()).isTrue();
   }
 }


### PR DESCRIPTION
```sh
HTTP/1.1 500 Server Error
Cache-Control: must-revalidate,no-cache,no-store
Connection: close
Content-Length: 41
Content-Type: application/json;charset=utf-8
Server: Jetty(9.4.24.v20191120)

{
    "description": "Unexpected error occurs"
}
```

In the stargate logs:
```java
09:23:35.797 [qtp231500219-152] WARN org.eclipse.jetty.server.HttpChannel - /v1/auth
javax.servlet.ServletException: javax.servlet.ServletException: java.lang.NullPointerException
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:162)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at org.eclipse.jetty.server.Server.handle(Server.java:500)
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:383)
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:547)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:375)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:270)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
	at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:117)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.produce(EatWhatYouKill.java:135)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:806)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:938)
	at java.lang.Thread.run(Thread.java:748)
Caused by: javax.servlet.ServletException: java.lang.NullPointerException
	at org.glassfish.jersey.servlet.WebComponent.serviceImpl(WebComponent.java:410)
	at org.glassfish.jersey.servlet.WebComponent.service(WebComponent.java:346)
	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:366)
	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:319)
	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:205)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:760)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1617)
	at org.eclipse.jetty.servlets.CrossOriginFilter.handle(CrossOriginFilter.java:310)
	at org.eclipse.jetty.servlets.CrossOriginFilter.doFilter(CrossOriginFilter.java:264)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1604)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:545)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1607)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1297)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:485)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1577)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1212)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:146)
	... 16 common frames omitted
Caused by: java.lang.NullPointerException: null
	at io.stargate.auth.api.AuthResource.createToken(AuthResource.java:70)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:124)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:167)
	at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$ResponseOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:176)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:79)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:469)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:391)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:80)
	at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:253)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:244)
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:265)
	at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:232)
	at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:680)
	at org.glassfish.jersey.servlet.WebComponent.serviceImpl(WebComponent.java:394)
	... 37 common frames omitted
09:23:35.798 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpChannelState - thrownException s=HANDLING rs=BLOCKING os=OPEN is=READY awp=false se=true i=true al=0
javax.servlet.ServletException: javax.servlet.ServletException: java.lang.NullPointerException
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:162)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at org.eclipse.jetty.server.Server.handle(Server.java:500)
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:383)
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:547)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:375)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:270)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
	at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:117)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.produce(EatWhatYouKill.java:135)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:806)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:938)
	at java.lang.Thread.run(Thread.java:748)
Caused by: javax.servlet.ServletException: java.lang.NullPointerException
	at org.glassfish.jersey.servlet.WebComponent.serviceImpl(WebComponent.java:410)
	at org.glassfish.jersey.servlet.WebComponent.service(WebComponent.java:346)
	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:366)
	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:319)
	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:205)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:760)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1617)
	at org.eclipse.jetty.servlets.CrossOriginFilter.handle(CrossOriginFilter.java:310)
	at org.eclipse.jetty.servlets.CrossOriginFilter.doFilter(CrossOriginFilter.java:264)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1604)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:545)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1607)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1297)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:485)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1577)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1212)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:146)
	... 16 common frames omitted
Caused by: java.lang.NullPointerException: null
	at io.stargate.auth.api.AuthResource.createToken(AuthResource.java:70)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:124)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:167)
	at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$ResponseOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:176)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:79)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:469)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:391)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:80)
	at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:253)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:244)
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:265)
	at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:232)
	at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:680)
	at org.glassfish.jersey.servlet.WebComponent.serviceImpl(WebComponent.java:394)
	... 37 common frames omitted
09:23:35.798 [qtp231500219-152] WARN org.eclipse.jetty.server.HttpChannelState - unhandled due to prior sendError
javax.servlet.ServletException: javax.servlet.ServletException: java.lang.NullPointerException
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:162)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at org.eclipse.jetty.server.Server.handle(Server.java:500)
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:383)
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:547)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:375)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:270)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
	at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:117)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.produce(EatWhatYouKill.java:135)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:806)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:938)
	at java.lang.Thread.run(Thread.java:748)
Caused by: javax.servlet.ServletException: java.lang.NullPointerException
	at org.glassfish.jersey.servlet.WebComponent.serviceImpl(WebComponent.java:410)
	at org.glassfish.jersey.servlet.WebComponent.service(WebComponent.java:346)
	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:366)
	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:319)
	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:205)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:760)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1617)
	at org.eclipse.jetty.servlets.CrossOriginFilter.handle(CrossOriginFilter.java:310)
	at org.eclipse.jetty.servlets.CrossOriginFilter.doFilter(CrossOriginFilter.java:264)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1604)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:545)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1607)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1297)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:485)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1577)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1212)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:146)
	... 16 common frames omitted
Caused by: java.lang.NullPointerException: null
	at io.stargate.auth.api.AuthResource.createToken(AuthResource.java:70)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:124)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:167)
	at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$ResponseOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:176)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:79)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:469)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:391)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:80)
	at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:253)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:244)
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:265)
	at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:232)
	at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:680)
	at org.glassfish.jersey.servlet.WebComponent.serviceImpl(WebComponent.java:394)
	... 37 common frames omitted
09:23:35.799 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpChannelState - unhandle HttpChannelState@4b8c17a2{s=HANDLING rs=BLOCKING os=OPEN is=READY awp=false se=true i=true al=0}
09:23:35.799 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpChannelState - nextAction(false) SEND_ERROR HttpChannelState@4b8c17a2{s=HANDLING rs=BLOCKING os=OPEN is=READY awp=false se=false i=false al=0}
09:23:35.799 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpChannel - action SEND_ERROR HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=HANDLING rs=BLOCKING os=OPEN is=READY awp=false se=false i=false al=0},r=1,c=false/false,a=HANDLING,uri=//10.101.37.135:8081/v1/auth,age=8}
09:23:35.799 [qtp231500219-152] DEBUG org.eclipse.jetty.servlet.ErrorPageErrorHandler - getErrorPage(POST /v1/auth) => error_page=null (from global default)
09:23:35.799 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpChannelState - unhandle HttpChannelState@4b8c17a2{s=HANDLING rs=BLOCKING os=OPEN is=READY awp=false se=false i=false al=0}
09:23:35.799 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpChannelState - nextAction(false) COMPLETE HttpChannelState@4b8c17a2{s=HANDLING rs=COMPLETING os=OPEN is=READY awp=false se=false i=false al=0}
09:23:35.799 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpChannel - action COMPLETE HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=HANDLING rs=COMPLETING os=OPEN is=READY awp=false se=false i=false al=0},r=1,c=false/false,a=HANDLING,uri=//10.101.37.135:8081/v1/auth,age=8}
09:23:35.799 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpChannel - sendResponse info=null content=DirectByteBuffer@6823b0cd[p=0,l=41,c=32768,r=41]={<<<{"description":"Unexpected error occurs"}>>>"}\x00\x00\x00\x00\x00\x00\x00...\x00\x00\x00\x00\x00\x00\x00} complete=true committing=true callback=org.eclipse.jetty.util.Callback$4@5c2e2020
09:23:35.799 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpChannel - COMMIT for /v1/auth on HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=HANDLING rs=COMPLETING os=COMMITTED is=READY awp=false se=false i=false al=0},r=1,c=false/false,a=HANDLING,uri=//10.101.37.135:8081/v1/auth,age=8}
500 null HTTP/1.1
Cache-Control: must-revalidate,no-cache,no-store
Content-Type: application/json;charset=utf-8


09:23:35.800 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpConnection - generate: NEED_HEADER for org.eclipse.jetty.server.HttpConnection$SendCallback@69ff81fa[PROCESSING][i=HTTP/1.1{s=500,h=2,cl=-1},cb=org.eclipse.jetty.server.HttpChannel$SendCallback@6d383d2c] (null,[p=0,l=41,c=32768,r=41],true)@START
09:23:35.800 [qtp231500219-152] DEBUG org.eclipse.jetty.http.HttpGenerator - generateHeaders HTTP/1.1{s=500,h=2,cl=-1} last=true content=DirectByteBuffer@6823b0cd[p=0,l=41,c=32768,r=41]={<<<{"description":"Unexpected error occurs"}>>>"}\x00\x00\x00\x00\x00\x00\x00...\x00\x00\x00\x00\x00\x00\x00}
09:23:35.800 [qtp231500219-152] DEBUG org.eclipse.jetty.http.HttpGenerator - Cache-Control: must-revalidate,no-cache,no-store
Content-Type: application/json;charset=utf-8


09:23:35.800 [qtp231500219-152] DEBUG org.eclipse.jetty.http.HttpGenerator - EOF_CONTENT
09:23:35.800 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpConnection - generate: FLUSH for org.eclipse.jetty.server.HttpConnection$SendCallback@69ff81fa[PROCESSING][i=HTTP/1.1{s=500,h=2,cl=-1},cb=org.eclipse.jetty.server.HttpChannel$SendCallback@6d383d2c] ([p=0,l=197,c=8192,r=197],[p=0,l=41,c=32768,r=41],true)@COMPLETING
09:23:35.800 [qtp231500219-152] DEBUG org.eclipse.jetty.io.WriteFlusher - write: WriteFlusher@1103c24f{IDLE}->null [HeapByteBuffer@4b4400dd[p=0,l=197,c=8192,r=197]={<<<HTTP/1.1 500 Server Error...y(9.4.24.v20191120)\r\n\r\n>>>-Length: ...\x00\x00\x00\x00\x00\x00\x00},DirectByteBuffer@6823b0cd[p=0,l=41,c=32768,r=41]={<<<{"description":"Unexpected error occurs"}>>>"}\x00\x00\x00\x00\x00\x00\x00...\x00\x00\x00\x00\x00\x00\x00}]
09:23:35.800 [qtp231500219-152] DEBUG org.eclipse.jetty.io.WriteFlusher - update WriteFlusher@1103c24f{WRITING}->null:IDLE-->WRITING
09:23:35.800 [qtp231500219-152] DEBUG org.eclipse.jetty.io.ChannelEndPoint - flushed 238 SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,OPEN,fill=-,flush=W,to=11/30000}{io=0/0,kio=0,kro=1}->HttpConnection@d95fd58[p=HttpParser{s=END,0 of 0},g=HttpGenerator@4dc61483{s=COMPLETING}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=HANDLING rs=COMPLETING os=COMMITTED is=READY awp=false se=false i=false al=0},r=1,c=false/false,a=HANDLING,uri=//10.101.37.135:8081/v1/auth,age=9}
09:23:35.800 [qtp231500219-152] DEBUG org.eclipse.jetty.io.WriteFlusher - Flushed=true written=238 remaining=0 WriteFlusher@1103c24f{WRITING}->null
09:23:35.800 [qtp231500219-152] DEBUG org.eclipse.jetty.io.WriteFlusher - update WriteFlusher@1103c24f{IDLE}->null:WRITING-->IDLE
09:23:35.800 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpConnection - generate: SHUTDOWN_OUT for org.eclipse.jetty.server.HttpConnection$SendCallback@69ff81fa[PROCESSING][i=HTTP/1.1{s=500,h=2,cl=-1},cb=org.eclipse.jetty.server.HttpChannel$SendCallback@6d383d2c] ([p=197,l=197,c=8192,r=0],[p=41,l=41,c=32768,r=0],true)@END
09:23:35.800 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpConnection - generate: DONE for org.eclipse.jetty.server.HttpConnection$SendCallback@69ff81fa[PROCESSING][i=HTTP/1.1{s=500,h=2,cl=-1},cb=org.eclipse.jetty.server.HttpChannel$SendCallback@6d383d2c] ([p=197,l=197,c=8192,r=0],[p=41,l=41,c=32768,r=0],true)@END
09:23:35.800 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpChannelState - completed HttpChannelState@4b8c17a2{s=HANDLING rs=COMPLETING os=COMPLETED is=READY awp=false se=false i=false al=0}
09:23:35.800 [qtp231500219-152] DEBUG org.eclipse.jetty.io.AbstractEndPoint - shutdownOutput SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,OPEN,fill=-,flush=-,to=0/30000}{io=0/0,kio=0,kro=1}->HttpConnection@d95fd58[p=HttpParser{s=END,0 of 0},g=HttpGenerator@4dc61483{s=END}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=HANDLING rs=COMPLETED os=COMPLETED is=READY awp=false se=false i=false al=0},r=1,c=true/true,a=HANDLING,uri=//10.101.37.135:8081/v1/auth,age=9}
09:23:35.800 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpChannelState - unhandle HttpChannelState@4b8c17a2{s=HANDLING rs=COMPLETED os=COMPLETED is=READY awp=false se=false i=false al=0}
09:23:35.800 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpChannelState - nextAction(false) TERMINATED HttpChannelState@4b8c17a2{s=IDLE rs=COMPLETED os=COMPLETED is=READY awp=false se=false i=false al=0}
09:23:35.800 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpChannel - action TERMINATED HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=COMPLETED os=COMPLETED is=READY awp=false se=false i=false al=0},r=1,c=true/true,a=IDLE,uri=//10.101.37.135:8081/v1/auth,age=9}
09:23:35.800 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpChannel - onCompleted for /v1/auth written=41
09:23:35.800 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpChannelState - recycle HttpChannelState@4b8c17a2{s=IDLE rs=COMPLETED os=COMPLETED is=READY awp=false se=false i=false al=0}
09:23:35.800 [qtp231500219-152] DEBUG org.eclipse.jetty.http.HttpParser - close HttpParser{s=END,0 of 0}
09:23:35.800 [qtp231500219-152] DEBUG org.eclipse.jetty.http.HttpParser - END --> CLOSE
09:23:35.801 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpChannel - !handle TERMINATED HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0}
09:23:35.801 [qtp231500219-152] DEBUG org.eclipse.jetty.io.ChannelEndPoint - filled 0 HeapByteBuffer@4b4400dd[p=0,l=0,c=8192,r=0]={<<<>>>HTTP/1.1 ...\x00\x00\x00\x00\x00\x00\x00}
09:23:35.801 [qtp231500219-152] DEBUG org.eclipse.jetty.io.ChannelEndPoint - filled 0 HeapByteBuffer@4b4400dd[p=0,l=0,c=8192,r=0]={<<<>>>HTTP/1.1 ...\x00\x00\x00\x00\x00\x00\x00}
09:23:35.801 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpConnection - HttpConnection@d95fd58::SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,OSHUT,fill=-,flush=-,to=0/30000}{io=0/0,kio=0,kro=1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0} filled 0 HeapByteBuffer@4b4400dd[p=0,l=0,c=8192,r=0]={<<<>>>HTTP/1.1 ...\x00\x00\x00\x00\x00\x00\x00}
09:23:35.801 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpConnection - HttpConnection@d95fd58::SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,OSHUT,fill=-,flush=-,to=0/30000}{io=0/0,kio=0,kro=1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0} parse HeapByteBuffer@4b4400dd[p=0,l=0,c=8192,r=0]={<<<>>>HTTP/1.1 ...\x00\x00\x00\x00\x00\x00\x00} {}
09:23:35.801 [qtp231500219-152] DEBUG org.eclipse.jetty.http.HttpParser - parseNext s=CLOSE HeapByteBuffer@4b4400dd[p=0,l=0,c=8192,r=0]={<<<>>>HTTP/1.1 ...\x00\x00\x00\x00\x00\x00\x00}
09:23:35.801 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpConnection - HttpConnection@d95fd58::SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,OSHUT,fill=-,flush=-,to=0/30000}{io=0/0,kio=0,kro=1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0} parsed false HttpParser{s=CLOSE,0 of 0}
09:23:35.801 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpConnection - releaseRequestBuffer HttpConnection@d95fd58::SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,OSHUT,fill=-,flush=-,to=0/30000}{io=0/0,kio=0,kro=1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0}
09:23:35.801 [qtp231500219-152] DEBUG org.eclipse.jetty.io.AbstractConnection - fillInterested HttpConnection@d95fd58::SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,OSHUT,fill=-,flush=-,to=1/30000}{io=0/0,kio=0,kro=1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0}
09:23:35.801 [qtp231500219-152] DEBUG org.eclipse.jetty.io.FillInterest - interested FillInterest@6488611d{AC.ReadCB@d95fd58{HttpConnection@d95fd58::SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,OSHUT,fill=FI,flush=-,to=0/30000}{io=0/0,kio=0,kro=1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0}}}
09:23:35.801 [qtp231500219-152] DEBUG org.eclipse.jetty.io.ChannelEndPoint - changeInterests p=false 0->1 for SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,OSHUT,fill=FI,flush=-,to=0/30000}{io=0/1,kio=0,kro=1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0}
09:23:35.801 [qtp231500219-152] DEBUG org.eclipse.jetty.io.ManagedSelector - Queued change org.eclipse.jetty.io.ChannelEndPoint$1@4f924b29 on ManagedSelector@6b6afca9{STARTED} id=7 keys=1 selected=0 updates=0
09:23:35.801 [qtp231500219-152] DEBUG org.eclipse.jetty.io.ManagedSelector - Wakeup on submit ManagedSelector@6b6afca9{STARTED} id=7 keys=1 selected=0 updates=1
09:23:35.801 [qtp231500219-152] DEBUG org.eclipse.jetty.server.HttpConnection - HttpConnection@d95fd58::SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,OSHUT,fill=FI,flush=-,to=0/30000}{io=0/1,kio=0,kro=1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0} onFillable exit HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0} null
09:23:35.801 [qtp231500219-215] DEBUG org.eclipse.jetty.io.ManagedSelector - Selector sun.nio.ch.EPollSelectorImpl@13d4c611 woken with none selected
09:23:35.802 [qtp231500219-152] DEBUG org.eclipse.jetty.util.thread.QueuedThreadPool - ran org.eclipse.jetty.io.ManagedSelector$$Lambda$518/1167858937@385e7d67 in QueuedThreadPool[qtp231500219]@dcc69bb{STARTED,8<=12<=200,i=0,r=16,q=0}[ReservedThreadExecutor@76b436fa{s=1/16,p=0}]
09:23:35.802 [qtp231500219-215] DEBUG org.eclipse.jetty.io.ManagedSelector - Selector sun.nio.ch.EPollSelectorImpl@13d4c611 woken up from select, 0/0/1 selected
09:23:35.802 [qtp231500219-215] DEBUG org.eclipse.jetty.io.ManagedSelector - Selector sun.nio.ch.EPollSelectorImpl@13d4c611 processing 0 keys, 1 updates
09:23:35.802 [qtp231500219-215] DEBUG org.eclipse.jetty.io.ManagedSelector - updateable 1
09:23:35.802 [qtp231500219-215] DEBUG org.eclipse.jetty.io.ManagedSelector - update org.eclipse.jetty.io.ChannelEndPoint$1@4f924b29
09:23:35.802 [qtp231500219-215] DEBUG org.eclipse.jetty.io.ChannelEndPoint - Key interests updated 0 -> 1 on SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,OSHUT,fill=FI,flush=-,to=0/30000}{io=1/1,kio=1,kro=1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0}
09:23:35.802 [qtp231500219-215] DEBUG org.eclipse.jetty.io.ManagedSelector - updates 0
09:23:35.802 [qtp231500219-215] DEBUG org.eclipse.jetty.io.ManagedSelector - Selector sun.nio.ch.EPollSelectorImpl@13d4c611 waiting with 1 keys
09:23:36.113 [qtp231500219-215] DEBUG org.eclipse.jetty.io.ManagedSelector - Selector sun.nio.ch.EPollSelectorImpl@13d4c611 woken up from select, 1/1/1 selected
09:23:36.113 [qtp231500219-215] DEBUG org.eclipse.jetty.io.ManagedSelector - Selector sun.nio.ch.EPollSelectorImpl@13d4c611 processing 1 keys, 0 updates
09:23:36.113 [qtp231500219-215] DEBUG org.eclipse.jetty.io.ManagedSelector - selected 1 sun.nio.ch.SelectionKeyImpl@1d132a1b SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,OSHUT,fill=FI,flush=-,to=311/30000}{io=1/1,kio=1,kro=1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0} 
09:23:36.113 [qtp231500219-215] DEBUG org.eclipse.jetty.io.ChannelEndPoint - onSelected 1->0 r=true w=false for SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,OSHUT,fill=FI,flush=-,to=312/30000}{io=1/0,kio=1,kro=1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0}
09:23:36.114 [qtp231500219-215] DEBUG org.eclipse.jetty.io.ChannelEndPoint - task CEP:SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,OSHUT,fill=FI,flush=-,to=312/30000}{io=1/0,kio=1,kro=1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0}:runFillable:BLOCKING
09:23:36.114 [qtp231500219-215] DEBUG org.eclipse.jetty.util.thread.ReservedThreadExecutor - ReservedThreadExecutor@76b436fa{s=1/16,p=0} tryExecute EatWhatYouKill@7edb2d40/SelectorProducer@464ab738/PRODUCING/p=false/QueuedThreadPool[qtp231500219]@dcc69bb{STARTED,8<=12<=200,i=1,r=16,q=0}[ReservedThreadExecutor@76b436fa{s=1/16,p=0}][pc=0,pic=0,pec=0,epc=1]@2020-09-14T09:23:36.114Z
09:23:36.114 [qtp231500219-215] DEBUG org.eclipse.jetty.util.thread.ReservedThreadExecutor - ReservedThreadExecutor@76b436fa{s=0/16,p=0}@3605953b offer EatWhatYouKill@7edb2d40/SelectorProducer@464ab738/PRODUCING/p=false/QueuedThreadPool[qtp231500219]@dcc69bb{STARTED,8<=12<=200,i=1,r=16,q=0}[ReservedThreadExecutor@76b436fa{s=0/16,p=0}][pc=0,pic=0,pec=0,epc=1]@2020-09-14T09:23:36.114Z
09:23:36.114 [qtp231500219-215] DEBUG org.eclipse.jetty.util.thread.ReservedThreadExecutor - ReservedThreadExecutor@76b436fa{s=0/16,p=1} startReservedThread p=1
09:23:36.115 [qtp231500219-215] DEBUG org.eclipse.jetty.util.thread.QueuedThreadPool - queue ReservedThreadExecutor@76b436fa{s=0/16,p=1}@e005e9 startThread=0
09:23:36.115 [qtp231500219-152] DEBUG org.eclipse.jetty.util.thread.QueuedThreadPool - run ReservedThreadExecutor@76b436fa{s=0/16,p=1}@e005e9 in QueuedThreadPool[qtp231500219]@dcc69bb{STARTED,8<=12<=200,i=0,r=16,q=0}[ReservedThreadExecutor@76b436fa{s=0/16,p=1}]
09:23:36.115 [qtp231500219-152] DEBUG org.eclipse.jetty.util.thread.ReservedThreadExecutor - ReservedThreadExecutor@76b436fa{s=1/16,p=1}@e005e9 started
09:23:36.115 [qtp231500219-152] DEBUG org.eclipse.jetty.util.thread.ReservedThreadExecutor - ReservedThreadExecutor@76b436fa{s=1/16,p=0}@e005e9 waiting
09:23:36.115 [qtp231500219-215] DEBUG org.eclipse.jetty.util.thread.strategy.EatWhatYouKill - EatWhatYouKill@7edb2d40/SelectorProducer@464ab738/IDLE/p=true/QueuedThreadPool[qtp231500219]@dcc69bb{STARTED,8<=12<=200,i=0,r=16,q=0}[ReservedThreadExecutor@76b436fa{s=0/16,p=1}][pc=0,pic=0,pec=0,epc=1]@2020-09-14T09:23:36.115Z m=EXECUTE_PRODUCE_CONSUME t=CEP:SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,OSHUT,fill=FI,flush=-,to=313/30000}{io=1/0,kio=1,kro=1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0}:runFillable:BLOCKING/BLOCKING
09:23:36.115 [qtp231500219-216] DEBUG org.eclipse.jetty.util.thread.ReservedThreadExecutor - ReservedThreadExecutor@76b436fa{s=0/16,p=1}@3605953b task=EatWhatYouKill@7edb2d40/SelectorProducer@464ab738/IDLE/p=true/QueuedThreadPool[qtp231500219]@dcc69bb{STARTED,8<=12<=200,i=0,r=16,q=0}[ReservedThreadExecutor@76b436fa{s=1/16,p=0}][pc=0,pic=0,pec=0,epc=1]@2020-09-14T09:23:36.115Z
09:23:36.115 [qtp231500219-215] DEBUG org.eclipse.jetty.io.FillInterest - fillable FillInterest@6488611d{AC.ReadCB@d95fd58{HttpConnection@d95fd58::SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,OSHUT,fill=FI,flush=-,to=314/30000}{io=1/0,kio=1,kro=1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0}}}
09:23:36.116 [qtp231500219-216] DEBUG org.eclipse.jetty.util.thread.strategy.EatWhatYouKill - EatWhatYouKill@7edb2d40/SelectorProducer@464ab738/IDLE/p=true/QueuedThreadPool[qtp231500219]@dcc69bb{STARTED,8<=12<=200,i=0,r=16,q=0}[ReservedThreadExecutor@76b436fa{s=1/16,p=0}][pc=0,pic=0,pec=0,epc=2]@2020-09-14T09:23:36.115Z tryProduce true
09:23:36.116 [qtp231500219-216] DEBUG org.eclipse.jetty.io.ManagedSelector - updateable 0
09:23:36.116 [qtp231500219-216] DEBUG org.eclipse.jetty.io.ManagedSelector - updates 0
09:23:36.116 [qtp231500219-215] DEBUG org.eclipse.jetty.server.HttpConnection - HttpConnection@d95fd58::SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,OSHUT,fill=-,flush=-,to=314/30000}{io=1/0,kio=1,kro=1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0} onFillable enter HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0} null
09:23:36.116 [qtp231500219-216] DEBUG org.eclipse.jetty.io.ChannelEndPoint - Key interests updated 1 -> 0 on SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,OSHUT,fill=-,flush=-,to=314/30000}{io=0/0,kio=0,kro=1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0}
09:23:36.116 [qtp231500219-215] DEBUG org.eclipse.jetty.io.AbstractEndPoint - shutdownInput SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,OSHUT,fill=-,flush=-,to=314/30000}{io=0/0,kio=0,kro=1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0}
09:23:36.116 [qtp231500219-216] DEBUG org.eclipse.jetty.io.ManagedSelector - Selector sun.nio.ch.EPollSelectorImpl@13d4c611 waiting with 1 keys
09:23:36.116 [qtp231500219-215] DEBUG org.eclipse.jetty.io.ChannelEndPoint - doClose SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,CLOSED,fill=-,flush=-,to=314/30000}{io=0/0,kio=0,kro=1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0}
09:23:36.117 [qtp231500219-215] DEBUG org.eclipse.jetty.io.WriteFlusher - ignored: WriteFlusher@1103c24f{IDLE}->null
java.nio.channels.ClosedChannelException: null
	at org.eclipse.jetty.io.WriteFlusher.onClose(WriteFlusher.java:521)
	at org.eclipse.jetty.io.AbstractEndPoint.onClose(AbstractEndPoint.java:354)
	at org.eclipse.jetty.io.ChannelEndPoint.onClose(ChannelEndPoint.java:214)
	at org.eclipse.jetty.io.AbstractEndPoint.doOnClose(AbstractEndPoint.java:225)
	at org.eclipse.jetty.io.AbstractEndPoint.shutdownInput(AbstractEndPoint.java:107)
	at org.eclipse.jetty.io.ChannelEndPoint.fill(ChannelEndPoint.java:237)
	at org.eclipse.jetty.server.HttpConnection.fillRequestBuffer(HttpConnection.java:333)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:251)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
	at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:117)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:129)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:388)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:806)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:938)
	at java.lang.Thread.run(Thread.java:748)
09:23:36.117 [qtp231500219-215] DEBUG org.eclipse.jetty.io.FillInterest - onClose FillInterest@6488611d{null}
09:23:36.117 [qtp231500219-215] DEBUG org.eclipse.jetty.io.ManagedSelector - Wakeup ManagedSelector@6b6afca9{STARTED} id=7 keys=1 selected=0 updates=0
09:23:36.117 [qtp231500219-215] DEBUG org.eclipse.jetty.util.thread.QueuedThreadPool - queue org.eclipse.jetty.io.ManagedSelector$DestroyEndPoint@2346b0b6 startThread=1
09:23:36.117 [qtp231500219-216] DEBUG org.eclipse.jetty.io.ManagedSelector - Selector sun.nio.ch.EPollSelectorImpl@13d4c611 woken with none selected
09:23:36.117 [qtp231500219-216] DEBUG org.eclipse.jetty.io.ManagedSelector - Selector sun.nio.ch.EPollSelectorImpl@13d4c611 woken up from select, 0/0/0 selected
09:23:36.117 [qtp231500219-215] DEBUG org.eclipse.jetty.util.thread.QueuedThreadPool - Starting Thread[qtp231500219-217,5,main]
09:23:36.117 [qtp231500219-216] DEBUG org.eclipse.jetty.io.ManagedSelector - Selector sun.nio.ch.EPollSelectorImpl@13d4c611 processing 0 keys, 0 updates
09:23:36.117 [qtp231500219-216] DEBUG org.eclipse.jetty.io.ManagedSelector - updateable 0
09:23:36.117 [qtp231500219-216] DEBUG org.eclipse.jetty.io.ManagedSelector - updates 0
09:23:36.117 [qtp231500219-216] DEBUG org.eclipse.jetty.io.ManagedSelector - Selector sun.nio.ch.EPollSelectorImpl@13d4c611 waiting with 0 keys
09:23:36.118 [qtp231500219-215] DEBUG org.eclipse.jetty.io.ChannelEndPoint - filled -1 HeapByteBuffer@4b4400dd[p=0,l=0,c=8192,r=0]={<<<>>>HTTP/1.1 ...\x00\x00\x00\x00\x00\x00\x00}
09:23:36.118 [qtp231500219-215] DEBUG org.eclipse.jetty.http.HttpParser - atEOF HttpParser{s=CLOSE,0 of 0}
09:23:36.118 [qtp231500219-215] DEBUG org.eclipse.jetty.server.HttpConnection - HttpConnection@d95fd58::SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,CLOSED,fill=-,flush=-,to=316/30000}{io=0/0,kio=-1,kro=-1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0} filled -1 HeapByteBuffer@4b4400dd[p=0,l=0,c=8192,r=0]={<<<>>>HTTP/1.1 ...\x00\x00\x00\x00\x00\x00\x00}
09:23:36.118 [qtp231500219-217] DEBUG org.eclipse.jetty.util.thread.QueuedThreadPool - Runner started for QueuedThreadPool[qtp231500219]@dcc69bb{STARTED,8<=13<=200,i=0,r=16,q=0}[ReservedThreadExecutor@76b436fa{s=1/16,p=0}]
09:23:36.118 [qtp231500219-217] DEBUG org.eclipse.jetty.util.thread.QueuedThreadPool - run org.eclipse.jetty.io.ManagedSelector$DestroyEndPoint@2346b0b6 in QueuedThreadPool[qtp231500219]@dcc69bb{STARTED,8<=13<=200,i=0,r=16,q=0}[ReservedThreadExecutor@76b436fa{s=1/16,p=0}]
09:23:36.119 [qtp231500219-215] DEBUG org.eclipse.jetty.io.AbstractEndPoint - close SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,CLOSED,fill=-,flush=-,to=317/30000}{io=0/0,kio=-1,kro=-1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0}
09:23:36.119 [qtp231500219-215] DEBUG org.eclipse.jetty.io.AbstractEndPoint - close(null) SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,CLOSED,fill=-,flush=-,to=317/30000}{io=0/0,kio=-1,kro=-1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0}
09:23:36.119 [qtp231500219-217] DEBUG org.eclipse.jetty.io.ManagedSelector - Destroyed SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,CLOSED,fill=-,flush=-,to=317/30000}{io=0/0,kio=-1,kro=-1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0}
09:23:36.119 [qtp231500219-215] DEBUG org.eclipse.jetty.server.HttpConnection - HttpConnection@d95fd58::SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,CLOSED,fill=-,flush=-,to=317/30000}{io=0/0,kio=-1,kro=-1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0} parse HeapByteBuffer@4b4400dd[p=0,l=0,c=8192,r=0]={<<<>>>HTTP/1.1 ...\x00\x00\x00\x00\x00\x00\x00} {}
09:23:36.119 [qtp231500219-215] DEBUG org.eclipse.jetty.http.HttpParser - parseNext s=CLOSE HeapByteBuffer@4b4400dd[p=0,l=0,c=8192,r=0]={<<<>>>HTTP/1.1 ...\x00\x00\x00\x00\x00\x00\x00}
09:23:36.119 [qtp231500219-217] DEBUG org.eclipse.jetty.io.AbstractConnection - onClose HttpConnection@d95fd58::SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,CLOSED,fill=-,flush=-,to=317/30000}{io=0/0,kio=-1,kro=-1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSE,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0}
09:23:36.119 [qtp231500219-215] DEBUG org.eclipse.jetty.http.HttpParser - CLOSE --> CLOSED
09:23:36.119 [qtp231500219-217] DEBUG org.eclipse.jetty.util.thread.QueuedThreadPool - ran org.eclipse.jetty.io.ManagedSelector$DestroyEndPoint@2346b0b6 in QueuedThreadPool[qtp231500219]@dcc69bb{STARTED,8<=13<=200,i=0,r=16,q=0}[ReservedThreadExecutor@76b436fa{s=1/16,p=0}]
09:23:36.119 [qtp231500219-215] DEBUG org.eclipse.jetty.server.HttpConnection - HttpConnection@d95fd58::SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,CLOSED,fill=-,flush=-,to=318/30000}{io=0/0,kio=-1,kro=-1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSED,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0} parsed false HttpParser{s=CLOSED,0 of 0}
09:23:36.120 [qtp231500219-215] DEBUG org.eclipse.jetty.server.HttpConnection - releaseRequestBuffer HttpConnection@d95fd58::SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,CLOSED,fill=-,flush=-,to=318/30000}{io=0/0,kio=-1,kro=-1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSED,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0}
09:23:36.120 [qtp231500219-215] DEBUG org.eclipse.jetty.io.AbstractEndPoint - shutdownOutput SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,CLOSED,fill=-,flush=-,to=318/30000}{io=0/0,kio=-1,kro=-1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSED,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0}
09:23:36.120 [qtp231500219-215] DEBUG org.eclipse.jetty.server.HttpConnection - HttpConnection@d95fd58::SocketChannelEndPoint@1b4b7b02{/10.151.0.238:33432<->/10.101.37.135:8081,CLOSED,fill=-,flush=-,to=319/30000}{io=0/0,kio=-1,kro=-1}->HttpConnection@d95fd58[p=HttpParser{s=CLOSED,0 of 0},g=HttpGenerator@4dc61483{s=START}]=>HttpChannelOverHttp@7a7a73bd{s=HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0},r=1,c=false/false,a=IDLE,uri=null,age=0} onFillable exit HttpChannelState@4b8c17a2{s=IDLE rs=BLOCKING os=OPEN is=IDLE awp=false se=false i=true al=0} null
09:23:36.121 [qtp231500219-215] DEBUG org.eclipse.jetty.util.thread.ReservedThreadExecutor - ReservedThreadExecutor@76b436fa{s=2/16,p=0}@16804601 waiting
09:23:47.562 [OptionalTasks:1] DEBUG o.a.c.db.SizeEstimatesRecorder - Node is not part of the ring; not recording size estimates
09:24:36.115 [qtp231500219-152] DEBUG org.eclipse.jetty.util.thread.ReservedThreadExecutor - ReservedThreadExecutor@76b436fa{s=2/16,p=0}@e005e9 IDLE
09:24:36.116 [qtp231500219-152] DEBUG org.eclipse.jetty.util.thread.ReservedThreadExecutor - ReservedThreadExecutor@76b436fa{s=2/16,p=0} tryExecute STOP!
09:24:36.116 [qtp231500219-152] DEBUG org.eclipse.jetty.util.thread.ReservedThreadExecutor - ReservedThreadExecutor@76b436fa{s=1/16,p=0}@16804601 offer STOP!
09:24:36.116 [qtp231500219-215] DEBUG org.eclipse.jetty.util.thread.ReservedThreadExecutor - ReservedThreadExecutor@76b436fa{s=1/16,p=0}@16804601 task=STOP!
09:24:36.116 [qtp231500219-215] DEBUG org.eclipse.jetty.util.thread.ReservedThreadExecutor - ReservedThreadExecutor@76b436fa{s=1/16,p=0}@16804601 Exited
09:24:36.116 [qtp231500219-215] DEBUG org.eclipse.jetty.util.thread.QueuedThreadPool - ran ReservedThreadExecutor@76b436fa{s=1/16,p=0}@16804601 in QueuedThreadPool[qtp231500219]@dcc69bb{STARTED,8<=13<=200,i=1,r=16,q=0}[ReservedThreadExecutor@76b436fa{s=1/16,p=0}]
09:24:36.120 [qtp231500219-217] DEBUG org.eclipse.jetty.util.thread.QueuedThreadPool - shrinking QueuedThreadPool[qtp231500219]@dcc69bb{STARTED,8<=13<=200,i=2,r=16,q=0}[ReservedThreadExecutor@76b436fa{s=1/16,p=0}]
09:24:36.120 [qtp231500219-217] DEBUG org.eclipse.jetty.util.thread.QueuedThreadPool - Thread[qtp231500219-217,5,main] exited for QueuedThreadPool[qtp231500219]@dcc69bb{STARTED,8<=12<=200,i=1,r=16,q=0}[ReservedThreadExecutor@76b436fa{s=1/16,p=0}]
```