### PR TITLE
REST v1 /query  errors 500 when unexpected JSON data key is used

### DIFF
--- a/testing/src/test/java/io/stargate/it/http/RestApiTest.java
+++ b/testing/src/test/java/io/stargate/it/http/RestApiTest.java
@@ -70,7 +70,8 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
   private static final ObjectMapper objectMapper = new ObjectMapper();
   private static String authToken;
   private static String host = "http://" + stargateHost;
-  @Rule public TestName name = new TestName();
+  @Rule
+  public TestName name = new TestName();
   private DataStore dataStore;
   private String keyspace;
 
@@ -586,9 +587,147 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             objectMapper.writeValueAsString(query),
             HttpStatus.SC_OK);
 
-    Rows rows = objectMapper.readValue(body, new TypeReference<Rows>() {});
+    Rows rows = objectMapper.readValue(body, new TypeReference<Rows>() {
+    });
     assertThat(rows.getCount()).isEqualTo(1);
     assertThat(rows.getRows().get(0).get("date")).isEqualTo("2020-08-10T18:48:31.020Z");
+  }
+
+  @Test
+  public void queryWithFilterMissingColumnName() throws IOException {
+    String tableName = "tbl_query_" + System.currentTimeMillis();
+    createTable(tableName);
+
+    Query query = new Query();
+    List<Filter> filters = new ArrayList<>();
+
+    Filter filter = new Filter();
+    filter.setOperator(Filter.Operator.eq);
+    filter.setValue(Collections.singletonList("John Doe"));
+    filters.add(filter);
+
+    query.setFilters(filters);
+
+    RestUtils.post(
+        authToken,
+        String.format("%s:8082/v1/keyspaces/%s/tables/%s/rows/query", host, keyspace, tableName),
+        objectMapper.writeValueAsString(query),
+        HttpStatus.SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void queryWithFilterMissingOperator() throws IOException {
+    String tableName = "tbl_query_" + System.currentTimeMillis();
+    createTable(tableName);
+
+    Query query = new Query();
+    List<Filter> filters = new ArrayList<>();
+
+    Filter filter = new Filter();
+    filter.setColumnName("firstName");
+    filter.setValue(Collections.singletonList("John Doe"));
+    filters.add(filter);
+
+    query.setFilters(filters);
+
+    RestUtils.post(
+        authToken,
+        String.format("%s:8082/v1/keyspaces/%s/tables/%s/rows/query", host, keyspace, tableName),
+        objectMapper.writeValueAsString(query),
+        HttpStatus.SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void queryWithFilterEmptyValueList() throws IOException {
+    String tableName = "tbl_query_" + System.currentTimeMillis();
+    createTable(tableName);
+
+    Query query = new Query();
+    List<Filter> filters = new ArrayList<>();
+
+    Filter filter = new Filter();
+    filter.setColumnName("firstName");
+    filter.setOperator(Filter.Operator.eq);
+    filter.setValue(Collections.emptyList());
+    filters.add(filter);
+
+    query.setFilters(filters);
+
+    RestUtils.post(
+        authToken,
+        String.format("%s:8082/v1/keyspaces/%s/tables/%s/rows/query", host, keyspace, tableName),
+        objectMapper.writeValueAsString(query),
+        HttpStatus.SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void queryWithFilterMissingValueList() throws IOException {
+    String tableName = "tbl_query_" + System.currentTimeMillis();
+    createTable(tableName);
+
+    Query query = new Query();
+    List<Filter> filters = new ArrayList<>();
+
+    Filter filter = new Filter();
+    filter.setColumnName("firstName");
+    filter.setOperator(Filter.Operator.eq);
+    filters.add(filter);
+
+    query.setFilters(filters);
+
+    RestUtils.post(
+        authToken,
+        String.format("%s:8082/v1/keyspaces/%s/tables/%s/rows/query", host, keyspace, tableName),
+        objectMapper.writeValueAsString(query),
+        HttpStatus.SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void queryWithEmptyFilter() throws IOException {
+    String tableName = "tbl_query_" + System.currentTimeMillis();
+    createTable(tableName);
+
+    Query query = new Query();
+    List<Filter> filters = new ArrayList<>();
+    filters.add(new Filter());
+
+    query.setFilters(filters);
+
+    RestUtils.post(
+        authToken,
+        String.format("%s:8082/v1/keyspaces/%s/tables/%s/rows/query", host, keyspace, tableName),
+        objectMapper.writeValueAsString(query),
+        HttpStatus.SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void queryWithEmptyFilters() throws IOException {
+    String tableName = "tbl_query_" + System.currentTimeMillis();
+    createTable(tableName);
+
+    Query query = new Query();
+
+    query.setFilters(Collections.emptyList());
+
+    RestUtils.post(
+        authToken,
+        String.format("%s:8082/v1/keyspaces/%s/tables/%s/rows/query", host, keyspace, tableName),
+        objectMapper.writeValueAsString(query),
+        HttpStatus.SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void queryWithMissingFilter() throws IOException {
+    String tableName = "tbl_query_" + System.currentTimeMillis();
+    createTable(tableName);
+
+    Query query = new Query();
+
+    RestUtils.post(
+        authToken,
+        String.format("%s:8082/v1/keyspaces/%s/tables/%s/rows/query", host, keyspace, tableName),
+        objectMapper.writeValueAsString(query),
+        HttpStatus.SC_BAD_REQUEST);
   }
 
   @Test

--- a/testing/src/test/java/io/stargate/it/http/RestApiTest.java
+++ b/testing/src/test/java/io/stargate/it/http/RestApiTest.java
@@ -70,8 +70,7 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
   private static final ObjectMapper objectMapper = new ObjectMapper();
   private static String authToken;
   private static String host = "http://" + stargateHost;
-  @Rule
-  public TestName name = new TestName();
+  @Rule public TestName name = new TestName();
   private DataStore dataStore;
   private String keyspace;
 
@@ -587,8 +586,7 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
             objectMapper.writeValueAsString(query),
             HttpStatus.SC_OK);
 
-    Rows rows = objectMapper.readValue(body, new TypeReference<Rows>() {
-    });
+    Rows rows = objectMapper.readValue(body, new TypeReference<Rows>() {});
     assertThat(rows.getCount()).isEqualTo(1);
     assertThat(rows.getRows().get(0).get("date")).isEqualTo("2020-08-10T18:48:31.020Z");
   }


### PR DESCRIPTION
```shell
http POST http://$STARGATE:8082/v1/keyspaces/ks1/tables/table8/rows/query X-Cassandra-Token:$TOKEN unknownparam=""
HTTP/1.1 500 Internal Server Error
Content-Length: 47
Content-Type: application/json
Date: Mon, 14 Sep 2020 12:25:55 GMT

{
    "code": 500, 
    "description": "Server error: null"
}
```

I think it should either be ignored or return some 4xx.