### PR TITLE
Fix pom.xml formatting so that build is not broken

### DIFF
--- a/persistence-cassandra-3.11/pom.xml
+++ b/persistence-cassandra-3.11/pom.xml
@@ -162,12 +162,12 @@
               <tasks>
                 <!-- Remove root package classes -->
                 <delete>
-                  <fileset dir="${project.build.directory}/sjk-core/" includes="*.class" />
+                  <fileset dir="${project.build.directory}/sjk-core/" includes="*.class"/>
                 </delete>
                 <jar destfile="${project.build.directory}/classes/sjk-core-0.14.jar">
-                  <fileset dir="${project.build.directory}/sjk-core" />
+                  <fileset dir="${project.build.directory}/sjk-core"/>
                 </jar>
-                <delete dir="${project.build.directory}/sjk-core" />
+                <delete dir="${project.build.directory}/sjk-core"/>
               </tasks>
             </configuration>
           </execution>


### PR DESCRIPTION
```
[INFO] ------------------------< io.stargate:stargate >------------------------
[INFO] Building io.stargate:stargate 0.0.8-SNAPSHOT                      [1/11]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:3.1.0:clean (default-clean) @ stargate ---
[INFO] Deleting /home/tomek/repos/tlasica/stargate/stargate-lib (includes = [], excludes = [.keep, logback.xml])
[INFO] 
[INFO] --- fmt-maven-plugin:2.9:check (default) @ stargate ---
[INFO] Skipping format check: project uses 'pom' packaging
[INFO] 
[INFO] --- xml-format-maven-plugin:3.1.2:xml-check (default) @ stargate ---
[ERROR] [xml-check] Needs formatting:/home/tomek/repos/tlasica/stargate/persistence-cassandra-3.11/pom.xml
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for io.stargate:stargate 0.0.8-SNAPSHOT:
[INFO] 
[INFO] io.stargate:stargate ............................... FAILURE [  0.375 s]
[INFO] stargate-starter ................................... SKIPPED
[INFO] persistence-api .................................... SKIPPED
[INFO] persistence-common ................................. SKIPPED
[INFO] persistence-cassandra-3.11 ......................... SKIPPED
[INFO] cql ................................................ SKIPPED
[INFO] authentication ..................................... SKIPPED
[INFO] restapi ............................................ SKIPPED
[INFO] auth-api ........................................... SKIPPED
[INFO] auth-table-based-service ........................... SKIPPED
[INFO] testing ............................................ SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.309 s
[INFO] Finished at: 2020-09-18T10:11:10+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal au.com.acegi:xml-format-maven-plugin:3.1.2:xml-check (default) on project stargate: [xml-check] At least one XML file needs formatting, see the error logs above)```