### PR TITLE
Move timestamp binding logic over to persistence-api

### DIFF
--- a/persistence-api/src/main/java/io/stargate/db/datastore/schema/AbstractTable.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/schema/AbstractTable.java
@@ -103,6 +103,9 @@ public abstract class AbstractTable implements Index, QualifiedSchemaEntity {
     if (Column.TTL.name().equals(name)) {
       return Column.TTL;
     }
+    if (Column.TIMESTAMP.name().equals(name)) {
+      return Column.TIMESTAMP;
+    }
     return columnMap().get(name);
   }
 

--- a/persistence-api/src/main/java/io/stargate/db/datastore/schema/Column.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/schema/Column.java
@@ -75,6 +75,7 @@ public abstract class Column implements SchemaEntity, Comparable<Column> {
 
   public static final Column STAR = reference("*");
   public static final Column TTL = Column.create("[ttl]", Type.Int);
+  public static final Column TIMESTAMP = Column.create("[timestamp]", Type.Bigint);
 
   public interface ColumnType extends java.io.Serializable {
     AttachmentPoint CUSTOM_ATTACHMENT_POINT =


### PR DESCRIPTION
Just porting some persistence-api changes that are required for timestamp parameter binding in CQL statements 