### PR TITLE
Enforce license headers in the build

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -11,6 +11,16 @@ To fix formatting issues from the command line, run the following:
 mvn xml-format:xml-format fmt:format
 ```
 
+Similarly, we use [license-maven-plugin](https://github.com/mycila/license-maven-plugin) to ensure
+that Java source files have the proper license headers. The build will fail if some headers are
+missing or incorrect.
+
+To fix headers from the command line, run the following:
+
+```
+mvn license:format
+```
+
 ## Building
 
 To build locally run the following:

--- a/auth-api/src/main/java/io/stargate/auth/model/UsernameCredentials.java
+++ b/auth-api/src/main/java/io/stargate/auth/model/UsernameCredentials.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.auth.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/cql/src/main/java/org/apache/cassandra/stargate/cql3/DefaultQueryOptions.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/cql3/DefaultQueryOptions.java
@@ -7,14 +7,13 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.apache.cassandra.stargate.cql3;
 

--- a/cql/src/main/java/org/apache/cassandra/stargate/metrics/ClientMetrics.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/metrics/ClientMetrics.java
@@ -7,16 +7,14 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.apache.cassandra.stargate.metrics;
 
 import com.codahale.metrics.Gauge;

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/ColumnUtils.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/ColumnUtils.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.cassandra.stargate.transport.internal;
 
 import io.netty.buffer.ByteBuf;

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/PlainTextTokenSaslNegotiator.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/PlainTextTokenSaslNegotiator.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.cassandra.stargate.transport.internal;
 
 import com.google.common.annotations.VisibleForTesting;

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/ProxyInfo.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/ProxyInfo.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.cassandra.stargate.transport.internal;
 
 import io.netty.util.AttributeKey;

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/SchemaAgreement.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/SchemaAgreement.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.cassandra.stargate.transport.internal;
 
 import io.stargate.db.Persistence;

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/TransportDescriptor.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/TransportDescriptor.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.cassandra.stargate.transport.internal;
 
 import java.net.Inet4Address;

--- a/graphqlapi/src/main/java/graphql/kickstart/servlet/CustomGraphQLServlet.java
+++ b/graphqlapi/src/main/java/graphql/kickstart/servlet/CustomGraphQLServlet.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package graphql.kickstart.servlet;
 
 import graphql.kickstart.execution.GraphQLObjectMapper;

--- a/graphqlapi/src/main/java/graphql/kickstart/servlet/SchemaGraphQLServlet.java
+++ b/graphqlapi/src/main/java/graphql/kickstart/servlet/SchemaGraphQLServlet.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package graphql.kickstart.servlet;
 
 import graphql.kickstart.execution.GraphQLObjectMapper;

--- a/graphqlapi/src/main/java/io/stargate/graphql/GraphqlActivator.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/GraphqlActivator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql;
 
 import io.stargate.auth.AuthenticationService;

--- a/graphqlapi/src/main/java/io/stargate/graphql/PlaygroundServlet.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/PlaygroundServlet.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql;
 
 import java.io.IOException;

--- a/graphqlapi/src/main/java/io/stargate/graphql/WebImpl.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/WebImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql;
 
 import graphql.kickstart.servlet.CustomGraphQLServlet;

--- a/graphqlapi/src/main/java/io/stargate/graphql/core/CaseUtil.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/core/CaseUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.core;
 
 import com.google.common.collect.ImmutableMap;

--- a/graphqlapi/src/main/java/io/stargate/graphql/core/CustomScalar.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/core/CustomScalar.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.core;
 /*
  * Copyright DataStax, Inc.

--- a/graphqlapi/src/main/java/io/stargate/graphql/core/DataFetchers.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/core/DataFetchers.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.core;
 
 import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.literal;

--- a/graphqlapi/src/main/java/io/stargate/graphql/core/GqlKeyspaceSchema.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/core/GqlKeyspaceSchema.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.core;
 
 import static graphql.Scalars.GraphQLString;

--- a/graphqlapi/src/main/java/io/stargate/graphql/core/KeyspaceFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/core/KeyspaceFetcher.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.core;
 
 import com.google.common.collect.ImmutableMap;

--- a/graphqlapi/src/main/java/io/stargate/graphql/core/KeyspaceManagementSchema.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/core/KeyspaceManagementSchema.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.core;
 
 import static graphql.schema.GraphQLList.list;

--- a/graphqlapi/src/main/java/io/stargate/graphql/core/NameMapping.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/core/NameMapping.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.core;
 
 import com.google.common.collect.BiMap;

--- a/graphqlapi/src/main/java/io/stargate/graphql/fetchers/AlterTableAddFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/fetchers/AlterTableAddFetcher.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.fetchers;
 
 import com.datastax.oss.driver.api.querybuilder.SchemaBuilder;

--- a/graphqlapi/src/main/java/io/stargate/graphql/fetchers/AlterTableDropFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/fetchers/AlterTableDropFetcher.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.fetchers;
 
 import com.datastax.oss.driver.api.querybuilder.SchemaBuilder;

--- a/graphqlapi/src/main/java/io/stargate/graphql/fetchers/CreateTableDataFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/fetchers/CreateTableDataFetcher.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.fetchers;
 
 import com.datastax.oss.driver.api.core.metadata.schema.ClusteringOrder;

--- a/graphqlapi/src/main/java/io/stargate/graphql/fetchers/DropTableFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/fetchers/DropTableFetcher.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.fetchers;
 
 import com.datastax.oss.driver.api.querybuilder.SchemaBuilder;

--- a/graphqlapi/src/main/java/io/stargate/graphql/fetchers/KeyspaceFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/fetchers/KeyspaceFetcher.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.fetchers;
 
 import com.google.common.collect.ImmutableMap;

--- a/graphqlapi/src/main/java/io/stargate/graphql/fetchers/SchemaDataFetcherFactory.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/fetchers/SchemaDataFetcherFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.fetchers;
 
 import io.stargate.auth.AuthenticationService;

--- a/graphqlapi/src/main/java/io/stargate/graphql/fetchers/SchemaFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/fetchers/SchemaFetcher.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.fetchers;
 
 import com.datastax.oss.driver.api.core.type.DataType;

--- a/graphqlapi/src/main/java/io/stargate/graphql/graphqlservlet/CassandraUnboxingGraphqlErrorHandler.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/graphqlservlet/CassandraUnboxingGraphqlErrorHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.graphqlservlet;
 
 import graphql.ExceptionWhileDataFetching;

--- a/graphqlapi/src/main/java/io/stargate/graphql/graphqlservlet/GraphqlCustomContextBuilder.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/graphqlservlet/GraphqlCustomContextBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.graphqlservlet;
 
 import graphql.kickstart.execution.context.DefaultGraphQLContextBuilder;

--- a/graphqlapi/src/main/java/io/stargate/graphql/graphqlservlet/HTTPAwareContextImpl.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/graphqlservlet/HTTPAwareContextImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.graphqlservlet;
 
 import graphql.kickstart.execution.context.GraphQLContext;

--- a/health-checker/src/main/java/io/stargate/health/ApplicationConfiguration.java
+++ b/health-checker/src/main/java/io/stargate/health/ApplicationConfiguration.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.health;
 
 import io.dropwizard.Configuration;

--- a/health-checker/src/main/java/io/stargate/health/BundleService.java
+++ b/health-checker/src/main/java/io/stargate/health/BundleService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.health;
 
 import io.stargate.db.Persistence;

--- a/health-checker/src/main/java/io/stargate/health/CheckerResource.java
+++ b/health-checker/src/main/java/io/stargate/health/CheckerResource.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.health;
 
 import javax.inject.Inject;

--- a/health-checker/src/main/java/io/stargate/health/HealthCheckerActivator.java
+++ b/health-checker/src/main/java/io/stargate/health/HealthCheckerActivator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.health;
 
 import io.stargate.health.metrics.api.Metrics;

--- a/health-checker/src/main/java/io/stargate/health/HealthCheckerAdminServlet.java
+++ b/health-checker/src/main/java/io/stargate/health/HealthCheckerAdminServlet.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.health;
 
 import com.codahale.metrics.servlets.AdminServlet;

--- a/health-checker/src/main/java/io/stargate/health/HealthCheckerServerFactory.java
+++ b/health-checker/src/main/java/io/stargate/health/HealthCheckerServerFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.health;
 
 import com.codahale.metrics.MetricRegistry;

--- a/health-checker/src/main/java/io/stargate/health/Server.java
+++ b/health-checker/src/main/java/io/stargate/health/Server.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.health;
 
 import com.codahale.metrics.MetricRegistry;

--- a/health-checker/src/main/java/io/stargate/health/WebImpl.java
+++ b/health-checker/src/main/java/io/stargate/health/WebImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.health;
 
 import io.stargate.health.metrics.api.Metrics;

--- a/health-checker/src/main/java/io/stargate/health/metrics/api/Metrics.java
+++ b/health-checker/src/main/java/io/stargate/health/metrics/api/Metrics.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.health.metrics.api;
 
 import com.codahale.metrics.MetricRegistry;

--- a/health-checker/src/main/java/io/stargate/health/metrics/impl/MetricsImpl.java
+++ b/health-checker/src/main/java/io/stargate/health/metrics/impl/MetricsImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.health.metrics.impl;
 
 import com.codahale.metrics.MetricRegistry;

--- a/health-checker/src/main/java/io/stargate/health/metrics/impl/PrefixingMetricRegistry.java
+++ b/health-checker/src/main/java/io/stargate/health/metrics/impl/PrefixingMetricRegistry.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.health.metrics.impl;
 
 import com.codahale.metrics.Counter;

--- a/persistence-api/src/main/java/io/stargate/db/datastore/DataStore.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/DataStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/ExecutionInfo.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/ExecutionInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/PreparedStatement.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/PreparedStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/ResultSet.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/ResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/Row.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/Row.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/query/AndWhere.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/query/AndWhere.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/query/ColumnOrder.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/query/ColumnOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/query/MixinPreparedStatement.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/query/MixinPreparedStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/query/NWhere.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/query/NWhere.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/query/OrWhere.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/query/OrWhere.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/query/Parameter.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/query/Parameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/query/QueryBuilderImpl.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/query/QueryBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/query/UnsupportedQueryException.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/query/UnsupportedQueryException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/query/Value.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/query/Value.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/query/Where.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/query/Where.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/query/WhereCondition.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/query/WhereCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/schema/AbstractTable.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/schema/AbstractTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/schema/CollectionIndexingType.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/schema/CollectionIndexingType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/schema/ColumnMappingMetadata.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/schema/ColumnMappingMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/schema/ColumnUtils.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/schema/ColumnUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/schema/Index.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/schema/Index.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/schema/Keyspace.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/schema/Keyspace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/schema/MaterializedView.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/schema/MaterializedView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/schema/ParameterizedType.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/schema/ParameterizedType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/schema/QualifiedSchemaEntity.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/schema/QualifiedSchemaEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/schema/Schema.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/schema/Schema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/schema/SchemaBuilderImpl.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/schema/SchemaBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/schema/SchemaEntity.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/schema/SchemaEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/schema/SecondaryIndex.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/schema/SecondaryIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/schema/Table.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/schema/Table.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/io/stargate/db/datastore/schema/UserDefinedType.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/schema/UserDefinedType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-api/src/main/java/org/apache/cassandra/stargate/utils/Architecture.java
+++ b/persistence-api/src/main/java/org/apache/cassandra/stargate/utils/Architecture.java
@@ -7,16 +7,14 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.apache.cassandra.stargate.utils;
 
 import com.datastax.oss.driver.shaded.guava.common.collect.Sets;

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/datastore/InternalDataStore.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/datastore/InternalDataStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/datastore/InternalResultSet.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/datastore/InternalResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/interceptors/DefaultQueryInterceptor.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/interceptors/DefaultQueryInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.db.cassandra.impl.interceptors;
 
 import static io.stargate.db.cassandra.impl.StargateSystemKeyspace.isStargateNode;

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/interceptors/QueryInterceptor.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/interceptors/QueryInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.db.cassandra.impl.interceptors;
 
 import io.stargate.db.QueryOptions;

--- a/persistence-cassandra-3.11/src/main/java/org/apache/cassandra/metrics/CassandraMetricsRegistry.java
+++ b/persistence-cassandra-3.11/src/main/java/org/apache/cassandra/metrics/CassandraMetricsRegistry.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.cassandra.metrics;
 
 import com.codahale.metrics.Counter;

--- a/persistence-common/src/main/java/io/stargate/db/datastore/common/InternalRow.java
+++ b/persistence-common/src/main/java/io/stargate/db/datastore/common/InternalRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-common/src/main/java/io/stargate/db/datastore/common/util/ColumnUtils.java
+++ b/persistence-common/src/main/java/io/stargate/db/datastore/common/util/ColumnUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence-common/src/main/java/io/stargate/db/datastore/common/util/SchemaTool.java
+++ b/persistence-common/src/main/java/io/stargate/db/datastore/common/util/SchemaTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc. and/or The Stargate Authors
+ * Copyright The Stargate Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,72 @@
           </excludes>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>4.0.rc1</version>
+        <configuration>
+          <mapping>
+            <java>SLASHSTAR_STYLE</java>
+          </mapping>
+          <strictCheck>true</strictCheck>
+          <licenseSets>
+            <licenseSet>
+              <includes>
+                <include>src/main/java/io/stargate/**/*.java</include>
+                <!--
+                TODO weird exception, these classes should eventually be refactored under io.stargate
+                -->
+                <include>src/main/java/graphql/kickstart/servlet/**/*.java</include>
+              </includes>
+              <inlineHeader><![CDATA[
+Copyright The Stargate Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.]]></inlineHeader>
+            </licenseSet>
+            <licenseSet>
+              <includes>
+                <include>src/main/java/org/apache/cassandra/**/*.java</include>
+              </includes>
+              <inlineHeader><![CDATA[
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.]]></inlineHeader>
+            </licenseSet>
+          </licenseSets>
+        </configuration>
+        <executions>
+          <execution>
+            <id>check-licenses</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
Currently this only checks production Java files.

It could be extended to any of the following if deemed necessary: test Java, XML, properties... Or any file type really, the plugin has flexible support for custom comment delimiters.