### PR TITLE
Fix building of QueryOptions ignoring some options

### DIFF
--- a/persistence-api/src/main/java/io/stargate/db/DefaultQueryOptions.java
+++ b/persistence-api/src/main/java/io/stargate/db/DefaultQueryOptions.java
@@ -107,7 +107,7 @@ public class DefaultQueryOptions<D> implements QueryOptions {
 
   @Override
   public boolean skipMetadata() {
-    return false;
+    return skipMetadata;
   }
 
   private SpecificOptions getSpecificOptions() {

--- a/persistence-api/src/main/java/io/stargate/db/DefaultQueryOptions.java
+++ b/persistence-api/src/main/java/io/stargate/db/DefaultQueryOptions.java
@@ -50,7 +50,7 @@ public class DefaultQueryOptions<D> implements QueryOptions {
     this.values = builder.values;
     this.names = builder.names;
     this.skipMetadata = builder.skipMetadata;
-    this.options = builder.options;
+    this.options = builder.options == null ? SpecificOptions.DEFAULT : builder.options;
     this.version = builder.version;
   }
 

--- a/persistence-api/src/main/java/io/stargate/db/Persistence.java
+++ b/persistence-api/src/main/java/io/stargate/db/Persistence.java
@@ -56,7 +56,7 @@ public interface Persistence<T, C, Q> {
 
   Authenticator getAuthenticator();
 
-  DataStore newDataStore(QueryState<Q> state, QueryOptions<C> queryOptions);
+  DataStore newDataStore(QueryState<Q> state, QueryOptions queryOptions);
 
   CompletableFuture<? extends Result> query(
       String cql,

--- a/persistence-api/src/main/java/io/stargate/db/QueryOptions.java
+++ b/persistence-api/src/main/java/io/stargate/db/QueryOptions.java
@@ -20,7 +20,7 @@ import java.util.List;
 import org.apache.cassandra.stargate.db.ConsistencyLevel;
 import org.apache.cassandra.stargate.transport.ProtocolVersion;
 
-public interface QueryOptions<T> {
+public interface QueryOptions {
   ConsistencyLevel getConsistency();
 
   List<ByteBuffer> getValues();

--- a/persistence-cassandra-3.11/pom.xml
+++ b/persistence-cassandra-3.11/pom.xml
@@ -102,6 +102,12 @@
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.14.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
@@ -338,7 +338,7 @@ public class CassandraPersistence
               throw new PreparedQueryNotFoundException(id);
             }
 
-            // Please note that this need to happen _before_ the beginTraceExecute, because when
+            // Please note that this needs to happen _before_ the beginTraceExecute, because when
             // we add bound values to the trace, we rely on the values having been re-ordered by
             // the following prepare (if named values were used that is).
             internalOptions.prepare(prepared.boundNames);

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
@@ -207,8 +207,7 @@ public class CassandraPersistence
 
   @Override
   public DataStore newDataStore(
-      QueryState<org.apache.cassandra.service.QueryState> state,
-      QueryOptions<org.apache.cassandra.service.ClientState> queryOptions) {
+      QueryState<org.apache.cassandra.service.QueryState> state, QueryOptions queryOptions) {
     return new InternalDataStore(
         this, Conversion.toInternal(state), Conversion.toInternal(queryOptions));
   }
@@ -285,7 +284,9 @@ public class CassandraPersistence
               beginTraceQuery(cql, state, options);
             }
 
-            CQLStatement statement = QueryProcessor.parseStatement(cql, internalState).statement;
+            ParsedStatement.Prepared prepared = QueryProcessor.parseStatement(cql, internalState);
+            internalOptions.prepare(prepared.boundNames);
+            CQLStatement statement = prepared.statement;
 
             Result result =
                 interceptor.interceptQuery(
@@ -337,9 +338,15 @@ public class CassandraPersistence
               throw new PreparedQueryNotFoundException(id);
             }
 
+            // Please note that this need to happen _before_ the beginTraceExecute, because when
+            // we add bound values to the trace, we rely on the values having been re-ordered by
+            // the following prepare (if named values were used that is).
+            internalOptions.prepare(prepared.boundNames);
+
             if (internalState.traceNextQuery()) {
               internalState.createTracingSession(customPayload);
-              beginTraceExecute(prepared, state, options, internalOptions.getProtocolVersion());
+              beginTraceExecute(
+                  prepared, state, internalOptions, internalOptions.getProtocolVersion());
             }
 
             CQLStatement statement = prepared.statement;
@@ -552,7 +559,7 @@ public class CassandraPersistence
   private void beginTraceExecute(
       ParsedStatement.Prepared prepared,
       QueryState state,
-      QueryOptions options,
+      org.apache.cassandra.cql3.QueryOptions options,
       ProtocolVersion version) {
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
     if (options.getPageSize() > 0) {

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
@@ -25,8 +25,10 @@ import io.stargate.db.cassandra.datastore.DataStoreUtil;
 import io.stargate.db.datastore.DataStore;
 import io.stargate.db.schema.Column;
 import io.stargate.db.schema.ImmutableColumn;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.net.InetAddress;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -74,6 +76,54 @@ import org.slf4j.LoggerFactory;
 public class Conversion {
   private static final Logger LOG = LoggerFactory.getLogger(Conversion.class);
 
+  // A number of constructors for classes related to QueryOptions but that are not accessible in C*
+  // at the moment and need to be accessed through reflection.
+
+  // SpecificOptions(int pageSize, PagingState state, ConsistencyLevel serialConsistency, long
+  // timestamp)
+  private static final Constructor<?> specificOptionsCtor;
+  // DefaultQueryOptions(ConsistencyLevel consistency, List<ByteBuffer> values, boolean
+  // skipMetadata, QueryOptions.SpecificOptions options, ProtocolVersion protocolVersion)
+  private static final Constructor<?> defaultOptionsCtor;
+  // OptionsWithNames(QueryOptions.DefaultQueryOptions wrapped, List<String> names)
+  private static final Constructor<?> optionsWithNameCtor;
+
+  static {
+    try {
+      Class<?> defaultOptionsClass =
+          Class.forName("org.apache.cassandra.cql3.QueryOptions$DefaultQueryOptions");
+      Class<?> specificOptionsClass =
+          Class.forName("org.apache.cassandra.cql3.QueryOptions$SpecificOptions");
+      Class<?> withNamesClass =
+          Class.forName("org.apache.cassandra.cql3.QueryOptions$OptionsWithNames");
+
+      specificOptionsCtor =
+          specificOptionsClass.getDeclaredConstructor(
+              int.class,
+              PagingState.class,
+              org.apache.cassandra.db.ConsistencyLevel.class,
+              long.class);
+      specificOptionsCtor.setAccessible(true);
+
+      defaultOptionsCtor =
+          defaultOptionsClass.getDeclaredConstructor(
+              org.apache.cassandra.db.ConsistencyLevel.class,
+              List.class,
+              boolean.class,
+              specificOptionsClass,
+              org.apache.cassandra.transport.ProtocolVersion.class);
+      defaultOptionsCtor.setAccessible(true);
+
+      optionsWithNameCtor = withNamesClass.getDeclaredConstructor(defaultOptionsClass, List.class);
+      optionsWithNameCtor.setAccessible(true);
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Error during initialization of the persistence layer: some "
+              + "reflection-based accesses cannot be setup.",
+          e);
+    }
+  }
+
   public static org.apache.cassandra.service.QueryState toInternal(
       QueryState<org.apache.cassandra.service.QueryState> state) {
     if (state == null) {
@@ -86,17 +136,57 @@ public class Conversion {
     if (options == null) {
       return org.apache.cassandra.cql3.QueryOptions.DEFAULT;
     }
+
     org.apache.cassandra.transport.ProtocolVersion protocolVersion =
         toInternal(options.getProtocolVersion());
-    // TODO(mpenick): timestamp and nowInSeconds?
-    return org.apache.cassandra.cql3.QueryOptions.create(
+    return createOptions(
         toInternal(options.getConsistency()),
         options.getValues(),
+        options.getNames(),
         options.skipMetadata(),
         options.getPageSize(),
-        PagingState.deserialize(options.getPagingState(), protocolVersion),
+        // Note that PagingState.deserialize modify its input, so we duplicate to avoid nasty
+        // surprises down the line
+        PagingState.deserialize(options.getPagingState().duplicate(), protocolVersion),
         toInternal(options.getSerialConsistency()),
-        protocolVersion);
+        protocolVersion,
+        options.getTimestamp());
+  }
+
+  private static org.apache.cassandra.cql3.QueryOptions createOptions(
+      org.apache.cassandra.db.ConsistencyLevel consistencyLevel,
+      List<ByteBuffer> values,
+      List<String> boundNames,
+      boolean skipMetadata,
+      int pageSize,
+      PagingState pagingState,
+      org.apache.cassandra.db.ConsistencyLevel serialConsistency,
+      org.apache.cassandra.transport.ProtocolVersion protocolVersion,
+      long timestamp) {
+
+    org.apache.cassandra.cql3.QueryOptions options;
+    try {
+      Object specificOptions =
+          specificOptionsCtor.newInstance(pageSize, pagingState, serialConsistency, timestamp);
+      Object defaultOptions =
+          defaultOptionsCtor.newInstance(
+              consistencyLevel, values, skipMetadata, specificOptions, protocolVersion);
+      options = (org.apache.cassandra.cql3.QueryOptions) defaultOptions;
+
+      // Adds names if there is some.
+      if (boundNames != null) {
+        options =
+            (org.apache.cassandra.cql3.QueryOptions)
+                optionsWithNameCtor.newInstance(defaultOptions, boundNames);
+      }
+    } catch (Exception e) {
+      // We can't afford to ignore that: the values wouldn't be in the proper order, and worst
+      // case scenario, this could end up inserting values in the wrong columns, which essentially
+      // boils down to corrupting the use DB.
+      throw new RuntimeException(
+          "Unexpected error while trying to bind the query values by name", e);
+    }
+    return options;
   }
 
   public static org.apache.cassandra.service.ClientState toInternal(

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
@@ -139,15 +139,17 @@ public class Conversion {
 
     org.apache.cassandra.transport.ProtocolVersion protocolVersion =
         toInternal(options.getProtocolVersion());
+    // Note that PagingState.deserialize below modifies its input, so we duplicate to avoid nasty
+    // surprises down the line
+    ByteBuffer pagingState =
+        options.getPagingState() == null ? null : options.getPagingState().duplicate();
     return createOptions(
         toInternal(options.getConsistency()),
         options.getValues(),
         options.getNames(),
         options.skipMetadata(),
         options.getPageSize(),
-        // Note that PagingState.deserialize modify its input, so we duplicate to avoid nasty
-        // surprises down the line
-        PagingState.deserialize(options.getPagingState().duplicate(), protocolVersion),
+        PagingState.deserialize(pagingState, protocolVersion),
         toInternal(options.getSerialConsistency()),
         protocolVersion,
         options.getTimestamp());

--- a/persistence-cassandra-3.11/src/test/java/io/stargate/db/cassandra/impl/ConversionTest.java
+++ b/persistence-cassandra-3.11/src/test/java/io/stargate/db/cassandra/impl/ConversionTest.java
@@ -1,0 +1,78 @@
+package io.stargate.db.cassandra.impl;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.stargate.db.DefaultQueryOptions;
+import io.stargate.db.QueryOptions;
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.ColumnSpecification;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.stargate.db.ConsistencyLevel;
+import org.apache.cassandra.stargate.transport.ProtocolVersion;
+import org.junit.jupiter.api.Test;
+
+class ConversionTest {
+
+  private static ByteBuffer bytes(String v) {
+    return UTF8Type.instance.decompose(v);
+  }
+
+  // The name is all we care about in this class, so we put the rest to random values.
+  private static ColumnSpecification spec(String name) {
+    ColumnIdentifier id = ColumnIdentifier.getInterned(name, true);
+    return new ColumnSpecification("ks", "tbl", id, UTF8Type.instance);
+  }
+
+  @Test
+  public void testQueryOptionsConversion() {
+
+    List<ByteBuffer> values = asList(bytes("world"), bytes("hello"));
+    List<String> names = asList("v2", "v1");
+    // QueryOptions deserialize the paging state so we need to have something valid. We really
+    // don't care otherwise, so this is the simplest paging state bytes that deserialize and
+    // is equal to itself when re-serialized.
+    ByteBuffer pagingState = ByteBuffer.wrap(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+
+    // Test a case that uses all non-default options (excluding nowInSeconds and keyspace because
+    // they are protocol v5 option and not supported by C* 3.11).
+    QueryOptions options =
+        DefaultQueryOptions.builder()
+            .consistency(ConsistencyLevel.LOCAL_QUORUM)
+            .skipMetadata(true)
+            .values(values)
+            .names(names)
+            .version(ProtocolVersion.V3)
+            .options(
+                DefaultQueryOptions.SpecificOptions.builder()
+                    .serialConsistency(ConsistencyLevel.LOCAL_SERIAL)
+                    .pageSize(15)
+                    .pagingState(pagingState)
+                    .timestamp(123456)
+                    .build())
+            .build();
+
+    org.apache.cassandra.cql3.QueryOptions converted = Conversion.toInternal(options);
+
+    // We have to prepare() to check the named parameters are re-ordered properly.
+    converted = converted.prepare(asList(spec("v1"), spec("v2")));
+
+    assertThat(converted.getConsistency())
+        .isEqualTo(org.apache.cassandra.db.ConsistencyLevel.LOCAL_QUORUM);
+    assertThat(converted.skipMetadata()).isTrue();
+    // Again, due to the names, we expect the values to have been re-ordered
+    assertThat(converted.getValues()).isEqualTo(asList(bytes("hello"), bytes("world")));
+    assertThat(converted.getProtocolVersion())
+        .isEqualTo(org.apache.cassandra.transport.ProtocolVersion.V3);
+    assertThat(converted.getSerialConsistency())
+        .isEqualTo(org.apache.cassandra.db.ConsistencyLevel.LOCAL_SERIAL);
+    assertThat(converted.getPageSize()).isEqualTo(15);
+    assertThat(
+            converted.getPagingState().serialize(org.apache.cassandra.transport.ProtocolVersion.V3))
+        .isEqualTo(pagingState);
+    // Since we don't use the default, we should we good passing null
+    assertThat(converted.getTimestamp(null)).isEqualTo(123456);
+  }
+}

--- a/persistence-cassandra-4.0/pom.xml
+++ b/persistence-cassandra-4.0/pom.xml
@@ -102,6 +102,12 @@
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.14.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
@@ -322,7 +322,7 @@ public class CassandraPersistence
 
             CQLStatement statement = prepared.statement;
 
-            // Please note that this need to happen _before_ the beginTraceExecute, because when
+            // Please note that this needs to happen _before_ the beginTraceExecute, because when
             // we add bound values to the trace, we rely on the values having been re-ordered by
             // the following prepare (if named values were used that is).
             internalOptions.prepare(statement.getBindVariables());

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
@@ -75,16 +75,17 @@ public class Conversion {
     }
     org.apache.cassandra.transport.ProtocolVersion protocolVersion =
         toInternal(options.getProtocolVersion());
-
+    // Note that PagingState.deserialize below modifies its input, so we duplicate to avoid nasty
+    // surprises down the line
+    ByteBuffer pagingState =
+        options.getPagingState() == null ? null : options.getPagingState().duplicate();
     org.apache.cassandra.cql3.QueryOptions internalOptions =
         org.apache.cassandra.cql3.QueryOptions.create(
             toInternal(options.getConsistency()),
             options.getValues(),
             options.skipMetadata(),
             options.getPageSize(),
-            // Note that PagingState.deserialize modify its input, so we duplicate to avoid nasty
-            // surprises down the line
-            PagingState.deserialize(options.getPagingState().duplicate(), protocolVersion),
+            PagingState.deserialize(pagingState, protocolVersion),
             toInternal(options.getSerialConsistency()),
             protocolVersion,
             options.getKeyspace(),

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
@@ -9,6 +9,7 @@ import io.stargate.db.cassandra.datastore.DataStoreUtil;
 import io.stargate.db.datastore.DataStore;
 import io.stargate.db.schema.Column;
 import io.stargate.db.schema.ImmutableColumn;
+import java.lang.reflect.Constructor;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -35,6 +36,31 @@ import org.apache.cassandra.transport.Event;
 import org.apache.cassandra.transport.messages.ResultMessage;
 
 public class Conversion {
+  // Constructor for a needed sub-class of QueryOptions that is not accessible in C* at the moment
+  // and need to be accessed through reflection.
+  // OptionsWithNames(QueryOptions.DefaultQueryOptions wrapped, List<String> names)
+  private static final Constructor<?> optionsWithNameCtor;
+
+  static {
+    try {
+      // Note that the ctor for OptionsWithNames directly takes a DefaultQueryOptions which is not
+      // accessible. That said, we know QueryOptions#create, which we'll use to build the object
+      // passed as that argument, actually does create a DefaultQueryOptions, so we're good.
+      Class<?> defaultOptionsClass =
+          Class.forName("org.apache.cassandra.cql3.QueryOptions$DefaultQueryOptions");
+      Class<?> withNamesClass =
+          Class.forName("org.apache.cassandra.cql3.QueryOptions$OptionsWithNames");
+
+      optionsWithNameCtor = withNamesClass.getDeclaredConstructor(defaultOptionsClass, List.class);
+      optionsWithNameCtor.setAccessible(true);
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Error during initialization of the persistence layer: some "
+              + "reflection-based accesses cannot be setup.",
+          e);
+    }
+  }
+
   public static org.apache.cassandra.service.QueryState toInternal(
       QueryState<org.apache.cassandra.service.QueryState> state) {
     if (state == null) {
@@ -49,16 +75,37 @@ public class Conversion {
     }
     org.apache.cassandra.transport.ProtocolVersion protocolVersion =
         toInternal(options.getProtocolVersion());
-    // TODO(mpenick): timestamp and nowInSeconds?
-    return org.apache.cassandra.cql3.QueryOptions.create(
-        toInternal(options.getConsistency()),
-        options.getValues(),
-        options.skipMetadata(),
-        options.getPageSize(),
-        PagingState.deserialize(options.getPagingState(), protocolVersion),
-        toInternal(options.getSerialConsistency()),
-        protocolVersion,
-        options.getKeyspace());
+
+    org.apache.cassandra.cql3.QueryOptions internalOptions =
+        org.apache.cassandra.cql3.QueryOptions.create(
+            toInternal(options.getConsistency()),
+            options.getValues(),
+            options.skipMetadata(),
+            options.getPageSize(),
+            // Note that PagingState.deserialize modify its input, so we duplicate to avoid nasty
+            // surprises down the line
+            PagingState.deserialize(options.getPagingState().duplicate(), protocolVersion),
+            toInternal(options.getSerialConsistency()),
+            protocolVersion,
+            options.getKeyspace(),
+            options.getTimestamp(),
+            options.getNowInSeconds());
+
+    // Adds names if there is some.
+    if (options.getNames() != null) {
+      try {
+        internalOptions =
+            (org.apache.cassandra.cql3.QueryOptions)
+                optionsWithNameCtor.newInstance(internalOptions, options.getNames());
+      } catch (Exception e) {
+        // We can't afford to ignore that: the values wouldn't be in the proper order, and worst
+        // case scenario, this could end up inserting values in the wrong columns, which essentially
+        // boils down to corrupting the use DB.
+        throw new RuntimeException(
+            "Unexpected error while trying to bind the query values by name", e);
+      }
+    }
+    return internalOptions;
   }
 
   public static org.apache.cassandra.service.ClientState toInternal(

--- a/persistence-cassandra-4.0/src/test/java/io/stargate/db/cassandra/impl/ConversionTest.java
+++ b/persistence-cassandra-4.0/src/test/java/io/stargate/db/cassandra/impl/ConversionTest.java
@@ -1,0 +1,81 @@
+package io.stargate.db.cassandra.impl;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.stargate.db.DefaultQueryOptions;
+import io.stargate.db.QueryOptions;
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.ColumnSpecification;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.stargate.db.ConsistencyLevel;
+import org.apache.cassandra.stargate.transport.ProtocolVersion;
+import org.junit.jupiter.api.Test;
+
+class ConversionTest {
+
+  private static ByteBuffer bytes(String v) {
+    return UTF8Type.instance.decompose(v);
+  }
+
+  // The name is all we care about in this class, so we put the rest to random values.
+  private static ColumnSpecification spec(String name) {
+    ColumnIdentifier id = ColumnIdentifier.getInterned(name, true);
+    return new ColumnSpecification("ks", "tbl", id, UTF8Type.instance);
+  }
+
+  @Test
+  public void testQueryOptionsConversion() {
+
+    List<ByteBuffer> values = asList(bytes("world"), bytes("hello"));
+    List<String> names = asList("v2", "v1");
+    // QueryOptions deserialize the paging state so we need to have something valid. We really
+    // don't care otherwise, so this is the simplest paging state bytes that deserialize and
+    // is equal to itself when re-serialized.
+    ByteBuffer pagingState = ByteBuffer.wrap(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+
+    // Test a case that uses all non-default options.
+    QueryOptions options =
+        DefaultQueryOptions.builder()
+            .consistency(ConsistencyLevel.LOCAL_QUORUM)
+            .skipMetadata(true)
+            .values(values)
+            .names(names)
+            .version(ProtocolVersion.V3)
+            .options(
+                DefaultQueryOptions.SpecificOptions.builder()
+                    .serialConsistency(ConsistencyLevel.LOCAL_SERIAL)
+                    .pageSize(15)
+                    .pagingState(pagingState)
+                    .timestamp(123456)
+                    .nowInSeconds(123)
+                    .keyspace("foobar")
+                    .build())
+            .build();
+
+    org.apache.cassandra.cql3.QueryOptions converted = Conversion.toInternal(options);
+
+    // We have to prepare() to check the named parameters are re-ordered properly.
+    converted = converted.prepare(asList(spec("v1"), spec("v2")));
+
+    assertThat(converted.getConsistency())
+        .isEqualTo(org.apache.cassandra.db.ConsistencyLevel.LOCAL_QUORUM);
+    assertThat(converted.skipMetadata()).isTrue();
+    // Again, due to the names, we expect the values to have been re-ordered
+    assertThat(converted.getValues()).isEqualTo(asList(bytes("hello"), bytes("world")));
+    assertThat(converted.getProtocolVersion())
+        .isEqualTo(org.apache.cassandra.transport.ProtocolVersion.V3);
+    assertThat(converted.getSerialConsistency())
+        .isEqualTo(org.apache.cassandra.db.ConsistencyLevel.LOCAL_SERIAL);
+    assertThat(converted.getPageSize()).isEqualTo(15);
+    assertThat(
+            converted.getPagingState().serialize(org.apache.cassandra.transport.ProtocolVersion.V3))
+        .isEqualTo(pagingState);
+    // Since we don't use the default, we should we good passing null
+    assertThat(converted.getTimestamp(null)).isEqualTo(123456);
+    assertThat(converted.getNowInSeconds(null)).isEqualTo(123);
+    assertThat(converted.getKeyspace()).isEqualTo("foobar");
+  }
+}

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/Conversion.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/Conversion.java
@@ -10,6 +10,7 @@ import io.stargate.db.datastore.DataStore;
 import io.stargate.db.dse.datastore.DataStoreUtil;
 import io.stargate.db.schema.Column;
 import io.stargate.db.schema.ImmutableColumn;
+import java.lang.reflect.Constructor;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -21,10 +22,12 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.cql3.PageSize;
 import org.apache.cassandra.cql3.QueryHandler;
+import org.apache.cassandra.cql3.QueryOptions.PagingOptions;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.cql3.ResultSet;
 import org.apache.cassandra.cql3.statements.BatchStatement;
 import org.apache.cassandra.exceptions.CassandraException;
+import org.apache.cassandra.service.pager.PagingState;
 import org.apache.cassandra.stargate.cql3.functions.FunctionName;
 import org.apache.cassandra.stargate.db.ConsistencyLevel;
 import org.apache.cassandra.stargate.db.WriteType;
@@ -56,6 +59,55 @@ import org.apache.cassandra.transport.messages.ResultMessage;
 import org.apache.cassandra.utils.Flags;
 
 public class Conversion {
+
+  // A number of constructors for classes related to QueryOptions but that are not accessible in C*
+  // at the moment and need to be accessed through reflection.
+
+  // SpecificOptions(QueryOptions.PagingOptions, ConsistencyLevel serialConsistency, long
+  // timestamp, String keyspace)
+  private static final Constructor<?> specificOptionsCtor;
+  // DefaultQueryOptions(ConsistencyLevel consistency, List<ByteBuffer> values, boolean
+  // skipMetadata, QueryOptions.SpecificOptions options, ProtocolVersion protocolVersion)
+  private static final Constructor<?> defaultOptionsCtor;
+  // OptionsWithNames(QueryOptions.DefaultQueryOptions wrapped, List<String> names)
+  private static final Constructor<?> optionsWithNameCtor;
+
+  static {
+    try {
+      Class<?> defaultOptionsClass =
+          Class.forName("org.apache.cassandra.cql3.QueryOptions$DefaultQueryOptions");
+      Class<?> specificOptionsClass =
+          Class.forName("org.apache.cassandra.cql3.QueryOptions$SpecificOptions");
+      Class<?> withNamesClass =
+          Class.forName("org.apache.cassandra.cql3.QueryOptions$OptionsWithNames");
+
+      specificOptionsCtor =
+          specificOptionsClass.getDeclaredConstructor(
+              PagingOptions.class,
+              org.apache.cassandra.db.ConsistencyLevel.class,
+              long.class,
+              String.class);
+      specificOptionsCtor.setAccessible(true);
+
+      defaultOptionsCtor =
+          defaultOptionsClass.getDeclaredConstructor(
+              org.apache.cassandra.db.ConsistencyLevel.class,
+              List.class,
+              boolean.class,
+              specificOptionsClass,
+              org.apache.cassandra.transport.ProtocolVersion.class);
+      defaultOptionsCtor.setAccessible(true);
+
+      optionsWithNameCtor = withNamesClass.getDeclaredConstructor(defaultOptionsClass, List.class);
+      optionsWithNameCtor.setAccessible(true);
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Error during initialization of the persistence layer: some "
+              + "reflection-based accesses cannot be setup.",
+          e);
+    }
+  }
+
   public static org.apache.cassandra.service.QueryState toInternal(
       QueryState<org.apache.cassandra.service.QueryState> state) {
     if (state == null) {
@@ -70,25 +122,67 @@ public class Conversion {
     }
     org.apache.cassandra.transport.ProtocolVersion protocolVersion =
         toInternal(options.getProtocolVersion());
-    // TODO(mpenick): timestamp and nowInSeconds?
-    return org.apache.cassandra.cql3.QueryOptions.create(
+    return createOptions(
         toInternal(options.getConsistency()),
         options.getValues(),
+        options.getNames(),
         options.skipMetadata(),
-        buildPagingOptions(options),
+        options.getPageSize(),
+        // Note that PagingState.deserialize modify its input, so we duplicate to avoid nasty
+        // surprises down the line
+        PagingState.deserialize(options.getPagingState().duplicate(), protocolVersion),
         toInternal(options.getSerialConsistency()),
         protocolVersion,
+        options.getTimestamp(),
         options.getKeyspace());
   }
 
-  private static org.apache.cassandra.cql3.QueryOptions.PagingOptions buildPagingOptions(
-      QueryOptions options) {
+  private static org.apache.cassandra.cql3.QueryOptions createOptions(
+      org.apache.cassandra.db.ConsistencyLevel consistencyLevel,
+      List<ByteBuffer> values,
+      List<String> boundNames,
+      boolean skipMetadata,
+      int pageSize,
+      PagingState pagingState,
+      org.apache.cassandra.db.ConsistencyLevel serialConsistency,
+      org.apache.cassandra.transport.ProtocolVersion protocolVersion,
+      long timestamp,
+      String keyspace) {
+    org.apache.cassandra.cql3.QueryOptions options;
+    try {
+      PagingOptions pagingOptions =
+          new PagingOptions(
+              PageSize.rowsSize(pageSize),
+              PagingOptions.Mechanism.SINGLE,
+              pagingState.serialize(protocolVersion));
+
+      Object specificOptions =
+          specificOptionsCtor.newInstance(pagingOptions, serialConsistency, timestamp, keyspace);
+      Object defaultOptions =
+          defaultOptionsCtor.newInstance(
+              consistencyLevel, values, skipMetadata, specificOptions, protocolVersion);
+      options = (org.apache.cassandra.cql3.QueryOptions) defaultOptions;
+
+      // Adds names if there is some.
+      if (boundNames != null) {
+        options =
+            (org.apache.cassandra.cql3.QueryOptions)
+                optionsWithNameCtor.newInstance(defaultOptions, boundNames);
+      }
+    } catch (Exception e) {
+      // We can't afford to ignore that: the values wouldn't be in the proper order, and worst
+      // case scenario, this could end up inserting values in the wrong columns, which essentially
+      // boils down to corrupting the use DB.
+      throw new RuntimeException(
+          "Unexpected error while trying to bind the query values by name", e);
+    }
+    return options;
+  }
+
+  private static PagingOptions buildPagingOptions(QueryOptions options) {
     PageSize size =
         options.getPageSize() > 0 ? PageSize.rowsSize(options.getPageSize()) : PageSize.NULL;
-    return new org.apache.cassandra.cql3.QueryOptions.PagingOptions(
-        size,
-        org.apache.cassandra.cql3.QueryOptions.PagingOptions.Mechanism.SINGLE,
-        options.getPagingState());
+    return new PagingOptions(size, PagingOptions.Mechanism.SINGLE, options.getPagingState());
   }
 
   public static org.apache.cassandra.service.ClientState toInternal(

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/Conversion.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/Conversion.java
@@ -122,15 +122,17 @@ public class Conversion {
     }
     org.apache.cassandra.transport.ProtocolVersion protocolVersion =
         toInternal(options.getProtocolVersion());
+    // Note that PagingState.deserialize below modifies its input, so we duplicate to avoid nasty
+    // surprises down the line
+    ByteBuffer pagingState =
+        options.getPagingState() == null ? null : options.getPagingState().duplicate();
     return createOptions(
         toInternal(options.getConsistency()),
         options.getValues(),
         options.getNames(),
         options.skipMetadata(),
         options.getPageSize(),
-        // Note that PagingState.deserialize modify its input, so we duplicate to avoid nasty
-        // surprises down the line
-        PagingState.deserialize(options.getPagingState().duplicate(), protocolVersion),
+        PagingState.deserialize(pagingState, protocolVersion),
         toInternal(options.getSerialConsistency()),
         protocolVersion,
         options.getTimestamp(),
@@ -150,11 +152,14 @@ public class Conversion {
       String keyspace) {
     org.apache.cassandra.cql3.QueryOptions options;
     try {
-      PagingOptions pagingOptions =
-          new PagingOptions(
-              PageSize.rowsSize(pageSize),
-              PagingOptions.Mechanism.SINGLE,
-              pagingState.serialize(protocolVersion));
+      PagingOptions pagingOptions = null;
+      if (pageSize > 0) {
+        pagingOptions =
+            new PagingOptions(
+                PageSize.rowsSize(pageSize),
+                PagingOptions.Mechanism.SINGLE,
+                pagingState.serialize(protocolVersion));
+      }
 
       Object specificOptions =
           specificOptionsCtor.newInstance(pagingOptions, serialConsistency, timestamp, keyspace);

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -276,6 +276,7 @@ public class DsePersistence
                   checkIsLoggedIn(internalState);
 
                   CQLStatement statement = QueryProcessor.parseStatement(cql, internalState);
+                  internalOptions.prepare(statement.getBindVariables());
 
                   return processStatement(
                       statement, state, options, customPayload, queryStartNanoTime, tracingId);
@@ -311,6 +312,13 @@ public class DsePersistence
                   }
 
                   final CQLStatement statement = prepared.statement;
+                  // Please note that this need to happen _before_ the beginTraceExecute, because
+                  // when
+                  // we add bound values to the trace, we rely on the values having been re-ordered
+                  // by
+                  // the following prepare (if named values were used that is).
+                  internalOptions.prepare(statement.getBindVariables());
+
                   final UUID tracingId =
                       beginTraceExecute(
                           statement,

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -312,11 +312,9 @@ public class DsePersistence
                   }
 
                   final CQLStatement statement = prepared.statement;
-                  // Please note that this need to happen _before_ the beginTraceExecute, because
-                  // when
-                  // we add bound values to the trace, we rely on the values having been re-ordered
-                  // by
-                  // the following prepare (if named values were used that is).
+                  // Please note that this needs to happen _before_ the beginTraceExecute, because
+                  // when we add bound values to the trace, we rely on the values having been
+                  // re-ordered by the following prepare (if named values were used that is).
                   internalOptions.prepare(statement.getBindVariables());
 
                   final UUID tracingId =

--- a/persistence-dse-6.8/src/test/java/io/stargate/db/dse/impl/ConversionTest.java
+++ b/persistence-dse-6.8/src/test/java/io/stargate/db/dse/impl/ConversionTest.java
@@ -1,0 +1,90 @@
+package io.stargate.db.dse.impl;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.stargate.db.DefaultQueryOptions;
+import io.stargate.db.QueryOptions;
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.ColumnSpecification;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.stargate.db.ConsistencyLevel;
+import org.apache.cassandra.stargate.transport.ProtocolVersion;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class ConversionTest {
+
+  private static ByteBuffer bytes(String v) {
+    return UTF8Type.instance.decompose(v);
+  }
+
+  // The name is all we care about in this class, so we put the rest to random values.
+  private static ColumnSpecification spec(String name) {
+    ColumnIdentifier id = ColumnIdentifier.getInterned(name, true);
+    return new ColumnSpecification("ks", "tbl", id, UTF8Type.instance);
+  }
+
+  @BeforeAll
+  public static void setup() {
+    // Wonderfully, the org.apache.cassandra.transport.ProtocolVersion#decode method, which ends up
+    // being used as part those tests, calls the DataDescriptor singleton, so we need to initialize
+    // it.
+    DatabaseDescriptor.clientInitialization();
+  }
+
+  @Test
+  public void testQueryOptionsConversion() {
+
+    List<ByteBuffer> values = asList(bytes("world"), bytes("hello"));
+    List<String> names = asList("v2", "v1");
+    // QueryOptions deserialize the paging state so we need to have something valid. We really
+    // don't care otherwise, so this is the simplest paging state bytes that deserialize and
+    // is equal to itself when re-serialized.
+    ByteBuffer pagingState = ByteBuffer.wrap(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+
+    // Test a case that uses all non-default options (we skip nowInSeconds, which is a protocol v5
+    // feature and is not implemented by DSE 6.8 yet).
+    QueryOptions options =
+        DefaultQueryOptions.builder()
+            .consistency(ConsistencyLevel.LOCAL_QUORUM)
+            .skipMetadata(true)
+            .values(values)
+            .names(names)
+            .version(ProtocolVersion.V3)
+            .options(
+                DefaultQueryOptions.SpecificOptions.builder()
+                    .serialConsistency(ConsistencyLevel.LOCAL_SERIAL)
+                    .pageSize(15)
+                    .pagingState(pagingState)
+                    .timestamp(123456)
+                    .nowInSeconds(123)
+                    .keyspace("foobar")
+                    .build())
+            .build();
+
+    org.apache.cassandra.cql3.QueryOptions converted = Conversion.toInternal(options);
+
+    // We have to prepare() to check the named parameters are re-ordered properly.
+    converted = converted.prepare(asList(spec("v1"), spec("v2")));
+
+    assertThat(converted.getConsistency())
+        .isEqualTo(org.apache.cassandra.db.ConsistencyLevel.LOCAL_QUORUM);
+    assertThat(converted.skipMetadata()).isTrue();
+    // Again, due to the names, we expect the values to have been re-ordered
+    assertThat(converted.getValues()).isEqualTo(asList(bytes("hello"), bytes("world")));
+    assertThat(converted.getProtocolVersion())
+        .isEqualTo(org.apache.cassandra.transport.ProtocolVersion.V3);
+    // Since we don't use the default, we should we good passing null
+    assertThat(converted.getSerialConsistency(null))
+        .isEqualTo(org.apache.cassandra.db.ConsistencyLevel.LOCAL_SERIAL);
+    assertThat(converted.getPagingOptions().pageSize().isInRows()).isTrue();
+    assertThat(converted.getPagingOptions().pageSize().inRows()).isEqualTo(15);
+    assertThat(converted.getPagingOptions().state()).isEqualTo(pagingState);
+    assertThat(converted.getTimestamp()).isEqualTo(123456);
+    assertThat(converted.getKeyspace()).isEqualTo("foobar");
+  }
+}


### PR DESCRIPTION
Some of the native protocol query options (mainly names of bind markers
and client-provided timestamps) where not passed down properly to the
persistence layers.

And indeed, handling them requires reflection as the involved classes
and constructores are not currently public in C*/DSE.

This patch adds the required reflection magic to pass those options
properly. We also ensure the `QueryOptions#prepare` method is called
on all path, so named bound values are properly re-ordered.