### PR TITLE
Health monitor for the CDC Producer

### DIFF
--- a/persistence-api/src/main/java/io/stargate/db/cdc/CDCHealthChecker.java
+++ b/persistence-api/src/main/java/io/stargate/db/cdc/CDCHealthChecker.java
@@ -16,14 +16,10 @@
 
 package io.stargate.db.cdc;
 
-import org.apache.cassandra.stargate.db.MutationEvent;
-
 interface CDCHealthChecker extends AutoCloseable {
-  void init(int minSamples, double maxFailureRatio, int reSampleAfterMs);
-
   boolean isHealthy();
 
-  void reportSendError(MutationEvent mutation, Throwable ex);
+  void reportSendError();
 
   void reportSendSuccess();
 }

--- a/persistence-api/src/main/java/io/stargate/db/cdc/DefaultCDCHealthChecker.java
+++ b/persistence-api/src/main/java/io/stargate/db/cdc/DefaultCDCHealthChecker.java
@@ -25,7 +25,7 @@ class DefaultCDCHealthChecker implements CDCHealthChecker {
    *     producer as unhealthy when there's low traffic and few errors.
    * @param ewmaIntervalMinutes The interval to determine the coefficient for the degree of
    *     weighting decrease in the exponentially weighted moving average (EWMA). The health checker
-   *     will use this value to set a soothing factor equivalent to UNIX load average.
+   *     will use this value to set a smoothing factor equivalent to UNIX load average.
    */
   DefaultCDCHealthChecker(
       double errorRateThreshold, int minErrorsPerSecond, int ewmaIntervalMinutes) {

--- a/persistence-api/src/main/java/io/stargate/db/cdc/DefaultCDCHealthChecker.java
+++ b/persistence-api/src/main/java/io/stargate/db/cdc/DefaultCDCHealthChecker.java
@@ -1,0 +1,136 @@
+package io.stargate.db.cdc;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.EWMA;
+import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+class DefaultCDCHealthChecker implements CDCHealthChecker {
+  private double errorRateThreshold;
+  private int minErrorsPerSecond;
+  static final int INTERVAL = 5;
+  static final long TICK_INTERVAL = TimeUnit.SECONDS.toNanos(INTERVAL);
+
+  private AutoTickEWMA successes;
+  private AutoTickEWMA errors;
+
+  /**
+   * Creates a new instance of {@link DefaultCDCHealthChecker}.
+   *
+   * @param errorRateThreshold The percentage of error requests compared to total, expressed in as a
+   *     double from 0 to 1.
+   * @param minErrorsPerSecond The minimum amount of error occurrences per second for the health
+   *     checker to consider the error ratio. This setting is created to prevent detecting the CDC
+   *     producer as unhealthy when there's low traffic and few errors.
+   * @param ewmaIntervalMinutes The interval to determine the coefficient for the degree of
+   *     weighting decrease in the exponentially weighted moving average (EWMA). The health checker
+   *     will use this value to set a soothing factor equivalent to UNIX load average.
+   */
+  DefaultCDCHealthChecker(
+      double errorRateThreshold, int minErrorsPerSecond, int ewmaIntervalMinutes) {
+    this(errorRateThreshold, minErrorsPerSecond, ewmaIntervalMinutes, TickClock.defaultClock);
+  }
+
+  @VisibleForTesting
+  DefaultCDCHealthChecker(
+      double errorRateThreshold, int minErrorsPerSecond, int ewmaIntervalMinutes, TickClock clock) {
+
+    if (errorRateThreshold <= 0 || errorRateThreshold > 1) {
+      throw new IllegalArgumentException(
+          "Error rate threshold should be greater than 0 and lower than 1");
+    }
+
+    if (ewmaIntervalMinutes <= 0 || ewmaIntervalMinutes > 15) {
+      throw new IllegalArgumentException(
+          "The interval used to determine the smoothing factor for the exponentially "
+              + "weighted moving average must be higher 0 and lower than 15 minutes");
+    }
+
+    this.errorRateThreshold = errorRateThreshold;
+    this.minErrorsPerSecond = minErrorsPerSecond;
+    successes = new AutoTickEWMA(ewmaIntervalMinutes, clock);
+    errors = new AutoTickEWMA(ewmaIntervalMinutes, clock);
+  }
+
+  @Override
+  public boolean isHealthy() {
+    double errorRate = errors.getRate();
+    if (errorRate < minErrorsPerSecond || errorRate == 0.0) {
+      return true;
+    }
+
+    double successRate = successes.getRate();
+    System.out.println(String.format("Error: %f; Success: %f", errorRate, successRate));
+    double percentage = errorRate / (successRate + errorRate);
+    return percentage < errorRateThreshold;
+  }
+
+  @Override
+  public void reportSendError() {
+    errors.update();
+  }
+
+  @Override
+  public void reportSendSuccess() {
+    successes.update();
+  }
+
+  interface TickClock {
+    long getTick();
+
+    TickClock defaultClock =
+        new TickClock() {
+          private final Clock clock = com.codahale.metrics.Clock.defaultClock();
+
+          @Override
+          public long getTick() {
+            return clock.getTick();
+          }
+        };
+  }
+
+  @Override
+  public void close() {}
+
+  private static class AutoTickEWMA {
+    private static final double SECONDS_PER_MINUTE = 60.0;
+    private final AtomicLong lastTick;
+    private final EWMA instance;
+    private final TickClock clock;
+
+    AutoTickEWMA(int minutes, TickClock clock) {
+      this.clock = clock;
+      // See com.codahale.metrics.EWMA for more information
+      double alpha = 1 - Math.exp(-INTERVAL / SECONDS_PER_MINUTE / minutes);
+      instance = new EWMA(alpha, INTERVAL, TimeUnit.SECONDS);
+      lastTick = new AtomicLong(clock.getTick());
+    }
+
+    void update() {
+      instance.update(1);
+    }
+
+    /** Gets the rate with seconds as unit of time. */
+    double getRate() {
+      tickIfNecessary();
+      return instance.getRate(TimeUnit.SECONDS);
+    }
+
+    /** Updates the time passed for the EWMA. */
+    private void tickIfNecessary() {
+      final long oldTick = lastTick.get();
+      final long newTick = clock.getTick();
+      final long age = newTick - oldTick;
+      if (age > TICK_INTERVAL) {
+        final long newIntervalStartTick = newTick - age % TICK_INTERVAL;
+        if (lastTick.compareAndSet(oldTick, newIntervalStartTick)) {
+          final long requiredTicks = age / TICK_INTERVAL;
+          for (long i = 0; i < requiredTicks; i++) {
+            instance.tick();
+          }
+        }
+      }
+    }
+  }
+}

--- a/persistence-api/src/main/java/io/stargate/db/cdc/DefaultCDCHealthChecker.java
+++ b/persistence-api/src/main/java/io/stargate/db/cdc/DefaultCDCHealthChecker.java
@@ -56,12 +56,12 @@ class DefaultCDCHealthChecker implements CDCHealthChecker {
   @Override
   public boolean isHealthy() {
     double errorRate = errors.getRate();
-    if (errorRate < minErrorsPerSecond || errorRate == 0.0) {
+    if (errorRate < minErrorsPerSecond) {
       return true;
     }
 
     double successRate = successes.getRate();
-    System.out.println(String.format("Error: %f; Success: %f", errorRate, successRate));
+
     double percentage = errorRate / (successRate + errorRate);
     return percentage < errorRateThreshold;
   }

--- a/persistence-api/src/test/java/io/stargate/db/cdc/DefaultCDCHealthCheckerTest.java
+++ b/persistence-api/src/test/java/io/stargate/db/cdc/DefaultCDCHealthCheckerTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -33,15 +32,13 @@ public class DefaultCDCHealthCheckerTest {
         () -> new DefaultCDCHealthChecker(0, 1, 1),
         () -> new DefaultCDCHealthChecker(1.1, 1, 1),
         () -> new DefaultCDCHealthChecker(0.5, 1, 0),
-        () -> new DefaultCDCHealthChecker(0.5, 1, 16)
-    );
+        () -> new DefaultCDCHealthChecker(0.5, 1, 16));
   }
 
   public static Stream<Executable> constructorWithValidParameters() {
     return Stream.of(
         () -> new DefaultCDCHealthChecker(0.5, 1, 1),
-        () -> new DefaultCDCHealthChecker(0.5, 1, 15)
-    );
+        () -> new DefaultCDCHealthChecker(0.5, 1, 15));
   }
 
   @Test

--- a/persistence-api/src/test/java/io/stargate/db/cdc/DefaultCDCHealthCheckerTest.java
+++ b/persistence-api/src/test/java/io/stargate/db/cdc/DefaultCDCHealthCheckerTest.java
@@ -1,0 +1,116 @@
+package io.stargate.db.cdc;
+
+import static io.stargate.db.cdc.DefaultCDCHealthChecker.INTERVAL;
+import static io.stargate.db.cdc.DefaultCDCHealthChecker.TICK_INTERVAL;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+public class DefaultCDCHealthCheckerTest {
+  @Test
+  public void shouldValidateConstructorParameters() {
+    assertThrows(IllegalArgumentException.class, () -> new DefaultCDCHealthChecker(0, 1, 1));
+    assertThrows(IllegalArgumentException.class, () -> new DefaultCDCHealthChecker(1.1, 1, 1));
+    assertThrows(IllegalArgumentException.class, () -> new DefaultCDCHealthChecker(0.5, 1, 0));
+    assertThrows(IllegalArgumentException.class, () -> new DefaultCDCHealthChecker(0.5, 1, 16));
+    assertDoesNotThrow(() -> new DefaultCDCHealthChecker(0.5, 1, 1));
+    assertDoesNotThrow(() -> new DefaultCDCHealthChecker(0.5, 1, 15));
+  }
+
+  @Test
+  public void shouldBeHealthyInitially() {
+    AtomicLong ticks = new AtomicLong();
+    DefaultCDCHealthChecker checker = new DefaultCDCHealthChecker(0.5, 1, 15, ticks::get);
+    assertThat(checker.isHealthy()).isTrue();
+  }
+
+  @Test
+  public void shouldConsiderMinErrorsPerSecond() {
+    final int ewmaMinutes = 1;
+    final int minErrorsPerSecond = 1;
+    AtomicLong ticks = new AtomicLong();
+    DefaultCDCHealthChecker checker =
+        new DefaultCDCHealthChecker(0.01, minErrorsPerSecond, ewmaMinutes, ticks::get);
+
+    checker.reportSendError();
+    checker.reportSendError();
+    setTimePassed(ticks);
+    assertThat(checker.isHealthy()).isTrue();
+
+    long occurrences = MINUTES.toSeconds(minErrorsPerSecond);
+    for (int i = 0; i < occurrences; i++) {
+      checker.reportSendError();
+    }
+    setTimePassed(ticks);
+    assertThat(checker.isHealthy()).isFalse();
+  }
+
+  @Test
+  public void shouldConsiderErrorRateThreshold() {
+    final double errorRateThreshold = 0.501;
+    final int minErrorsPerSecond = 2;
+    AtomicLong ticks = new AtomicLong();
+    DefaultCDCHealthChecker checker =
+        new DefaultCDCHealthChecker(errorRateThreshold, minErrorsPerSecond, 1, ticks::get);
+    long occurrences = MINUTES.toSeconds(minErrorsPerSecond) / INTERVAL;
+
+    // 50% error and success
+    for (int i = 0; i < occurrences; i++) {
+      checker.reportSendSuccess();
+      checker.reportSendError();
+    }
+
+    setTimePassed(ticks);
+    // It should be healthy because it doesn't reached the threshold
+    assertThat(checker.isHealthy()).isTrue();
+
+    // More errors to pass the threshold
+    for (int i = 0; i < occurrences; i++) {
+      checker.reportSendError();
+    }
+
+    setTimePassed(ticks);
+    // It should be healthy because it doesn't reached the threshold
+    assertThat(checker.isHealthy()).isFalse();
+  }
+
+  @Test
+  public void shouldConsiderBeBackToHealthyOnceTheTimePasses() {
+    final double errorRateThreshold = 0.4;
+    final int minErrorsPerSecond = 1;
+    AtomicLong ticks = new AtomicLong();
+    DefaultCDCHealthChecker checker =
+        new DefaultCDCHealthChecker(errorRateThreshold, minErrorsPerSecond, 1, ticks::get);
+    long occurrences = MINUTES.toSeconds(minErrorsPerSecond) / INTERVAL;
+
+    // 50% error and success
+    for (int i = 0; i < occurrences; i++) {
+      checker.reportSendSuccess();
+      checker.reportSendError();
+    }
+    setTimePassed(ticks);
+    setTimePassed(ticks);
+    // Marked unhealthy because it passed the threshold
+    assertThat(checker.isHealthy()).isFalse();
+
+    // 50s
+    setTimePassed(ticks, 10);
+    // It should be healthy because minErrorsPerSecond is not reached
+    assertThat(checker.isHealthy()).isTrue();
+  }
+
+  /** Fakes the clock moving forward n times */
+  private static void setTimePassed(AtomicLong ticks, int numTickIntervals) {
+    for (int i = 0; i < numTickIntervals; i++) {
+      ticks.addAndGet(TICK_INTERVAL + 1);
+    }
+  }
+
+  private static void setTimePassed(AtomicLong ticks) {
+    setTimePassed(ticks, 1);
+  }
+}

--- a/persistence-api/src/test/java/io/stargate/db/cdc/DefaultCDCHealthCheckerTest.java
+++ b/persistence-api/src/test/java/io/stargate/db/cdc/DefaultCDCHealthCheckerTest.java
@@ -8,17 +8,40 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class DefaultCDCHealthCheckerTest {
-  @Test
-  public void shouldValidateConstructorParameters() {
-    assertThrows(IllegalArgumentException.class, () -> new DefaultCDCHealthChecker(0, 1, 1));
-    assertThrows(IllegalArgumentException.class, () -> new DefaultCDCHealthChecker(1.1, 1, 1));
-    assertThrows(IllegalArgumentException.class, () -> new DefaultCDCHealthChecker(0.5, 1, 0));
-    assertThrows(IllegalArgumentException.class, () -> new DefaultCDCHealthChecker(0.5, 1, 16));
-    assertDoesNotThrow(() -> new DefaultCDCHealthChecker(0.5, 1, 1));
-    assertDoesNotThrow(() -> new DefaultCDCHealthChecker(0.5, 1, 15));
+  @ParameterizedTest
+  @MethodSource("constructorWithInvalidParameters")
+  public void shouldThrowWithInvalidConstructorParameters(Executable executable) {
+    assertThrows(IllegalArgumentException.class, executable);
+  }
+
+  @ParameterizedTest
+  @MethodSource("constructorWithValidParameters")
+  public void shouldNotThrowWithValidConstructorParameters(Executable executable) {
+    assertDoesNotThrow(executable);
+  }
+
+  public static Stream<Executable> constructorWithInvalidParameters() {
+    return Stream.of(
+        () -> new DefaultCDCHealthChecker(0, 1, 1),
+        () -> new DefaultCDCHealthChecker(1.1, 1, 1),
+        () -> new DefaultCDCHealthChecker(0.5, 1, 0),
+        () -> new DefaultCDCHealthChecker(0.5, 1, 16)
+    );
+  }
+
+  public static Stream<Executable> constructorWithValidParameters() {
+    return Stream.of(
+        () -> new DefaultCDCHealthChecker(0.5, 1, 1),
+        () -> new DefaultCDCHealthChecker(0.5, 1, 15)
+    );
   }
 
   @Test
@@ -74,7 +97,7 @@ public class DefaultCDCHealthCheckerTest {
     }
 
     setTimePassed(ticks);
-    // It should be healthy because it doesn't reached the threshold
+    // It should be unhealthy because the amount of errors is greater than errorRateThreshold
     assertThat(checker.isHealthy()).isFalse();
   }
 


### PR DESCRIPTION
Use a EWMA of errors/successes to short-circuit the CDC service and stop sending requests to the producer.

Thanks to the moving average behaviour, after time passes it will be below min errors per second , allowing the producer to be probed again.