### PR TITLE
Fix handling of unset values

### DIFF
--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/CBUtil.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/CBUtil.java
@@ -23,6 +23,7 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.util.concurrent.FastThreadLocal;
+import io.stargate.db.Persistence;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -68,7 +69,30 @@ public abstract class CBUtil {
 
   private static final FastThreadLocal<CharBuffer> TL_CHAR_BUFFER = new FastThreadLocal<>();
 
+  private static volatile ByteBuffer unsetValue;
+
   private CBUtil() {}
+
+  /**
+   * Sets the value to use when deserializing an "unset" bound value.
+   *
+   * <p>Within Cassandra/DSE (so, our persistence extensions), unset values are implemented through
+   * a specific ByteBuffer instance, that is a 'public static final' and whose usage is detected
+   * through reference equality. But we can't access that specific object statically, as it leaves
+   * within the persistence extension. Instead, that object is exposed through the {@link
+   * Persistence#unsetValue()} method, but as this class (which is originally copied from C*) is
+   * full of static, we resort to that ugly ugly hack (please note that using {@link
+   * ByteBufferUtil#UNSET_BYTE_BUFFER} in this class would be wrong: the {@link ByteBufferUtil} we
+   * reference here is _not_ the one of the persistence API).
+   *
+   * <p>TODO: longer term, we should consider refactoring this to not be static.
+   */
+  public static void setUnsetValue(ByteBuffer unset) {
+    if (unsetValue != null) {
+      throw new IllegalStateException("The UNSET value has already be set");
+    }
+    unsetValue = unset;
+  }
 
   // Taken from Netty's ChannelBuffers.decodeString(). We need to use our own decoder to properly
   // handle invalid
@@ -367,7 +391,7 @@ public abstract class CBUtil {
           ProtocolVersion.V4)) // backward compatibility for pre-version 4
       return null;
       if (length == -1) return null;
-      else if (length == -2) return ByteBufferUtil.UNSET_BYTE_BUFFER;
+      else if (length == -2) return unsetValue;
       else throw new ProtocolException("Invalid ByteBuf length " + length);
     }
     return ByteBuffer.wrap(readRawBytes(cb, length));

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/CBUtil.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/CBUtil.java
@@ -390,9 +390,12 @@ public abstract class CBUtil {
       if (protocolVersion.isSmallerThan(
           ProtocolVersion.V4)) // backward compatibility for pre-version 4
       return null;
-      if (length == -1) return null;
-      else if (length == -2) return unsetValue;
-      else throw new ProtocolException("Invalid ByteBuf length " + length);
+      if (length == -1) {
+        return null;
+      } else if (length == -2) {
+        assert unsetValue != null : "The UNSET value should have been set by now";
+        return unsetValue;
+      } else throw new ProtocolException("Invalid ByteBuf length " + length);
     }
     return ByteBuffer.wrap(readRawBytes(cb, length));
   }

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Server.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Server.java
@@ -116,6 +116,9 @@ public class Server implements CassandraDaemon.Server {
       else workerGroup = new NioEventLoopGroup();
     }
     this.persistence.registerEventListener(new EventNotifier(this));
+
+    // Please see the comment on setUnsetValue().
+    CBUtil.setUnsetValue(persistence.unsetValue());
   }
 
   public void stop() {

--- a/persistence-api/src/main/java/io/stargate/db/Persistence.java
+++ b/persistence-api/src/main/java/io/stargate/db/Persistence.java
@@ -58,6 +58,16 @@ public interface Persistence<T, C, Q> {
 
   DataStore newDataStore(QueryState<Q> state, QueryOptions queryOptions);
 
+  /**
+   * The object that should be used to act as an 'unset' value for this persistence (for use in
+   * {@link QueryOptions#getValues()} or in the {@code values} argument of {@link #batch}).
+   *
+   * <p>Please note that persistence implementations are allowed to use <b>reference equality</b> to
+   * detect this value, so the object returned by this method should be used "as-is" and should
+   * <b>not</b> be copied (through {@link ByteBuffer#duplicate()} or any other method).
+   */
+  ByteBuffer unsetValue();
+
   CompletableFuture<? extends Result> query(
       String cql,
       QueryState state,

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
@@ -79,6 +79,7 @@ import org.apache.cassandra.stargate.utils.MD5Digest;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.transport.messages.ResultMessage;
+import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.UUIDGen;
 import org.slf4j.Logger;
@@ -211,6 +212,11 @@ public class CassandraPersistence
       QueryState<org.apache.cassandra.service.QueryState> state, QueryOptions queryOptions) {
     return new InternalDataStore(
         this, Conversion.toInternal(state), Conversion.toInternal(queryOptions));
+  }
+
+  @Override
+  public ByteBuffer unsetValue() {
+    return ByteBufferUtil.UNSET_BYTE_BUFFER;
   }
 
   @Override

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
@@ -65,6 +65,7 @@ import org.apache.cassandra.stargate.utils.MD5Digest;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.transport.messages.ResultMessage;
+import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.UUIDGen;
 import org.slf4j.Logger;
@@ -198,6 +199,11 @@ public class CassandraPersistence
       QueryState<org.apache.cassandra.service.QueryState> state, QueryOptions queryOptions) {
     return new InternalDataStore(
         this, Conversion.toInternal(state), Conversion.toInternal(queryOptions));
+  }
+
+  @Override
+  public ByteBuffer unsetValue() {
+    return ByteBufferUtil.UNSET_BYTE_BUFFER;
   }
 
   @Override

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -63,6 +63,7 @@ import org.apache.cassandra.stargate.locator.InetAddressAndPort;
 import org.apache.cassandra.stargate.utils.MD5Digest;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.transport.messages.ResultMessage;
+import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -258,6 +259,11 @@ public class DsePersistence
   @Override
   public Authenticator getAuthenticator() {
     return authenticator;
+  }
+
+  @Override
+  public ByteBuffer unsetValue() {
+    return ByteBufferUtil.UNSET_BYTE_BUFFER;
   }
 
   @Override


### PR DESCRIPTION
In C*/DSE, the unset value is implement through a specific `ByteBuffer` instance that is `public static` (and reference equality is used on that instance, so we need _that_ instance). We cannot however access directly (as a static variable) from the stargate code.

The current code (technically, the `CBUtil` class that is used to deserialize client queries) was actually using the `ByteBuffer#UNSET_BYTE_BUFFER` from the C* jar that the `cql` module import, which is definitively not the one the persistence layer expects.

I'll note that there is 2 options to fix this:
1. we define our own `public static` ByteBuffer instance (in say `Persistence`), use that from the `cql` module (and any other consumer for the `Persistence` API that needs it), and require each persistence extensions to translate that value into their own instance. The main downside of this approach is:
    - every persistence extensions has to walk over every value it gets to check for the 'stargate unset' and replace it by its own 'internal unset'.
2. we add a new method (`unsetValue()`) to the `Persistence` API so that each persistence extension exposes the actual instance it uses for unset values. We can then use that value in the `cql` module. The downsides of this approach are:
    - it's one more method to the `Persistence` API (albeit a trivial one to implement).
    - you need access to the persistence to be able to produce an unset value.  Which is not a huge deal, except that the code that currently produce those, `CBUtil` is all static, so the patch currently uses an ugly hack to work around that.

This PR actually implement the 2nd option. My rational is that having to convert the values within the persistence layer feels error prone (easy to forget an entry point) and requires more code, code that ends up duplicated for every persistence extensions. The downsides of option 2 feel smaller.  That is, the hack in `CBUtil` is admittedly ugly, but it's very small and can be refactored out at some point (and we need to give some love to the `cql` module at some point, at least to remove the dependencies on `cassandra-all` it currently have).
