### PR TITLE
Bind DSE JMX server to listen address

### DIFF
--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -138,6 +138,12 @@ public class DsePersistence
     System.setProperty("cassandra-foreground", "true");
     System.setProperty("cassandra.consistent.rangemovement", "false");
 
+    if (Boolean.parseBoolean(System.getProperty("stargate.bind_to_listen_address"))) {
+      // Bind JMX server to listen address
+      System.setProperty(
+          "com.sun.management.jmxremote.host", System.getProperty("stargate.listen_address"));
+    }
+
     DatabaseDescriptor.daemonInitialization(true, config);
     cassandraDaemon = new CassandraDaemon(true);
 


### PR DESCRIPTION
When specified, it binds JMX server to the listen address.

It looks like in C* it's not possible:
- https://github.com/apache/cassandra/blob/9802a70f68cdcd239a9128f90f5d8f9a941168de/src/java/org/apache/cassandra/utils/JMXServerUtils.java#L82-L86
- https://github.com/apache/cassandra/blob/9802a70f68cdcd239a9128f90f5d8f9a941168de/src/java/org/apache/cassandra/utils/JMXServerUtils.java#L261