### PR TITLE
Fix native protocol version negotiation for DSE persistence

### DIFF
--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/StargateNodeView.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/StargateNodeView.java
@@ -44,7 +44,9 @@ public abstract class StargateNodeView extends AbstractVirtualTable {
         // + "jmx_port int,"
         .addColumn("jmx_port", info::getJmxPort)
         // + "dse_version text,"
-        .addColumn("dse_version", () -> safeToString(info.getDseVersion()))
+        // This is set to null, otherwise the java-driver, and maybe other drivers, will attempt to
+        // connect using the DSE_V1 and DSE_V2 protocols.
+        .addColumn("dse_version", () -> null)
         // + "graph boolean,"
         .addColumn("graph", () -> false)
         // + "server_id text,"


### PR DESCRIPTION
The java-driver overrides the negotiated protocol version based on `dse_version`. If it's null then it uses the `cluster_version` (Cassandra's version) instead.