### PR TITLE
Avoid accessing java service interfaces in backbox tests

### DIFF
--- a/testing/src/test/java/io/stargate/it/MultipleStargateInstancesTest.java
+++ b/testing/src/test/java/io/stargate/it/MultipleStargateInstancesTest.java
@@ -63,9 +63,9 @@ public class MultipleStargateInstancesTest extends BaseOsgiIntegrationTest {
             .withString(
                 DefaultDriverOption.LOAD_BALANCING_POLICY_CLASS,
                 DcInferringLoadBalancingPolicy.class.getName())
-            .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(5))
-            .withDuration(DefaultDriverOption.CONNECTION_INIT_QUERY_TIMEOUT, Duration.ofSeconds(5))
-            .withDuration(DefaultDriverOption.CONTROL_CONNECTION_TIMEOUT, Duration.ofSeconds(5))
+            .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(30))
+            .withDuration(DefaultDriverOption.CONNECTION_INIT_QUERY_TIMEOUT, Duration.ofSeconds(30))
+            .withDuration(DefaultDriverOption.CONTROL_CONNECTION_TIMEOUT, Duration.ofSeconds(30))
             .withDuration(DefaultDriverOption.REQUEST_TRACE_INTERVAL, Duration.ofSeconds(1))
             .withStringList(
                 DefaultDriverOption.METRICS_NODE_ENABLED,

--- a/testing/src/test/java/io/stargate/it/cql/JavaDriverTestBase.java
+++ b/testing/src/test/java/io/stargate/it/cql/JavaDriverTestBase.java
@@ -61,8 +61,8 @@ public abstract class JavaDriverTestBase extends BaseOsgiIntegrationTest {
     config.put(
         TypedDriverOption.LOAD_BALANCING_POLICY_CLASS,
         DcInferringLoadBalancingPolicy.class.getName());
-    config.put(TypedDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(5));
-    config.put(TypedDriverOption.CONTROL_CONNECTION_TIMEOUT, Duration.ofSeconds(5));
+    config.put(TypedDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(60));
+    config.put(TypedDriverOption.CONTROL_CONNECTION_TIMEOUT, Duration.ofSeconds(30));
     config.put(TypedDriverOption.REQUEST_TRACE_INTERVAL, Duration.ofSeconds(5));
     config.put(TypedDriverOption.REQUEST_WARN_IF_SET_KEYSPACE, false);
     customizeConfig(config);


### PR DESCRIPTION
This is in preparation to running test Stargate nodes in forked JVMs