### PR TITLE
Add logback config for integration tests

### DIFF
--- a/testing/src/test/resources/logback-test.xml
+++ b/testing/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This only controls logging from the test code.
+  For the Stargate code, use stargate-lib/logback.xml.
+-->
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="${stargate.logging.level.root:-INFO}">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>


### PR DESCRIPTION
This avoids getting DEBUG logs from the test harness (e.g. the Java driver in CQL tests).