### PR TITLE
Fix and test GraphQL error handling

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.6.2</version>
+            <version>5.7.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>

--- a/cql/pom.xml
+++ b/cql/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>cql</artifactId>
   <version>0.0.15-SNAPSHOT</version>
   <properties>
-    <junit.version>5.6.2</junit.version>
+    <junit.version>5.7.0</junit.version>
   </properties>
   <dependencies>
     <dependency>

--- a/graphqlapi/src/main/java/graphql/kickstart/servlet/CustomGraphQLServlet.java
+++ b/graphqlapi/src/main/java/graphql/kickstart/servlet/CustomGraphQLServlet.java
@@ -25,8 +25,8 @@ import io.stargate.db.datastore.ResultSet;
 import io.stargate.db.datastore.Row;
 import io.stargate.db.schema.Column;
 import io.stargate.db.schema.Keyspace;
-import io.stargate.graphql.graphqlservlet.CassandraUnboxingGraphqlErrorHandler;
 import io.stargate.graphql.graphqlservlet.GraphqlCustomContextBuilder;
+import io.stargate.graphql.graphqlservlet.StargateGraphqlErrorHandler;
 import io.stargate.graphql.schema.SchemaFactory;
 import java.io.IOException;
 import java.util.Comparator;
@@ -212,7 +212,7 @@ public class CustomGraphQLServlet extends HttpServlet implements Servlet, EventL
             .with(new GraphqlCustomContextBuilder())
             .with(
                 GraphQLObjectMapper.newBuilder()
-                    .withGraphQLErrorHandler(new CassandraUnboxingGraphqlErrorHandler())
+                    .withGraphQLErrorHandler(new StargateGraphqlErrorHandler())
                     .build())
             .build();
     return new HttpRequestHandlerImpl(configuration);

--- a/graphqlapi/src/main/java/graphql/kickstart/servlet/SchemaGraphQLServlet.java
+++ b/graphqlapi/src/main/java/graphql/kickstart/servlet/SchemaGraphQLServlet.java
@@ -19,8 +19,8 @@ import graphql.kickstart.execution.GraphQLObjectMapper;
 import graphql.schema.GraphQLSchema;
 import io.stargate.auth.AuthenticationService;
 import io.stargate.db.Persistence;
-import io.stargate.graphql.graphqlservlet.CassandraUnboxingGraphqlErrorHandler;
 import io.stargate.graphql.graphqlservlet.GraphqlCustomContextBuilder;
+import io.stargate.graphql.graphqlservlet.StargateGraphqlErrorHandler;
 import io.stargate.graphql.schema.SchemaFactory;
 
 public class SchemaGraphQLServlet extends SimpleGraphQLHttpServlet {
@@ -39,7 +39,7 @@ public class SchemaGraphQLServlet extends SimpleGraphQLHttpServlet {
         .with(new GraphqlCustomContextBuilder())
         .with(
             GraphQLObjectMapper.newBuilder()
-                .withGraphQLErrorHandler(new CassandraUnboxingGraphqlErrorHandler())
+                .withGraphQLErrorHandler(new StargateGraphqlErrorHandler())
                 .build())
         .build();
   }

--- a/graphqlapi/src/main/java/io/stargate/graphql/graphqlservlet/CassandraUnboxingGraphqlErrorHandler.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/graphqlservlet/CassandraUnboxingGraphqlErrorHandler.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class CassandraUnboxingGraphqlErrorHandler implements GraphQLErrorHandler {
+
   @Override
   public List<GraphQLError> processErrors(List<GraphQLError> errors) {
     List<GraphQLError> unboxed = new ArrayList<>();
@@ -37,6 +38,7 @@ public class CassandraUnboxingGraphqlErrorHandler implements GraphQLErrorHandler
 
   private GraphQLError unbox(GraphQLError error) {
     if (error instanceof ExceptionWhileDataFetching) {
+      // Hide the stack trace to the client
       ExceptionWhileDataFetching fetchingError = (ExceptionWhileDataFetching) error;
       Throwable unboxed = unboxException(fetchingError.getException());
       return GraphqlErrorException.newErrorException()
@@ -45,7 +47,9 @@ public class CassandraUnboxingGraphqlErrorHandler implements GraphQLErrorHandler
           .path(error.getPath())
           .build();
     }
-    return null;
+
+    // ValidationError should not be unboxed
+    return error;
   }
 
   public Throwable unboxException(Throwable exception) {

--- a/graphqlapi/src/main/java/io/stargate/graphql/graphqlservlet/CassandraUnboxingGraphqlErrorHandler.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/graphqlservlet/CassandraUnboxingGraphqlErrorHandler.java
@@ -48,7 +48,7 @@ public class CassandraUnboxingGraphqlErrorHandler implements GraphQLErrorHandler
           .build();
     }
 
-    // ValidationError should not be unboxed
+    // ValidationError, TypeMismatchError, ... should not be unboxed
     return error;
   }
 

--- a/graphqlapi/src/main/java/io/stargate/graphql/graphqlservlet/StargateGraphqlErrorHandler.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/graphqlservlet/StargateGraphqlErrorHandler.java
@@ -22,7 +22,7 @@ import graphql.kickstart.execution.error.GraphQLErrorHandler;
 import java.util.ArrayList;
 import java.util.List;
 
-public class CassandraUnboxingGraphqlErrorHandler implements GraphQLErrorHandler {
+public class StargateGraphqlErrorHandler implements GraphQLErrorHandler {
 
   @Override
   public List<GraphQLError> processErrors(List<GraphQLError> errors) {

--- a/health-checker/pom.xml
+++ b/health-checker/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <jettyVersion>9.4.24.v20191120</jettyVersion>
     <dropwizard.version>2.0.10</dropwizard.version>
-    <junit.version>5.6.2</junit.version>
+    <junit.version>5.7.0</junit.version>
   </properties>
   <dependencies>
     <dependency>
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.6.2</version>
+      <version>${junit.version}</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.guava</groupId>

--- a/persistence-api/pom.xml
+++ b/persistence-api/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.6.2</version>
+      <version>5.7.0</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.guava</groupId>

--- a/persistence-cassandra-3.11/pom.xml
+++ b/persistence-cassandra-3.11/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>persistence-cassandra-3.11</artifactId>
   <properties>
     <cassandra.version>3.11.6</cassandra.version>
-    <junit.version>5.6.2</junit.version>
+    <junit.version>5.7.0</junit.version>
     <surefire.version>3.0.0-M3</surefire.version>
     <failsafe.version>3.0.0-M3</failsafe.version>
   </properties>

--- a/persistence-cassandra-4.0/pom.xml
+++ b/persistence-cassandra-4.0/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>persistence-cassandra-4.0</artifactId>
   <properties>
     <cassandra.version>4.0-beta1</cassandra.version>
-    <junit.version>5.6.2</junit.version>
+    <junit.version>5.7.0</junit.version>
     <surefire.version>3.0.0-M3</surefire.version>
     <failsafe.version>3.0.0-M3</failsafe.version>
   </properties>

--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>persistence-dse-6.8</artifactId>
   <properties>
     <dse.version>6.8.2-69139b3</dse.version>
-    <junit.version>5.6.2</junit.version>
+    <junit.version>5.7.0</junit.version>
     <surefire.version>3.0.0-M3</surefire.version>
     <failsafe.version>3.0.0-M3</failsafe.version>
   </properties>

--- a/persistence-test/pom.xml
+++ b/persistence-test/pom.xml
@@ -9,7 +9,7 @@
   <groupId>io.stargate.db</groupId>
   <artifactId>persistence-test</artifactId>
   <properties>
-    <junit.version>5.6.2</junit.version>
+    <junit.version>5.7.0</junit.version>
   </properties>
   <dependencies>
     <dependency>

--- a/restapi/pom.xml
+++ b/restapi/pom.xml
@@ -13,7 +13,7 @@
     <osgi.bundle.version>${project.version}</osgi.bundle.version>
     <jettyVersion>9.4.24.v20191120</jettyVersion>
     <dropwizard.version>2.0.12</dropwizard.version>
-    <junit.version>5.6.2</junit.version>
+    <junit.version>5.7.0</junit.version>
     <swagger-ui.version>3.35.0</swagger-ui.version>
   </properties>
   <dependencies>

--- a/stargate-starter/pom.xml
+++ b/stargate-starter/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>stargate-starter</artifactId>
   <properties>
     <airline.version>2.7.0</airline.version>
-    <junit.version>5.6.2</junit.version>
+    <junit.version>5.7.0</junit.version>
   </properties>
   <dependencies>
     <dependency>

--- a/testing/src/test/java/io/stargate/it/http/GraphqlTest.java
+++ b/testing/src/test/java/io/stargate/it/http/GraphqlTest.java
@@ -893,7 +893,7 @@ public class GraphqlTest extends BaseOsgiIntegrationTest {
   @MethodSource("getInvalidQueries")
   @DisplayName("Invalid GraphQL queries and mutations should return error response")
   public void invalidGraphQLParametersReturnsErrorResponse(
-      String path, String query, String errorName, String message) throws IOException {
+      String path, String query, String message1, String message2) throws IOException {
 
     OkHttpClient okHttpClient =
         new OkHttpClient.Builder()
@@ -921,7 +921,7 @@ public class GraphqlTest extends BaseOsgiIntegrationTest {
     List<Map<String, Object>> errors = (List<Map<String, Object>>) mapResponse.get("errors");
     assertThat(errors)
         .hasOnlyOneElementSatisfying(
-            item -> assertThat(item.get("message")).asString().contains(errorName, message));
+            item -> assertThat(item.get("message")).asString().contains(message1, message2));
     response.close();
   }
 
@@ -939,6 +939,11 @@ public class GraphqlTest extends BaseOsgiIntegrationTest {
             "invalidWrapper { zzz { name } }",
             "offending token 'invalidWrapper'",
             "Invalid Syntax"),
+        arguments(
+            dmlPath,
+            "query { products(filter: { name: { gt: \"a\"} }) { values { id } }}",
+            "Cannot execute this query",
+            "use ALLOW FILTERING"),
         arguments(
             ddlPath,
             "query { zzz { name } }",


### PR DESCRIPTION
Fixes #207 .

GraphQL over HTTP [surfaces errors](https://spec.graphql.org/June2018/#sec-Errors) in the property `"errors"`. This patch adds a small fix and tests for expected behaviour on graphql errors.

Also, I've unified the junit version used across all modules because it was giving me issues when running parameterized tests from IDE.