### PR TITLE
Upgrade maven bundle plugin to avoid ConcurrentModificationException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
           <extensions>true</extensions>
-          <version>4.2.1</version>
+          <version>5.1.1</version>
           <executions>
             <execution>
               <id>bundle-manifest</id>


### PR DESCRIPTION
# Problem

I tried executing `./mvnw test` with JDK 15 but it failed with an `ConcurrentModificationException` in the [`maven-bundle-plugin`](https://mvnrepository.com/artifact/org.apache.felix/maven-bundle-plugin). The fix is to upgrade the `maven-bundle-plugin`.

```
$ ./mvnw test
...
[INFO] --- maven-bundle-plugin:4.2.1:manifest (bundle-manifest) @ core ---
[ERROR] An internal error occurred
java.util.ConcurrentModificationException
    at java.util.TreeMap.callMappingFunctionWithCheck (TreeMap.java:742)
    at java.util.TreeMap.computeIfAbsent (TreeMap.java:558)
    at aQute.bnd.osgi.Jar.putResource (Jar.java:288)
    at aQute.bnd.osgi.Jar$1.visitFile (Jar.java:202)
    at aQute.bnd.osgi.Jar$1.visitFile (Jar.java:177)
    at java.nio.file.Files.walkFileTree (Files.java:2804)
    at aQute.bnd.osgi.Jar.buildFromDirectory (Jar.java:176)
    at aQute.bnd.osgi.Jar.<init> (Jar.java:119)
    at aQute.bnd.osgi.Jar.<init> (Jar.java:172)
    at org.apache.felix.bundleplugin.BundlePlugin.getOSGiBuilder (BundlePlugin.java:604)
    at org.apache.felix.bundleplugin.ManifestPlugin.getAnalyzer (ManifestPlugin.java:285)
    at org.apache.felix.bundleplugin.ManifestPlugin.execute (ManifestPlugin.java:111)
    at org.apache.felix.bundleplugin.BundlePlugin.execute (BundlePlugin.java:364)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:64)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:564)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:64)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:564)
    at org.apache.maven.wrapper.BootstrapMainStarter.start (BootstrapMainStarter.java:39)
    at org.apache.maven.wrapper.WrapperExecutor.execute (WrapperExecutor.java:122)
    at org.apache.maven.wrapper.MavenWrapperMain.main (MavenWrapperMain.java:61)
```

# Environment

```
$ java -version
openjdk version "15" 2020-09-15
OpenJDK Runtime Environment AdoptOpenJDK (build 15+36)
OpenJDK 64-Bit Server VM AdoptOpenJDK (build 15+36, mixed mode, sharing)
```

```
 $ sw_vers
ProductName:    Mac OS X
ProductVersion: 10.14.6
BuildVersion:   18G6032
```