### PR TITLE
Fix failing test due to timestamp parsing (Java 9)

### DIFF
--- a/persistence-api/src/test/java/io/stargate/db/schema/ColumnTest.java
+++ b/persistence-api/src/test/java/io/stargate/db/schema/ColumnTest.java
@@ -53,8 +53,8 @@ public class ColumnTest {
     assertThat(Type.Text.fromString("2")).isEqualTo("2");
     assertThat(Type.Time.fromString("2")).isEqualTo(LocalTime.ofNanoOfDay(2));
 
-    Instant now = Instant.now();
-    assertThat(Type.Timestamp.fromString(now.toString())).isEqualTo(now);
+    Instant instant = Instant.parse("2020-10-10T10:34:34.664Z");
+    assertThat(Type.Timestamp.fromString(instant.toString())).isEqualTo(instant);
 
     UUID uuid = UUID.fromString("50554d6e-29bb-11e5-b345-feff819cdc9f");
     assertThat(Type.Timeuuid.fromString(uuid.toString())).isEqualTo(uuid);


### PR DESCRIPTION
# Problem

The `ColumnTest` fails if run with Java 15.

```
[ERROR] Tests run: 26, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.647 s <<< FAILURE! - in io.stargate.db.schema.ColumnTest
[ERROR] testFromString  Time elapsed: 0.012 s  <<< ERROR!
java.lang.IllegalArgumentException: Cannot parse timestamp value from "'2020-10-10T10:20:29.062366Z'"
        at io.stargate.db.schema.ColumnTest.testFromString(ColumnTest.java:57)
```

The reason is that since Java 9, `Instance.now()` returns nano second precision if available (`2020-10-10T10:20:29.062366Z`), but the `com.datastax.oss.driver.internal.core.type.codec.TimestampCodec` doesn't seem to work with nano seconds. The test is green when passing `2020-10-10T10:20:29.062Z`, however.

I think we should address the root cause as well but I'm not sure yet if I know where to look / what to do. Still figuring everything out.

# Fix

In order to make the test pass and more deterministic, I included a fixed instant instead.

# Environment

```
$ java -version
openjdk version "15" 2020-09-15
OpenJDK Runtime Environment AdoptOpenJDK (build 15+36)
OpenJDK 64-Bit Server VM AdoptOpenJDK (build 15+36, mixed mode, sharing)
```