### PR TITLE
Small fixes/additions to the Documents API

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/examples/WriteDocResponse.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/examples/WriteDocResponse.java
@@ -1,0 +1,6 @@
+package io.stargate.web.docsapi.examples;
+
+/** Used just for Swagger generation. */
+public class WriteDocResponse {
+  public String documentId;
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/models/DocumentResponseWrapper.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/models/DocumentResponseWrapper.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.web.docsapi.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DocumentResponseWrapper<T> {
+  @JsonProperty("id")
+  String documentId;
+
+  @JsonProperty("pageState")
+  String pageState;
+
+  @JsonProperty("data")
+  T data;
+
+  @ApiModelProperty(value = "The id of the document")
+  public String getDocumentId() {
+    return documentId;
+  }
+
+  public DocumentResponseWrapper setDocumentId(String documentId) {
+    this.documentId = documentId;
+    return this;
+  }
+
+  @ApiModelProperty(
+      value = "A string representing the paging state to be used on future paging requests.")
+  public String getPageState() {
+    return pageState;
+  }
+
+  public DocumentResponseWrapper setPageState(String pageState) {
+    this.pageState = pageState;
+    return this;
+  }
+
+  @ApiModelProperty(value = "The data returned by the request")
+  public T getData() {
+    return data;
+  }
+
+  public DocumentResponseWrapper setData(T data) {
+    this.data = data;
+    return this;
+  }
+
+  @JsonCreator
+  public DocumentResponseWrapper(
+      @JsonProperty("documentId") final String documentId,
+      @JsonProperty("pageState") final String pageState,
+      @JsonProperty("data") final T data) {
+    this.documentId = documentId;
+    this.pageState = pageState;
+    this.data = data;
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/models/DocumentResponseWrapper.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/models/DocumentResponseWrapper.java
@@ -22,7 +22,7 @@ import io.swagger.annotations.ApiModelProperty;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DocumentResponseWrapper<T> {
-  @JsonProperty("id")
+  @JsonProperty("documentId")
   String documentId;
 
   @JsonProperty("pageState")

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/NamespacesResource.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/NamespacesResource.java
@@ -74,7 +74,7 @@ public class NamespacesResource {
   @ApiResponses(
       value = {
         @ApiResponse(code = 200, message = "OK", response = ResponseWrapper.class),
-        @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized"),
         @ApiResponse(code = 500, message = "Internal server error", response = Error.class)
       })
   public Response getAllNamespaces(
@@ -110,9 +110,9 @@ public class NamespacesResource {
   @ApiResponses(
       value = {
         @ApiResponse(code = 200, message = "OK", response = Keyspace.class),
-        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
-        @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
-        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 400, message = "Bad Request"),
+        @ApiResponse(code = 401, message = "Unauthorized"),
+        @ApiResponse(code = 404, message = "Not Found"),
         @ApiResponse(code = 500, message = "Internal server error", response = Error.class)
       })
   @Path("/{namespace-id: [a-zA-Z_0-9]+}")
@@ -159,9 +159,9 @@ public class NamespacesResource {
   @ApiResponses(
       value = {
         @ApiResponse(code = 201, message = "Created", response = Map.class),
-        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
-        @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
-        @ApiResponse(code = 409, message = "Conflict", response = Error.class),
+        @ApiResponse(code = 400, message = "Bad Request"),
+        @ApiResponse(code = 401, message = "Unauthorized"),
+        @ApiResponse(code = 409, message = "Conflict"),
         @ApiResponse(code = 500, message = "Internal server error", response = Error.class)
       })
   public Response createNamespace(
@@ -242,7 +242,7 @@ public class NamespacesResource {
   @ApiResponses(
       value = {
         @ApiResponse(code = 204, message = "No Content"),
-        @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized"),
         @ApiResponse(code = 500, message = "Internal server error", response = Error.class)
       })
   @Path("/{namespace-id: [a-zA-Z_0-9]+}")

--- a/restapi/src/test/java/io/stargate/web/docsapi/dao/DocumentDBTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/dao/DocumentDBTest.java
@@ -110,39 +110,6 @@ public class DocumentDBTest {
   }
 
   @Test
-  public void getRootDocInsertStatement() {
-    TestPreparedStatement stmt =
-        (TestPreparedStatement) documentDB.getRootDocInsertStatement("keyspace", "table", true);
-    String allPaths = "";
-    for (int i = 0; i < 64; i++) {
-      allPaths += "p" + i + ", ";
-    }
-
-    String allPathValues = "";
-    for (int i = 0; i < 64; i++) {
-      allPathValues += "'', ";
-    }
-
-    assertThat(stmt.getCql())
-        .isEqualTo(
-            "INSERT INTO \"keyspace\".\"table\" (key, "
-                + allPaths
-                + "leaf) VALUES (:key, "
-                + allPathValues
-                + "'DOCROOT-a9fb1f04-0394-4c74-b77b-49b4e0ef7900') IF NOT EXISTS");
-
-    stmt = (TestPreparedStatement) documentDB.getRootDocInsertStatement("keyspace", "table", false);
-
-    assertThat(stmt.getCql())
-        .isEqualTo(
-            "INSERT INTO \"keyspace\".\"table\" (key, "
-                + allPaths
-                + "leaf) VALUES (:key, "
-                + allPathValues
-                + "'DOCROOT-a9fb1f04-0394-4c74-b77b-49b4e0ef7900') USING TIMESTAMP ?");
-  }
-
-  @Test
   public void deleteThenInsertBatch() {
     ds = mock(TestDataStore.class);
     when(ds.prepare(anyString())).thenCallRealMethod();
@@ -161,9 +128,6 @@ public class DocumentDBTest {
     expectedStmts.add(
         new TestPreparedStatement(
             "DELETE FROM \"keyspace\".\"table\" USING TIMESTAMP ? WHERE key = :key AND p0 = :p0 AND p1 = :p1 AND p2 = :p2"));
-    expectedStmts.add(
-        new TestPreparedStatement(
-            "INSERT INTO \"keyspace\".\"table\" (key, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p30, p31, p32, p33, p34, p35, p36, p37, p38, p39, p40, p41, p42, p43, p44, p45, p46, p47, p48, p49, p50, p51, p52, p53, p54, p55, p56, p57, p58, p59, p60, p61, p62, p63, leaf) VALUES (:key, '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', 'DOCROOT-a9fb1f04-0394-4c74-b77b-49b4e0ef7900') USING TIMESTAMP ?"));
     expectedStmts.add(
         new TestPreparedStatement(
             "INSERT INTO \"keyspace\".\"table\" (key, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p30, p31, p32, p33, p34, p35, p36, p37, p38, p39, p40, p41, p42, p43, p44, p45, p46, p47, p48, p49, p50, p51, p52, p53, p54, p55, p56, p57, p58, p59, p60, p61, p62, p63, leaf, text_value, dbl_value, bool_value) VALUES (:key, :p0, :p1, :p2, :p3, :p4, :p5, :p6, :p7, :p8, :p9, :p10, :p11, :p12, :p13, :p14, :p15, :p16, :p17, :p18, :p19, :p20, :p21, :p22, :p23, :p24, :p25, :p26, :p27, :p28, :p29, :p30, :p31, :p32, :p33, :p34, :p35, :p36, :p37, :p38, :p39, :p40, :p41, :p42, :p43, :p44, :p45, :p46, :p47, :p48, :p49, :p50, :p51, :p52, :p53, :p54, :p55, :p56, :p57, :p58, :p59, :p60, :p61, :p62, :p63, :leaf, :text_value, :dbl_value, :bool_value) USING TIMESTAMP ?"));
@@ -198,39 +162,10 @@ public class DocumentDBTest {
             "DELETE FROM \"keyspace\".\"table\" USING TIMESTAMP ?  WHERE key = :key AND p0 = :p0 AND p1 = :p1 AND p2 = :p2 AND p3 = '' AND p4 = '' AND p5 = '' AND p6 = '' AND p7 = '' AND p8 = '' AND p9 = '' AND p10 = '' AND p11 = '' AND p12 = '' AND p13 = '' AND p14 = '' AND p15 = '' AND p16 = '' AND p17 = '' AND p18 = '' AND p19 = '' AND p20 = '' AND p21 = '' AND p22 = '' AND p23 = '' AND p24 = '' AND p25 = '' AND p26 = '' AND p27 = '' AND p28 = '' AND p29 = '' AND p30 = '' AND p31 = '' AND p32 = '' AND p33 = '' AND p34 = '' AND p35 = '' AND p36 = '' AND p37 = '' AND p38 = '' AND p39 = '' AND p40 = '' AND p41 = '' AND p42 = '' AND p43 = '' AND p44 = '' AND p45 = '' AND p46 = '' AND p47 = '' AND p48 = '' AND p49 = '' AND p50 = '' AND p51 = '' AND p52 = '' AND p53 = '' AND p54 = '' AND p55 = '' AND p56 = '' AND p57 = '' AND p58 = '' AND p59 = '' AND p60 = '' AND p61 = '' AND p62 = '' AND p63 = ''"));
     expectedStmts.add(
         new TestPreparedStatement(
-            "INSERT INTO \"keyspace\".\"table\" (key, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p30, p31, p32, p33, p34, p35, p36, p37, p38, p39, p40, p41, p42, p43, p44, p45, p46, p47, p48, p49, p50, p51, p52, p53, p54, p55, p56, p57, p58, p59, p60, p61, p62, p63, leaf) VALUES (:key, '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', 'DOCROOT-a9fb1f04-0394-4c74-b77b-49b4e0ef7900') USING TIMESTAMP ?"));
-    expectedStmts.add(
-        new TestPreparedStatement(
             "DELETE FROM \"keyspace\".\"table\" USING TIMESTAMP ? WHERE key = :key AND p0 = :p0 AND p1 = :p1 AND p2 = :p2 AND p3 >= '[000000]' AND p3 <= '[999999]' "));
     expectedStmts.add(
         new TestPreparedStatement(
             "DELETE FROM \"keyspace\".\"table\" USING TIMESTAMP ? WHERE key = :key AND p0 = :p0 AND p1 = :p1 AND p2 = :p2 AND p3 IN (:p3) "));
-    verify(ds, times(1))
-        .processBatch(expectedStmts, vars, Optional.of(ConsistencyLevel.LOCAL_QUORUM));
-  }
-
-  @Test
-  public void insertBatchIfNotExists() {
-    ds = mock(TestDataStore.class);
-    when(ds.prepare(anyString())).thenCallRealMethod();
-    when(ds.processBatch(anyObject(), anyList(), anyObject())).thenCallRealMethod();
-    documentDB = new DocumentDB(ds);
-    List<String> path = ImmutableList.of("a", "b", "c");
-    Map<String, Object> map = documentDB.newBindMap(path, 1L);
-    map.put("bool_value", null);
-    map.put("dbl_value", 3.0);
-    map.put("text_value", null);
-    List<Object[]> vars = new ArrayList<>();
-    vars.add(map.values().toArray());
-    documentDB.insertBatchIfNotExists("keyspace", "table", "key", vars);
-
-    List<PreparedStatement> expectedStmts = new ArrayList<>();
-    expectedStmts.add(
-        new TestPreparedStatement(
-            "INSERT INTO \"keyspace\".\"table\" (key, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p30, p31, p32, p33, p34, p35, p36, p37, p38, p39, p40, p41, p42, p43, p44, p45, p46, p47, p48, p49, p50, p51, p52, p53, p54, p55, p56, p57, p58, p59, p60, p61, p62, p63, leaf) VALUES (:key, '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', 'DOCROOT-a9fb1f04-0394-4c74-b77b-49b4e0ef7900') IF NOT EXISTS"));
-    expectedStmts.add(
-        new TestPreparedStatement(
-            "INSERT INTO \"keyspace\".\"table\" (key, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p30, p31, p32, p33, p34, p35, p36, p37, p38, p39, p40, p41, p42, p43, p44, p45, p46, p47, p48, p49, p50, p51, p52, p53, p54, p55, p56, p57, p58, p59, p60, p61, p62, p63, leaf, text_value, dbl_value, bool_value) VALUES (:key, :p0, :p1, :p2, :p3, :p4, :p5, :p6, :p7, :p8, :p9, :p10, :p11, :p12, :p13, :p14, :p15, :p16, :p17, :p18, :p19, :p20, :p21, :p22, :p23, :p24, :p25, :p26, :p27, :p28, :p29, :p30, :p31, :p32, :p33, :p34, :p35, :p36, :p37, :p38, :p39, :p40, :p41, :p42, :p43, :p44, :p45, :p46, :p47, :p48, :p49, :p50, :p51, :p52, :p53, :p54, :p55, :p56, :p57, :p58, :p59, :p60, :p61, :p62, :p63, :leaf, :text_value, :dbl_value, :bool_value) USING TIMESTAMP ?"));
     verify(ds, times(1))
         .processBatch(expectedStmts, vars, Optional.of(ConsistencyLevel.LOCAL_QUORUM));
   }

--- a/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
@@ -193,43 +193,18 @@ public class DocumentResourceV2Test {
   }
 
   @Test
-  public void postDoc_success() throws UnauthorizedException, JsonProcessingException {
+  public void postDoc_success() throws JsonProcessingException {
     HttpHeaders headers = mock(HttpHeaders.class);
     UriInfo ui = mock(UriInfo.class);
     String authToken = "auth_token";
     String keyspace = "keyspace";
     String collection = "collection";
     String payload = "{}";
-
-    PowerMockito.when(
-            documentServiceMock.putAtRoot(
-                anyString(), anyString(), anyString(), anyString(), anyString(), anyObject()))
-        .thenReturn(true);
 
     Response r = documentResourceV2.postDoc(headers, ui, authToken, keyspace, collection, payload);
 
     assertThat(r.getStatus()).isEqualTo(201);
     mapper.readTree((String) r.getEntity()).requiredAt("/documentId");
-  }
-
-  @Test
-  public void postDoc_idCollision() throws UnauthorizedException {
-    HttpHeaders headers = mock(HttpHeaders.class);
-    UriInfo ui = mock(UriInfo.class);
-    String authToken = "auth_token";
-    String keyspace = "keyspace";
-    String collection = "collection";
-    String payload = "{}";
-
-    PowerMockito.when(
-            documentServiceMock.putAtRoot(
-                anyString(), anyString(), anyString(), anyString(), anyString(), anyObject()))
-        .thenReturn(false);
-
-    Response r = documentResourceV2.postDoc(headers, ui, authToken, keyspace, collection, payload);
-
-    assertThat(r.getStatus()).isEqualTo(500);
-    assertThat((String) r.getEntity()).startsWith("Fatal ID collision, try once more: ");
   }
 
   @Test
@@ -242,39 +217,11 @@ public class DocumentResourceV2Test {
     String id = "id";
     String payload = "{}";
 
-    PowerMockito.when(
-            documentServiceMock.putAtRoot(
-                anyString(), anyString(), anyString(), anyString(), anyString(), anyObject()))
-        .thenReturn(true);
-
     Response r =
         documentResourceV2.putDoc(headers, ui, authToken, keyspace, collection, id, payload);
 
     assertThat(r.getStatus()).isEqualTo(200);
     mapper.readTree((String) r.getEntity()).requiredAt("/documentId");
-  }
-
-  @Test
-  public void putDoc_idCollision() throws UnauthorizedException, JsonProcessingException {
-    HttpHeaders headers = mock(HttpHeaders.class);
-    UriInfo ui = mock(UriInfo.class);
-    String authToken = "auth_token";
-    String keyspace = "keyspace";
-    String collection = "collection";
-    String id = "id";
-    String payload = "{}";
-
-    PowerMockito.when(
-            documentServiceMock.putAtRoot(
-                anyString(), anyString(), anyString(), anyString(), anyString(), anyObject()))
-        .thenReturn(false);
-
-    Response r =
-        documentResourceV2.putDoc(headers, ui, authToken, keyspace, collection, id, payload);
-
-    assertThat(r.getStatus()).isEqualTo(409);
-    assertThat((String) r.getEntity())
-        .startsWith("Document id already exists in collection collection");
   }
 
   @Test

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -908,41 +908,6 @@ public class DocumentServiceTest {
   }
 
   @Test
-  public void putAtRoot() throws UnauthorizedException {
-    DocumentDB dbMock = mock(DocumentDB.class);
-    Db dbFactoryMock = mock(Db.class);
-    when(dbFactoryMock.getDocDataStoreForToken(anyString())).thenReturn(dbMock);
-    when(dbMock.newBindMap(anyObject(), anyLong())).thenCallRealMethod();
-    when(dbMock.insertBatchIfNotExists(anyString(), anyString(), anyString(), anyObject()))
-        .thenReturn(true);
-
-    boolean success =
-        service.putAtRoot(
-            "authToken", "ks", "collection", "id", "{\"some\": \"data\"}", dbFactoryMock);
-
-    assertThat(success).isTrue();
-  }
-
-  @Test
-  public void putAtRoot_noData() throws UnauthorizedException {
-    DocumentDB dbMock = mock(DocumentDB.class);
-    Db dbFactoryMock = mock(Db.class);
-    when(dbFactoryMock.getDocDataStoreForToken(anyString())).thenReturn(dbMock);
-    when(dbMock.newBindMap(anyObject(), anyLong())).thenCallRealMethod();
-    when(dbMock.insertBatchIfNotExists(anyString(), anyString(), anyString(), anyObject()))
-        .thenReturn(true);
-
-    Throwable thrown =
-        catchThrowable(
-            () -> service.putAtRoot("authToken", "ks", "collection", "id", "1", dbFactoryMock));
-
-    assertThat(thrown)
-        .isInstanceOf(DocumentAPIRequestException.class)
-        .hasMessageContaining(
-            "Updating a key with just a JSON primitive, empty object, or empty array is not allowed.");
-  }
-
-  @Test
   public void putAtPath() throws UnauthorizedException {
     DocumentDB dbMock = mock(DocumentDB.class);
     Db dbFactoryMock = mock(Db.class);

--- a/testing/src/test/java/io/stargate/it/http/DocumentApiV2Test.java
+++ b/testing/src/test/java/io/stargate/it/http/DocumentApiV2Test.java
@@ -127,12 +127,12 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1");
     assertThat(r.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1", null));
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1/quiz/maths");
     assertThat(r.code()).isEqualTo(200);
     assertThat(objectMapper.readTree(r.body().string()))
-        .isEqualTo(wrapResponse(obj.requiredAt("/quiz/maths"), "1"));
+        .isEqualTo(wrapResponse(obj.requiredAt("/quiz/maths"), "1", null));
 
     r =
         get(
@@ -209,7 +209,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     r.close();
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1/path");
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1", null));
 
     obj = objectMapper.readTree("{ \"$30\": \"not as weird\" }");
     r = put("/v2/namespaces/" + keyspace + "/collections/collection/1/path", obj);
@@ -217,7 +217,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     r.close();
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1/path");
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1", null));
 
     obj = objectMapper.readTree("{ \"@\": \"weird but allowed\" }");
     r = put("/v2/namespaces/" + keyspace + "/collections/collection/1/path", obj);
@@ -225,7 +225,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     r.close();
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1/path");
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1", null));
 
     obj = objectMapper.readTree("{ \"meet me @ the place\": \"not as weird\" }");
     r = put("/v2/namespaces/" + keyspace + "/collections/collection/1/path", obj);
@@ -233,7 +233,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     r.close();
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1/path");
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1", null));
 
     obj = objectMapper.readTree("{ \"?\": \"weird but allowed\" }");
     r = put("/v2/namespaces/" + keyspace + "/collections/collection/1/path", obj);
@@ -241,7 +241,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     r.close();
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1/path");
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1", null));
 
     obj = objectMapper.readTree("{ \"spac es\": \"weird but allowed\" }");
     r = put("/v2/namespaces/" + keyspace + "/collections/collection/1/path", obj);
@@ -249,7 +249,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     r.close();
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1/path");
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1", null));
 
     obj = objectMapper.readTree("{ \"3\": [\"totally allowed\"] }");
     r = put("/v2/namespaces/" + keyspace + "/collections/collection/1/path", obj);
@@ -257,11 +257,11 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     r.close();
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1/path");
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1", null));
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1/path/3/[0]");
     assertThat(objectMapper.readTree(r.body().string()))
-        .isEqualTo(wrapResponse(objectMapper.readTree("\"totally allowed\""), "1"));
+        .isEqualTo(wrapResponse(objectMapper.readTree("\"totally allowed\""), "1", null));
 
     obj = objectMapper.readTree("{ \"-1\": \"totally allowed\" }");
     r = put("/v2/namespaces/" + keyspace + "/collections/collection/1/path", obj);
@@ -269,11 +269,11 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     r.close();
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1/path");
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1", null));
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1/path/-1");
     assertThat(objectMapper.readTree(r.body().string()))
-        .isEqualTo(wrapResponse(objectMapper.readTree("\"totally allowed\""), "1"));
+        .isEqualTo(wrapResponse(objectMapper.readTree("\"totally allowed\""), "1", null));
 
     obj = objectMapper.readTree("{ \"Eric says \\\"hello\\\"\": \"totally allowed\" }");
     r = put("/v2/namespaces/" + keyspace + "/collections/collection/1/path", obj);
@@ -281,7 +281,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     r.close();
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1/path");
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1", null));
   }
 
   @Test
@@ -309,7 +309,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1/quiz/maths/q1/options/[0]");
     assertThat(r.code()).isEqualTo(200);
     assertThat(objectMapper.readTree(r.body().string()))
-        .isEqualTo(wrapResponse(obj.requiredAt("/quiz/maths/q1/options/0"), "1"));
+        .isEqualTo(wrapResponse(obj.requiredAt("/quiz/maths/q1/options/0"), "1", null));
 
     r =
         get(
@@ -327,7 +327,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
                 + "/collections/collection/1/quiz/nests/q1/options/[3]/this");
     assertThat(r.code()).isEqualTo(200);
     assertThat(objectMapper.readTree(r.body().string()))
-        .isEqualTo(wrapResponse(obj.requiredAt("/quiz/nests/q1/options/3/this"), "1"));
+        .isEqualTo(wrapResponse(obj.requiredAt("/quiz/nests/q1/options/3/this"), "1", null));
   }
 
   @Test
@@ -361,7 +361,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1");
     assertThat(r.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1", null));
 
     obj = objectMapper.readTree("{\"abc\": {}}");
     r = put("/v2/namespaces/" + keyspace + "/collections/collection/2", obj);
@@ -370,7 +370,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/2");
     assertThat(r.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "2"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "2", null));
 
     obj = objectMapper.readTree("{\"abc\": []}");
     r = put("/v2/namespaces/" + keyspace + "/collections/collection/3", obj);
@@ -379,7 +379,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/3");
     assertThat(r.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "3"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "3", null));
 
     obj =
         objectMapper.readTree(
@@ -390,22 +390,22 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/4");
     assertThat(r.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "4"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "4", null));
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/4/abc");
     assertThat(r.code()).isEqualTo(200);
     assertThat(objectMapper.readTree(r.body().string()))
-        .isEqualTo(wrapResponse(objectMapper.createArrayNode(), "4"));
+        .isEqualTo(wrapResponse(objectMapper.createArrayNode(), "4", null));
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/4/bcd");
     assertThat(r.code()).isEqualTo(200);
     assertThat(objectMapper.readTree(r.body().string()))
-        .isEqualTo(wrapResponse(objectMapper.createObjectNode(), "4"));
+        .isEqualTo(wrapResponse(objectMapper.createObjectNode(), "4", null));
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/4/abcd/nest1");
     assertThat(r.code()).isEqualTo(200);
     assertThat(objectMapper.readTree(r.body().string()))
-        .isEqualTo(wrapResponse(objectMapper.createArrayNode(), "4"));
+        .isEqualTo(wrapResponse(objectMapper.createArrayNode(), "4", null));
   }
 
   @Test
@@ -418,7 +418,8 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1");
     assertThat(r.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(fullObj, "1"));
+    assertThat(objectMapper.readTree(r.body().string()))
+        .isEqualTo(wrapResponse(fullObj, "1", null));
 
     JsonNode obj;
     obj = objectMapper.readTree("{\"q5000\": \"hello?\"}");
@@ -428,7 +429,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1/quiz/sport");
     assertThat(r.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1", null));
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1");
     assertThat(r.code()).isEqualTo(200);
@@ -438,7 +439,8 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     ObjectNode fullObjNode = (ObjectNode) fullObj;
     ((ObjectNode) fullObjNode.get("quiz")).set("sport", sportNode);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(fullObjNode, "1"));
+    assertThat(objectMapper.readTree(r.body().string()))
+        .isEqualTo(wrapResponse(fullObjNode, "1", null));
   }
 
   @Test
@@ -451,7 +453,8 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1");
     assertThat(r.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(fullObj, "1"));
+    assertThat(objectMapper.readTree(r.body().string()))
+        .isEqualTo(wrapResponse(fullObj, "1", null));
 
     JsonNode obj;
     obj = objectMapper.readTree("{\"q5000\": \"hello?\"}");
@@ -464,7 +467,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1/quiz/nests/q1/options/[0]");
     assertThat(r.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1", null));
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1");
     assertThat(r.code()).isEqualTo(200);
@@ -474,7 +477,8 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     ObjectNode fullObjNode = (ObjectNode) fullObj;
     ((ArrayNode) fullObjNode.at("/quiz/nests/q1/options")).set(0, optionNode);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(fullObjNode, "1"));
+    assertThat(objectMapper.readTree(r.body().string()))
+        .isEqualTo(wrapResponse(fullObjNode, "1", null));
   }
 
   @Test
@@ -487,7 +491,8 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1");
     assertThat(r.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(fullObj, "1"));
+    assertThat(objectMapper.readTree(r.body().string()))
+        .isEqualTo(wrapResponse(fullObj, "1", null));
 
     JsonNode obj = objectMapper.readTree("[{\"array\": \"at\"}, \"sub\", \"doc\"]");
     r = put("/v2/namespaces/" + keyspace + "/collections/collection/1/quiz", obj);
@@ -496,7 +501,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1/quiz");
     assertThat(r.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1", null));
 
     obj = objectMapper.readTree("[0, \"a\", \"2\", true]");
     r = put("/v2/namespaces/" + keyspace + "/collections/collection/1/quiz/nests/q1", obj);
@@ -505,7 +510,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1/quiz/nests/q1");
     assertThat(r.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1", null));
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1");
     ObjectNode nestsNode =
@@ -515,7 +520,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     String body = r.body().string();
     assertThat(body).startsWith("{");
-    assertThat(objectMapper.readTree(body)).isEqualTo(wrapResponse(fullObjNode, "1"));
+    assertThat(objectMapper.readTree(body)).isEqualTo(wrapResponse(fullObjNode, "1", null));
     assertThat(r.code()).isEqualTo(200);
 
     obj = objectMapper.readTree("[{\"array\": \"at\"}, \"\", \"doc\"]");
@@ -525,7 +530,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1/quiz");
     assertThat(r.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1", null));
 
     obj = objectMapper.readTree("{\"we\": {\"are\": \"done\"}}");
     r = put("/v2/namespaces/" + keyspace + "/collections/collection/1/quiz", obj);
@@ -534,7 +539,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1/quiz");
     assertThat(r.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1", null));
   }
 
   @Test
@@ -547,7 +552,8 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1");
     assertThat(r.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(fullObj, "1"));
+    assertThat(objectMapper.readTree(r.body().string()))
+        .isEqualTo(wrapResponse(fullObj, "1", null));
 
     JsonNode obj;
     obj = objectMapper.readTree("3");
@@ -589,7 +595,8 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1");
     assertThat(r.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(fullObj, "1"));
+    assertThat(objectMapper.readTree(r.body().string()))
+        .isEqualTo(wrapResponse(fullObj, "1", null));
 
     r = delete("/v2/namespaces/" + keyspace + "/collections/collection/1/quiz/sport/q1/question");
     assertThat(r.code()).isEqualTo(204);
@@ -616,7 +623,8 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
             wrapResponse(
                 objectMapper.readTree(
                     "[null,\"not a nest\",\"definitely not a nest\",{ \"this\":  true }]"),
-                "1"));
+                "1",
+                null));
 
     r = delete("/v2/namespaces/" + keyspace + "/collections/collection/1");
     assertThat(r.code()).isEqualTo(204);
@@ -639,7 +647,8 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     resp = get(newLocation.replace(host + ":8082", ""));
     assertThat(resp.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(resp.body().string())).isEqualTo(wrapResponse(fullObj, newId));
+    assertThat(objectMapper.readTree(resp.body().string()))
+        .isEqualTo(wrapResponse(fullObj, newId, null));
   }
 
   @Test
@@ -651,7 +660,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1");
     assertThat(r.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1", null));
 
     obj = objectMapper.readTree("{\"bcd\": true}");
     r = patch("/v2/namespaces/" + keyspace + "/collections/collection/1", obj);
@@ -661,7 +670,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1");
     assertThat(r.code()).isEqualTo(200);
     assertThat(objectMapper.readTree(r.body().string()))
-        .isEqualTo(wrapResponse(objectMapper.readTree("{ \"abc\": 1, \"bcd\": true }"), "1"));
+        .isEqualTo(wrapResponse(objectMapper.readTree("{ \"abc\": 1, \"bcd\": true }"), "1", null));
 
     obj = objectMapper.readTree("{\"bcd\": {\"a\": {\"b\": 0 }}}");
     r = patch("/v2/namespaces/" + keyspace + "/collections/collection/1", obj);
@@ -673,7 +682,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(objectMapper.readTree(r.body().string()))
         .isEqualTo(
             wrapResponse(
-                objectMapper.readTree("{ \"abc\": 1, \"bcd\": {\"a\": {\"b\": 0 }} }"), "1"));
+                objectMapper.readTree("{ \"abc\": 1, \"bcd\": {\"a\": {\"b\": 0 }} }"), "1", null));
 
     obj = objectMapper.readTree("{\"bcd\": [1,2,3,4]}");
     r = patch("/v2/namespaces/" + keyspace + "/collections/collection/1", obj);
@@ -683,7 +692,8 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1");
     assertThat(r.code()).isEqualTo(200);
     assertThat(objectMapper.readTree(r.body().string()))
-        .isEqualTo(wrapResponse(objectMapper.readTree("{ \"abc\": 1, \"bcd\": [1,2,3,4] }"), "1"));
+        .isEqualTo(
+            wrapResponse(objectMapper.readTree("{ \"abc\": 1, \"bcd\": [1,2,3,4] }"), "1", null));
 
     obj = objectMapper.readTree("{\"bcd\": [5,{\"a\": 23},7,8]}");
     r = patch("/v2/namespaces/" + keyspace + "/collections/collection/1", obj);
@@ -695,7 +705,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(objectMapper.readTree(r.body().string()))
         .isEqualTo(
             wrapResponse(
-                objectMapper.readTree("{ \"abc\": 1, \"bcd\": [5,{\"a\": 23},7,8] }"), "1"));
+                objectMapper.readTree("{ \"abc\": 1, \"bcd\": [5,{\"a\": 23},7,8] }"), "1", null));
 
     obj = objectMapper.readTree("{\"bcd\": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]}");
     r = patch("/v2/namespaces/" + keyspace + "/collections/collection/1", obj);
@@ -709,7 +719,8 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
             wrapResponse(
                 objectMapper.readTree(
                     "{ \"abc\": 1, \"bcd\": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] }"),
-                "1"));
+                "1",
+                null));
 
     obj = objectMapper.readTree("{\"bcd\": {\"replace\": \"array\"}}");
     r = patch("/v2/namespaces/" + keyspace + "/collections/collection/1", obj);
@@ -721,7 +732,9 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(objectMapper.readTree(r.body().string()))
         .isEqualTo(
             wrapResponse(
-                objectMapper.readTree("{ \"abc\": 1, \"bcd\": {\"replace\": \"array\"} }"), "1"));
+                objectMapper.readTree("{ \"abc\": 1, \"bcd\": {\"replace\": \"array\"} }"),
+                "1",
+                null));
 
     obj = objectMapper.readTree("{\"done\": \"done\"}");
     r = patch("/v2/namespaces/" + keyspace + "/collections/collection/1", obj);
@@ -735,7 +748,8 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
             wrapResponse(
                 objectMapper.readTree(
                     "{ \"abc\": 1, \"bcd\": {\"replace\": \"array\"}, \"done\": \"done\" }"),
-                "1"));
+                "1",
+                null));
   }
 
   @Test
@@ -747,7 +761,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1");
     assertThat(r.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1"));
+    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1", null));
 
     obj = objectMapper.readTree("{\"bcd\": null}");
     r = patch("/v2/namespaces/" + keyspace + "/collections/collection/1", obj);
@@ -757,7 +771,8 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1");
     assertThat(r.code()).isEqualTo(200);
     assertThat(objectMapper.readTree(r.body().string()))
-        .isEqualTo(wrapResponse(objectMapper.readTree("{ \"abc\": null, \"bcd\": null }"), "1"));
+        .isEqualTo(
+            wrapResponse(objectMapper.readTree("{ \"abc\": null, \"bcd\": null }"), "1", null));
 
     obj = objectMapper.readTree("{\"bcd\": {\"a\": {\"b\": null }}}");
     r = patch("/v2/namespaces/" + keyspace + "/collections/collection/1", obj);
@@ -769,7 +784,9 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(objectMapper.readTree(r.body().string()))
         .isEqualTo(
             wrapResponse(
-                objectMapper.readTree("{ \"abc\": null, \"bcd\": {\"a\": {\"b\": null }} }"), "1"));
+                objectMapper.readTree("{ \"abc\": null, \"bcd\": {\"a\": {\"b\": null }} }"),
+                "1",
+                null));
 
     obj = objectMapper.readTree("{\"bcd\": [null,2,null,4]}");
     r = patch("/v2/namespaces/" + keyspace + "/collections/collection/1", obj);
@@ -781,7 +798,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(objectMapper.readTree(r.body().string()))
         .isEqualTo(
             wrapResponse(
-                objectMapper.readTree("{ \"abc\": null, \"bcd\": [null,2,null,4] }"), "1"));
+                objectMapper.readTree("{ \"abc\": null, \"bcd\": [null,2,null,4] }"), "1", null));
 
     obj = objectMapper.readTree("{\"bcd\": [1,{\"a\": null},3,4]}");
     r = patch("/v2/namespaces/" + keyspace + "/collections/collection/1", obj);
@@ -793,7 +810,9 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(objectMapper.readTree(r.body().string()))
         .isEqualTo(
             wrapResponse(
-                objectMapper.readTree("{ \"abc\": null, \"bcd\": [1,{\"a\": null},3,4] }"), "1"));
+                objectMapper.readTree("{ \"abc\": null, \"bcd\": [1,{\"a\": null},3,4] }"),
+                "1",
+                null));
 
     obj = objectMapper.readTree("{\"bcd\": [null]}");
     r = patch("/v2/namespaces/" + keyspace + "/collections/collection/1", obj);
@@ -803,7 +822,8 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1");
     assertThat(r.code()).isEqualTo(200);
     assertThat(objectMapper.readTree(r.body().string()))
-        .isEqualTo(wrapResponse(objectMapper.readTree("{ \"abc\": null, \"bcd\": [null] }"), "1"));
+        .isEqualTo(
+            wrapResponse(objectMapper.readTree("{ \"abc\": null, \"bcd\": [null] }"), "1", null));
 
     obj = objectMapper.readTree("{\"null\": null}");
     r = patch("/v2/namespaces/" + keyspace + "/collections/collection/1", obj);
@@ -815,7 +835,9 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(objectMapper.readTree(r.body().string()))
         .isEqualTo(
             wrapResponse(
-                objectMapper.readTree("{ \"abc\": null, \"bcd\": [null], \"null\": null }"), "1"));
+                objectMapper.readTree("{ \"abc\": null, \"bcd\": [null], \"null\": null }"),
+                "1",
+                null));
   }
 
   @Test
@@ -828,7 +850,8 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     r = get("/v2/namespaces/" + keyspace + "/collections/collection/1");
     assertThat(r.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(fullObj, "1"));
+    assertThat(objectMapper.readTree(r.body().string()))
+        .isEqualTo(wrapResponse(fullObj, "1", null));
 
     JsonNode obj;
     obj = objectMapper.readTree("[{\"array\": \"at\"}, \"root\", \"doc\"]");
@@ -1499,7 +1522,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     JsonNode responseBody2 = objectMapper.readTree(responseBody);
 
     assertThat(responseBody2.requiredAt("/data").size()).isEqualTo(5);
-    assertThat(responseBody2.at("/pageState")).isNull();
+    assertThat(responseBody2.at("/pageState").isMissingNode()).isTrue();
 
     JsonNode data = responseBody2.requiredAt("/data");
     Iterator<JsonNode> iter = data.iterator();
@@ -1537,7 +1560,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     responseBody2 = objectMapper.readTree(responseBody);
 
     assertThat(responseBody2.requiredAt("/data").size()).isEqualTo(34);
-    assertThat(responseBody2.at("/pageState")).isNull();
+    assertThat(responseBody2.at("/pageState").isMissingNode()).isTrue();
 
     data = responseBody2.requiredAt("/data");
     iter = data.iterator();
@@ -1615,7 +1638,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(body).startsWith("{");
     assertThat(r.code()).isEqualTo(200);
     resp = objectMapper.readTree(body);
-    assertThat(resp.at("/pageState")).isNull();
+    assertThat(resp.at("/pageState").isMissingNode()).isTrue();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
     // Any document could come back, find out which one is there
@@ -1655,7 +1678,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(body).startsWith("{");
     assertThat(r.code()).isEqualTo(200);
     resp = objectMapper.readTree(body);
-    assertThat(resp.at("/pageState")).isNull();
+    assertThat(resp.at("/pageState").isMissingNode()).isTrue();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
     // Any document could come back, find out which one is there
@@ -1674,7 +1697,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(body).startsWith("{");
     assertThat(r.code()).isEqualTo(200);
     resp = objectMapper.readTree(body);
-    assertThat(resp.at("/pageState")).isNull();
+    assertThat(resp.at("/pageState").isMissingNode()).isTrue();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(3);
     Iterator<String> iter = data.fieldNames();
@@ -1769,7 +1792,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(body).startsWith("{");
     assertThat(r.code()).isEqualTo(200);
     resp = objectMapper.readTree(body);
-    assertThat(resp.at("/pageState")).isNull();
+    assertThat(resp.at("/pageState").isMissingNode()).isTrue();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
     // Any document could come back, find out which one is there
@@ -1830,7 +1853,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(body).startsWith("{");
     assertThat(r.code()).isEqualTo(200);
     resp = objectMapper.readTree(body);
-    assertThat(resp.at("/pageState")).isNull();
+    assertThat(resp.at("/pageState").isMissingNode()).isTrue();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
     // Any document could come back, find out which one is there
@@ -1856,7 +1879,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(body).startsWith("{");
     assertThat(r.code()).isEqualTo(200);
     resp = objectMapper.readTree(body);
-    assertThat(resp.at("/pageState")).isNull();
+    assertThat(resp.at("/pageState").isMissingNode()).isTrue();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(3);
     Iterator<String> iter = data.fieldNames();
@@ -1912,7 +1935,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
                 + "/collections/collection?where={\"b.value\": {\"$eq\": 2}}&fields=[\"a\"]");
     assertThat(r.code()).isEqualTo(200);
     JsonNode resp = objectMapper.readTree(r.body().string());
-    assertThat(resp.at("/pageState")).isNull();
+    assertThat(resp.at("/pageState").isMissingNode()).isTrue();
     JsonNode data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
     // The only matching document based on `where` is document 1
@@ -1955,7 +1978,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
                 + URLEncoder.encode(pageState, "UTF-8"));
     assertThat(r.code()).isEqualTo(200);
     resp = objectMapper.readTree(r.body().string());
-    assertThat(resp.at("/pageState")).isNull();
+    assertThat(resp.at("/pageState").isMissingNode()).isTrue();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
     key = data.fieldNames().next();
@@ -2177,18 +2200,6 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     return client.newCall(request).execute();
   }
 
-  private JsonNode wrapResponse(JsonNode node, String id) {
-    ObjectNode wrapperNode = objectMapper.createObjectNode();
-
-    if (id != null) {
-      wrapperNode.set("documentId", TextNode.valueOf(id));
-    }
-    if (node != null) {
-      wrapperNode.set("data", node);
-    }
-    return wrapperNode;
-  }
-
   private JsonNode wrapResponse(JsonNode node, String id, String pagingState) {
     ObjectNode wrapperNode = objectMapper.createObjectNode();
 
@@ -2198,7 +2209,9 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     if (node != null) {
       wrapperNode.set("data", node);
     }
-    wrapperNode.set("pageState", TextNode.valueOf(pagingState));
+    if (pagingState != null) {
+      wrapperNode.set("pageState", TextNode.valueOf(pagingState));
+    }
     return wrapperNode;
   }
 

--- a/testing/src/test/java/io/stargate/it/http/DocumentApiV2Test.java
+++ b/testing/src/test/java/io/stargate/it/http/DocumentApiV2Test.java
@@ -1499,7 +1499,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     JsonNode responseBody2 = objectMapper.readTree(responseBody);
 
     assertThat(responseBody2.requiredAt("/data").size()).isEqualTo(5);
-    assertThat(responseBody2.at("/pageState").isNull()).isEqualTo(true);
+    assertThat(responseBody2.at("/pageState")).isNull();
 
     JsonNode data = responseBody2.requiredAt("/data");
     Iterator<JsonNode> iter = data.iterator();
@@ -1537,7 +1537,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     responseBody2 = objectMapper.readTree(responseBody);
 
     assertThat(responseBody2.requiredAt("/data").size()).isEqualTo(34);
-    assertThat(responseBody2.at("/pageState").isNull()).isEqualTo(true);
+    assertThat(responseBody2.at("/pageState")).isNull();
 
     data = responseBody2.requiredAt("/data");
     iter = data.iterator();
@@ -1615,7 +1615,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(body).startsWith("{");
     assertThat(r.code()).isEqualTo(200);
     resp = objectMapper.readTree(body);
-    assertThat(resp.at("/pageState").isNull()).isEqualTo(true);
+    assertThat(resp.at("/pageState")).isNull();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
     // Any document could come back, find out which one is there
@@ -1655,7 +1655,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(body).startsWith("{");
     assertThat(r.code()).isEqualTo(200);
     resp = objectMapper.readTree(body);
-    assertThat(resp.at("/pageState").isNull()).isEqualTo(true);
+    assertThat(resp.at("/pageState")).isNull();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
     // Any document could come back, find out which one is there
@@ -1674,7 +1674,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(body).startsWith("{");
     assertThat(r.code()).isEqualTo(200);
     resp = objectMapper.readTree(body);
-    assertThat(resp.at("/pageState").isNull()).isEqualTo(true);
+    assertThat(resp.at("/pageState")).isNull();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(3);
     Iterator<String> iter = data.fieldNames();
@@ -1769,7 +1769,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(body).startsWith("{");
     assertThat(r.code()).isEqualTo(200);
     resp = objectMapper.readTree(body);
-    assertThat(resp.at("/pageState").isNull()).isEqualTo(true);
+    assertThat(resp.at("/pageState")).isNull();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
     // Any document could come back, find out which one is there
@@ -1830,7 +1830,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(body).startsWith("{");
     assertThat(r.code()).isEqualTo(200);
     resp = objectMapper.readTree(body);
-    assertThat(resp.at("/pageState").isNull()).isEqualTo(true);
+    assertThat(resp.at("/pageState")).isNull();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
     // Any document could come back, find out which one is there
@@ -1856,7 +1856,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(body).startsWith("{");
     assertThat(r.code()).isEqualTo(200);
     resp = objectMapper.readTree(body);
-    assertThat(resp.at("/pageState").isNull()).isEqualTo(true);
+    assertThat(resp.at("/pageState")).isNull();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(3);
     Iterator<String> iter = data.fieldNames();
@@ -1912,7 +1912,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
                 + "/collections/collection?where={\"b.value\": {\"$eq\": 2}}&fields=[\"a\"]");
     assertThat(r.code()).isEqualTo(200);
     JsonNode resp = objectMapper.readTree(r.body().string());
-    assertThat(resp.at("/pageState").isNull()).isEqualTo(true);
+    assertThat(resp.at("/pageState")).isNull();
     JsonNode data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
     // The only matching document based on `where` is document 1
@@ -1955,7 +1955,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
                 + URLEncoder.encode(pageState, "UTF-8"));
     assertThat(r.code()).isEqualTo(200);
     resp = objectMapper.readTree(r.body().string());
-    assertThat(resp.at("/pageState").isNull()).isEqualTo(true);
+    assertThat(resp.at("/pageState")).isNull();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
     key = data.fieldNames().next();

--- a/testing/src/test/java/io/stargate/it/http/DocumentApiV2Test.java
+++ b/testing/src/test/java/io/stargate/it/http/DocumentApiV2Test.java
@@ -353,59 +353,6 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
   }
 
   @Test
-  public void testRootDocumentPut() throws IOException {
-    JsonNode obj = objectMapper.readTree("{\"abc\": 1}");
-    Response r = put("/v2/namespaces/" + keyspace + "/collections/collection/1", obj);
-    assertThat(r.code()).isEqualTo(200);
-    r.close();
-
-    r = get("/v2/namespaces/" + keyspace + "/collections/collection/1");
-    assertThat(r.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1"));
-
-    obj = objectMapper.readTree("{\"bcd\": true}");
-    r = put("/v2/namespaces/" + keyspace + "/collections/collection/1", obj);
-    assertThat(r.code()).isEqualTo(409);
-    assertThat(r.body().string()).isEqualTo("Document 1 already exists in collection collection");
-
-    obj = objectMapper.readTree("{\"bcd\": true}");
-    r = post("/v2/namespaces/" + keyspace + "/collections/collection", obj);
-    assertThat(r.code()).isEqualTo(201);
-    String body = r.body().string();
-    JsonNode newId = objectMapper.readTree(body).requiredAt("/documentId");
-    assertThat(newId).isNotNull();
-
-    obj = objectMapper.readTree("{\"bcd\": true}");
-    r = put("/v2/namespaces/" + keyspace + "/collections/collection/" + newId.asText(), obj);
-    assertThat(r.code()).isEqualTo(409);
-    assertThat(r.body().string())
-        .isEqualTo(
-            String.format("Document %s already exists in collection collection", newId.asText()));
-
-    obj = objectMapper.readTree("{\"cde\": 1}");
-    r = patch("/v2/namespaces/" + keyspace + "/collections/collection/2", obj);
-    assertThat(r.code()).isEqualTo(200);
-    r.close();
-
-    obj = objectMapper.readTree("{\"bcd\": true}");
-    r = put("/v2/namespaces/" + keyspace + "/collections/collection/2", obj);
-    assertThat(r.code()).isEqualTo(409);
-    assertThat(r.body().string()).isEqualTo("Document 2 already exists in collection collection");
-
-    r = delete("/v2/namespaces/" + keyspace + "/collections/collection/1");
-    assertThat(r.code()).isEqualTo(204);
-
-    obj = objectMapper.readTree("{\"bcd\": true}");
-    r = put("/v2/namespaces/" + keyspace + "/collections/collection/1", obj);
-    assertThat(r.code()).isEqualTo(200);
-    r.close();
-
-    r = get("/v2/namespaces/" + keyspace + "/collections/collection/1");
-    assertThat(r.code()).isEqualTo(200);
-    assertThat(objectMapper.readTree(r.body().string())).isEqualTo(wrapResponse(obj, "1"));
-  }
-
-  @Test
   public void testPutNullsAndEmpties() throws IOException {
     JsonNode obj = objectMapper.readTree("{\"abc\": null}");
     Response r = put("/v2/namespaces/" + keyspace + "/collections/collection/1", obj);
@@ -2261,7 +2208,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     RestUtils.post(
         authToken,
-        String.format("%s:8082/v2/schemas/keyspaces", host),
+        String.format("%s:8082/v2/schemas/namespaces", host),
         createKeyspaceRequest,
         HttpStatus.SC_CREATED);
   }


### PR DESCRIPTION
- [x] Sylvain pointed out that using `if not exists` sometimes but not others can cause concurrency issues, and I never agreed with having the `if not exists` behavior anyway, so...PUTting a document with an ID that already exists will overwrite the document. This is behavior that is seen in Mongo and in Firebase, as I went over it with Denise.
- [x] Additions to the swagger UI to include response types/examples