### PR TITLE
Make `replicas` always default to 1 when missing, for SimpleStrategy

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/NamespacesResource.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/NamespacesResource.java
@@ -173,10 +173,10 @@ public class NamespacesResource {
           String token,
       @ApiParam(
               value =
-                  "A map representing a namespace with SimpleStrategy or NetworkTopologyStrategy \n"
+                  "A map representing a namespace with SimpleStrategy or NetworkTopologyStrategy with default replicas of 1 and 3 respectively \n"
                       + "Simple:\n"
                       + "```json\n"
-                      + "{ \"name\": \"killrvideo\", \"replicas\": 1 // default }\n"
+                      + "{ \"name\": \"killrvideo\", \"replicas\": 1 }\n"
                       + "````\n"
                       + "Network Topology:\n"
                       + "```json\n"
@@ -184,7 +184,7 @@ public class NamespacesResource {
                       + "  \"name\": \"killrvideo\",\n"
                       + "   \"datacenters\":\n"
                       + "      [\n"
-                      + "         { \"name\": \"dc1\", \"replicas\": 3 // default },\n"
+                      + "         { \"name\": \"dc1\", \"replicas\": 3 },\n"
                       + "         { \"name\": \"dc2\", \"replicas\": 3 },\n"
                       + "      ],\n"
                       + "}\n"

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/NamespacesResource.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/NamespacesResource.java
@@ -176,7 +176,7 @@ public class NamespacesResource {
                   "A map representing a namespace with SimpleStrategy or NetworkTopologyStrategy \n"
                       + "Simple:\n"
                       + "```json\n"
-                      + "{ \"name\": \"killrvideo\", \"replicas\": 1}\n"
+                      + "{ \"name\": \"killrvideo\", \"replicas\": 1 // default }\n"
                       + "````\n"
                       + "Network Topology:\n"
                       + "```json\n"
@@ -184,12 +184,11 @@ public class NamespacesResource {
                       + "  \"name\": \"killrvideo\",\n"
                       + "   \"datacenters\":\n"
                       + "      [\n"
-                      + "         { \"name\": \"dc1\", \"replicas\": 3 },\n"
+                      + "         { \"name\": \"dc1\", \"replicas\": 3 // default },\n"
                       + "         { \"name\": \"dc2\", \"replicas\": 3 },\n"
                       + "      ],\n"
                       + "}\n"
-                      + "```",
-              defaultValue = "false")
+                      + "```")
           String payload) {
     return RequestHandler.handle(
         () -> {
@@ -219,7 +218,7 @@ public class NamespacesResource {
             replication =
                 String.format(
                     "{ 'class' : 'SimpleStrategy', 'replication_factor' : %s }",
-                    requestBody.get("replicas"));
+                    requestBody.getOrDefault("replicas", 1));
           }
 
           localDB

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/KeyspacesResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/KeyspacesResource.java
@@ -185,8 +185,7 @@ public class KeyspacesResource {
                       + "         { \"name\": \"dc2\", \"replicas\": 3 },\n"
                       + "      ],\n"
                       + "}\n"
-                      + "```",
-              defaultValue = "false")
+                      + "```")
           String payload) {
     return RequestHandler.handle(
         () -> {
@@ -216,7 +215,7 @@ public class KeyspacesResource {
             replication =
                 String.format(
                     "{ 'class' : 'SimpleStrategy', 'replication_factor' : %s }",
-                    requestBody.get("replicas"));
+                    requestBody.getOrDefault("replicas", 1));
           }
 
           localDB

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/KeyspacesResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/KeyspacesResource.java
@@ -170,7 +170,7 @@ public class KeyspacesResource {
           String token,
       @ApiParam(
               value =
-                  "A map representing a keyspace with SimpleStrategy or NetworkTopologyStrategy \n"
+                  "A map representing a keyspace with SimpleStrategy or NetworkTopologyStrategy with default replicas of 1 and 3 respectively \n"
                       + "Simple:\n"
                       + "```json\n"
                       + "{ \"name\": \"killrvideo\", \"replicas\": 1}\n"


### PR DESCRIPTION
Seems that when NetworkTopologyStrategy is chosen in the REST API, a default of 3 is always chosen when `replicas` is missing, but no default was supplied for the SimpleStrategy.  This PR adds that default of 1.