### PR TITLE
GraphQL: various fixes

### DIFF
--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/DmlSchemaBuilder.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/DmlSchemaBuilder.java
@@ -167,22 +167,19 @@ class DmlSchemaBuilder {
             .argument(
                 GraphQLArgument.newArgument()
                     .name("value")
-                    .type(
-                        new GraphQLTypeReference(
-                            nameMapping.getEntityNames().get(table) + "Input")))
+                    .type(new GraphQLTypeReference(nameMapping.getGraphqlName(table) + "Input")))
             .argument(
                 GraphQLArgument.newArgument()
                     .name("filter")
                     .type(
                         new GraphQLTypeReference(
-                            nameMapping.getEntityNames().get(table) + "FilterInput")))
+                            nameMapping.getGraphqlName(table) + "FilterInput")))
             .argument(
                 GraphQLArgument.newArgument()
                     .name("orderBy")
                     .type(
                         new GraphQLList(
-                            new GraphQLTypeReference(
-                                nameMapping.getEntityNames().get(table) + "Order"))))
+                            new GraphQLTypeReference(nameMapping.getGraphqlName(table) + "Order"))))
             .argument(
                 GraphQLArgument.newArgument()
                     .name("options")
@@ -200,14 +197,13 @@ class DmlSchemaBuilder {
                     .name("filter")
                     .type(
                         new GraphQLTypeReference(
-                            nameMapping.getEntityNames().get(table) + "FilterInput")))
+                            nameMapping.getGraphqlName(table) + "FilterInput")))
             .argument(
                 GraphQLArgument.newArgument()
                     .name("orderBy")
                     .type(
                         new GraphQLList(
-                            new GraphQLTypeReference(
-                                nameMapping.getEntityNames().get(table) + "Order"))))
+                            new GraphQLTypeReference(nameMapping.getGraphqlName(table) + "Order"))))
             .argument(
                 GraphQLArgument.newArgument()
                     .name("options")
@@ -241,30 +237,27 @@ class DmlSchemaBuilder {
 
   private GraphQLType buildFilterInput(Table table) {
     return GraphQLInputObjectType.newInputObject()
-        .name(nameMapping.getEntityNames().get(table) + "FilterInput")
+        .name(nameMapping.getGraphqlName(table) + "FilterInput")
         .fields(buildFilterInputFields(table))
         .build();
   }
 
   private GraphQLFieldDefinition buildUpdate(Table table) {
     return GraphQLFieldDefinition.newFieldDefinition()
-        .name("update" + nameMapping.getEntityNames().get(table))
+        .name("update" + nameMapping.getGraphqlName(table))
         .argument(
             GraphQLArgument.newArgument()
                 .name("value")
                 .type(
                     new GraphQLNonNull(
-                        new GraphQLTypeReference(
-                            nameMapping.getEntityNames().get(table) + "Input"))))
+                        new GraphQLTypeReference(nameMapping.getGraphqlName(table) + "Input"))))
         .argument(GraphQLArgument.newArgument().name("ifExists").type(Scalars.GraphQLBoolean))
         .argument(
             GraphQLArgument.newArgument()
                 .name("ifCondition")
-                .type(
-                    new GraphQLTypeReference(
-                        nameMapping.getEntityNames().get(table) + "FilterInput")))
+                .type(new GraphQLTypeReference(nameMapping.getGraphqlName(table) + "FilterInput")))
         .argument(GraphQLArgument.newArgument().name("options").type(MUTATION_OPTIONS))
-        .type(new GraphQLTypeReference(nameMapping.getEntityNames().get(table) + "MutationResult"))
+        .type(new GraphQLTypeReference(nameMapping.getGraphqlName(table) + "MutationResult"))
         .dataFetcher(
             new UpdateMutationFetcher(table, nameMapping, persistence, authenticationService))
         .build();
@@ -272,17 +265,16 @@ class DmlSchemaBuilder {
 
   private GraphQLFieldDefinition buildInsert(Table table) {
     return GraphQLFieldDefinition.newFieldDefinition()
-        .name("insert" + nameMapping.getEntityNames().get(table))
+        .name("insert" + nameMapping.getGraphqlName(table))
         .argument(
             GraphQLArgument.newArgument()
                 .name("value")
                 .type(
                     new GraphQLNonNull(
-                        new GraphQLTypeReference(
-                            nameMapping.getEntityNames().get(table) + "Input"))))
+                        new GraphQLTypeReference(nameMapping.getGraphqlName(table) + "Input"))))
         .argument(GraphQLArgument.newArgument().name("ifNotExists").type(Scalars.GraphQLBoolean))
         .argument(GraphQLArgument.newArgument().name("options").type(MUTATION_OPTIONS))
-        .type(new GraphQLTypeReference(nameMapping.getEntityNames().get(table) + "MutationResult"))
+        .type(new GraphQLTypeReference(nameMapping.getGraphqlName(table) + "MutationResult"))
         .dataFetcher(
             new InsertMutationFetcher(table, nameMapping, persistence, authenticationService))
         .build();
@@ -290,23 +282,20 @@ class DmlSchemaBuilder {
 
   private GraphQLFieldDefinition buildDelete(Table table) {
     return GraphQLFieldDefinition.newFieldDefinition()
-        .name("delete" + nameMapping.getEntityNames().get(table))
+        .name("delete" + nameMapping.getGraphqlName(table))
         .argument(
             GraphQLArgument.newArgument()
                 .name("value")
                 .type(
                     new GraphQLNonNull(
-                        new GraphQLTypeReference(
-                            nameMapping.getEntityNames().get(table) + "Input"))))
+                        new GraphQLTypeReference(nameMapping.getGraphqlName(table) + "Input"))))
         .argument(GraphQLArgument.newArgument().name("ifExists").type(Scalars.GraphQLBoolean))
         .argument(
             GraphQLArgument.newArgument()
                 .name("ifCondition")
-                .type(
-                    new GraphQLTypeReference(
-                        nameMapping.getEntityNames().get(table) + "FilterInput")))
+                .type(new GraphQLTypeReference(nameMapping.getGraphqlName(table) + "FilterInput")))
         .argument(GraphQLArgument.newArgument().name("options").type(MUTATION_OPTIONS))
-        .type(new GraphQLTypeReference(nameMapping.getEntityNames().get(table) + "MutationResult"))
+        .type(new GraphQLTypeReference(nameMapping.getGraphqlName(table) + "MutationResult"))
         .dataFetcher(
             new DeleteMutationFetcher(table, nameMapping, persistence, authenticationService))
         .build();
@@ -317,7 +306,7 @@ class DmlSchemaBuilder {
     for (Column column : table.columns()) {
       fields.add(
           GraphQLInputObjectField.newInputObjectField()
-              .name(nameMapping.getColumnNames(table).get(column))
+              .name(nameMapping.getGraphqlName(table, column))
               .type(fieldFilterInputTypes.get(column.type()))
               .build());
     }
@@ -330,7 +319,7 @@ class DmlSchemaBuilder {
 
   private GraphQLOutputType buildMutationResult(Table table) {
     return GraphQLObjectType.newObject()
-        .name(nameMapping.getEntityNames().get(table) + "MutationResult")
+        .name(nameMapping.getGraphqlName(table) + "MutationResult")
         .field(
             GraphQLFieldDefinition.newFieldDefinition()
                 .name("applied")
@@ -338,7 +327,7 @@ class DmlSchemaBuilder {
         .field(
             GraphQLFieldDefinition.newFieldDefinition()
                 .name("value")
-                .type(new GraphQLTypeReference(nameMapping.getEntityNames().get(table))))
+                .type(new GraphQLTypeReference(nameMapping.getGraphqlName(table))))
         .build();
   }
 
@@ -379,23 +368,22 @@ class DmlSchemaBuilder {
 
   private GraphQLType buildOrderType(Table table) {
     GraphQLEnumType.Builder input =
-        GraphQLEnumType.newEnum().name(nameMapping.getEntityNames().get(table) + "Order");
+        GraphQLEnumType.newEnum().name(nameMapping.getGraphqlName(table) + "Order");
     for (Column columnMetadata : table.columns()) {
-      input.value(nameMapping.getColumnNames(table).get(columnMetadata) + "_DESC");
-      input.value(nameMapping.getColumnNames(table).get(columnMetadata) + "_ASC");
+      input.value(nameMapping.getGraphqlName(table, columnMetadata) + "_DESC");
+      input.value(nameMapping.getGraphqlName(table, columnMetadata) + "_ASC");
     }
     return input.build();
   }
 
   private GraphQLType buildInputType(Table table) {
     GraphQLInputObjectType.Builder input =
-        GraphQLInputObjectType.newInputObject()
-            .name(nameMapping.getEntityNames().get(table) + "Input");
+        GraphQLInputObjectType.newInputObject().name(nameMapping.getGraphqlName(table) + "Input");
     for (Column columnMetadata : table.columns()) {
       try {
         GraphQLInputObjectField field =
             GraphQLInputObjectField.newInputObjectField()
-                .name(nameMapping.getColumnNames(table).get(columnMetadata))
+                .name(nameMapping.getGraphqlName(table, columnMetadata))
                 .type(fieldInputTypes.get(columnMetadata.type()))
                 .build();
         input.field(field);
@@ -414,7 +402,7 @@ class DmlSchemaBuilder {
 
     GraphQLOutputType entityResultType =
         GraphQLObjectType.newObject()
-            .name(nameMapping.getEntityNames().get(table) + "Result")
+            .name(nameMapping.getGraphqlName(table) + "Result")
             .field(
                 GraphQLFieldDefinition.newFieldDefinition().name("pageState").type(GraphQLString))
             .field(
@@ -423,8 +411,7 @@ class DmlSchemaBuilder {
                     .type(
                         new GraphQLList(
                             new GraphQLNonNull(
-                                new GraphQLTypeReference(
-                                    nameMapping.getEntityNames().get(table))))))
+                                new GraphQLTypeReference(nameMapping.getGraphqlName(table))))))
             .build();
 
     entityResultMap.put(table, entityResultType);
@@ -434,7 +421,7 @@ class DmlSchemaBuilder {
 
   public GraphQLObjectType buildType(Table table) {
     GraphQLObjectType.Builder builder =
-        GraphQLObjectType.newObject().name(nameMapping.getEntityNames().get(table));
+        GraphQLObjectType.newObject().name(nameMapping.getGraphqlName(table));
     for (Column columnMetadata : table.columns()) {
       try {
         GraphQLFieldDefinition.Builder fieldBuilder = buildOutputField(table, columnMetadata);
@@ -449,7 +436,7 @@ class DmlSchemaBuilder {
 
   private GraphQLFieldDefinition.Builder buildOutputField(Table table, Column columnMetadata) {
     return new GraphQLFieldDefinition.Builder()
-        .name(nameMapping.getColumnNames(table).get(columnMetadata))
+        .name(nameMapping.getGraphqlName(table, columnMetadata))
         .type(fieldOutputTypes.get(columnMetadata.type()));
   }
 

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldInputTypeCache.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldInputTypeCache.java
@@ -51,12 +51,12 @@ class FieldInputTypeCache extends FieldTypeCache<GraphQLInputType> {
 
   private GraphQLInputType computeUdt(UserDefinedType udt) {
     GraphQLInputObjectType.Builder builder =
-        GraphQLInputObjectType.newInputObject().name(nameMapping.getUdtNames().get(udt) + "Input");
+        GraphQLInputObjectType.newInputObject().name(nameMapping.getGraphqlName(udt) + "Input");
     for (Column column : udt.columns()) {
       try {
         builder.field(
             GraphQLInputObjectField.newInputObjectField()
-                .name(nameMapping.getFieldNames(udt).get(column))
+                .name(nameMapping.getGraphqlName(udt, column))
                 .type(get(column.type()))
                 .build());
       } catch (Exception e) {

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldOutputTypeCache.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldOutputTypeCache.java
@@ -51,12 +51,12 @@ class FieldOutputTypeCache extends FieldTypeCache<GraphQLOutputType> {
 
   private GraphQLOutputType computeUdt(UserDefinedType udt) {
     GraphQLObjectType.Builder builder =
-        GraphQLObjectType.newObject().name(nameMapping.getUdtNames().get(udt));
+        GraphQLObjectType.newObject().name(nameMapping.getGraphqlName(udt));
     for (Column column : udt.columns()) {
       try {
         builder.field(
             new GraphQLFieldDefinition.Builder()
-                .name(nameMapping.getFieldNames(udt).get(column))
+                .name(nameMapping.getGraphqlName(udt, column))
                 .type(get(column.type()))
                 .build());
       } catch (Exception e) {

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/fetchers/dml/DataTypeMapping.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/fetchers/dml/DataTypeMapping.java
@@ -121,9 +121,9 @@ class DataTypeMapping {
       } else {
         out.append(',');
       }
-      Column field = nameMapping.getFieldNames(type).inverse().get(entry.getKey());
-      Column.ColumnType fieldType = field.type();
-      out.append('"').append(field.name()).append("\":");
+      String fieldName = nameMapping.getCqlName(type, entry.getKey());
+      Column.ColumnType fieldType = type.fieldType(fieldName);
+      out.append('"').append(fieldName).append("\":");
       format(fieldType, entry.getValue(), nameMapping, out);
     }
     out.append('}');
@@ -136,8 +136,7 @@ class DataTypeMapping {
     for (Column column : columns) {
       if (!row.isNull(column.name())) {
         map.put(
-            nameMapping.getColumnNames(table).get(column),
-            toGraphQLValue(nameMapping, column, row));
+            nameMapping.getGraphqlName(table, column), toGraphQLValue(nameMapping, column, row));
       }
     }
     return map;
@@ -181,7 +180,7 @@ class DataTypeMapping {
       for (Column column : udt.columns()) {
         Object dbFieldValue = udtValue.getObject(CqlIdentifier.fromInternal(column.name()));
         if (dbFieldValue != null) {
-          String graphQlFieldName = nameMapping.getFieldNames(udt).get(column);
+          String graphQlFieldName = nameMapping.getGraphqlName(udt, column);
           Object graphQlFieldValue = toGraphQLValue(nameMapping, column.type(), dbFieldValue);
           result.put(graphQlFieldName, graphQlFieldValue);
         }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/fetchers/dml/DmlFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/fetchers/dml/DmlFetcher.java
@@ -172,7 +172,8 @@ public abstract class DmlFetcher<ResultT> extends CassandraFetcher<ResultT> {
   }
 
   protected Column getColumn(Table table, String fieldName) {
-    return nameMapping.getColumnNames(table).inverse().get(fieldName);
+    String columnName = nameMapping.getCqlName(table, fieldName);
+    return table.column(columnName);
   }
 
   protected Term toCqlTerm(Column column, Object value) {


### PR DESCRIPTION
There were corner cases where some types are frozen when we construct the name mapping, but not when we query (or vice-versa).

This also better encapsulates the logic in `NameMapping` behind specific methods, instead of exposing maps.