### PR TITLE
GraphQL: deserialize floating-point JSON values to BigDecimal

### DIFF
--- a/graphqlapi/src/main/java/graphql/kickstart/servlet/CustomGraphQLServlet.java
+++ b/graphqlapi/src/main/java/graphql/kickstart/servlet/CustomGraphQLServlet.java
@@ -15,6 +15,7 @@
  */
 package graphql.kickstart.servlet;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import graphql.execution.AsyncExecutionStrategy;
 import graphql.kickstart.execution.GraphQLObjectMapper;
 import graphql.kickstart.execution.GraphQLQueryInvoker;
@@ -218,6 +219,10 @@ public class CustomGraphQLServlet extends HttpServlet implements Servlet, EventL
             .with(
                 GraphQLObjectMapper.newBuilder()
                     .withGraphQLErrorHandler(new StargateGraphqlErrorHandler())
+                    .withObjectMapperConfigurer(
+                        mapper ->
+                            mapper.configure(
+                                DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true))
                     .build())
             .build();
     return new HttpRequestHandlerImpl(configuration);


### PR DESCRIPTION
When a query is parameterized and the variables are sent separately (e.g. "Query variables" tab in Playground web UI), the variables are in JSON format.

graphql-java-servlet uses Jackson to deserialize them. By default, the object mapper used deserializes floating-point literals to `Double`, this can lead to loss of precision issues.

We should only do the conversion until we know the target CQL type. It's ok to lose precision for `float` or `double`, but not for `decimal`.