### PR TITLE
Add consistency level to delete

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -531,7 +531,9 @@ public class DocumentDB {
   public void delete(
       String keyspace, String table, String key, List<String> pathToDelete, long microsSinceEpoch) {
 
-    getPrefixDeleteStatement(keyspace, table, key, microsSinceEpoch, pathToDelete).execute().join();
+    getPrefixDeleteStatement(keyspace, table, key, microsSinceEpoch, pathToDelete)
+        .execute(ConsistencyLevel.LOCAL_QUORUM)
+        .join();
   }
 
   public void deleteDeadLeaves(


### PR DESCRIPTION
Consistency level defaults to ONE, which is not usable in Astra.

This fixes a long-lived bug that no one has encountered because no one has yet to use DELETE hah