### PR TITLE
GraphQL: Surface conversion errors to the client (fixes #256)

### DIFF
--- a/graphqlapi/src/main/java/graphql/kickstart/servlet/CustomGraphQLServlet.java
+++ b/graphqlapi/src/main/java/graphql/kickstart/servlet/CustomGraphQLServlet.java
@@ -329,14 +329,15 @@ public class CustomGraphQLServlet extends HttpServlet implements Servlet, EventL
     HttpRequestHandler get() {
       // Double-checked locking
       HttpRequestHandlerImpl result = handler;
-      if (handler == null) {
-        synchronized (this) {
-          if (handler == null) {
-            handler = result = computeHandler();
-          }
-        }
+      if (result != null) {
+        return result;
       }
-      return result;
+      synchronized (this) {
+        if (handler == null) {
+          handler = computeHandler();
+        }
+        return handler;
+      }
     }
 
     private HttpRequestHandlerImpl computeHandler() {

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/DmlSchemaBuilder.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/DmlSchemaBuilder.java
@@ -489,8 +489,10 @@ class DmlSchemaBuilder {
 
   private void warn(Exception e, String format, Object... arguments) {
     String message = String.format(format, arguments);
-    warnings.add(message + "(" + e.getMessage() + ")");
-    LOG.warn(message, e);
+    warnings.add(message + " (" + e.getMessage() + ")");
+    if (!(e instanceof SchemaWarningException)) {
+      LOG.warn(message, e);
+    }
   }
 
   private static final GraphQLInputType MUTATION_OPTIONS =

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/DmlSchemaBuilder.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/DmlSchemaBuilder.java
@@ -321,8 +321,8 @@ class DmlSchemaBuilder {
         } catch (Exception e) {
           warnings.add(
               String.format(
-                  "Could not create filter input type for column %s.%s, skipping (%s)",
-                  column.table(), column.name(), e.getMessage()));
+                  "Could not create filter input type for column %s in table %s, skipping (%s)",
+                  column.name(), column.table(), e.getMessage()));
         }
       }
     }
@@ -407,8 +407,8 @@ class DmlSchemaBuilder {
         } catch (Exception e) {
           warnings.add(
               String.format(
-                  "Could not create input type for column %s.%s, skipping (%s)",
-                  columnMetadata.table(), columnMetadata.name(), e.getMessage()));
+                  "Could not create input type for column %s in table %s, skipping (%s)",
+                  columnMetadata.name(), columnMetadata.table(), e.getMessage()));
         }
       }
     }
@@ -454,8 +454,8 @@ class DmlSchemaBuilder {
         } catch (Exception e) {
           warnings.add(
               String.format(
-                  "Could not create output type for column %s.%s, skipping (%s)",
-                  columnMetadata.table(), columnMetadata.name(), e.getMessage()));
+                  "Could not create output type for column %s in table %s, skipping (%s)",
+                  columnMetadata.name(), columnMetadata.table(), e.getMessage()));
         }
       }
     }
@@ -465,12 +465,11 @@ class DmlSchemaBuilder {
 
   private GraphQLFieldDefinition buildWarnings() {
     StringBuilder description =
-        new StringBuilder(
-            "Warnings encountered during the translation of the backend schema into GraphQL.\n"
-                + "For convenience they are also listed below:");
+        new StringBuilder("Warnings encountered during the CQL to GraphQL conversion.");
     if (warnings.isEmpty()) {
-      description.append("\n<none>");
+      description.append("No warnings found, this will return an empty list.\n");
     } else {
+      description.append("\nThis will return:");
       for (String warning : warnings) {
         description.append("\n- ").append(warning);
       }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/DmlSchemaBuilder.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/DmlSchemaBuilder.java
@@ -381,8 +381,8 @@ class DmlSchemaBuilder {
   private GraphQLType buildOrderType(Table table) {
     GraphQLEnumType.Builder input =
         GraphQLEnumType.newEnum().name(nameMapping.getGraphqlName(table) + "Order");
-    for (Column columnMetadata : table.columns()) {
-      String graphqlName = nameMapping.getGraphqlName(table, columnMetadata);
+    for (Column column : table.columns()) {
+      String graphqlName = nameMapping.getGraphqlName(table, column);
       if (graphqlName != null) {
         input.value(graphqlName + "_DESC");
         input.value(graphqlName + "_ASC");
@@ -394,21 +394,21 @@ class DmlSchemaBuilder {
   private GraphQLType buildInputType(Table table) {
     GraphQLInputObjectType.Builder input =
         GraphQLInputObjectType.newInputObject().name(nameMapping.getGraphqlName(table) + "Input");
-    for (Column columnMetadata : table.columns()) {
-      String graphqlName = nameMapping.getGraphqlName(table, columnMetadata);
+    for (Column column : table.columns()) {
+      String graphqlName = nameMapping.getGraphqlName(table, column);
       if (graphqlName != null) {
         try {
           GraphQLInputObjectField field =
               GraphQLInputObjectField.newInputObjectField()
                   .name(graphqlName)
-                  .type(fieldInputTypes.get(columnMetadata.type()))
+                  .type(fieldInputTypes.get(column.type()))
                   .build();
           input.field(field);
         } catch (Exception e) {
           warnings.add(
               String.format(
                   "Could not create input type for column %s in table %s, skipping (%s)",
-                  columnMetadata.name(), columnMetadata.table(), e.getMessage()));
+                  column.name(), column.table(), e.getMessage()));
         }
       }
     }
@@ -442,20 +442,20 @@ class DmlSchemaBuilder {
   public GraphQLObjectType buildType(Table table) {
     GraphQLObjectType.Builder builder =
         GraphQLObjectType.newObject().name(nameMapping.getGraphqlName(table));
-    for (Column columnMetadata : table.columns()) {
-      String graphqlName = nameMapping.getGraphqlName(table, columnMetadata);
+    for (Column column : table.columns()) {
+      String graphqlName = nameMapping.getGraphqlName(table, column);
       if (graphqlName != null) {
         try {
           GraphQLFieldDefinition.Builder fieldBuilder =
               new GraphQLFieldDefinition.Builder()
                   .name(graphqlName)
-                  .type(fieldOutputTypes.get(columnMetadata.type()));
+                  .type(fieldOutputTypes.get(column.type()));
           builder.field(fieldBuilder.build());
         } catch (Exception e) {
           warnings.add(
               String.format(
                   "Could not create output type for column %s in table %s, skipping (%s)",
-                  columnMetadata.name(), columnMetadata.table(), e.getMessage()));
+                  column.name(), column.table(), e.getMessage()));
         }
       }
     }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/DmlSchemaBuilder.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/DmlSchemaBuilder.java
@@ -51,8 +51,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class DmlSchemaBuilder {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DmlSchemaBuilder.class);
 
   private final Persistence persistence;
   private final AuthenticationService authenticationService;
@@ -99,9 +103,7 @@ class DmlSchemaBuilder {
         tableQueryField = buildQuery(table);
         tableMutationFields = buildMutations(table);
       } catch (Exception e) {
-        warnings.add(
-            String.format(
-                "Could not convert table %s, skipping (%s)", table.name(), e.getMessage()));
+        warn(e, "Could not convert table %s, skipping", table.name());
         continue;
       }
 
@@ -319,10 +321,11 @@ class DmlSchemaBuilder {
                   .type(fieldFilterInputTypes.get(column.type()))
                   .build());
         } catch (Exception e) {
-          warnings.add(
-              String.format(
-                  "Could not create filter input type for column %s in table %s, skipping (%s)",
-                  column.name(), column.table(), e.getMessage()));
+          warn(
+              e,
+              "Could not create filter input type for column %s in table %s, skipping",
+              column.name(),
+              column.table());
         }
       }
     }
@@ -405,10 +408,11 @@ class DmlSchemaBuilder {
                   .build();
           input.field(field);
         } catch (Exception e) {
-          warnings.add(
-              String.format(
-                  "Could not create input type for column %s in table %s, skipping (%s)",
-                  column.name(), column.table(), e.getMessage()));
+          warn(
+              e,
+              "Could not create input type for column %s in table %s, skipping",
+              column.name(),
+              column.table());
         }
       }
     }
@@ -452,10 +456,11 @@ class DmlSchemaBuilder {
                   .type(fieldOutputTypes.get(column.type()));
           builder.field(fieldBuilder.build());
         } catch (Exception e) {
-          warnings.add(
-              String.format(
-                  "Could not create output type for column %s in table %s, skipping (%s)",
-                  column.name(), column.table(), e.getMessage()));
+          warn(
+              e,
+              "Could not create output type for column %s in table %s, skipping",
+              column.name(),
+              column.table());
         }
       }
     }
@@ -480,6 +485,12 @@ class DmlSchemaBuilder {
         .type(list(GraphQLString))
         .dataFetcher((d) -> warnings)
         .build();
+  }
+
+  private void warn(Exception e, String format, Object... arguments) {
+    String message = String.format(format, arguments);
+    warnings.add(message + "(" + e.getMessage() + ")");
+    LOG.warn(message, e);
   }
 
   private static final GraphQLInputType MUTATION_OPTIONS =

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldFilterInputTypeCache.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldFilterInputTypeCache.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.schema;
 
 import static graphql.schema.GraphQLList.list;

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldInputTypeCache.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldInputTypeCache.java
@@ -8,8 +8,7 @@ import graphql.schema.GraphQLType;
 import io.stargate.db.schema.Column;
 import io.stargate.db.schema.UserDefinedType;
 import io.stargate.graphql.schema.types.GqlMapBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.List;
 
 /**
  * Caches GraphQL field input types, for example 'String' in:
@@ -25,10 +24,11 @@ import org.slf4j.LoggerFactory;
  */
 class FieldInputTypeCache extends FieldTypeCache<GraphQLInputType> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(FieldInputTypeCache.class);
+  private final List<String> warnings;
 
-  FieldInputTypeCache(NameMapping nameMapping) {
+  FieldInputTypeCache(NameMapping nameMapping, List<String> warnings) {
     super(nameMapping);
+    this.warnings = warnings;
   }
 
   @Override
@@ -50,18 +50,31 @@ class FieldInputTypeCache extends FieldTypeCache<GraphQLInputType> {
   }
 
   private GraphQLInputType computeUdt(UserDefinedType udt) {
+    String graphqlName = nameMapping.getGraphqlName(udt);
+    if (graphqlName == null) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Could find a GraphQL name mapping for UDT %s, "
+                  + "this is probably because it clashes with another UDT",
+              udt.name()));
+    }
     GraphQLInputObjectType.Builder builder =
-        GraphQLInputObjectType.newInputObject().name(nameMapping.getGraphqlName(udt) + "Input");
+        GraphQLInputObjectType.newInputObject().name(graphqlName + "Input");
     for (Column column : udt.columns()) {
-      try {
-        builder.field(
-            GraphQLInputObjectField.newInputObjectField()
-                .name(nameMapping.getGraphqlName(udt, column))
-                .type(get(column.type()))
-                .build());
-      } catch (Exception e) {
-        // TODO find a better way to surface errors
-        LOG.error(String.format("Input type for %s could not be created", column.name()), e);
+      String graphqlFieldName = nameMapping.getGraphqlName(udt, column);
+      if (graphqlFieldName != null) {
+        try {
+          builder.field(
+              GraphQLInputObjectField.newInputObjectField()
+                  .name(graphqlFieldName)
+                  .type(get(column.type()))
+                  .build());
+        } catch (Exception e) {
+          warnings.add(
+              String.format(
+                  "Could not create input type for UDT field %s.%s, skipping (%s)",
+                  column.table(), column.name(), e.getMessage()));
+        }
       }
     }
     return builder.build();

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldInputTypeCache.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldInputTypeCache.java
@@ -72,8 +72,8 @@ class FieldInputTypeCache extends FieldTypeCache<GraphQLInputType> {
         } catch (Exception e) {
           warnings.add(
               String.format(
-                  "Could not create input type for UDT field %s.%s, skipping (%s)",
-                  column.table(), column.name(), e.getMessage()));
+                  "Could not create input type for field %s in UDT %s, skipping (%s)",
+                  column.name(), column.table(), e.getMessage()));
         }
       }
     }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldInputTypeCache.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldInputTypeCache.java
@@ -54,7 +54,7 @@ class FieldInputTypeCache extends FieldTypeCache<GraphQLInputType> {
     if (graphqlName == null) {
       throw new IllegalArgumentException(
           String.format(
-              "Could find a GraphQL name mapping for UDT %s, "
+              "Could not find a GraphQL name mapping for UDT %s, "
                   + "this is probably because it clashes with another UDT",
               udt.name()));
     }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldInputTypeCache.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldInputTypeCache.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.schema;
 
 import graphql.schema.GraphQLInputObjectField;
@@ -52,7 +67,7 @@ class FieldInputTypeCache extends FieldTypeCache<GraphQLInputType> {
   private GraphQLInputType computeUdt(UserDefinedType udt) {
     String graphqlName = nameMapping.getGraphqlName(udt);
     if (graphqlName == null) {
-      throw new IllegalArgumentException(
+      throw new SchemaWarningException(
           String.format(
               "Could not find a GraphQL name mapping for UDT %s, "
                   + "this is probably because it clashes with another UDT",

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldOutputTypeCache.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldOutputTypeCache.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.schema;
 
 import graphql.schema.GraphQLFieldDefinition;
@@ -52,7 +67,7 @@ class FieldOutputTypeCache extends FieldTypeCache<GraphQLOutputType> {
   private GraphQLOutputType computeUdt(UserDefinedType udt) {
     String graphqlName = nameMapping.getGraphqlName(udt);
     if (graphqlName == null) {
-      throw new IllegalArgumentException(
+      throw new SchemaWarningException(
           String.format(
               "Could not find a GraphQL name mapping for UDT %s, "
                   + "this is probably because it clashes with another UDT",

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldOutputTypeCache.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldOutputTypeCache.java
@@ -8,8 +8,7 @@ import graphql.schema.GraphQLType;
 import io.stargate.db.schema.Column;
 import io.stargate.db.schema.UserDefinedType;
 import io.stargate.graphql.schema.types.GqlMapBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.List;
 
 /**
  * Caches GraphQL field output types, for example 'String' in:
@@ -25,10 +24,11 @@ import org.slf4j.LoggerFactory;
  */
 class FieldOutputTypeCache extends FieldTypeCache<GraphQLOutputType> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(FieldOutputTypeCache.class);
+  private final List<String> warnings;
 
-  FieldOutputTypeCache(NameMapping nameMapping) {
+  FieldOutputTypeCache(NameMapping nameMapping, List<String> warnings) {
     super(nameMapping);
+    this.warnings = warnings;
   }
 
   @Override
@@ -50,18 +50,30 @@ class FieldOutputTypeCache extends FieldTypeCache<GraphQLOutputType> {
   }
 
   private GraphQLOutputType computeUdt(UserDefinedType udt) {
-    GraphQLObjectType.Builder builder =
-        GraphQLObjectType.newObject().name(nameMapping.getGraphqlName(udt));
+    String graphqlName = nameMapping.getGraphqlName(udt);
+    if (graphqlName == null) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Could find a GraphQL name mapping for UDT %s, "
+                  + "this is probably because it clashes with another UDT",
+              udt.name()));
+    }
+    GraphQLObjectType.Builder builder = GraphQLObjectType.newObject().name(graphqlName);
     for (Column column : udt.columns()) {
-      try {
-        builder.field(
-            new GraphQLFieldDefinition.Builder()
-                .name(nameMapping.getGraphqlName(udt, column))
-                .type(get(column.type()))
-                .build());
-      } catch (Exception e) {
-        // TODO find a better way to surface errors
-        LOG.error(String.format("Type for %s could not be created", column.name()), e);
+      String graphqlFieldName = nameMapping.getGraphqlName(udt, column);
+      if (graphqlFieldName != null) {
+        try {
+          builder.field(
+              new GraphQLFieldDefinition.Builder()
+                  .name(graphqlFieldName)
+                  .type(get(column.type()))
+                  .build());
+        } catch (Exception e) {
+          warnings.add(
+              String.format(
+                  "Could not create output type for UDT field %s.%s, skipping (%s)",
+                  column.table(), column.name(), e.getMessage()));
+        }
       }
     }
     return builder.build();

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldOutputTypeCache.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldOutputTypeCache.java
@@ -54,7 +54,7 @@ class FieldOutputTypeCache extends FieldTypeCache<GraphQLOutputType> {
     if (graphqlName == null) {
       throw new IllegalArgumentException(
           String.format(
-              "Could find a GraphQL name mapping for UDT %s, "
+              "Could not find a GraphQL name mapping for UDT %s, "
                   + "this is probably because it clashes with another UDT",
               udt.name()));
     }
@@ -71,8 +71,8 @@ class FieldOutputTypeCache extends FieldTypeCache<GraphQLOutputType> {
         } catch (Exception e) {
           warnings.add(
               String.format(
-                  "Could not create output type for UDT field %s.%s, skipping (%s)",
-                  column.table(), column.name(), e.getMessage()));
+                  "Could not create output type for field %s in UDT %s, skipping (%s)",
+                  column.name(), column.table(), e.getMessage()));
         }
       }
     }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldTypeCache.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/FieldTypeCache.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.schema;
 
 import graphql.Scalars;

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/NameMapping.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/NameMapping.java
@@ -48,7 +48,7 @@ public class NameMapping {
       if (clashingCqlName != null) {
         warnings.add(
             String.format(
-                "Can't convert table %s because its GraphQL name %s would collide with table %s",
+                "Couldn't convert table %s because its GraphQL name %s would collide with table %s",
                 table.name(), graphqlName, clashingCqlName));
       } else {
         entityNames.put(table.name(), graphqlName);
@@ -65,7 +65,7 @@ public class NameMapping {
       if (clashingCqlName != null) {
         warnings.add(
             String.format(
-                "Can't convert UDT %s because its GraphQL name %s would collide with UDT %s",
+                "Could not convert UDT %s because its GraphQL name %s would collide with UDT %s",
                 udt.name(), graphqlName, clashingCqlName));
       } else {
         udtNames.put(udt.name(), graphqlName);
@@ -82,7 +82,7 @@ public class NameMapping {
       if (clashingCqlName != null) {
         warnings.add(
             String.format(
-                "Can't convert column %s in table/UDT %s because its GraphQL name %s "
+                "Could not convert column %s in table/UDT %s because its GraphQL name %s "
                     + "would collide with column %s",
                 column.name(), column.table(), graphqlName, clashingCqlName));
       } else {

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/NameMapping.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/NameMapping.java
@@ -82,8 +82,9 @@ public class NameMapping {
       if (clashingCqlName != null) {
         warnings.add(
             String.format(
-                "Can't convert column %s.%s because its GraphQL name %s would collide with column %s",
-                column.table(), column.name(), graphqlName, clashingCqlName));
+                "Can't convert column %s in table/UDT %s because its GraphQL name %s "
+                    + "would collide with column %s",
+                column.name(), column.table(), graphqlName, clashingCqlName));
       } else {
         map.put(column.name(), graphqlName);
       }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/SchemaFactory.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/SchemaFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.graphql.schema;
 
 import graphql.schema.GraphQLSchema;

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/SchemaWarningException.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/SchemaWarningException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.graphql.schema;
+
+/**
+ * When a warning occurs deep in the schema conversion logic, it's sometimes easier to throw an
+ * exception to interrupt the flow. We use that type to signal that the top-level code doesn't need
+ * to log the stack trace.
+ */
+public class SchemaWarningException extends RuntimeException {
+  public SchemaWarningException(String message) {
+    super(message);
+  }
+}

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/fetchers/dml/DataTypeMapping.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/fetchers/dml/DataTypeMapping.java
@@ -134,9 +134,9 @@ class DataTypeMapping {
     List<Column> columns = row.columns();
     Map<String, Object> map = new HashMap<>(columns.size());
     for (Column column : columns) {
-      if (!row.isNull(column.name())) {
-        map.put(
-            nameMapping.getGraphqlName(table, column), toGraphQLValue(nameMapping, column, row));
+      String graphqlName = nameMapping.getGraphqlName(table, column);
+      if (graphqlName != null && !row.isNull(column.name())) {
+        map.put(graphqlName, toGraphQLValue(nameMapping, column, row));
       }
     }
     return map;
@@ -179,8 +179,8 @@ class DataTypeMapping {
       Map<String, Object> result = new HashMap<>(udt.columns().size());
       for (Column column : udt.columns()) {
         Object dbFieldValue = udtValue.getObject(CqlIdentifier.fromInternal(column.name()));
-        if (dbFieldValue != null) {
-          String graphQlFieldName = nameMapping.getGraphqlName(udt, column);
+        String graphQlFieldName = nameMapping.getGraphqlName(udt, column);
+        if (dbFieldValue != null && graphQlFieldName != null) {
           Object graphQlFieldValue = toGraphQLValue(nameMapping, column.type(), dbFieldValue);
           result.put(graphQlFieldName, graphQlFieldValue);
         }

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/FieldFilterInputTypeCacheTest.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/FieldFilterInputTypeCacheTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import graphql.schema.GraphQLInputObjectType;
 import io.stargate.db.schema.Column;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,10 +18,11 @@ public class FieldFilterInputTypeCacheTest {
 
   @Mock private NameMapping nameMapping;
   private FieldFilterInputTypeCache fieldFilterInputTypes;
+  private List<String> warnings = new ArrayList<>();
 
   @BeforeEach
   public void setup() {
-    FieldInputTypeCache fieldInputTypes = new FieldInputTypeCache(nameMapping);
+    FieldInputTypeCache fieldInputTypes = new FieldInputTypeCache(nameMapping, warnings);
     fieldFilterInputTypes = new FieldFilterInputTypeCache(fieldInputTypes, nameMapping);
   }
 

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/FieldTypeCachesTest.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/FieldTypeCachesTest.java
@@ -18,6 +18,7 @@ import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchemaElement;
 import graphql.schema.GraphQLType;
 import io.stargate.db.schema.Column;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -36,10 +37,12 @@ public class FieldTypeCachesTest {
   private FieldInputTypeCache fieldInputTypes;
   private FieldOutputTypeCache fieldOutputTypes;
 
+  private List<String> warnings = new ArrayList<>();
+
   @BeforeEach
   public void setup() {
-    fieldInputTypes = new FieldInputTypeCache(nameMapping);
-    fieldOutputTypes = new FieldOutputTypeCache(nameMapping);
+    fieldInputTypes = new FieldInputTypeCache(nameMapping, warnings);
+    fieldOutputTypes = new FieldOutputTypeCache(nameMapping, warnings);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Expected or unexpected errors can happen when we convert the CQL data model into a GraphQL schema. Up to this point, those errors are logged on the server. The user who manages the data model won't necessarily have access to those logs.

The goal of this PR is to surface them in the GraphQL schema. The best way I've found is to add a special `__conversionWarnings` query. I also added a comment on this query with all the warnings, because it might be convenient to have them in `schema.graphql` without having to execute a query (and I think there won't be a lot of warnings in general).

Example scenarios that produce warnings:
* tuple columns (not implemented yet): `create table foo(k int primary key, t tuple<int,text>)`
* name clash between two tables: `create table foo_bar(k int primary key); create table "fooBar"(k int primary key)`
* name clash between two columns within the same table: `create table foo(k int primary key, a int, "A" text)`

How it looks in the schema definition:
```
type Query {
  [...]
  # Warnings encountered during the translation of the backend schema into GraphQL.
  # For convenience they are also listed below:
  # - Can't convert column foo.a because its GraphQL name a would collide with column A
  __conversionWarnings: [String]
}
```
How it looks as a query:
```
query {
  __conversionWarnings
}
```
Result:
```
{
  "data": {
    "__conversionWarnings": [
      "Can't convert column foo.a because its GraphQL name a would collide with column A"
    ]
  }
}
```