### PR TITLE
Add basic support for URL-encoded forms in Documents API

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -87,6 +87,14 @@ public class DocumentDB {
     return forbiddenCharacters.stream().anyMatch(ch -> x.indexOf(ch) >= 0);
   }
 
+  public static String replaceIllegalChars(String x) {
+    String newStr = x;
+    for (Character y : forbiddenCharacters) {
+      newStr.replace(y, '_');
+    }
+    return newStr;
+  }
+
   public static List<Column> allColumns() {
     List<Column> allColumns = new ArrayList<>(allColumnNames.size());
     for (int i = 0; i < allColumnNames.size(); i++) {

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
@@ -102,6 +102,7 @@ public class DocumentResourceV2 {
     String newId = UUID.randomUUID().toString();
     return handle(
         () -> {
+          boolean isJson = headers.getHeaderString(HttpHeaders.CONTENT_TYPE).toLowerCase().contains("application/json");
           documentService.putAtPath(
               authToken,
               namespace,
@@ -110,7 +111,8 @@ public class DocumentResourceV2 {
               payload,
               new ArrayList<>(),
               false,
-              dbFactory);
+              dbFactory,
+              isJson);
 
           return Response.created(
                   URI.create(
@@ -154,8 +156,9 @@ public class DocumentResourceV2 {
     logger.debug("Put: Collection = {}, id = {}", collection, id);
     return handle(
         () -> {
+          boolean isJson = headers.getHeaderString(HttpHeaders.CONTENT_TYPE).toLowerCase().contains("application/json");
           documentService.putAtPath(
-              authToken, namespace, collection, id, payload, new ArrayList<>(), false, dbFactory);
+              authToken, namespace, collection, id, payload, new ArrayList<>(), false, dbFactory, isJson);
           return Response.ok()
               .entity(mapper.writeValueAsString(new DocumentResponseWrapper<>(id, null, null)))
               .build();
@@ -200,8 +203,9 @@ public class DocumentResourceV2 {
     logger.debug("Put: Collection = {}, id = {}, path = {}", collection, id, path);
     return handle(
         () -> {
+          boolean isJson = headers.getHeaderString(HttpHeaders.CONTENT_TYPE).toLowerCase().contains("application/json");
           documentService.putAtPath(
-              authToken, namespace, collection, id, payload, path, false, dbFactory);
+              authToken, namespace, collection, id, payload, path, false, dbFactory, isJson);
           return Response.ok()
               .entity(mapper.writeValueAsString(new DocumentResponseWrapper<>(id, null, null)))
               .build();
@@ -243,8 +247,9 @@ public class DocumentResourceV2 {
     logger.debug("Patch: Collection = {}, id = {}", collection, id);
     return handle(
         () -> {
+          boolean isJson = headers.getHeaderString(HttpHeaders.CONTENT_TYPE).toLowerCase().contains("application/json");
           documentService.putAtPath(
-              authToken, namespace, collection, id, payload, new ArrayList<>(), true, dbFactory);
+              authToken, namespace, collection, id, payload, new ArrayList<>(), true, dbFactory, isJson);
           return Response.ok()
               .entity(mapper.writeValueAsString(new DocumentResponseWrapper<>(id, null, null)))
               .build();
@@ -290,8 +295,9 @@ public class DocumentResourceV2 {
     logger.debug("Patch: Collection = {}, id = {}, path = {}", collection, id, path);
     return handle(
         () -> {
-          documentService.putAtPath(
-              authToken, namespace, collection, id, payload, path, true, dbFactory);
+            boolean isJson = headers.getHeaderString(HttpHeaders.CONTENT_TYPE).toLowerCase().contains("application/json");
+            documentService.putAtPath(
+              authToken, namespace, collection, id, payload, path, true, dbFactory, isJson);
           return Response.ok()
               .entity(mapper.writeValueAsString(new DocumentResponseWrapper<>(id, null, null)))
               .build();

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
@@ -102,7 +102,11 @@ public class DocumentResourceV2 {
     String newId = UUID.randomUUID().toString();
     return handle(
         () -> {
-          boolean isJson = headers.getHeaderString(HttpHeaders.CONTENT_TYPE).toLowerCase().contains("application/json");
+          boolean isJson =
+              headers
+                  .getHeaderString(HttpHeaders.CONTENT_TYPE)
+                  .toLowerCase()
+                  .contains("application/json");
           documentService.putAtPath(
               authToken,
               namespace,
@@ -156,9 +160,21 @@ public class DocumentResourceV2 {
     logger.debug("Put: Collection = {}, id = {}", collection, id);
     return handle(
         () -> {
-          boolean isJson = headers.getHeaderString(HttpHeaders.CONTENT_TYPE).toLowerCase().contains("application/json");
+          boolean isJson =
+              headers
+                  .getHeaderString(HttpHeaders.CONTENT_TYPE)
+                  .toLowerCase()
+                  .contains("application/json");
           documentService.putAtPath(
-              authToken, namespace, collection, id, payload, new ArrayList<>(), false, dbFactory, isJson);
+              authToken,
+              namespace,
+              collection,
+              id,
+              payload,
+              new ArrayList<>(),
+              false,
+              dbFactory,
+              isJson);
           return Response.ok()
               .entity(mapper.writeValueAsString(new DocumentResponseWrapper<>(id, null, null)))
               .build();
@@ -203,7 +219,11 @@ public class DocumentResourceV2 {
     logger.debug("Put: Collection = {}, id = {}, path = {}", collection, id, path);
     return handle(
         () -> {
-          boolean isJson = headers.getHeaderString(HttpHeaders.CONTENT_TYPE).toLowerCase().contains("application/json");
+          boolean isJson =
+              headers
+                  .getHeaderString(HttpHeaders.CONTENT_TYPE)
+                  .toLowerCase()
+                  .contains("application/json");
           documentService.putAtPath(
               authToken, namespace, collection, id, payload, path, false, dbFactory, isJson);
           return Response.ok()
@@ -247,9 +267,21 @@ public class DocumentResourceV2 {
     logger.debug("Patch: Collection = {}, id = {}", collection, id);
     return handle(
         () -> {
-          boolean isJson = headers.getHeaderString(HttpHeaders.CONTENT_TYPE).toLowerCase().contains("application/json");
+          boolean isJson =
+              headers
+                  .getHeaderString(HttpHeaders.CONTENT_TYPE)
+                  .toLowerCase()
+                  .contains("application/json");
           documentService.putAtPath(
-              authToken, namespace, collection, id, payload, new ArrayList<>(), true, dbFactory, isJson);
+              authToken,
+              namespace,
+              collection,
+              id,
+              payload,
+              new ArrayList<>(),
+              true,
+              dbFactory,
+              isJson);
           return Response.ok()
               .entity(mapper.writeValueAsString(new DocumentResponseWrapper<>(id, null, null)))
               .build();
@@ -295,8 +327,12 @@ public class DocumentResourceV2 {
     logger.debug("Patch: Collection = {}, id = {}, path = {}", collection, id, path);
     return handle(
         () -> {
-            boolean isJson = headers.getHeaderString(HttpHeaders.CONTENT_TYPE).toLowerCase().contains("application/json");
-            documentService.putAtPath(
+          boolean isJson =
+              headers
+                  .getHeaderString(HttpHeaders.CONTENT_TYPE)
+                  .toLowerCase()
+                  .contains("application/json");
+          documentService.putAtPath(
               authToken, namespace, collection, id, payload, path, true, dbFactory, isJson);
           return Response.ok()
               .entity(mapper.writeValueAsString(new DocumentResponseWrapper<>(id, null, null)))

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
@@ -79,7 +79,7 @@ public class DocumentResourceV2 {
         @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
       })
   @Path("collections/{collection-id}")
-  @Consumes("application/json")
+  @Consumes("application/json, application/x-www-form-urlencoded")
   @Produces("application/json")
   public Response postDoc(
       @Context HttpHeaders headers,
@@ -132,7 +132,7 @@ public class DocumentResourceV2 {
         @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
       })
   @Path("collections/{collection-id}/{document-id}")
-  @Consumes("application/json")
+  @Consumes("application/json, application/x-www-form-urlencoded")
   @Produces("application/json")
   public Response putDoc(
       @Context HttpHeaders headers,
@@ -175,7 +175,7 @@ public class DocumentResourceV2 {
         @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
       })
   @Path("collections/{collection-id}/{document-id}/{document-path: .*}")
-  @Consumes("application/json")
+  @Consumes("application/json, application/x-www-form-urlencoded")
   @Produces("application/json")
   public Response putDocPath(
       @Context HttpHeaders headers,
@@ -221,7 +221,7 @@ public class DocumentResourceV2 {
         @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
       })
   @Path("collections/{collection-id}/{document-id}")
-  @Consumes("application/json")
+  @Consumes("application/json, application/x-www-form-urlencoded")
   @Produces("application/json")
   public Response patchDoc(
       @Context HttpHeaders headers,
@@ -265,7 +265,7 @@ public class DocumentResourceV2 {
         @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
       })
   @Path("collections/{collection-id}/{document-id}/{document-path: .*}")
-  @Consumes("application/json")
+  @Consumes("application/json, application/x-www-form-urlencoded")
   @Produces("application/json")
   public Response patchDocPath(
       @Context HttpHeaders headers,

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -112,7 +112,8 @@ public class DocumentService {
    * @param payload a JSON object, or a URL-encoded form with the relevant data in it
    * @param patching If this payload meant to be part of a PATCH request (this causes a small amount
    *     of extra validation if true)
-   * @param isJson if the request had a content type of application/json, else it will be interpreted as a URL encoded form
+   * @param isJson if the request had a content type of application/json, else it will be
+   *     interpreted as a URL encoded form
    * @return The full bind variable list for the subsequent inserts, and all first-level keys, as an
    *     ImmutablePair.
    */
@@ -335,10 +336,11 @@ public class DocumentService {
           bindMap.put("dbl_value", doubleValue);
           bindMap.put("bool_value", null);
           bindMap.put("text_value", null);
+        } else {
+          bindMap.put("dbl_value", null);
+          bindMap.put("bool_value", null);
+          bindMap.put("text_value", value);
         }
-        bindMap.put("dbl_value", null);
-        bindMap.put("bool_value", null);
-        bindMap.put("text_value", value);
       }
       logger.debug("{}", bindMap.values());
       bindVariableList.add(bindMap.values().toArray());

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -21,6 +21,8 @@ import io.stargate.web.docsapi.service.filter.FilterOp;
 import io.stargate.web.docsapi.service.filter.ListFilterCondition;
 import io.stargate.web.docsapi.service.filter.SingleFilterCondition;
 import io.stargate.web.resources.Db;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -109,7 +111,7 @@ public class DocumentService {
    * @param path The path within the document that is being written to. If empty, writes to the root
    *     of the document.
    * @param key The name of the document that will be written
-   * @param payload a JSON object
+   * @param payload a JSON object, or a URL-encoded form with the relevant data in it
    * @param patching If this payload meant to be part of a PATCH request (this causes a small amount
    *     of extra validation if true)
    * @return The full bind variable list for the subsequent inserts, and all first-level keys, as an
@@ -121,9 +123,27 @@ public class DocumentService {
       List<String> path,
       String key,
       String payload,
+      boolean patching)
+      throws UnsupportedEncodingException {
+    String trimmed = payload.trim();
+    boolean isJson = trimmed.startsWith("{") || trimmed.startsWith("[");
+    if (isJson) {
+      return shredJson(surfer, db, path, key, trimmed, patching);
+    } else {
+      return shredForm(db, path, key, trimmed, patching);
+    }
+  }
+
+  private ImmutablePair<List<Object[]>, List<String>> shredJson(
+      JsonSurfer surfer,
+      DocumentDB db,
+      List<String> path,
+      String key,
+      String jsonPayload,
       boolean patching) {
     List<Object[]> bindVariableList = new ArrayList<>();
     List<String> firstLevelKeys = new ArrayList<>();
+
     surfer
         .configBuilder()
         .bind(
@@ -227,7 +247,109 @@ public class DocumentService {
               }
             })
         .withErrorStrategy(new DocumentAPIErrorHandlingStrategy())
-        .buildAndSurf(payload);
+        .buildAndSurf(jsonPayload);
+    return ImmutablePair.of(bindVariableList, firstLevelKeys);
+  }
+
+  private ImmutablePair<List<Object[]>, List<String>> shredForm(
+      DocumentDB db, List<String> path, String key, String formPayload, boolean patching)
+      throws UnsupportedEncodingException {
+    List<Object[]> bindVariableList = new ArrayList<>();
+    List<String> firstLevelKeys = new ArrayList<>();
+    String[] pairs = formPayload.split("&");
+    for (String pair : pairs) {
+      String[] data = pair.split("=");
+      if (data.length != 2) {
+        continue;
+      }
+      String fullyQualifiedField = data[0];
+      String value = URLDecoder.decode(data[1], "UTF-8");
+      String[] fieldNames = fullyQualifiedField.split("\\.");
+      for (int i = 0; i < fieldNames.length; i++) {
+        fieldNames[i] = URLDecoder.decode(fieldNames[i], "UTF-8");
+      }
+
+      if (path.size() + fieldNames.length > DocumentDB.MAX_DEPTH) {
+        throw new DocumentAPIRequestException(
+            String.format("Max depth of %s exceeded", DocumentDB.MAX_DEPTH));
+      }
+
+      Map<String, Object> bindMap = db.newBindMap(path);
+      bindMap.put("key", key);
+
+      String leaf = null;
+      for (int i = 0; i < fieldNames.length; i++) {
+        String fieldName = fieldNames[i];
+        boolean isArrayElement = fieldName.startsWith("[");
+        if (isArrayElement) {
+          if (i == 0 && patching) {
+            throw new DocumentAPIRequestException(
+                "A patch operation must be done with a JSON object, not an array.");
+          }
+
+          String innerPath = fieldName.substring(1, fieldName.length() - 1);
+          if (DocumentDB.containsIllegalChars(innerPath)) {
+            throw new DocumentAPIRequestException(
+                String.format(
+                    "The characters %s are not permitted in JSON field names, invalid field %s",
+                    DocumentDB.getForbiddenCharactersMessage(), fieldNames[i]));
+          }
+
+          int idx = Integer.parseInt(innerPath);
+          if (idx > DocumentDB.MAX_ARRAY_LENGTH - 1) {
+            throw new DocumentAPIRequestException(
+                String.format("Max array length of %s exceeded.", DocumentDB.MAX_ARRAY_LENGTH));
+          }
+
+          // left-pad the array element to 6 characters
+          fieldName = "[" + leftPadTo6(innerPath) + "]";
+        } else if (i == 0) {
+          firstLevelKeys.add(fieldName);
+        }
+
+        if (!isArrayElement) {
+          if (DocumentDB.containsIllegalChars(fieldName)) {
+            throw new DocumentAPIRequestException(
+                String.format(
+                    "The characters %s are not permitted in JSON field names, invalid field %s",
+                    DocumentDB.getForbiddenCharactersMessage(), fieldName));
+          }
+        }
+
+        bindMap.put("p" + (i + path.size()), fieldName);
+        leaf = fieldName;
+      }
+      bindMap.put("leaf", leaf);
+
+      if (value.equals("null")) {
+        bindMap.put("dbl_value", null);
+        bindMap.put("bool_value", null);
+        bindMap.put("text_value", null);
+      } else if (value.equals("true") || value.equals("false")) {
+        bindMap.put("dbl_value", null);
+        bindMap.put("bool_value", Boolean.parseBoolean(value));
+        bindMap.put("text_value", null);
+      } else {
+        boolean isNumber;
+        Double doubleValue = null;
+        try {
+          doubleValue = Double.parseDouble(value);
+          isNumber = true;
+        } catch (NumberFormatException e) {
+          isNumber = false;
+        }
+        if (isNumber) {
+          bindMap.put("dbl_value", doubleValue);
+          bindMap.put("bool_value", null);
+          bindMap.put("text_value", null);
+        }
+        bindMap.put("dbl_value", null);
+        bindMap.put("bool_value", null);
+        bindMap.put("text_value", value);
+      }
+      logger.debug("{}", bindMap.values());
+      bindVariableList.add(bindMap.values().toArray());
+    }
     return ImmutablePair.of(bindVariableList, firstLevelKeys);
   }
 
@@ -240,7 +362,7 @@ public class DocumentService {
       List<PathSegment> path,
       boolean patching,
       Db dbFactory)
-      throws UnauthorizedException {
+      throws UnauthorizedException, UnsupportedEncodingException {
     DocumentDB db = dbFactory.getDocDataStoreForToken(authToken);
 
     JsonSurfer surfer = JsonSurferGson.INSTANCE;

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -112,6 +112,7 @@ public class DocumentService {
    * @param payload a JSON object, or a URL-encoded form with the relevant data in it
    * @param patching If this payload meant to be part of a PATCH request (this causes a small amount
    *     of extra validation if true)
+   * @param isJson if the request had a content type of application/json, else it will be interpreted as a URL encoded form
    * @return The full bind variable list for the subsequent inserts, and all first-level keys, as an
    *     ImmutablePair.
    */
@@ -121,9 +122,9 @@ public class DocumentService {
       List<String> path,
       String key,
       String payload,
-      boolean patching) {
+      boolean patching,
+      boolean isJson) {
     String trimmed = payload.trim();
-    boolean isJson = trimmed.startsWith("{") || trimmed.startsWith("[");
     if (isJson) {
       return shredJson(surfer, db, path, key, trimmed, patching);
     } else {
@@ -353,7 +354,8 @@ public class DocumentService {
       String payload,
       List<PathSegment> path,
       boolean patching,
-      Db dbFactory)
+      Db dbFactory,
+      boolean isJson)
       throws UnauthorizedException {
     DocumentDB db = dbFactory.getDocDataStoreForToken(authToken);
 
@@ -375,7 +377,7 @@ public class DocumentService {
     }
 
     ImmutablePair<List<Object[]>, List<String>> shreddingResults =
-        shredPayload(surfer, db, convertedPath, id, payload, patching);
+        shredPayload(surfer, db, convertedPath, id, payload, patching, isJson);
 
     List<Object[]> bindVariableList = shreddingResults.left;
     List<String> firstLevelKeys = shreddingResults.right;

--- a/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
@@ -39,8 +39,6 @@ public class DocumentResourceV2Test {
   private DocumentService documentServiceMock = mock(DocumentService.class);
   private Db dbFactoryMock = mock(Db.class);
   private DocumentResourceV2 documentResourceV2;
-  private Method wrapResponseId;
-  private Method wrapResponseIdPageState;
 
   @Before
   public void setup() {
@@ -52,6 +50,7 @@ public class DocumentResourceV2Test {
   @Test
   public void postDoc_success() throws JsonProcessingException {
     HttpHeaders headers = mock(HttpHeaders.class);
+    when(headers.getHeaderString(anyString())).thenReturn("application/json");
     UriInfo ui = mock(UriInfo.class);
     String authToken = "auth_token";
     String keyspace = "keyspace";
@@ -67,6 +66,7 @@ public class DocumentResourceV2Test {
   @Test
   public void putDoc_success() throws UnauthorizedException, JsonProcessingException {
     HttpHeaders headers = mock(HttpHeaders.class);
+    when(headers.getHeaderString(anyString())).thenReturn("application/json");
     UriInfo ui = mock(UriInfo.class);
     String authToken = "auth_token";
     String keyspace = "keyspace";
@@ -84,6 +84,7 @@ public class DocumentResourceV2Test {
   @Test
   public void putDocPath() throws JsonProcessingException {
     HttpHeaders headers = mock(HttpHeaders.class);
+    when(headers.getHeaderString(anyString())).thenReturn("application/json");
     UriInfo ui = mock(UriInfo.class);
     String authToken = "auth_token";
     String keyspace = "keyspace";
@@ -104,6 +105,7 @@ public class DocumentResourceV2Test {
   @Test
   public void patchDoc() throws JsonProcessingException {
     HttpHeaders headers = mock(HttpHeaders.class);
+    when(headers.getHeaderString(anyString())).thenReturn("application/json");
     UriInfo ui = mock(UriInfo.class);
     String authToken = "auth_token";
     String keyspace = "keyspace";
@@ -122,6 +124,7 @@ public class DocumentResourceV2Test {
   @Test
   public void patchDocPath() throws JsonProcessingException {
     HttpHeaders headers = mock(HttpHeaders.class);
+    when(headers.getHeaderString(anyString())).thenReturn("application/json");
     UriInfo ui = mock(UriInfo.class);
     String authToken = "auth_token";
     String keyspace = "keyspace";

--- a/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
@@ -15,7 +15,6 @@ import io.stargate.web.docsapi.service.DocumentService;
 import io.stargate.web.docsapi.service.filter.FilterCondition;
 import io.stargate.web.docsapi.service.filter.SingleFilterCondition;
 import io.stargate.web.resources.Db;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -29,7 +29,6 @@ import io.stargate.web.docsapi.service.filter.FilterCondition;
 import io.stargate.web.docsapi.service.filter.ListFilterCondition;
 import io.stargate.web.docsapi.service.filter.SingleFilterCondition;
 import io.stargate.web.resources.Db;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
@@ -894,7 +893,7 @@ public class DocumentServiceTest {
   }
 
   @Test
-  public void putAtPath() throws UnauthorizedException, UnsupportedEncodingException {
+  public void putAtPath() throws UnauthorizedException {
     DocumentDB dbMock = mock(DocumentDB.class);
     Db dbFactoryMock = mock(Db.class);
     when(dbFactoryMock.getDocDataStoreForToken(anyString())).thenReturn(dbMock);
@@ -925,7 +924,7 @@ public class DocumentServiceTest {
   }
 
   @Test
-  public void putAtPath_patching() throws UnauthorizedException, UnsupportedEncodingException {
+  public void putAtPath_patching() throws UnauthorizedException {
     DocumentDB dbMock = mock(DocumentDB.class);
     Db dbFactoryMock = mock(Db.class);
     when(dbFactoryMock.getDocDataStoreForToken(anyString())).thenReturn(dbMock);

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -92,7 +92,8 @@ public class DocumentServiceTest {
             List.class,
             String.class,
             String.class,
-            boolean.class, boolean.class);
+            boolean.class,
+            boolean.class);
     shredPayload.setAccessible(true);
     validateOpAndValue =
         DocumentService.class.getDeclaredMethod(
@@ -908,7 +909,7 @@ public class DocumentServiceTest {
         new ArrayList<>(),
         false,
         dbFactoryMock,
-            true);
+        true);
 
     verify(dbMock, times(1))
         .deleteThenInsertBatch(
@@ -939,7 +940,8 @@ public class DocumentServiceTest {
         "{\"some\": \"data\"}",
         new ArrayList<>(),
         true,
-        dbFactoryMock, true);
+        dbFactoryMock,
+        true);
 
     verify(dbMock, times(0))
         .deleteThenInsertBatch(
@@ -973,7 +975,8 @@ public class DocumentServiceTest {
                     "\"a\"",
                     new ArrayList<>(),
                     true,
-                    dbFactoryMock, true));
+                    dbFactoryMock,
+                    true));
 
     assertThat(thrown)
         .isInstanceOf(DocumentAPIRequestException.class)

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -92,7 +92,7 @@ public class DocumentServiceTest {
             List.class,
             String.class,
             String.class,
-            boolean.class);
+            boolean.class, boolean.class);
     shredPayload.setAccessible(true);
     validateOpAndValue =
         DocumentService.class.getDeclaredMethod(
@@ -287,7 +287,7 @@ public class DocumentServiceTest {
     ImmutablePair<List<Object[]>, List<String>> shredResult =
         (ImmutablePair<List<Object[]>, List<String>>)
             shredPayload.invoke(
-                service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, false);
+                service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, false, true);
     List<Object[]> bindVariables = shredResult.left;
     List<String> topLevelKeys = shredResult.right;
     assertThat(bindVariables.size()).isEqualTo(1);
@@ -383,7 +383,7 @@ public class DocumentServiceTest {
     ImmutablePair<List<Object[]>, List<String>> shredResult =
         (ImmutablePair<List<Object[]>, List<String>>)
             shredPayload.invoke(
-                service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, false);
+                service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, false, true);
     List<Object[]> bindVariables = shredResult.left;
     List<String> topLevelKeys = shredResult.right;
     assertThat(bindVariables.size()).isEqualTo(1);
@@ -479,7 +479,7 @@ public class DocumentServiceTest {
     ImmutablePair<List<Object[]>, List<String>> shredResult =
         (ImmutablePair<List<Object[]>, List<String>>)
             shredPayload.invoke(
-                service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, false);
+                service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, false, true);
     List<Object[]> bindVariables = shredResult.left;
     List<String> topLevelKeys = shredResult.right;
     assertThat(bindVariables.size()).isEqualTo(1);
@@ -576,7 +576,7 @@ public class DocumentServiceTest {
     ImmutablePair<List<Object[]>, List<String>> shredResult =
         (ImmutablePair<List<Object[]>, List<String>>)
             shredPayload.invoke(
-                service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, false);
+                service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, false, true);
     List<Object[]> bindVariables = shredResult.left;
     List<String> topLevelKeys = shredResult.right;
     assertThat(bindVariables.size()).isEqualTo(1);
@@ -673,7 +673,7 @@ public class DocumentServiceTest {
     ImmutablePair<List<Object[]>, List<String>> shredResult =
         (ImmutablePair<List<Object[]>, List<String>>)
             shredPayload.invoke(
-                service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, false);
+                service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, false, true);
     List<Object[]> bindVariables = shredResult.left;
     List<String> topLevelKeys = shredResult.right;
     assertThat(bindVariables.size()).isEqualTo(1);
@@ -769,7 +769,7 @@ public class DocumentServiceTest {
     ImmutablePair<List<Object[]>, List<String>> shredResult =
         (ImmutablePair<List<Object[]>, List<String>>)
             shredPayload.invoke(
-                service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, false);
+                service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, false, true);
     List<Object[]> bindVariables = shredResult.left;
     List<String> topLevelKeys = shredResult.right;
     assertThat(bindVariables.size()).isEqualTo(1);
@@ -866,7 +866,7 @@ public class DocumentServiceTest {
         catchThrowable(
             () ->
                 shredPayload.invoke(
-                    service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, false));
+                    service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, false, true));
     assertThat(thrown.getCause())
         .isInstanceOf(DocumentAPIRequestException.class)
         .hasMessageContaining("are not permitted in JSON field names, invalid field coo]");
@@ -885,7 +885,7 @@ public class DocumentServiceTest {
         catchThrowable(
             () ->
                 shredPayload.invoke(
-                    service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, true));
+                    service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, true, true));
     assertThat(thrown.getCause())
         .isInstanceOf(DocumentAPIRequestException.class)
         .hasMessageContaining("A patch operation must be done with a JSON object, not an array.");
@@ -907,7 +907,8 @@ public class DocumentServiceTest {
         "{\"some\": \"data\"}",
         new ArrayList<>(),
         false,
-        dbFactoryMock);
+        dbFactoryMock,
+            true);
 
     verify(dbMock, times(1))
         .deleteThenInsertBatch(
@@ -938,7 +939,7 @@ public class DocumentServiceTest {
         "{\"some\": \"data\"}",
         new ArrayList<>(),
         true,
-        dbFactoryMock);
+        dbFactoryMock, true);
 
     verify(dbMock, times(0))
         .deleteThenInsertBatch(
@@ -972,7 +973,7 @@ public class DocumentServiceTest {
                     "\"a\"",
                     new ArrayList<>(),
                     true,
-                    dbFactoryMock));
+                    dbFactoryMock, true));
 
     assertThat(thrown)
         .isInstanceOf(DocumentAPIRequestException.class)

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -29,6 +29,7 @@ import io.stargate.web.docsapi.service.filter.FilterCondition;
 import io.stargate.web.docsapi.service.filter.ListFilterCondition;
 import io.stargate.web.docsapi.service.filter.SingleFilterCondition;
 import io.stargate.web.resources.Db;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
@@ -893,7 +894,7 @@ public class DocumentServiceTest {
   }
 
   @Test
-  public void putAtPath() throws UnauthorizedException {
+  public void putAtPath() throws UnauthorizedException, UnsupportedEncodingException {
     DocumentDB dbMock = mock(DocumentDB.class);
     Db dbFactoryMock = mock(Db.class);
     when(dbFactoryMock.getDocDataStoreForToken(anyString())).thenReturn(dbMock);
@@ -924,7 +925,7 @@ public class DocumentServiceTest {
   }
 
   @Test
-  public void putAtPath_patching() throws UnauthorizedException {
+  public void putAtPath_patching() throws UnauthorizedException, UnsupportedEncodingException {
     DocumentDB dbMock = mock(DocumentDB.class);
     Db dbFactoryMock = mock(Db.class);
     when(dbFactoryMock.getDocDataStoreForToken(anyString())).thenReturn(dbMock);

--- a/testing/src/test/java/io/stargate/it/http/RestUtils.java
+++ b/testing/src/test/java/io/stargate/it/http/RestUtils.java
@@ -139,24 +139,28 @@ public class RestUtils {
   }
 
   public static String putForm(
-          String authToken, String path, String requestBody, int expectedStatusCode)
-          throws IOException {
+      String authToken, String path, String requestBody, int expectedStatusCode)
+      throws IOException {
     OkHttpClient client = new OkHttpClient().newBuilder().build();
 
     Request request;
     if (authToken != null) {
       request =
-              new Request.Builder()
-                      .url(path)
-                      .put(RequestBody.create(MediaType.parse("application/x-www-form-urlencoded"), requestBody))
-                      .addHeader("X-Cassandra-Token", authToken)
-                      .build();
+          new Request.Builder()
+              .url(path)
+              .put(
+                  RequestBody.create(
+                      MediaType.parse("application/x-www-form-urlencoded"), requestBody))
+              .addHeader("X-Cassandra-Token", authToken)
+              .build();
     } else {
       request =
-              new Request.Builder()
-                      .url(path)
-                      .put(RequestBody.create(MediaType.parse("application/x-www-form-urlencoded"), requestBody))
-                      .build();
+          new Request.Builder()
+              .url(path)
+              .put(
+                  RequestBody.create(
+                      MediaType.parse("application/x-www-form-urlencoded"), requestBody))
+              .build();
     }
 
     Response response = client.newCall(request).execute();

--- a/testing/src/test/java/io/stargate/it/http/RestUtils.java
+++ b/testing/src/test/java/io/stargate/it/http/RestUtils.java
@@ -138,6 +138,36 @@ public class RestUtils {
     return body.string();
   }
 
+  public static String putForm(
+          String authToken, String path, String requestBody, int expectedStatusCode)
+          throws IOException {
+    OkHttpClient client = new OkHttpClient().newBuilder().build();
+
+    Request request;
+    if (authToken != null) {
+      request =
+              new Request.Builder()
+                      .url(path)
+                      .put(RequestBody.create(MediaType.parse("application/x-www-form-urlencoded"), requestBody))
+                      .addHeader("X-Cassandra-Token", authToken)
+                      .build();
+    } else {
+      request =
+              new Request.Builder()
+                      .url(path)
+                      .put(RequestBody.create(MediaType.parse("application/x-www-form-urlencoded"), requestBody))
+                      .build();
+    }
+
+    Response response = client.newCall(request).execute();
+    assertStatusCode(response, expectedStatusCode);
+
+    ResponseBody body = response.body();
+    assertThat(body).isNotNull();
+
+    return body.string();
+  }
+
   public static String patch(
       String authToken, String path, String requestBody, int expectedStatusCode)
       throws IOException {

--- a/testing/src/test/java/io/stargate/it/http/docsapi/DocumentApiV2Test.java
+++ b/testing/src/test/java/io/stargate/it/http/docsapi/DocumentApiV2Test.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.collect.ImmutableList;
@@ -208,22 +207,19 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
   @Test
   public void testBasicForms() throws IOException {
     RestUtils.put(
-            authToken,
-            hostWithPort + "/v2/namespaces/" + keyspace + "/collections/collection/1",
-            "a=b&b=null&c.b=3.3&d.[0].[2]=true",
-            200);
+        authToken,
+        hostWithPort + "/v2/namespaces/" + keyspace + "/collections/collection/1",
+        "a=b&b=null&c.b=3.3&d.[0].[2]=true",
+        200);
 
     String resp =
-            RestUtils.get(
-                    authToken,
-                    hostWithPort
-                            + "/v2/namespaces/"
-                            + keyspace
-                            + "/collections/collection/1",
-                    200);
-    JsonNode expected = objectMapper.readTree(
-            "{\"a\":\"b\", \"b\":null, \"c\":{\"b\": 3.3}, \"d\":[[null, null, true]]}"
-    );
+        RestUtils.get(
+            authToken,
+            hostWithPort + "/v2/namespaces/" + keyspace + "/collections/collection/1",
+            200);
+    JsonNode expected =
+        objectMapper.readTree(
+            "{\"a\":\"b\", \"b\":null, \"c\":{\"b\": 3.3}, \"d\":[[null, null, true]]}");
     assertThat(objectMapper.readTree(resp)).isEqualTo(wrapResponse(expected, "1", null));
   }
 

--- a/testing/src/test/java/io/stargate/it/http/docsapi/DocumentApiV2Test.java
+++ b/testing/src/test/java/io/stargate/it/http/docsapi/DocumentApiV2Test.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.collect.ImmutableList;
@@ -202,6 +203,28 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
         "garbage", hostWithPort + "/v2/namespaces/" + keyspace + "/collections/collection/1", 401);
     RestUtils.get(
         "garbage", hostWithPort + "/v2/namespaces/" + keyspace + "/collections/collection", 401);
+  }
+
+  @Test
+  public void testBasicForms() throws IOException {
+    RestUtils.put(
+            authToken,
+            hostWithPort + "/v2/namespaces/" + keyspace + "/collections/collection/1",
+            "a=b&b=null&c.b=3.3&d.[0].[2]=true",
+            200);
+
+    String resp =
+            RestUtils.get(
+                    authToken,
+                    hostWithPort
+                            + "/v2/namespaces/"
+                            + keyspace
+                            + "/collections/collection/1",
+                    200);
+    JsonNode expected = objectMapper.readTree(
+            "{\"a\":\"b\", \"b\":null, \"c\":{\"b\": 3.3}, \"d\":[[null, null, true]]}"
+    );
+    assertThat(objectMapper.readTree(resp)).isEqualTo(wrapResponse(expected, "1", null));
   }
 
   @Test

--- a/testing/src/test/java/io/stargate/it/http/docsapi/DocumentApiV2Test.java
+++ b/testing/src/test/java/io/stargate/it/http/docsapi/DocumentApiV2Test.java
@@ -206,7 +206,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
   @Test
   public void testBasicForms() throws IOException {
-    RestUtils.put(
+    RestUtils.putForm(
         authToken,
         hostWithPort + "/v2/namespaces/" + keyspace + "/collections/collection/1",
         "a=b&b=null&c.b=3.3&d.[0].[2]=true",
@@ -220,7 +220,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     JsonNode expected =
         objectMapper.readTree(
             "{\"a\":\"b\", \"b\":null, \"c\":{\"b\": 3.3}, \"d\":[[null, null, true]]}");
-    assertThat(objectMapper.readTree(resp)).isEqualTo(wrapResponse(expected, "1", null));
+    assertThat(objectMapper.readTree(resp).toString()).isEqualTo(wrapResponse(expected, "1", null).toString());
   }
 
   @Test

--- a/testing/src/test/java/io/stargate/it/http/docsapi/DocumentApiV2Test.java
+++ b/testing/src/test/java/io/stargate/it/http/docsapi/DocumentApiV2Test.java
@@ -220,7 +220,8 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
     JsonNode expected =
         objectMapper.readTree(
             "{\"a\":\"b\", \"b\":null, \"c\":{\"b\": 3.3}, \"d\":[[null, null, true]]}");
-    assertThat(objectMapper.readTree(resp).toString()).isEqualTo(wrapResponse(expected, "1", null).toString());
+    assertThat(objectMapper.readTree(resp).toString())
+        .isEqualTo(wrapResponse(expected, "1", null).toString());
   }
 
   @Test


### PR DESCRIPTION
This is really only used for the YCSB benchmarks.

I noticed just recently that Even if you try and set headers on the YCSB client to try and send application/json, it always tries to send application/x-www-form-urlencoded. This kind of sucks, since it caused YCSB to have "update failures" that were silently written to the results.

To fix this, I had the choice of:
1) Asking the maintainers of YCSB to change their stuff (a potentially slow process)
2) Forking that repo, making the change, and then pointing Fallout to that fork of YCSB (a potentially hard process because I don't know everything about Fallout)
3) Allow the documents API to accept URL-encoded forms on PUT/POST/PATCH

I decided on 3) because it was the devil that I knew best and knew it would take not that much time.

By adding basic urlencoded form support, YCSB can continue to be used for benchmarking the documents API.  I decided that really I'd rather not document this behavior too heavily because it's sort of experimental and there might be edge cases that aren't working.