### PR TITLE
When supplying a where clause to the "full document" search, the path should be matched exactly

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -1183,14 +1183,13 @@ public class DocumentService {
                       .filter(
                           r -> {
                             if (r == null || r.getString("leaf") == null) {
-                              System.out.println("Returning false");
                               return false;
                             }
                             String[] parentPath = getParentPathFromRow(r).split("/");
-                            if (parentPath.length != 2) {
-                              return false;
+                            String rowPath = "";
+                            if (parentPath.length == 2) {
+                              rowPath = parentPath[1];
                             }
-                            String rowPath = parentPath[1];
                             return pathsMatch(rowPath + r.getString("leaf"), filterFieldPath);
                           })
                       .findFirst();

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -1156,7 +1156,7 @@ public class DocumentService {
     if (inMemoryFilters.size() == 0) {
       return rows;
     }
-    String filterField = inMemoryFilters.get(0).getField();
+    String filterFieldPath = inMemoryFilters.get(0).getFullFieldPath();
 
     return Lists.partition(rows, fieldsPerDoc).stream()
         .filter(
@@ -1164,7 +1164,14 @@ public class DocumentService {
               Optional<Row> fieldRow =
                   docChunk.stream()
                       .filter(
-                          r -> r != null && StringUtils.equals(r.getString("leaf"), filterField))
+                          r -> {
+                            if (r == null || r.getString("leaf") == null) {
+                              return false;
+                            }
+                            String parentPath = getParentPathFromRow(r);
+                            return StringUtils.equals(
+                                parentPath + "." + r.getString("leaf"), filterFieldPath);
+                          })
                       .findFirst();
               return fieldRow.isPresent() && allFiltersMatch(fieldRow.get(), inMemoryFilters);
             })

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -26,6 +26,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.PathSegment;
 import org.apache.commons.lang3.StringUtils;
@@ -41,6 +42,7 @@ import org.slf4j.LoggerFactory;
 public class DocumentService {
   private static final Logger logger = LoggerFactory.getLogger(DocumentService.class);
   private static final ObjectMapper mapper = new ObjectMapper();
+  private static final Pattern PERIOD_PATTERN = Pattern.compile("\\.");
 
   /*
    * Converts a JSON path string (e.g. "$.a.b.c[0]") into a JSON path string
@@ -48,7 +50,7 @@ public class DocumentService {
    * This is to allow escaping of certain characters, such as space, $, and @.
    */
   private String convertToBracketedPath(String path) {
-    String[] parts = path.split("\\.");
+    String[] parts = PERIOD_PATTERN.split(path);
     StringBuilder newPath = new StringBuilder();
     for (int i = 0; i < parts.length; i++) {
       String part = parts[i];
@@ -268,7 +270,7 @@ public class DocumentService {
       } else {
         continue;
       }
-      String[] fieldNames = fullyQualifiedField.split("\\.");
+      String[] fieldNames = PERIOD_PATTERN.split(fullyQualifiedField);
 
       if (path.size() + fieldNames.length > DocumentDB.MAX_DEPTH) {
         throw new DocumentAPIRequestException(
@@ -523,7 +525,7 @@ public class DocumentService {
         throw new DocumentAPIRequestException(
             "The field(s) you are searching for can't be the empty string!");
       }
-      String[] fieldNamePath = fieldName.split("\\.");
+      String[] fieldNamePath = PERIOD_PATTERN.split(fieldName);
       List<String> convertedFieldNamePath =
           Arrays.asList(fieldNamePath).stream()
               .map(this::convertArrayPath)
@@ -1103,8 +1105,8 @@ public class DocumentService {
   }
 
   private boolean pathsMatch(String path1, String path2) {
-    String[] parts1 = path1.split("\\.");
-    String[] parts2 = path2.split("\\.");
+    String[] parts1 = PERIOD_PATTERN.split(path1);
+    String[] parts2 = PERIOD_PATTERN.split(path2);
     if (parts1.length != parts2.length) {
       return false;
     }
@@ -1136,7 +1138,7 @@ public class DocumentService {
       String path = getParentPathFromRow(row);
       if (!currentPath.equals(path)
           && !currentPath.isEmpty()
-          && currentPath.split("\\.").length == requestedPath.size()) {
+          && PERIOD_PATTERN.split(currentPath).length == requestedPath.size()) {
         for (int i = 0; i < selectionSet.size() - docSize; i++) {
           normalizedList.add(null);
         }
@@ -1145,13 +1147,13 @@ public class DocumentService {
       currentPath = path;
 
       if (selectionSet.contains(row.getString("leaf"))
-          && currentPath.split("\\.").length == requestedPath.size()) {
+          && PERIOD_PATTERN.split(currentPath).length == requestedPath.size()) {
         normalizedList.add(row);
         docSize++;
       }
     }
 
-    if (currentPath.split("\\.").length == requestedPath.size()) {
+    if (PERIOD_PATTERN.split(currentPath).length == requestedPath.size()) {
       for (int i = 0; i < selectionSet.size() - docSize; i++) {
         normalizedList.add(null);
       }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/filter/ListFilterCondition.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/filter/ListFilterCondition.java
@@ -40,6 +40,7 @@ public class ListFilterCondition implements FilterCondition {
   }
 
   public String getFullFieldPath() {
+    if (getPathString().isEmpty()) return field;
     return getPathString() + "." + field;
   }
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/filter/SingleFilterCondition.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/filter/SingleFilterCondition.java
@@ -73,6 +73,7 @@ public class SingleFilterCondition implements FilterCondition {
   }
 
   public String getFullFieldPath() {
+    if (getPathString().isEmpty()) return field;
     return getPathString() + "." + field;
   }
 

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -62,6 +62,7 @@ public class DocumentServiceTest {
   private Method getParentPathFromRow;
   private Method filterToSelectionSet;
   private Method applyInMemoryFilters;
+  private Method pathsMatch;
   private Method checkEqualsOp;
   private Method checkInOp;
   private Method checkGtOp;
@@ -116,6 +117,8 @@ public class DocumentServiceTest {
         DocumentService.class.getDeclaredMethod(
             "applyInMemoryFilters", List.class, List.class, int.class);
     applyInMemoryFilters.setAccessible(true);
+    pathsMatch = DocumentService.class.getDeclaredMethod("pathsMatch", String.class, String.class);
+    pathsMatch.setAccessible(true);
     checkEqualsOp =
         DocumentService.class.getDeclaredMethod(
             "checkEqualsOp",
@@ -1564,6 +1567,30 @@ public class DocumentServiceTest {
                 ImmutableList.of("a", "b", "c"), "$nin", ImmutableList.of(true)));
     result = (List<Row>) applyInMemoryFilters.invoke(service, rows, filters, 1);
     assertThat(result.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void pathsMatch() throws InvocationTargetException, IllegalAccessException {
+    boolean res = (boolean) pathsMatch.invoke(service, "", "");
+    assertThat(res).isTrue();
+
+    res = (boolean) pathsMatch.invoke(service, "a", "a");
+    assertThat(res).isTrue();
+
+    res = (boolean) pathsMatch.invoke(service, "a", "b");
+    assertThat(res).isFalse();
+
+    res = (boolean) pathsMatch.invoke(service, "a.b", "a.b");
+    assertThat(res).isTrue();
+
+    res = (boolean) pathsMatch.invoke(service, "a.b", "a.c");
+    assertThat(res).isFalse();
+
+    res = (boolean) pathsMatch.invoke(service, "a.*.c", "a.b.c");
+    assertThat(res).isTrue();
+
+    res = (boolean) pathsMatch.invoke(service, "a.*.d", "a.b.c");
+    assertThat(res).isFalse();
   }
 
   @Test

--- a/testing/src/test/java/io/stargate/it/http/docsapi/DocumentApiV2Test.java
+++ b/testing/src/test/java/io/stargate/it/http/docsapi/DocumentApiV2Test.java
@@ -93,6 +93,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
 
   @AfterEach
   public void teardown() {
+    session.execute(String.format("drop keyspace %s", keyspace));
     session.close();
   }
 
@@ -1661,7 +1662,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
                 + "/collections/collection?page-size=2&where={\"someStuff.someOtherStuff.value\": {\"$eq\": \"a\"}}&raw=true",
             200);
 
-    expected = "{\"cool-search-id\":{\"someStuff\": {\"someOtherStuff\": {\"value\": \"a\"}}}";
+    expected = "{\"cool-search-id\":{\"someStuff\": {\"someOtherStuff\": {\"value\": \"a\"}}}}";
     assertThat(objectMapper.readTree(r)).isEqualTo(objectMapper.readTree(expected));
 
     r =
@@ -1673,7 +1674,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
                 + "/collections/collection?page-size=2&where={\"someStuff.*.value\": {\"$eq\": \"a\"}}&raw=true",
             200);
 
-    expected = "{\"cool-search-id\":{\"someStuff\": {\"someOtherStuff\": {\"value\": \"a\"}}}";
+    expected = "{\"cool-search-id\":{\"someStuff\": {\"someOtherStuff\": {\"value\": \"a\"}}}}";
     assertThat(objectMapper.readTree(r)).isEqualTo(objectMapper.readTree(expected));
   }
 

--- a/testing/src/test/java/io/stargate/it/http/docsapi/DocumentApiV2Test.java
+++ b/testing/src/test/java/io/stargate/it/http/docsapi/DocumentApiV2Test.java
@@ -1646,7 +1646,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?page-size=2&where={\"value\": {\"$eq\": \"a\"}}&raw=true",
+                + "/collections/collection?page-size=2&where={\"value\": {\"$eq\": \"a\"}}&raw=true",
             200);
 
     String expected = "{\"cool-search-id-2\":{\"value\":\"a\"}}";
@@ -1658,7 +1658,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?page-size=2&where={\"someStuff.someOtherStuff.value\": {\"$eq\": \"a\"}}&raw=true",
+                + "/collections/collection?page-size=2&where={\"someStuff.someOtherStuff.value\": {\"$eq\": \"a\"}}&raw=true",
             200);
 
     expected = "{\"cool-search-id\":{\"someStuff\": {\"someOtherStuff\": {\"value\": \"a\"}}}";
@@ -1670,7 +1670,7 @@ public class DocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?page-size=2&where={\"someStuff.*.value\": {\"$eq\": \"a\"}}&raw=true",
+                + "/collections/collection?page-size=2&where={\"someStuff.*.value\": {\"$eq\": \"a\"}}&raw=true",
             200);
 
     expected = "{\"cool-search-id\":{\"someStuff\": {\"someOtherStuff\": {\"value\": \"a\"}}}";


### PR DESCRIPTION
Sourav pointed out a bug that he found - when there were two documents, one that had a nested value and one not, such as:
`{ "some": { "nested": {"value": "a"}}` and `{"value": "a"}`

The search `where={"value": {"$eq": "a"}}}` was matching BOTH of these documents, which was not the intention ("recursive" searching was removed a while ago). Also, even more wrong - searching `where={"some.*.value": {"$eq": "a"}}}` was _also_ matching both documents (definitely a bug)

So This PR fixes both those cases