### PR TITLE
Increase query trace fetching attempts in tests

### DIFF
--- a/testing/src/test/java/io/stargate/it/driver/CqlSessionExtension.java
+++ b/testing/src/test/java/io/stargate/it/driver/CqlSessionExtension.java
@@ -389,6 +389,7 @@ public class CqlSessionExtension
     config.put(TypedDriverOption.CONNECTION_INIT_QUERY_TIMEOUT, Duration.ofSeconds(180));
     config.put(TypedDriverOption.CONTROL_CONNECTION_TIMEOUT, Duration.ofSeconds(180));
     config.put(TypedDriverOption.REQUEST_TRACE_INTERVAL, Duration.ofSeconds(5));
+    config.put(TypedDriverOption.REQUEST_TRACE_ATTEMPTS, 180 / 5);
     config.put(TypedDriverOption.REQUEST_WARN_IF_SET_KEYSPACE, false);
     return config;
   }


### PR DESCRIPTION
This is to compensate for slow CI nodes.

----

e.g.
```
[ERROR] io.stargate.it.cql.BoundStatementTest.tracingTest(CqlSession,StargateEnvironmentInfo)  Time elapsed: 20.75 s  <<< ERROR!
java.lang.IllegalStateException: Trace 1150d300-2f54-11eb-af05-3f35e55e755c still not complete after 5 attempts
````