### PR TITLE
Remove outdated CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-![Java CI](https://github.com/stargate/stargate/workflows/Java%20CI/badge.svg)
 [![Maven Central](https://img.shields.io/maven-central/v/io.stargate/stargate.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/io.stargate/stargate/)
 
 # Stargate


### PR DESCRIPTION
The badge is no longer valid since it points to the old method of using GH actions