### PR TITLE
Fix #522 - Allow space between CQL base types and parameters

### DIFF
--- a/persistence-api/src/main/java/io/stargate/db/schema/Column.java
+++ b/persistence-api/src/main/java/io/stargate/db/schema/Column.java
@@ -522,7 +522,8 @@ public abstract class Column implements SchemaEntity, Comparable<Column> {
       }
 
       int paramsIdx = dataTypeName.indexOf('<');
-      String baseTypeName = paramsIdx < 0 ? dataTypeName : dataTypeName.substring(0, paramsIdx);
+      String baseTypeName =
+          paramsIdx < 0 ? dataTypeName : dataTypeName.substring(0, paramsIdx).trim();
       if (!ColumnUtils.isValidUnquotedIdentifier(baseTypeName)) {
         throw new IllegalArgumentException("Malformed type name: " + dataTypeName);
       }

--- a/persistence-api/src/test/java/io/stargate/db/schema/ColumnTest.java
+++ b/persistence-api/src/test/java/io/stargate/db/schema/ColumnTest.java
@@ -712,14 +712,23 @@ public class ColumnTest {
     assertThat(Type.fromCqlDefinitionOf(ks, "text")).isEqualTo(Type.Text);
     assertThat(Type.fromCqlDefinitionOf(ks, "int")).isEqualTo(Type.Int);
     assertThat(Type.fromCqlDefinitionOf(ks, "list<text>")).isEqualTo(Type.List.of(Type.Text));
+    assertThat(Type.fromCqlDefinitionOf(ks, "list  <text>")).isEqualTo(Type.List.of(Type.Text));
     assertThat(Type.fromCqlDefinitionOf(ks, "set<bigint>")).isEqualTo(Type.Set.of(Type.Bigint));
+    assertThat(Type.fromCqlDefinitionOf(ks, "set  <bigint>")).isEqualTo(Type.Set.of(Type.Bigint));
     assertThat(Type.fromCqlDefinitionOf(ks, "map<text, bigint>"))
+        .isEqualTo(Type.Map.of(Type.Text, Type.Bigint));
+    assertThat(Type.fromCqlDefinitionOf(ks, "map  <text, bigint>"))
         .isEqualTo(Type.Map.of(Type.Text, Type.Bigint));
     assertThat(Type.fromCqlDefinitionOf(ks, "my_udt")).isEqualTo(udt);
     assertThat(Type.fromCqlDefinitionOf(ks, "set<my_udt>")).isEqualTo(Type.Set.of(udt));
+    assertThat(Type.fromCqlDefinitionOf(ks, "set  <my_udt>")).isEqualTo(Type.Set.of(udt));
     assertThat(Type.fromCqlDefinitionOf(ks, "frozen<list<int>>"))
         .isEqualTo(Type.List.of(Type.Int).frozen());
+    assertThat(Type.fromCqlDefinitionOf(ks, "frozen  <list<int>>"))
+        .isEqualTo(Type.List.of(Type.Int).frozen());
     assertThat(Type.fromCqlDefinitionOf(ks, "frozen<map<text, my_udt>>"))
+        .isEqualTo(Type.Map.of(Type.Text, udt).frozen());
+    assertThat(Type.fromCqlDefinitionOf(ks, "frozen  <map<text, my_udt>>"))
         .isEqualTo(Type.Map.of(Type.Text, udt).frozen());
   }
 }


### PR DESCRIPTION
Allows the insertion of whitespace between the base type and its parameters. For example: `map<text,int>` as well as `map <text,int>` are accepted.