### PR TITLE
Fix: Move CQL AuthResponse request handling to request threads

### DIFF
--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/AuthResponse.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/AuthResponse.java
@@ -91,9 +91,11 @@ public class AuthResponse extends Message.Request {
                 } else {
                   future.complete(new AuthChallenge(challenge));
                 }
-              } catch (AuthenticationException e) {
+              } catch (AuthenticationException ae) {
                 ClientMetrics.instance.markAuthFailure();
-                future.complete(ErrorMessage.fromException(e));
+                future.complete(ErrorMessage.fromException(ae));
+              } catch (Exception e) {
+                future.completeExceptionally(e);
               }
             });
     return future;

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/AuthResponse.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/AuthResponse.java
@@ -67,25 +67,35 @@ public class AuthResponse extends Message.Request {
 
   @Override
   protected CompletableFuture<? extends Response> execute(long queryStartNanoTime) {
-    try {
-      Authenticator.SaslNegotiator negotiator = ((ServerConnection) connection).getSaslNegotiator();
-      byte[] challenge = negotiator.evaluateResponse(token);
-      if (negotiator.isComplete()) {
-        AuthenticatedUser authenticatedUser = negotiator.getAuthenticatedUser();
-        persistenceConnection().login(authenticatedUser);
-        if (authenticatedUser.token() != null) {
-          ((ServerConnection) connection).clientInfo().setAuthToken(authenticatedUser.token());
-        }
+    CompletableFuture<Response> future = new CompletableFuture<>();
+    persistence()
+        .executeAuthResponse(
+            () -> {
+              try {
+                Authenticator.SaslNegotiator negotiator =
+                    ((ServerConnection) connection).getSaslNegotiator();
+                byte[] challenge = negotiator.evaluateResponse(token);
+                if (negotiator.isComplete()) {
+                  AuthenticatedUser authenticatedUser = negotiator.getAuthenticatedUser();
+                  persistenceConnection().login(authenticatedUser);
+                  if (authenticatedUser.token() != null) {
+                    ((ServerConnection) connection)
+                        .clientInfo()
+                        .setAuthToken(authenticatedUser.token());
+                  }
 
-        ClientMetrics.instance.markAuthSuccess();
-        // authentication is complete, send a ready message to the client
-        return CompletableFuture.completedFuture(new AuthSuccess(challenge));
-      } else {
-        return CompletableFuture.completedFuture(new AuthChallenge(challenge));
-      }
-    } catch (AuthenticationException e) {
-      ClientMetrics.instance.markAuthFailure();
-      return CompletableFuture.completedFuture(ErrorMessage.fromException(e));
-    }
+                  ClientMetrics.instance.markAuthSuccess();
+                  // authentication is complete, send a ready message to the client
+
+                  future.complete(new AuthSuccess(challenge));
+                } else {
+                  future.complete(new AuthChallenge(challenge));
+                }
+              } catch (AuthenticationException e) {
+                ClientMetrics.instance.markAuthFailure();
+                future.complete(ErrorMessage.fromException(e));
+              }
+            });
+    return future;
   }
 }

--- a/persistence-api/src/main/java/io/stargate/db/Persistence.java
+++ b/persistence-api/src/main/java/io/stargate/db/Persistence.java
@@ -113,6 +113,13 @@ public interface Persistence {
   Map<String, List<String>> cqlSupportedOptions();
 
   /**
+   * Execute AUTH_RESPONSE request handling asynchronously on the correct thread pool.
+   *
+   * @param handler a runnable that handles a AUTH_RESPONSE request
+   */
+  void executeAuthResponse(Runnable handler);
+
+  /**
    * A connection to the persistence.
    *
    * <p>It is through this object that a user can be logged in and that the persistence can be

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
@@ -292,6 +292,11 @@ public class CassandraPersistence
         .build();
   }
 
+  @Override
+  public void executeAuthResponse(Runnable handler) {
+    executor.execute(handler);
+  }
+
   /**
    * When "cassandra.join_ring" is "false" {@link StorageService#initServer()} will not wait for
    * schema to propagate to the coordinator only node. This method fixes that limitation by waiting

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
@@ -281,6 +281,11 @@ public class CassandraPersistence
         .build();
   }
 
+  @Override
+  public void executeAuthResponse(Runnable handler) {
+    executor.execute(handler);
+  }
+
   /**
    * When "cassandra.join_ring" is "false" {@link StorageService#initServer()} will not wait for
    * schema to propagate to the coordinator only node. This method fixes that limitation by waiting

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.Uninterruptibles;
+import io.reactivex.Completable;
 import io.reactivex.Single;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.db.Authenticator;
@@ -38,6 +39,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.cassandra.auth.AuthenticatedUser;
 import org.apache.cassandra.auth.user.UserRolesAndPermissions;
+import org.apache.cassandra.concurrent.TPCTaskType;
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.PageSize;
@@ -75,6 +77,7 @@ import org.apache.cassandra.transport.messages.QueryMessage;
 import org.apache.cassandra.transport.messages.ResultMessage;
 import org.apache.cassandra.transport.messages.StartupMessage;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.flow.RxThreads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -277,6 +280,11 @@ public class DsePersistence
             Collections.singletonList(String.valueOf(DatabaseDescriptor.isEmulateDbaasDefaults())))
         .put(StartupMessage.CQL_VERSION, ImmutableList.of(QueryProcessor.CQL_VERSION.toString()))
         .build();
+  }
+
+  @Override
+  public void executeAuthResponse(Runnable handler) {
+    RxThreads.subscribeOnIo(Completable.fromRunnable(handler), TPCTaskType.AUTHENTICATION);
   }
 
   /**

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -284,7 +284,8 @@ public class DsePersistence
 
   @Override
   public void executeAuthResponse(Runnable handler) {
-    RxThreads.subscribeOnIo(Completable.fromRunnable(handler), TPCTaskType.AUTHENTICATION);
+    RxThreads.subscribeOnIo(Completable.fromRunnable(handler), TPCTaskType.AUTHENTICATION)
+        .subscribe();
   }
 
   /**


### PR DESCRIPTION
This moves AuthResponse request handling off of the event loop threads
to the appropriate request thread pool.

In C* (and DSE) the request logic normally runs on a separate threads
from the event loop threads. However, in Stargate, the logic for
AuthResponse is run directly on event loop threads which is unlike other
requests that run on Persistence backend threads. This was done so that
custom authentication logic could be added for Stargate. The problem
with running this logic on event loop threads is PasswordAuthenticator
runs BCrypt.checkpw(password, hash) which is quite CPU intensive
(intentionally) and causes significant delays to other requests.