### PR TITLE
Re-include Docs API unit tests (fixes #527)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -519,6 +519,12 @@
         <groupId>io.dropwizard</groupId>
         <artifactId>dropwizard-testing</artifactId>
         <version>${dropwizard.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.awaitility</groupId>

--- a/restapi/pom.xml
+++ b/restapi/pom.xml
@@ -126,15 +126,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>1.6.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>1.6.1</version>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
@@ -3,6 +3,7 @@ package io.stargate.web.docsapi.resources;
 import com.datastax.oss.driver.api.core.NoNodeAvailableException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import io.stargate.auth.UnauthorizedException;
 import io.stargate.web.docsapi.dao.DocumentDB;
 import io.stargate.web.docsapi.examples.WriteDocResponse;
@@ -59,8 +60,18 @@ public class DocumentResourceV2 {
   @Inject private Db dbFactory;
   private static final Logger logger = LoggerFactory.getLogger(DocumentResourceV2.class);
   private static final ObjectMapper mapper = new ObjectMapper();
-  private final DocumentService documentService = new DocumentService();
+  private final DocumentService documentService;
   private final int DEFAULT_PAGE_SIZE = 100;
+
+  public DocumentResourceV2() {
+    documentService = new DocumentService();
+  }
+
+  @VisibleForTesting
+  DocumentResourceV2(Db dbFactory, DocumentService documentService) {
+    this.dbFactory = dbFactory;
+    this.documentService = documentService;
+  }
 
   @POST
   @ManagedAsync

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.node.LongNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.gson.JsonArray;
@@ -745,7 +746,8 @@ public class DocumentService {
     return ImmutablePair.of(docsResult, pageState);
   }
 
-  private void addRowsToMap(Map<String, List<Row>> rowsByDoc, List<Row> rows) {
+  @VisibleForTesting
+  void addRowsToMap(Map<String, List<Row>> rowsByDoc, List<Row> rows) {
     for (Row row : rows) {
       String key = row.getString("key");
       List<Row> rowsAtKey = rowsByDoc.getOrDefault(key, new ArrayList<>());
@@ -969,7 +971,8 @@ public class DocumentService {
    * @throws ExecutionException
    * @throws InterruptedException
    */
-  private ImmutablePair<List<Row>, ByteBuffer> searchRows(
+  @VisibleForTesting
+  ImmutablePair<List<Row>, ByteBuffer> searchRows(
       String keyspace,
       String collection,
       DocumentDB db,

--- a/restapi/src/test/java/io/stargate/web/docsapi/dao/DocumentDBTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/dao/DocumentDBTest.java
@@ -1,6 +1,8 @@
 package io.stargate.web.docsapi.dao;
 
 import static io.stargate.db.query.TypedValue.javaValues;
+import static io.stargate.db.schema.Column.Kind.Clustering;
+import static io.stargate.db.schema.Column.Kind.PartitionKey;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,7 +25,9 @@ import io.stargate.db.datastore.ResultSet;
 import io.stargate.db.query.BoundQuery;
 import io.stargate.db.query.Query;
 import io.stargate.db.query.TypedValue.Codec;
+import io.stargate.db.schema.Column.Type;
 import io.stargate.db.schema.Schema;
+import io.stargate.db.schema.SchemaBuilder.SchemaBuilder__5;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -32,17 +36,37 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.UnaryOperator;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DocumentDBTest {
+  private static final Schema schema = buildSchema();
+
   private DocumentDB documentDB;
   private TestDataStore ds;
   private static final ObjectMapper mapper = new ObjectMapper();
 
-  @Before
+  private static Schema buildSchema() {
+    SchemaBuilder__5 schemaBuilder =
+        Schema.build()
+            .keyspace("keyspace")
+            .table("table")
+            .column("key", Type.Text, PartitionKey)
+            .column("leaf", Type.Text)
+            .column("text_value", Type.Text)
+            .column("dbl_value", Type.Double)
+            .column("bool_value", Type.Boolean);
+
+    for (int i = 0; i < DocumentDB.MAX_DEPTH; i++) {
+      schemaBuilder = schemaBuilder.column("p" + i, Type.Text, Clustering);
+    }
+
+    return schemaBuilder.build();
+  }
+
+  @BeforeEach
   public void setup() throws UnauthorizedException {
-    ds = new TestDataStore();
+    ds = new TestDataStore(schema);
     AuthorizationService authorizationService = mock(AuthorizationService.class);
     doNothing().when(authorizationService).authorizeDataRead(anyString(), anyString(), anyString());
     documentDB = new DocumentDB(ds, "foo", authorizationService);
@@ -68,12 +92,22 @@ public class DocumentDBTest {
 
   @Test
   public void getInsertStatement() {
-    BoundQuery query =
-        documentDB.getInsertStatement(
-            "keyspace", "table", 1, new Object[DocumentDB.allColumns().size()]);
+    Object[] values = new Object[DocumentDB.allColumns().size()];
+    int idx = 0;
+    values[idx++] = "key";
+    for (int i = 0; i < DocumentDB.MAX_DEPTH; i++) {
+      values[idx++] = "value" + i;
+    }
+    values[idx++] = "leaf";
+    values[idx++] = "text";
+    values[idx++] = 1.2d; // dbl_value
+    values[idx++] = true; // bool_value
+    assertThat(idx).isEqualTo(values.length);
+
+    BoundQuery query = documentDB.getInsertStatement("keyspace", "table", 1, values);
     assertThat(query.queryString())
         .isEqualTo(
-            "INSERT INTO keyspace.table(key, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p30, p31, p32, p33, p34, p35, p36, p37, p38, p39, p40, p41, p42, p43, p44, p45, p46, p47, p48, p49, p50, p51, p52, p53, p54, p55, p56, p57, p58, p59, p60, p61, p62, p63, leaf, text_value, dbl_value, bool_value) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) USING TIMESTAMP ?");
+            "INSERT INTO \"keyspace\".\"table\" (key, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p30, p31, p32, p33, p34, p35, p36, p37, p38, p39, p40, p41, p42, p43, p44, p45, p46, p47, p48, p49, p50, p51, p52, p53, p54, p55, p56, p57, p58, p59, p60, p61, p62, p63, leaf, text_value, dbl_value, bool_value) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) USING TIMESTAMP ?");
   }
 
   @Test
@@ -84,7 +118,7 @@ public class DocumentDBTest {
     assertThat(query.queryString())
         .isEqualTo(
             "DELETE FROM \"keyspace\".\"table\" USING TIMESTAMP ? WHERE key = ? AND p0 = ? AND p1 = ? AND p2 = ?");
-    assertThat(javaValues(query.values())).isEqualTo(asList(1, "k", "a", "b", "c"));
+    assertThat(javaValues(query.values())).isEqualTo(asList(1L, "k", "a", "b", "c"));
   }
 
   @Test
@@ -94,9 +128,9 @@ public class DocumentDBTest {
             "keyspace", "table", "k", 1, ImmutableList.of("a", "b", "c", "d"));
     assertThat(query.queryString())
         .isEqualTo(
-            "DELETE FROM \"keyspace\".\"table\" USING TIMESTAMP ? WHERE key = ? AND p0 = ? AND p1 = ? AND p2 = ? AND p3 = ? AND p4 >= ? AND p4 <= ? ");
+            "DELETE FROM \"keyspace\".\"table\" USING TIMESTAMP ? WHERE key = ? AND p0 = ? AND p1 = ? AND p2 = ? AND p3 = ? AND p4 >= ? AND p4 <= ?");
     assertThat(javaValues(query.values()))
-        .isEqualTo(asList(1, "k", "a", "b", "c", "d", "[000000]", "[999999]"));
+        .isEqualTo(asList(1L, "k", "a", "b", "c", "d", "[000000]", "[999999]"));
   }
 
   @Test
@@ -111,9 +145,9 @@ public class DocumentDBTest {
             ImmutableList.of("a", "few", "keys"));
     assertThat(query.queryString())
         .isEqualTo(
-            "DELETE FROM keyspace.table USING TIMESTAMP ? WHERE key = ? AND p0 = ? AND p1 = ? AND p2 = ? AND p3 = ? AND p4 = ? AND p5 IN ?");
+            "DELETE FROM \"keyspace\".\"table\" USING TIMESTAMP ? WHERE key = ? AND p0 = ? AND p1 = ? AND p2 = ? AND p3 = ? AND p4 = ? AND p5 IN ?");
     assertThat(javaValues(query.values()))
-        .isEqualTo(asList(1, "k", "a", "b", "c", "d", "e", ImmutableList.of("a", "few", "keys")));
+        .isEqualTo(asList(1L, "k", "a", "b", "c", "d", "e", ImmutableList.of("a", "few", "keys")));
   }
 
   @Test
@@ -122,14 +156,14 @@ public class DocumentDBTest {
         documentDB.getExactPathDeleteStatement(
             "keyspace", "table", "key", 1, ImmutableList.of("a", "b", "c", "d", "e"));
     StringBuilder expected =
-        new StringBuilder("DELETE FROM \"keyspace\".\"table\" USING TIMESTAMP ?  WHERE key = ?");
+        new StringBuilder("DELETE FROM \"keyspace\".\"table\" USING TIMESTAMP ? WHERE key = ?");
     for (int i = 0; i < 64; i++) {
       expected.append(" AND p").append(i).append(" = ?");
     }
     assertThat(query.queryString()).isEqualTo(expected.toString());
 
     List<Object> expectedValues = new ArrayList<>();
-    expectedValues.add(1);
+    expectedValues.add(1L);
     expectedValues.add("key");
     expectedValues.addAll(ImmutableList.of("a", "b", "c", "d", "e"));
     for (int i = 5; i < 64; i++) {
@@ -156,12 +190,14 @@ public class DocumentDBTest {
 
   @Test
   public void deleteThenInsertBatch() throws UnauthorizedException {
-    ds = new TestDataStore();
+    ds = new TestDataStore(schema);
     AuthorizationService authorizationService = mock(AuthorizationService.class);
     doNothing().when(authorizationService).authorizeDataRead(anyString(), anyString(), anyString());
     documentDB = new DocumentDB(ds, "foo", authorizationService);
     List<String> path = ImmutableList.of("a", "b", "c");
     Map<String, Object> map = documentDB.newBindMap(path);
+    map.put("key", "key");
+    map.put("leaf", "c");
     map.put("bool_value", true);
     map.put("dbl_value", null);
     map.put("text_value", null);
@@ -173,24 +209,26 @@ public class DocumentDBTest {
 
     assertThat(generatedQueries.get(0).queryString())
         .isEqualTo(
-            "DELETE FROM \"keyspace\".\"table\" USING TIMESTAMP ? WHERE key = :key AND p0 = :p0 AND p1 = :p1 AND p2 = :p2");
+            "DELETE FROM \"keyspace\".\"table\" USING TIMESTAMP ? WHERE key = ? AND p0 = ? AND p1 = ? AND p2 = ?");
     assertThat(javaValues(generatedQueries.get(0).values())).isEqualTo(makeValues(0L, "key", path));
 
     assertThat(generatedQueries.get(1).queryString())
         .isEqualTo(
-            "INSERT INTO \"keyspace\".\"table\" (key, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p30, p31, p32, p33, p34, p35, p36, p37, p38, p39, p40, p41, p42, p43, p44, p45, p46, p47, p48, p49, p50, p51, p52, p53, p54, p55, p56, p57, p58, p59, p60, p61, p62, p63, leaf, text_value, dbl_value, bool_value) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) USING TIMESTAMP ?");
+            "INSERT INTO \"keyspace\".\"table\" (key, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p30, p31, p32, p33, p34, p35, p36, p37, p38, p39, p40, p41, p42, p43, p44, p45, p46, p47, p48, p49, p50, p51, p52, p53, p54, p55, p56, p57, p58, p59, p60, p61, p62, p63, leaf, text_value, dbl_value, bool_value) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) USING TIMESTAMP ?");
     assertThat(javaValues(generatedQueries.get(1).values())).isEqualTo(makeValues(values, 1L));
   }
 
   @Test
   public void deletePatchedPathsThenInsertBatch() throws UnauthorizedException {
-    ds = new TestDataStore();
+    ds = new TestDataStore(schema);
     AuthorizationService authorizationService = mock(AuthorizationService.class);
     doNothing().when(authorizationService).authorizeDataRead(anyString(), anyString(), anyString());
     documentDB = new DocumentDB(ds, "foo", authorizationService);
     List<String> path = ImmutableList.of("a", "b", "c");
     List<String> patchedKeys = ImmutableList.of("eric");
     Map<String, Object> map = documentDB.newBindMap(path);
+    map.put("key", "key");
+    map.put("leaf", "c");
     map.put("bool_value", null);
     map.put("dbl_value", 3.0);
     map.put("text_value", null);
@@ -208,7 +246,7 @@ public class DocumentDBTest {
 
     assertThat(generatedQueries.get(1).queryString())
         .isEqualTo(
-            "DELETE FROM \"keyspace\".\"table\" USING TIMESTAMP ?  WHERE key = ? AND p0 = ? AND p1 = ? AND p2 = ? AND p3 = ? AND p4 = ? AND p5 = ? AND p6 = ? AND p7 = ? AND p8 = ? AND p9 = ? AND p10 = ? AND p11 = ? AND p12 = ? AND p13 = ? AND p14 = ? AND p15 = ? AND p16 = ? AND p17 = ? AND p18 = ? AND p19 = ? AND p20 = ? AND p21 = ? AND p22 = ? AND p23 = ? AND p24 = ? AND p25 = ? AND p26 = ? AND p27 = ? AND p28 = ? AND p29 = ? AND p30 = ? AND p31 = ? AND p32 = ? AND p33 = ? AND p34 = ? AND p35 = ? AND p36 = ? AND p37 = ? AND p38 = ? AND p39 = ? AND p40 = ? AND p41 = ? AND p42 = ? AND p43 = ? AND p44 = ? AND p45 = ? AND p46 = ? AND p47 = ? AND p48 = ? AND p49 = ? AND p50 = ? AND p51 = ? AND p52 = ? AND p53 = ? AND p54 = ? AND p55 = ? AND p56 = ? AND p57 = ? AND p58 = ? AND p59 = ? AND p60 = ? AND p61 = ? AND p62 = ? AND p63 = ?");
+            "DELETE FROM \"keyspace\".\"table\" USING TIMESTAMP ? WHERE key = ? AND p0 = ? AND p1 = ? AND p2 = ? AND p3 = ? AND p4 = ? AND p5 = ? AND p6 = ? AND p7 = ? AND p8 = ? AND p9 = ? AND p10 = ? AND p11 = ? AND p12 = ? AND p13 = ? AND p14 = ? AND p15 = ? AND p16 = ? AND p17 = ? AND p18 = ? AND p19 = ? AND p20 = ? AND p21 = ? AND p22 = ? AND p23 = ? AND p24 = ? AND p25 = ? AND p26 = ? AND p27 = ? AND p28 = ? AND p29 = ? AND p30 = ? AND p31 = ? AND p32 = ? AND p33 = ? AND p34 = ? AND p35 = ? AND p36 = ? AND p37 = ? AND p38 = ? AND p39 = ? AND p40 = ? AND p41 = ? AND p42 = ? AND p43 = ? AND p44 = ? AND p45 = ? AND p46 = ? AND p47 = ? AND p48 = ? AND p49 = ? AND p50 = ? AND p51 = ? AND p52 = ? AND p53 = ? AND p54 = ? AND p55 = ? AND p56 = ? AND p57 = ? AND p58 = ? AND p59 = ? AND p60 = ? AND p61 = ? AND p62 = ? AND p63 = ?");
     String[] emptyStrings = new String[61];
     Arrays.fill(emptyStrings, "");
     assertThat(javaValues(generatedQueries.get(1).values()))
@@ -229,7 +267,7 @@ public class DocumentDBTest {
 
   @Test
   public void delete() throws UnauthorizedException {
-    ds = new TestDataStore();
+    ds = new TestDataStore(schema);
     AuthorizationService authorizationService = mock(AuthorizationService.class);
     doNothing().when(authorizationService).authorizeDataRead(anyString(), anyString(), anyString());
     documentDB = new DocumentDB(ds, "foo", authorizationService);
@@ -255,7 +293,7 @@ public class DocumentDBTest {
 
   @Test
   public void deleteDeadLeaves() throws UnauthorizedException {
-    ds = new TestDataStore();
+    ds = new TestDataStore(schema);
     AuthorizationService authorizationService = mock(AuthorizationService.class);
     doNothing().when(authorizationService).authorizeDataRead(anyString(), anyString(), anyString());
     documentDB = new DocumentDB(ds, "foo", authorizationService);
@@ -278,19 +316,24 @@ public class DocumentDBTest {
 
     assertThat(generatedQueries.get(0).queryString())
         .isEqualTo(
-            "DELETE FROM keyspace.table USING TIMESTAMP ? WHERE key = ? AND p0 = ? AND p1 IN (?)");
+            "DELETE FROM \"keyspace\".\"table\" USING TIMESTAMP ? WHERE key = ? AND p0 = ? AND p1 IN ?");
     assertThat(javaValues(generatedQueries.get(0).values()))
         .isEqualTo(asList(1L, "key", "a", singletonList("b")));
 
     assertThat(generatedQueries.get(1).queryString())
         .isEqualTo(
-            "DELETE FROM keyspace.table USING TIMESTAMP ? WHERE key = ? AND p0 = ? AND p1 >= ? AND p1 <= ?");
+            "DELETE FROM \"keyspace\".\"table\" USING TIMESTAMP ? WHERE key = ? AND p0 = ? AND p1 >= ? AND p1 <= ?");
     assertThat(javaValues(generatedQueries.get(1).values()))
         .isEqualTo(makeValues(1L, "key", "b", "[000000]", "[999999]"));
   }
 
   private static class TestDataStore implements DataStore {
     private final List<BoundQuery> recentQueries = new ArrayList<>();
+    private final Schema schema;
+
+    public TestDataStore(Schema schema) {
+      this.schema = schema;
+    }
 
     @Override
     public Codec valueCodec() {
@@ -320,7 +363,7 @@ public class DocumentDBTest {
 
     @Override
     public Schema schema() {
-      return null;
+      return schema;
     }
 
     @Override

--- a/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
@@ -28,27 +28,19 @@ import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest
 public class DocumentResourceV2Test {
   private static final ObjectMapper mapper = new ObjectMapper();
-  private DocumentService documentServiceMock = mock(DocumentService.class);
-  private Db dbFactoryMock = mock(Db.class);
+  private final DocumentService documentServiceMock = mock(DocumentService.class);
+  private final Db dbFactoryMock = mock(Db.class);
   private DocumentResourceV2 documentResourceV2;
 
-  @Before
+  @BeforeEach
   public void setup() {
-    documentResourceV2 = new DocumentResourceV2();
-    Whitebox.setInternalState(documentResourceV2, DocumentService.class, documentServiceMock);
-    Whitebox.setInternalState(documentResourceV2, Db.class, dbFactoryMock);
+    documentResourceV2 = new DocumentResourceV2(dbFactoryMock, documentServiceMock);
   }
 
   @Test
@@ -194,7 +186,7 @@ public class DocumentResourceV2Test {
     ObjectNode mockedReturn = mapper.createObjectNode();
     mockedReturn.set("someData", BooleanNode.valueOf(true));
 
-    PowerMockito.when(
+    Mockito.when(
             documentServiceMock.getJsonAtPath(
                 anyObject(), anyString(), anyString(), anyString(), anyObject()))
         .thenReturn(mockedReturn);
@@ -236,7 +228,7 @@ public class DocumentResourceV2Test {
     ObjectNode mockedReturn = mapper.createObjectNode();
     mockedReturn.set("someData", BooleanNode.valueOf(true));
 
-    PowerMockito.when(
+    Mockito.when(
             documentServiceMock.getJsonAtPath(
                 anyObject(), anyString(), anyString(), anyString(), anyObject()))
         .thenReturn(mockedReturn);
@@ -279,15 +271,15 @@ public class DocumentResourceV2Test {
     ObjectNode mockedReturn = mapper.createObjectNode();
     mockedReturn.set("someData", BooleanNode.valueOf(true));
 
-    PowerMockito.when(
+    Mockito.when(
             documentServiceMock.searchDocumentsV2(
                 anyObject(), anyString(), anyString(), anyList(), anyList(), anyString()))
         .thenReturn(ImmutablePair.of(mockedReturn, null));
 
-    PowerMockito.when(documentServiceMock.convertToFilterOps(anyList(), anyObject()))
+    Mockito.when(documentServiceMock.convertToFilterOps(anyList(), anyObject()))
         .thenCallRealMethod();
 
-    PowerMockito.when(documentServiceMock.convertToSelectionList(anyObject())).thenCallRealMethod();
+    Mockito.when(documentServiceMock.convertToSelectionList(anyObject())).thenCallRealMethod();
 
     Response r =
         documentResourceV2.getDocPath(
@@ -327,7 +319,7 @@ public class DocumentResourceV2Test {
     ObjectNode mockedReturn = mapper.createObjectNode();
     mockedReturn.set("someData", BooleanNode.valueOf(true));
 
-    PowerMockito.when(
+    Mockito.when(
             documentServiceMock.getJsonAtPath(
                 anyObject(), anyString(), anyString(), anyString(), anyObject()))
         .thenReturn(mockedReturn);
@@ -369,7 +361,7 @@ public class DocumentResourceV2Test {
     String pageStateParam = null;
     List<PathSegment> path = new ArrayList<>();
 
-    PowerMockito.when(
+    Mockito.when(
             documentServiceMock.getJsonAtPath(
                 anyObject(), anyString(), anyString(), anyString(), anyObject()))
         .thenReturn(null);
@@ -429,10 +421,10 @@ public class DocumentResourceV2Test {
     searchResult.set("id1", mapper.createArrayNode());
     searchResult.set("id2", mapper.createArrayNode());
 
-    PowerMockito.when(documentServiceMock.convertToFilterOps(anyList(), anyObject()))
+    Mockito.when(documentServiceMock.convertToFilterOps(anyList(), anyObject()))
         .thenReturn(conditions);
 
-    PowerMockito.when(
+    Mockito.when(
             documentServiceMock.getFullDocumentsFiltered(
                 anyObject(),
                 anyObject(),
@@ -488,10 +480,10 @@ public class DocumentResourceV2Test {
     searchResult.set("id1", mapper.createArrayNode());
     searchResult.set("id2", mapper.createArrayNode());
 
-    PowerMockito.when(documentServiceMock.convertToFilterOps(anyList(), anyObject()))
+    Mockito.when(documentServiceMock.convertToFilterOps(anyList(), anyObject()))
         .thenReturn(conditions);
 
-    PowerMockito.when(
+    Mockito.when(
             documentServiceMock.getFullDocumentsFiltered(
                 anyObject(),
                 anyObject(),
@@ -544,13 +536,13 @@ public class DocumentResourceV2Test {
     searchResult.set("id1", mapper.createArrayNode());
     searchResult.set("id2", mapper.createArrayNode());
 
-    PowerMockito.when(documentServiceMock.convertToFilterOps(anyList(), anyObject()))
+    Mockito.when(documentServiceMock.convertToFilterOps(anyList(), anyObject()))
         .thenReturn(conditions);
 
-    PowerMockito.when(documentServiceMock.convertToSelectionList(anyObject()))
+    Mockito.when(documentServiceMock.convertToSelectionList(anyObject()))
         .thenReturn(ImmutableList.of("field1"));
 
-    PowerMockito.when(
+    Mockito.when(
             documentServiceMock.getFullDocumentsFiltered(
                 anyObject(),
                 anyObject(),
@@ -597,9 +589,9 @@ public class DocumentResourceV2Test {
     conditions.add(
         new SingleFilterCondition(ImmutableList.of("a", "b", "c", "field1"), "$eq", "value"));
 
-    PowerMockito.when(documentServiceMock.convertToFilterOps(anyList(), anyObject()))
+    Mockito.when(documentServiceMock.convertToFilterOps(anyList(), anyObject()))
         .thenReturn(conditions);
-    PowerMockito.when(documentServiceMock.convertToSelectionList(anyObject()))
+    Mockito.when(documentServiceMock.convertToSelectionList(anyObject()))
         .thenReturn(ImmutableList.of("field1"));
 
     Response r =
@@ -636,7 +628,7 @@ public class DocumentResourceV2Test {
     conditions.add(
         new SingleFilterCondition(ImmutableList.of("a", "b", "c", "field2"), "$eq", "value"));
 
-    PowerMockito.when(documentServiceMock.convertToFilterOps(anyList(), anyObject()))
+    Mockito.when(documentServiceMock.convertToFilterOps(anyList(), anyObject()))
         .thenReturn(conditions);
 
     Response r =
@@ -673,10 +665,10 @@ public class DocumentResourceV2Test {
     conditions.add(
         new SingleFilterCondition(ImmutableList.of("a", "b", "c", "field1"), "$eq", "value"));
 
-    PowerMockito.when(documentServiceMock.convertToFilterOps(anyList(), anyObject()))
+    Mockito.when(documentServiceMock.convertToFilterOps(anyList(), anyObject()))
         .thenReturn(conditions);
 
-    PowerMockito.when(documentServiceMock.convertToSelectionList(anyObject()))
+    Mockito.when(documentServiceMock.convertToSelectionList(anyObject()))
         .thenReturn(ImmutableList.of("field1"));
 
     Response r =
@@ -714,7 +706,7 @@ public class DocumentResourceV2Test {
     searchResult.set("id1", mapper.createArrayNode());
     searchResult.set("id2", mapper.createArrayNode());
 
-    PowerMockito.when(
+    Mockito.when(
             documentServiceMock.getFullDocuments(
                 anyObject(),
                 anyObject(),

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -2,13 +2,13 @@ package io.stargate.web.docsapi.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyMap;
-import static org.mockito.Mockito.anyObject;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -55,15 +55,10 @@ import javax.ws.rs.core.PathSegment;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.jsfr.json.JsonSurfer;
 import org.jsfr.json.JsonSurferGson;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(DocumentService.class)
 public class DocumentServiceTest {
   private DocumentService service;
   private Method convertToBracketedPath;
@@ -86,7 +81,7 @@ public class DocumentServiceTest {
   private Method searchRows;
   private static final ObjectMapper mapper = new ObjectMapper();
 
-  @Before
+  @BeforeEach
   public void setup() throws NoSuchMethodException {
     service = new DocumentService();
 
@@ -299,7 +294,7 @@ public class DocumentServiceTest {
   @Test
   public void shredPayload_booleanLeaf() throws InvocationTargetException, IllegalAccessException {
     DocumentDB dbMock = mock(DocumentDB.class);
-    when(dbMock.newBindMap(anyObject())).thenCallRealMethod();
+    when(dbMock.newBindMap(any())).thenCallRealMethod();
 
     List<String> path = new ArrayList<>();
     String key = "eric";
@@ -395,7 +390,7 @@ public class DocumentServiceTest {
   @Test
   public void shredPayload_numberLeaf() throws InvocationTargetException, IllegalAccessException {
     DocumentDB dbMock = mock(DocumentDB.class);
-    when(dbMock.newBindMap(anyObject())).thenCallRealMethod();
+    when(dbMock.newBindMap(any())).thenCallRealMethod();
 
     List<String> path = new ArrayList<>();
     String key = "eric";
@@ -491,7 +486,7 @@ public class DocumentServiceTest {
   @Test
   public void shredPayload_stringLeaf() throws InvocationTargetException, IllegalAccessException {
     DocumentDB dbMock = mock(DocumentDB.class);
-    when(dbMock.newBindMap(anyObject())).thenCallRealMethod();
+    when(dbMock.newBindMap(any())).thenCallRealMethod();
 
     List<String> path = new ArrayList<>();
     String key = "eric";
@@ -588,7 +583,7 @@ public class DocumentServiceTest {
   public void shredPayload_emptyObjectLeaf()
       throws InvocationTargetException, IllegalAccessException {
     DocumentDB dbMock = mock(DocumentDB.class);
-    when(dbMock.newBindMap(anyObject())).thenCallRealMethod();
+    when(dbMock.newBindMap(any())).thenCallRealMethod();
 
     List<String> path = new ArrayList<>();
     String key = "eric";
@@ -685,7 +680,7 @@ public class DocumentServiceTest {
   public void shredPayload_emptyArrayLeaf()
       throws InvocationTargetException, IllegalAccessException {
     DocumentDB dbMock = mock(DocumentDB.class);
-    when(dbMock.newBindMap(anyObject())).thenCallRealMethod();
+    when(dbMock.newBindMap(any())).thenCallRealMethod();
 
     List<String> path = new ArrayList<>();
     String key = "eric";
@@ -781,7 +776,7 @@ public class DocumentServiceTest {
   @Test
   public void shredPayload_nullLeaf() throws InvocationTargetException, IllegalAccessException {
     DocumentDB dbMock = mock(DocumentDB.class);
-    when(dbMock.newBindMap(anyObject())).thenCallRealMethod();
+    when(dbMock.newBindMap(any())).thenCallRealMethod();
 
     List<String> path = new ArrayList<>();
     String key = "eric";
@@ -877,7 +872,7 @@ public class DocumentServiceTest {
   @Test
   public void shredPayload_invalidKeys() {
     DocumentDB dbMock = mock(DocumentDB.class);
-    when(dbMock.newBindMap(anyObject())).thenCallRealMethod();
+    when(dbMock.newBindMap(any())).thenCallRealMethod();
 
     List<String> path = new ArrayList<>();
     String key = "eric";
@@ -896,7 +891,7 @@ public class DocumentServiceTest {
   @Test
   public void shredPayload_patchingArrayInvalid() {
     DocumentDB dbMock = mock(DocumentDB.class);
-    when(dbMock.newBindMap(anyObject())).thenCallRealMethod();
+    when(dbMock.newBindMap(any())).thenCallRealMethod();
 
     List<String> path = new ArrayList<>();
     String key = "eric";
@@ -917,7 +912,7 @@ public class DocumentServiceTest {
     DocumentDB dbMock = mock(DocumentDB.class);
     Db dbFactoryMock = mock(Db.class);
     when(dbFactoryMock.getDocDataStoreForToken(anyString())).thenReturn(dbMock);
-    when(dbMock.newBindMap(anyObject())).thenCallRealMethod();
+    when(dbMock.newBindMap(any())).thenCallRealMethod();
 
     service.putAtPath(
         "authToken",
@@ -931,17 +926,10 @@ public class DocumentServiceTest {
         true);
 
     verify(dbMock, times(1))
-        .deleteThenInsertBatch(
-            anyString(), anyString(), anyString(), anyObject(), anyObject(), anyLong());
+        .deleteThenInsertBatch(anyString(), anyString(), anyString(), any(), any(), anyLong());
     verify(dbMock, times(0))
         .deletePatchedPathsThenInsertBatch(
-            anyString(),
-            anyString(),
-            anyString(),
-            anyObject(),
-            anyObject(),
-            anyObject(),
-            anyLong());
+            anyString(), anyString(), anyString(), any(), any(), any(), anyLong());
   }
 
   @Test
@@ -949,7 +937,7 @@ public class DocumentServiceTest {
     DocumentDB dbMock = mock(DocumentDB.class);
     Db dbFactoryMock = mock(Db.class);
     when(dbFactoryMock.getDocDataStoreForToken(anyString())).thenReturn(dbMock);
-    when(dbMock.newBindMap(anyObject())).thenCallRealMethod();
+    when(dbMock.newBindMap(any())).thenCallRealMethod();
 
     service.putAtPath(
         "authToken",
@@ -963,17 +951,10 @@ public class DocumentServiceTest {
         true);
 
     verify(dbMock, times(0))
-        .deleteThenInsertBatch(
-            anyString(), anyString(), anyString(), anyObject(), anyObject(), anyLong());
+        .deleteThenInsertBatch(anyString(), anyString(), anyString(), any(), any(), anyLong());
     verify(dbMock, times(1))
         .deletePatchedPathsThenInsertBatch(
-            anyString(),
-            anyString(),
-            anyString(),
-            anyObject(),
-            anyObject(),
-            anyObject(),
-            anyLong());
+            anyString(), anyString(), anyString(), any(), any(), any(), anyLong());
   }
 
   @Test
@@ -981,7 +962,7 @@ public class DocumentServiceTest {
     DocumentDB dbMock = mock(DocumentDB.class);
     Db dbFactoryMock = mock(Db.class);
     when(dbFactoryMock.getDocDataStoreForToken(anyString())).thenReturn(dbMock);
-    when(dbMock.newBindMap(anyObject())).thenCallRealMethod();
+    when(dbMock.newBindMap(any())).thenCallRealMethod();
 
     Throwable thrown =
         catchThrowable(
@@ -1216,23 +1197,11 @@ public class DocumentServiceTest {
 
   @Test
   public void searchDocumentsV2_emptyResult() throws Exception {
-    DocumentDB dbMock = PowerMockito.mock(DocumentDB.class);
-    DocumentService serviceMock = PowerMockito.mock(DocumentService.class);
-    PowerMockito.when(
-            serviceMock.searchDocumentsV2(
-                anyObject(), anyString(), anyString(), anyList(), anyList(), anyString()))
+    DocumentDB dbMock = Mockito.mock(DocumentDB.class);
+    DocumentService serviceMock = Mockito.mock(DocumentService.class);
+    Mockito.when(serviceMock.searchDocumentsV2(any(), any(), any(), any(), any(), any()))
         .thenCallRealMethod();
-    PowerMockito.when(
-            serviceMock,
-            "searchRows",
-            anyString(),
-            anyString(),
-            anyObject(),
-            anyList(),
-            anyList(),
-            anyList(),
-            anyBoolean(),
-            anyString())
+    Mockito.when(serviceMock.searchRows(any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(ImmutablePair.of(new ArrayList<>(), null));
 
     List<FilterCondition> filters =
@@ -1246,25 +1215,13 @@ public class DocumentServiceTest {
 
   @Test
   public void searchDocumentsV2_existingResult() throws Exception {
-    DocumentDB dbMock = PowerMockito.mock(DocumentDB.class);
-    DocumentService serviceMock = PowerMockito.mock(DocumentService.class);
-    PowerMockito.when(
-            serviceMock.searchDocumentsV2(
-                anyObject(), anyString(), anyString(), anyList(), anyList(), anyString()))
+    DocumentDB dbMock = Mockito.mock(DocumentDB.class);
+    DocumentService serviceMock = Mockito.mock(DocumentService.class);
+    Mockito.when(serviceMock.searchDocumentsV2(any(), any(), any(), any(), any(), any()))
         .thenCallRealMethod();
-    PowerMockito.when(
-            serviceMock,
-            "searchRows",
-            anyString(),
-            anyString(),
-            anyObject(),
-            anyList(),
-            anyList(),
-            anyList(),
-            anyBoolean(),
-            anyString())
+    Mockito.when(serviceMock.searchRows(any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(ImmutablePair.of(makeInitialRowData(), null));
-    PowerMockito.when(serviceMock.convertToJsonDoc(anyObject(), anyBoolean(), anyBoolean()))
+    Mockito.when(serviceMock.convertToJsonDoc(any(), anyBoolean(), anyBoolean()))
         .thenReturn(ImmutablePair.of(mapper.readTree("{\"a\": 1}"), new HashMap<>()));
 
     List<FilterCondition> filters =
@@ -1279,25 +1236,13 @@ public class DocumentServiceTest {
 
   @Test
   public void searchDocumentsV2_existingResultWithFields() throws Exception {
-    DocumentDB dbMock = PowerMockito.mock(DocumentDB.class);
-    DocumentService serviceMock = PowerMockito.mock(DocumentService.class);
-    PowerMockito.when(
-            serviceMock.searchDocumentsV2(
-                anyObject(), anyString(), anyString(), anyList(), anyList(), anyString()))
+    DocumentDB dbMock = Mockito.mock(DocumentDB.class);
+    DocumentService serviceMock = Mockito.mock(DocumentService.class);
+    Mockito.when(serviceMock.searchDocumentsV2(any(), any(), any(), any(), any(), any()))
         .thenCallRealMethod();
-    PowerMockito.when(
-            serviceMock,
-            "searchRows",
-            anyString(),
-            anyString(),
-            anyObject(),
-            anyList(),
-            anyList(),
-            anyList(),
-            anyBoolean(),
-            anyString())
+    Mockito.when(serviceMock.searchRows(any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(ImmutablePair.of(makeInitialRowData(), null));
-    PowerMockito.when(serviceMock.convertToJsonDoc(anyObject(), anyBoolean(), anyBoolean()))
+    Mockito.when(serviceMock.convertToJsonDoc(any(), anyBoolean(), anyBoolean()))
         .thenReturn(ImmutablePair.of(mapper.readTree("{\"a\": 1}"), new HashMap<>()));
 
     List<FilterCondition> filters =
@@ -1331,37 +1276,27 @@ public class DocumentServiceTest {
 
   @Test
   public void getFullDocuments_lessThanLimit() throws Exception {
-    Db dbFactoryMock = PowerMockito.mock(Db.class);
-    DocumentDB dbMock = PowerMockito.mock(DocumentDB.class);
-    DocumentService serviceMock = PowerMockito.mock(DocumentService.class);
-    PowerMockito.when(dbFactoryMock.getDocDataStoreForToken(anyString(), anyInt(), anyObject()))
+    Db dbFactoryMock = Mockito.mock(Db.class);
+    DocumentDB dbMock = Mockito.mock(DocumentDB.class);
+    DocumentService serviceMock = Mockito.mock(DocumentService.class);
+    Mockito.when(dbFactoryMock.getDocDataStoreForToken(anyString(), anyInt(), any()))
         .thenReturn(dbMock);
-    PowerMockito.when(
-            serviceMock,
-            "searchRows",
-            anyString(),
-            anyString(),
-            anyObject(),
-            anyList(),
-            anyList(),
-            anyList(),
-            anyBoolean(),
-            anyString())
+    Mockito.when(serviceMock.searchRows(any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(ImmutablePair.of(makeInitialRowData(), null));
-    PowerMockito.when(
+    Mockito.when(
             serviceMock.getFullDocuments(
-                anyObject(),
-                anyObject(),
+                any(),
+                any(),
                 anyString(),
                 anyString(),
                 anyString(),
                 anyList(),
-                anyObject(),
+                any(),
                 anyInt(),
                 anyInt()))
         .thenCallRealMethod();
-    PowerMockito.when(serviceMock, "addRowsToMap", anyMap(), anyList()).thenCallRealMethod();
-    PowerMockito.when(serviceMock.convertToJsonDoc(anyObject(), anyBoolean(), anyBoolean()))
+    Mockito.doCallRealMethod().when(serviceMock).addRowsToMap(anyMap(), anyList());
+    Mockito.when(serviceMock.convertToJsonDoc(any(), anyBoolean(), anyBoolean()))
         .thenReturn(ImmutablePair.of(mapper.readTree("{\"a\": 1}"), new HashMap<>()));
 
     ImmutablePair<JsonNode, ByteBuffer> result =
@@ -1381,39 +1316,29 @@ public class DocumentServiceTest {
 
   @Test
   public void getFullDocuments_greaterThanLimit() throws Exception {
-    Db dbFactoryMock = PowerMockito.mock(Db.class);
-    DocumentDB dbMock = PowerMockito.mock(DocumentDB.class);
-    DocumentService serviceMock = PowerMockito.mock(DocumentService.class);
+    Db dbFactoryMock = Mockito.mock(Db.class);
+    DocumentDB dbMock = Mockito.mock(DocumentDB.class);
+    DocumentService serviceMock = Mockito.mock(DocumentService.class);
     List<Row> twoDocsRows = makeInitialRowData();
     twoDocsRows.addAll(makeRowDataForSecondDoc());
-    PowerMockito.when(dbFactoryMock.getDocDataStoreForToken(anyString(), anyInt(), anyObject()))
+    Mockito.when(dbFactoryMock.getDocDataStoreForToken(anyString(), anyInt(), any()))
         .thenReturn(dbMock);
-    PowerMockito.when(
-            serviceMock,
-            "searchRows",
-            anyString(),
-            anyString(),
-            anyObject(),
-            anyList(),
-            anyList(),
-            anyList(),
-            anyBoolean(),
-            anyString())
+    Mockito.when(serviceMock.searchRows(any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(ImmutablePair.of(twoDocsRows, null));
-    PowerMockito.when(
+    Mockito.when(
             serviceMock.getFullDocuments(
-                anyObject(),
-                anyObject(),
+                any(),
+                any(),
                 anyString(),
                 anyString(),
                 anyString(),
                 anyList(),
-                anyObject(),
+                any(),
                 anyInt(),
                 anyInt()))
         .thenCallRealMethod();
-    PowerMockito.when(serviceMock, "addRowsToMap", anyMap(), anyList()).thenCallRealMethod();
-    PowerMockito.when(serviceMock.convertToJsonDoc(anyObject(), anyBoolean(), anyBoolean()))
+    Mockito.doCallRealMethod().when(serviceMock).addRowsToMap(anyMap(), anyList());
+    Mockito.when(serviceMock.convertToJsonDoc(any(), anyBoolean(), anyBoolean()))
         .thenReturn(ImmutablePair.of(mapper.readTree("{\"a\": 1}"), new HashMap<>()));
 
     ImmutablePair<JsonNode, ByteBuffer> result =
@@ -1441,8 +1366,7 @@ public class DocumentServiceTest {
     ResultSet rsMock = mock(ResultSet.class);
     List<Row> rows = makeInitialRowData();
     when(dbMock.executeSelectAll(anyString(), anyString())).thenReturn(rsMock);
-    when(dbMock.executeSelect(anyString(), anyString(), anyObject(), anyBoolean()))
-        .thenReturn(rsMock);
+    when(dbMock.executeSelect(anyString(), anyString(), any(), anyBoolean())).thenReturn(rsMock);
     when(rsMock.currentPageRows()).thenReturn(rows);
     when(dbMock.getAuthorizationService()).thenReturn(authorizationService);
     doNothing().when(authorizationService).authorizeDataRead(anyString(), anyString(), anyString());
@@ -1491,8 +1415,7 @@ public class DocumentServiceTest {
     ResultSet rsMock = mock(ResultSet.class);
     List<Row> rows = makeInitialRowData();
     when(dbMock.executeSelectAll(anyString(), anyString())).thenReturn(rsMock);
-    when(dbMock.executeSelect(anyString(), anyString(), anyObject(), anyBoolean()))
-        .thenReturn(rsMock);
+    when(dbMock.executeSelect(anyString(), anyString(), any(), anyBoolean())).thenReturn(rsMock);
     when(dbMock.getAuthorizationService()).thenReturn(authorizationService);
     doNothing().when(authorizationService).authorizeDataRead(anyString(), anyString(), anyString());
     when(rsMock.rows()).thenReturn(rows);


### PR DESCRIPTION
* Convert Docs API tests to JUnit 5

* Remove dependency on PowerMock as it does not appear to be usable under JUnit 5

* Exclude transitive dependencies on JUnit4 to make sure tests do not use it accidentally