### PR TITLE
Docs API changes to improve performance

### DIFF
--- a/persistence-api/src/main/java/io/stargate/db/query/builder/QueryBuilderImpl.java
+++ b/persistence-api/src/main/java/io/stargate/db/query/builder/QueryBuilderImpl.java
@@ -1089,11 +1089,7 @@ public class QueryBuilderImpl {
   }
 
   private static List<Column> convertToColumns(Table table, Collection<String> columnNames) {
-    List<Column> columns = new ArrayList<>(columnNames.size());
-    for (String name : columnNames) {
-      columns.add(table.column(name));
-    }
-    return columns;
+    return columnNames.stream().map(table::column).collect(toList());
   }
 
   private Set<String> names(Collection<Column> columns) {

--- a/persistence-api/src/main/java/io/stargate/db/query/builder/QueryBuilderImpl.java
+++ b/persistence-api/src/main/java/io/stargate/db/query/builder/QueryBuilderImpl.java
@@ -1088,6 +1088,14 @@ public class QueryBuilderImpl {
     return columnNames.stream().map(table::existingColumn).collect(toList());
   }
 
+  private static List<Column> convertToColumns(Table table, Collection<String> columnNames) {
+    List<Column> columns = new ArrayList<>(columnNames.size());
+    for (String name : columnNames) {
+      columns.add(table.column(name));
+    }
+    return columns;
+  }
+
   private Set<String> names(Collection<Column> columns) {
     return columns.stream().map(SchemaEntity::name).collect(toSet());
   }
@@ -1380,13 +1388,13 @@ public class QueryBuilderImpl {
   protected BuiltSelect selectQuery() {
     Table table = schemaTable();
     QueryStringBuilder builder = new QueryStringBuilder(markerIndex);
-    List<Column> selectedColumns = validateColumns(table, selection);
+    List<Column> selectedColumns = convertToColumns(table, selection);
     // Using a linked set for the minor convenience of get back the columns in the order they were
     // passed to the builder "in general".
     Set<Column> allSelected = new LinkedHashSet<>(selectedColumns);
     Column wtColumn = null;
     if (writeTimeColumn != null) {
-      wtColumn = table.existingColumn(writeTimeColumn);
+      wtColumn = table.column(writeTimeColumn);
       allSelected.add(wtColumn);
     }
     builder.append("SELECT");

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -373,7 +373,13 @@ public class DocumentDB {
       int pageSize,
       ByteBuffer pageState) {
     UnaryOperator<Parameters> parametersModifier =
-        p -> ImmutableParameters.builder().pageSize(pageSize).pagingState(pageState).build();
+        p -> {
+          if (pageState != null) {
+            return ImmutableParameters.builder().pageSize(pageSize).pagingState(pageState).build();
+          } else {
+            return ImmutableParameters.builder().pageSize(pageSize).build();
+          }
+        };
     return this.builder()
         .select()
         .column(DocumentDB.allColumns())
@@ -409,7 +415,14 @@ public class DocumentDB {
     getAuthorizationService()
         .authorizeDataRead(getAuthToken(), keyspace, collection, SourceAPI.REST);
     UnaryOperator<Parameters> parametersModifier =
-        p -> ImmutableParameters.builder().pageSize(pageSize).pagingState(pageState).build();
+        p -> {
+          if (pageState != null) {
+            return ImmutableParameters.builder().pageSize(pageSize).pagingState(pageState).build();
+          } else {
+            return ImmutableParameters.builder().pageSize(pageSize).build();
+          }
+        };
+
     return this.builder()
         .select()
         .column(DocumentDB.allColumns())

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -406,7 +406,8 @@ public class DocumentDB {
       String keyspace, String collection, int pageSize, ByteBuffer pageState)
       throws UnauthorizedException {
     // Run generic authorizeDataRead for now
-    getAuthorizationService().authorizeDataRead(getAuthToken(), keyspace, collection);
+    getAuthorizationService()
+        .authorizeDataRead(getAuthToken(), keyspace, collection, SourceAPI.REST);
     UnaryOperator<Parameters> parametersModifier =
         p -> ImmutableParameters.builder().pageSize(pageSize).pagingState(pageState).build();
     return this.builder()

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -318,7 +318,10 @@ public class DocumentDB {
 
   public ResultSet executeSelect(
       String keyspace, String collection, List<BuiltCondition> predicates)
-      throws ExecutionException, InterruptedException {
+      throws UnauthorizedException {
+    // Run generic authorizeDataRead for now
+    getAuthorizationService()
+        .authorizeDataRead(getAuthenticationSubject(), keyspace, collection, SourceAPI.REST);
     return this.builder()
         .select()
         .column(DocumentDB.allColumns())
@@ -336,7 +339,10 @@ public class DocumentDB {
       List<BuiltCondition> predicates,
       int pageSize,
       ByteBuffer pageState)
-      throws ExecutionException, InterruptedException {
+      throws UnauthorizedException {
+    // Run generic authorizeDataRead for now
+    getAuthorizationService()
+        .authorizeDataRead(getAuthenticationSubject(), keyspace, collection, SourceAPI.REST);
     UnaryOperator<Parameters> parametersModifier =
         p -> ImmutableParameters.builder().pageSize(pageSize).pagingState(pageState).build();
     return this.builder()
@@ -375,7 +381,11 @@ public class DocumentDB {
       List<BuiltCondition> predicates,
       boolean allowFiltering,
       int pageSize,
-      ByteBuffer pageState) {
+      ByteBuffer pageState)
+      throws UnauthorizedException {
+    // Run generic authorizeDataRead for now
+    getAuthorizationService()
+        .authorizeDataRead(getAuthenticationSubject(), keyspace, collection, SourceAPI.REST);
     UnaryOperator<Parameters> parametersModifier =
         p -> {
           if (pageState != null) {

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 public class DocumentDB {
   private static final Logger logger = LoggerFactory.getLogger(DocumentDB.class);
   private static final List<Character> forbiddenCharacters;
+  private static final List<Column> allColumns;
   private static final List<String> allColumnNames;
   private static final List<Column.ColumnType> allColumnTypes;
   private static final List<String> allPathColumnNames;
@@ -68,26 +69,33 @@ public class DocumentDB {
   private final AuthenticationSubject authenticationSubject;
 
   static {
+    allColumns = new ArrayList<>();
     allColumnNames = new ArrayList<>();
     allColumnTypes = new ArrayList<>();
     allPathColumnNames = new ArrayList<>();
     allPathColumnTypes = new ArrayList<>();
     allColumnNames.add("key");
     allColumnTypes.add(Type.Text);
+    allColumns.add(Column.create("key", Type.Text));
     for (int i = 0; i < MAX_DEPTH; i++) {
       allPathColumnNames.add("p" + i);
       allPathColumnTypes.add(Type.Text);
+      allColumns.add(Column.create("p" + i, Type.Text));
     }
     allColumnNames.addAll(allPathColumnNames);
     allColumnTypes.addAll(allPathColumnTypes);
     allColumnNames.add("leaf");
     allColumnTypes.add(Type.Text);
+    allColumns.add(Column.create("leaf", Type.Text));
     allColumnNames.add("text_value");
     allColumnTypes.add(Type.Text);
+    allColumns.add(Column.create("text_value", Type.Text));
     allColumnNames.add("dbl_value");
     allColumnTypes.add(Type.Double);
+    allColumns.add(Column.create("dbl_value", Type.Double));
     allColumnNames.add("bool_value");
     allColumnTypes.add(Type.Boolean);
+    allColumns.add(Column.create("bool_value", Type.Boolean));
 
     forbiddenCharacters = ImmutableList.of('[', ']', ',', '.', '\'', '*');
 
@@ -139,10 +147,6 @@ public class DocumentDB {
   }
 
   public static List<Column> allColumns() {
-    List<Column> allColumns = new ArrayList<>(allColumnNames.size());
-    for (int i = 0; i < allColumnNames.size(); i++) {
-      allColumns.add(Column.create(allColumnNames.get(i), allColumnTypes.get(i)));
-    }
     return allColumns;
   }
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -417,7 +417,7 @@ public class DocumentDB {
       throws UnauthorizedException {
     // Run generic authorizeDataRead for now
     getAuthorizationService()
-        .authorizeDataRead(getAuthToken(), keyspace, collection, SourceAPI.REST);
+        .authorizeDataRead(getAuthenticationSubject(), keyspace, collection, SourceAPI.REST);
     UnaryOperator<Parameters> parametersModifier =
         p -> {
           if (pageState != null) {

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
@@ -621,12 +621,11 @@ public class DocumentResourceV2 {
               byte[] decodedBytes = Base64.getDecoder().decode(pageStateParam);
               pageState = ByteBuffer.wrap(decodedBytes);
             }
-            DocumentDB db =
-                dbFactory.getDocDataStoreForToken(
-                    authToken, pageSizeParam > 0 ? pageSizeParam : DEFAULT_PAGE_SIZE, pageState);
+            DocumentDB db = dbFactory.getDocDataStoreForToken(authToken);
+            int pageSize = pageSizeParam > 0 ? pageSizeParam : DEFAULT_PAGE_SIZE;
             ImmutablePair<JsonNode, ByteBuffer> result =
                 documentService.searchDocumentsV2(
-                    db, namespace, collection, filters, selectionList, id);
+                    db, namespace, collection, filters, selectionList, id, pageSize, pageState);
 
             if (result == null) {
               return Response.noContent().build();
@@ -739,7 +738,7 @@ public class DocumentResourceV2 {
           int pageSize = DEFAULT_PAGE_SIZE;
 
           ByteBuffer cloneState = pageState != null ? pageState.duplicate() : null;
-          DocumentDB db = dbFactory.getDocDataStoreForToken(authToken, pageSize, pageState);
+          DocumentDB db = dbFactory.getDocDataStoreForToken(authToken);
 
           ImmutablePair<JsonNode, ByteBuffer> results;
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -999,8 +999,8 @@ public class DocumentService {
    * @param path the path in the document that is being searched on
    * @param recurse legacy boolean, only used for v1 of the API
    * @param documentKey filter down to only one document's results
-   * @param pageSize Cassandra page size
-   * @param pageState Cassandra page state
+   * @param pageSize number of rows to return
+   * @param pageState current state of database paging
    * @return
    * @throws ExecutionException
    * @throws InterruptedException

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -635,7 +635,9 @@ public class DocumentService {
       String documentKey,
       List<FilterCondition> filters,
       List<PathSegment> path,
-      Boolean recurse)
+      Boolean recurse,
+      int pageSize,
+      ByteBuffer pageState)
       throws ExecutionException, InterruptedException, UnauthorizedException {
     StringBuilder pathStr = new StringBuilder();
 
@@ -650,7 +652,9 @@ public class DocumentService {
                 new ArrayList<>(),
                 pathSegmentValues,
                 recurse,
-                documentKey)
+                documentKey,
+                pageSize,
+                pageState)
             .left;
 
     if (rows.size() == 0) return null;
@@ -683,15 +687,27 @@ public class DocumentService {
       String collection,
       List<FilterCondition> filters,
       List<String> fields,
-      String documentId)
+      String documentId,
+      int pageSize,
+      ByteBuffer pageState)
       throws ExecutionException, InterruptedException, UnauthorizedException {
     FilterCondition first = filters.get(0);
     List<String> path = first.getPath();
 
     ImmutablePair<List<Row>, ByteBuffer> searchResult =
-        searchRows(keyspace, collection, db, filters, fields, path, false, documentId);
+        searchRows(
+            keyspace,
+            collection,
+            db,
+            filters,
+            fields,
+            path,
+            false,
+            documentId,
+            pageSize,
+            pageState);
     List<Row> rows = searchResult.left;
-    ByteBuffer pageState = searchResult.right;
+    ByteBuffer newpageState = searchResult.right;
     if (rows.size() == 0) {
       return null;
     }
@@ -748,7 +764,7 @@ public class DocumentService {
       return null;
     }
 
-    return ImmutablePair.of(docsResult, pageState);
+    return ImmutablePair.of(docsResult, newpageState);
   }
 
   @VisibleForTesting
@@ -801,6 +817,7 @@ public class DocumentService {
     LinkedHashMap<String, List<Row>> rowsByDoc = new LinkedHashMap<>();
 
     ImmutablePair<List<Row>, ByteBuffer> page;
+    ByteBuffer currentPageState = initialPagingState;
     do {
       page =
           searchRows(
@@ -811,10 +828,12 @@ public class DocumentService {
               new ArrayList<>(),
               new ArrayList<>(),
               false,
-              null);
+              null,
+              pageSize,
+              currentPageState);
       addRowsToMap(rowsByDoc, page.left);
-      db = dbFactory.getDocDataStoreForToken(authToken, pageSize, page.right);
-    } while (rowsByDoc.keySet().size() <= limit && page.right != null);
+      currentPageState = page.right;
+    } while (rowsByDoc.keySet().size() <= limit && currentPageState != null);
 
     // Either we've reached the end of all rows in the collection, or we have enough rows
     // in memory to build the final result.
@@ -831,7 +850,6 @@ public class DocumentService {
         }
         docsResult.set(e.getKey(), convertToJsonDoc(rows, false, db.treatBooleansAsNumeric()).left);
       }
-      db = dbFactory.getDocDataStoreForToken(authToken, totalSize, initialPagingState);
       ByteBuffer finalPagingState =
           searchRows(
                   keyspace,
@@ -841,7 +859,9 @@ public class DocumentService {
                   new ArrayList<>(),
                   new ArrayList<>(),
                   false,
-                  null)
+                  null,
+                  pageSize,
+                  initialPagingState)
               .right;
       return ImmutablePair.of(docsResult, finalPagingState);
     } else {
@@ -881,6 +901,7 @@ public class DocumentService {
     LinkedHashMap<String, Integer> countsByDoc = new LinkedHashMap<>();
 
     ImmutablePair<List<Row>, ByteBuffer> page;
+    ByteBuffer currentPageState = initialPagingState;
     do {
       page =
           searchRows(
@@ -891,11 +912,13 @@ public class DocumentService {
               new ArrayList<>(),
               new ArrayList<>(),
               false,
-              null);
+              null,
+              pageSize,
+              currentPageState);
       updateExistenceForMap(
           existsByDoc, countsByDoc, page.left, filters, db.treatBooleansAsNumeric());
-      db = dbFactory.getDocDataStoreForToken(authToken, pageSize, page.right);
-    } while (existsByDoc.keySet().size() <= limit && page.right != null);
+      currentPageState = page.right;
+    } while (existsByDoc.keySet().size() <= limit && currentPageState != null);
 
     // Either we've reached the end of all rows in the collection, or we have enough rows
     // in memory to build the final result.
@@ -914,7 +937,6 @@ public class DocumentService {
           i++;
         }
       }
-      db = dbFactory.getDocDataStoreForToken(authToken, totalSize, initialPagingState);
       finalPagingState =
           searchRows(
                   keyspace,
@@ -924,7 +946,9 @@ public class DocumentService {
                   new ArrayList<>(),
                   new ArrayList<>(),
                   false,
-                  null)
+                  null,
+                  pageSize,
+                  initialPagingState)
               .right;
     } else {
       finalPagingState = null;
@@ -972,6 +996,8 @@ public class DocumentService {
    * @param path the path in the document that is being searched on
    * @param recurse legacy boolean, only used for v1 of the API
    * @param documentKey filter down to only one document's results
+   * @param pageSize Cassandra page size
+   * @param pageState Cassandra page state
    * @return
    * @throws ExecutionException
    * @throws InterruptedException
@@ -985,7 +1011,9 @@ public class DocumentService {
       List<String> fields,
       List<String> path,
       Boolean recurse,
-      String documentKey)
+      String documentKey,
+      int pageSize,
+      ByteBuffer pageState)
       throws UnauthorizedException {
     StringBuilder pathStr = new StringBuilder();
     List<BuiltCondition> predicates = new ArrayList<>();
@@ -1064,9 +1092,9 @@ public class DocumentService {
     ResultSet r;
 
     if (predicates.size() > 0) {
-      r = db.executeSelect(keyspace, collection, predicates, true);
+      r = db.executeSelect(keyspace, collection, predicates, true, pageSize, pageState);
     } else {
-      r = db.executeSelectAll(keyspace, collection);
+      r = db.executeSelectAll(keyspace, collection, pageSize, pageState);
     }
 
     List<Row> rows = r.currentPageRows();

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -860,7 +860,7 @@ public class DocumentService {
                   new ArrayList<>(),
                   false,
                   null,
-                  pageSize,
+                  totalSize,
                   initialPagingState)
               .right;
       return ImmutablePair.of(docsResult, finalPagingState);
@@ -947,7 +947,7 @@ public class DocumentService {
                   new ArrayList<>(),
                   false,
                   null,
-                  pageSize,
+                  totalSize,
                   initialPagingState)
               .right;
     } else {

--- a/restapi/src/main/java/io/stargate/web/resources/Db.java
+++ b/restapi/src/main/java/io/stargate/web/resources/Db.java
@@ -77,11 +77,17 @@ public class Db {
     return new AuthenticatedDB(dataStore, authenticationSubject);
   }
 
+<<<<<<< HEAD
   public AuthenticatedDB getDataStoreForToken(String token, int pageSize, ByteBuffer pagingState)
       throws UnauthorizedException {
     AuthenticationSubject authenticationSubject = authenticationService.validateToken(token);
     return new AuthenticatedDB(
         getDataStoreInternal(authenticationSubject, pageSize, pagingState), authenticationSubject);
+=======
+  private DataStore getDataStoreInternal(String role) {
+    DataStoreOptions options = DataStoreOptions.builder().alwaysPrepareQueries(true).build();
+    return dataStoreFactory.create(role, options);
+>>>>>>> Remove validation of columns, we'll see if that's faster
   }
 
   private DataStore getDataStoreInternal(

--- a/restapi/src/main/java/io/stargate/web/resources/Db.java
+++ b/restapi/src/main/java/io/stargate/web/resources/Db.java
@@ -90,7 +90,7 @@ public class Db {
         authenticationService.validateToken(token, headers);
     if (authenticationSubject == null) {
       throw new UnauthorizedException("Missing authenticationSubject");
-    }    
+    }
     return new AuthenticatedDB(
         getDataStoreInternal(authenticationSubject, pageSize, pagingState, headers),
         authenticationSubject);

--- a/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
@@ -273,7 +273,14 @@ public class DocumentResourceV2Test {
 
     Mockito.when(
             documentServiceMock.searchDocumentsV2(
-                anyObject(), anyString(), anyString(), anyList(), anyList(), anyString()))
+                anyObject(),
+                anyString(),
+                anyString(),
+                anyList(),
+                anyList(),
+                anyString(),
+                anyInt(),
+                anyObject()))
         .thenReturn(ImmutablePair.of(mockedReturn, null));
 
     Mockito.when(documentServiceMock.convertToFilterOps(anyList(), anyObject()))

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -167,7 +167,9 @@ public class DocumentServiceTest {
             List.class,
             List.class,
             Boolean.class,
-            String.class);
+            String.class,
+            int.class,
+            ByteBuffer.class);
     searchRows.setAccessible(true);
   }
 
@@ -1223,9 +1225,13 @@ public class DocumentServiceTest {
   public void searchDocumentsV2_emptyResult() throws Exception {
     DocumentDB dbMock = Mockito.mock(DocumentDB.class);
     DocumentService serviceMock = Mockito.mock(DocumentService.class);
-    Mockito.when(serviceMock.searchDocumentsV2(any(), any(), any(), any(), any(), any()))
+    Mockito.when(
+            serviceMock.searchDocumentsV2(
+                any(), any(), any(), any(), any(), any(), anyInt(), any()))
         .thenCallRealMethod();
-    Mockito.when(serviceMock.searchRows(any(), any(), any(), any(), any(), any(), any(), any()))
+    Mockito.when(
+            serviceMock.searchRows(
+                any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
         .thenReturn(ImmutablePair.of(new ArrayList<>(), null));
 
     List<FilterCondition> filters =
@@ -1233,7 +1239,7 @@ public class DocumentServiceTest {
             new SingleFilterCondition(ImmutableList.of("a", "b", "c"), "$eq", "value"));
     ImmutablePair<JsonNode, ByteBuffer> result =
         serviceMock.searchDocumentsV2(
-            dbMock, "keyspace", "collection", filters, new ArrayList<>(), null);
+            dbMock, "keyspace", "collection", filters, new ArrayList<>(), null, 100, null);
     assertThat(result).isNull();
   }
 
@@ -1241,9 +1247,13 @@ public class DocumentServiceTest {
   public void searchDocumentsV2_existingResult() throws Exception {
     DocumentDB dbMock = Mockito.mock(DocumentDB.class);
     DocumentService serviceMock = Mockito.mock(DocumentService.class);
-    Mockito.when(serviceMock.searchDocumentsV2(any(), any(), any(), any(), any(), any()))
+    Mockito.when(
+            serviceMock.searchDocumentsV2(
+                any(), any(), any(), any(), any(), any(), anyInt(), any()))
         .thenCallRealMethod();
-    Mockito.when(serviceMock.searchRows(any(), any(), any(), any(), any(), any(), any(), any()))
+    Mockito.when(
+            serviceMock.searchRows(
+                any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
         .thenReturn(ImmutablePair.of(makeInitialRowData(), null));
     Mockito.when(serviceMock.convertToJsonDoc(any(), anyBoolean(), anyBoolean()))
         .thenReturn(ImmutablePair.of(mapper.readTree("{\"a\": 1}"), new HashMap<>()));
@@ -1253,7 +1263,7 @@ public class DocumentServiceTest {
             new SingleFilterCondition(ImmutableList.of("a", "b", "c"), "$eq", "value"));
     ImmutablePair<JsonNode, ByteBuffer> result =
         serviceMock.searchDocumentsV2(
-            dbMock, "keyspace", "collection", filters, new ArrayList<>(), null);
+            dbMock, "keyspace", "collection", filters, new ArrayList<>(), null, 100, null);
     assertThat(result.right).isNull();
     assertThat(result.left).isEqualTo(mapper.readTree("{\"1\":[{\"a\":1},{\"a\":1},{\"a\":1}]}"));
   }
@@ -1262,19 +1272,22 @@ public class DocumentServiceTest {
   public void searchDocumentsV2_existingResultWithFields() throws Exception {
     DocumentDB dbMock = Mockito.mock(DocumentDB.class);
     DocumentService serviceMock = Mockito.mock(DocumentService.class);
-    Mockito.when(serviceMock.searchDocumentsV2(any(), any(), any(), any(), any(), any()))
+    Mockito.when(
+            serviceMock.searchDocumentsV2(
+                any(), any(), any(), any(), any(), any(), anyInt(), any()))
         .thenCallRealMethod();
-    Mockito.when(serviceMock.searchRows(any(), any(), any(), any(), any(), any(), any(), any()))
+    Mockito.when(
+            serviceMock.searchRows(
+                any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
         .thenReturn(ImmutablePair.of(makeInitialRowData(), null));
     Mockito.when(serviceMock.convertToJsonDoc(any(), anyBoolean(), anyBoolean()))
         .thenReturn(ImmutablePair.of(mapper.readTree("{\"a\": 1}"), new HashMap<>()));
-
     List<FilterCondition> filters =
         ImmutableList.of(
             new SingleFilterCondition(ImmutableList.of("a", "b", "c"), "$exists", true));
     ImmutablePair<JsonNode, ByteBuffer> result =
         serviceMock.searchDocumentsV2(
-            dbMock, "keyspace", "collection", filters, ImmutableList.of("field"), null);
+            dbMock, "keyspace", "collection", filters, ImmutableList.of("field"), null, 100, null);
     assertThat(result.right).isNull();
     assertThat(result.left).isEqualTo(mapper.readTree("{\"1\":[{\"a\":1},{\"a\":1},{\"a\":1}]}"));
   }
@@ -1303,9 +1316,10 @@ public class DocumentServiceTest {
     Db dbFactoryMock = Mockito.mock(Db.class);
     DocumentDB dbMock = Mockito.mock(DocumentDB.class);
     DocumentService serviceMock = Mockito.mock(DocumentService.class);
-    Mockito.when(dbFactoryMock.getDocDataStoreForToken(anyString(), anyInt(), any()))
-        .thenReturn(dbMock);
-    Mockito.when(serviceMock.searchRows(any(), any(), any(), any(), any(), any(), any(), any()))
+    Mockito.when(dbFactoryMock.getDocDataStoreForToken(anyString())).thenReturn(dbMock);
+    Mockito.when(
+            serviceMock.searchRows(
+                any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
         .thenReturn(ImmutablePair.of(makeInitialRowData(), null));
     Mockito.when(
             serviceMock.getFullDocuments(
@@ -1345,9 +1359,10 @@ public class DocumentServiceTest {
     DocumentService serviceMock = Mockito.mock(DocumentService.class);
     List<Row> twoDocsRows = makeInitialRowData();
     twoDocsRows.addAll(makeRowDataForSecondDoc());
-    Mockito.when(dbFactoryMock.getDocDataStoreForToken(anyString(), anyInt(), any()))
-        .thenReturn(dbMock);
-    Mockito.when(serviceMock.searchRows(any(), any(), any(), any(), any(), any(), any(), any()))
+    Mockito.when(dbFactoryMock.getDocDataStoreForToken(anyString())).thenReturn(dbMock);
+    Mockito.when(
+            serviceMock.searchRows(
+                any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
         .thenReturn(ImmutablePair.of(twoDocsRows, null));
     Mockito.when(
             serviceMock.getFullDocuments(
@@ -1388,8 +1403,9 @@ public class DocumentServiceTest {
 
     ResultSet rsMock = mock(ResultSet.class);
     List<Row> rows = makeInitialRowData();
-    when(dbMock.executeSelectAll(anyString(), anyString())).thenReturn(rsMock);
-    when(dbMock.executeSelect(anyString(), anyString(), any(), anyBoolean())).thenReturn(rsMock);
+    when(dbMock.executeSelectAll(anyString(), anyString(), anyInt(), any())).thenReturn(rsMock);
+    when(dbMock.executeSelect(anyString(), anyString(), any(), anyBoolean(), anyInt(), any()))
+        .thenReturn(rsMock);
     when(rsMock.currentPageRows()).thenReturn(rows);
     when(dbMock.getAuthorizationService()).thenReturn(authorizationService);
     doNothing()
@@ -1410,7 +1426,9 @@ public class DocumentServiceTest {
                 filters,
                 new ArrayList<>(),
                 ImmutableList.of("a,b", "*", "c"),
+                false,
                 null,
+                100,
                 null);
 
     assertThat(result.right).isNull();
@@ -1426,7 +1444,9 @@ public class DocumentServiceTest {
                 new ArrayList<>(),
                 new ArrayList<>(),
                 new ArrayList<>(),
+                false,
                 null,
+                100,
                 null);
 
     assertThat(result.right).isNull();
@@ -1439,8 +1459,9 @@ public class DocumentServiceTest {
     DocumentDB dbMock = mock(DocumentDB.class);
     ResultSet rsMock = mock(ResultSet.class);
     List<Row> rows = makeInitialRowData();
-    when(dbMock.executeSelectAll(anyString(), anyString())).thenReturn(rsMock);
-    when(dbMock.executeSelect(anyString(), anyString(), any(), anyBoolean())).thenReturn(rsMock);
+    when(dbMock.executeSelectAll(anyString(), anyString(), anyInt(), any())).thenReturn(rsMock);
+    when(dbMock.executeSelect(anyString(), anyString(), any(), anyBoolean(), anyInt(), any()))
+        .thenReturn(rsMock);
     when(dbMock.getAuthorizationService()).thenReturn(authorizationService);
     doNothing()
         .when(authorizationService)
@@ -1464,6 +1485,8 @@ public class DocumentServiceTest {
                     new ArrayList<>(),
                     ImmutableList.of("a,b", "*", "c"),
                     null,
+                    null,
+                    1,
                     null));
 
     assertThat(thrown.getCause())


### PR DESCRIPTION
A few changes that improve performance for the docs API.

Summary of changes:
1) validating columns for document API queries gets skipped (since we control the schema, the change is [here](https://github.com/stargate/stargate/pull/534/files#diff-b8c255d9e805201cb8ed7ab124b0de34256e996dbc41ac155ac99dab4e6f7ae5R1391)
2) allColumns() doesn't have to be calculated each time the function is called, fix is [here](https://github.com/stargate/stargate/pull/534/files#diff-d36bfbe0c5f35c2d92be42df6186c221c2a80c49022c728aae5ccd217443be3aR46)
3) Caching of the _entire_ data store is now done.  This was achieved by setting pageSize/pageState values on each individual query, rather than on the data store itself, to allow proper reuse. See [here](https://github.com/stargate/stargate/pull/534/files#diff-d36bfbe0c5f35c2d92be42df6186c221c2a80c49022c728aae5ccd217443be3aR336) for an example of that querying change.

These changes all together cause latency on a setup with 2 stargate/2 storage nodes, 4000 ops/sec to drop from 40ms per read to 20ms per read. Not bad!
