### PR TITLE
Build timeout to 4hr

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -91,6 +91,6 @@ steps:
 
 substitutions:
   _BUCKET: 'stargateio-github_cloudbuild'
-timeout: 10800s
+timeout: 14400s
 options:
   machineType: 'N1_HIGHCPU_32'


### PR DESCRIPTION
Up the build timeout from 3hr to 4hr while we have to run things sequentially.