### PR TITLE
Fix #545 - NPE is thrown if TableOptions is null

### DIFF
--- a/restapi/src/main/java/io/stargate/web/resources/TableResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/TableResource.java
@@ -200,13 +200,15 @@ public class TableResource {
           db.getAuthorizationService()
               .authorizeSchemaWrite(token, keyspaceName, tableName, Scope.CREATE, SourceAPI.REST);
 
+          int ttl = (options == null) ? 0 : options.getDefaultTimeToLive();
+
           localDB
               .queryBuilder()
               .create()
               .table(keyspaceName, tableName)
               .ifNotExists(tableAdd.getIfNotExists())
               .column(columns)
-              .withDefaultTTL(options.getDefaultTimeToLive())
+              .withDefaultTTL(ttl)
               .build()
               .execute(ConsistencyLevel.LOCAL_QUORUM)
               .get();

--- a/restapi/src/main/java/io/stargate/web/resources/TableResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/TableResource.java
@@ -200,7 +200,10 @@ public class TableResource {
           db.getAuthorizationService()
               .authorizeSchemaWrite(token, keyspaceName, tableName, Scope.CREATE, SourceAPI.REST);
 
-          int ttl = (options == null) ? 0 : options.getDefaultTimeToLive();
+          int ttl = 0;
+          if (options != null && options.getDefaultTimeToLive() != null) {
+            ttl = options.getDefaultTimeToLive();
+          }
 
           localDB
               .queryBuilder()

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/TablesResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/TablesResource.java
@@ -258,7 +258,10 @@ public class TablesResource {
             columns.add(Column.create(columnName, kind, type, order));
           }
 
-          int ttl = (options == null) ? 0 : options.getDefaultTimeToLive();
+          int ttl = 0;
+          if (options != null && options.getDefaultTimeToLive() != null) {
+            ttl = options.getDefaultTimeToLive();
+          }
 
           localDB
               .queryBuilder()

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/TablesResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/TablesResource.java
@@ -258,13 +258,15 @@ public class TablesResource {
             columns.add(Column.create(columnName, kind, type, order));
           }
 
+          int ttl = (options == null) ? 0 : options.getDefaultTimeToLive();
+
           localDB
               .queryBuilder()
               .create()
               .table(keyspaceName, tableName)
               .ifNotExists(tableAdd.getIfNotExists())
               .column(columns)
-              .withDefaultTTL(options.getDefaultTimeToLive())
+              .withDefaultTTL(ttl)
               .build()
               .execute(ConsistencyLevel.LOCAL_QUORUM)
               .get();

--- a/testing/src/test/java/io/stargate/it/http/RestApiTest.java
+++ b/testing/src/test/java/io/stargate/it/http/RestApiTest.java
@@ -243,6 +243,36 @@ public class RestApiTest extends BaseOsgiIntegrationTest {
   }
 
   @Test
+  public void createTableWithNullOptions() throws IOException {
+    TableAdd tableAdd = new TableAdd();
+    tableAdd.setName("t1");
+
+    List<ColumnDefinition> columnDefinitions = new ArrayList<>();
+
+    columnDefinitions.add(new ColumnDefinition("id", "uuid"));
+    columnDefinitions.add(new ColumnDefinition("lastName", "text"));
+    columnDefinitions.add(new ColumnDefinition("firstName", "text"));
+
+    tableAdd.setColumnDefinitions(columnDefinitions);
+
+    PrimaryKey primaryKey = new PrimaryKey();
+    primaryKey.setPartitionKey(Collections.singletonList("id"));
+    tableAdd.setPrimaryKey(primaryKey);
+    tableAdd.setTableOptions(null);
+
+    String body =
+        RestUtils.post(
+            authToken,
+            String.format("%s:8082/v1/keyspaces/%s/tables", host, keyspace),
+            objectMapper.writeValueAsString(tableAdd),
+            HttpStatus.SC_CREATED);
+
+    SuccessResponse successResponse =
+        objectMapper.readValue(body, new TypeReference<SuccessResponse>() {});
+    assertThat(successResponse.getSuccess()).isTrue();
+  }
+
+  @Test
   public void getRow() throws IOException {
     String tableName = "tbl_getrow_" + System.currentTimeMillis();
     createTable(tableName);

--- a/testing/src/test/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/test/java/io/stargate/it/http/RestApiv2Test.java
@@ -358,6 +358,38 @@ public class RestApiv2Test extends BaseOsgiIntegrationTest {
   }
 
   @Test
+  public void createTableWithNullOptions() throws IOException {
+    createKeyspace(keyspaceName);
+
+    TableAdd tableAdd = new TableAdd();
+    tableAdd.setName("t1");
+
+    List<ColumnDefinition> columnDefinitions = new ArrayList<>();
+
+    columnDefinitions.add(new ColumnDefinition("id", "uuid"));
+    columnDefinitions.add(new ColumnDefinition("lastName", "text"));
+    columnDefinitions.add(new ColumnDefinition("firstName", "text"));
+
+    tableAdd.setColumnDefinitions(columnDefinitions);
+
+    PrimaryKey primaryKey = new PrimaryKey();
+    primaryKey.setPartitionKey(Collections.singletonList("id"));
+    tableAdd.setPrimaryKey(primaryKey);
+    tableAdd.setTableOptions(null);
+
+    String body =
+        RestUtils.post(
+            authToken,
+            String.format("%s:8082/v2/schemas/keyspaces/%s/tables", host, keyspaceName),
+            objectMapper.writeValueAsString(tableAdd),
+            HttpStatus.SC_CREATED);
+
+    SuccessResponse successResponse =
+        objectMapper.readValue(body, new TypeReference<SuccessResponse>() {});
+    assertThat(successResponse.getSuccess()).isTrue();
+  }
+
+  @Test
   public void getRowsWithQuery() throws IOException {
     createKeyspace(keyspaceName);
     createTable(keyspaceName, tableName);


### PR DESCRIPTION
A NPE is thrown whenever TableOptions is set to null in TableResources.