### PR TITLE
Increase heartbeat timeout and interval in test

### DIFF
--- a/testing/src/test/java/io/stargate/it/driver/CqlSessionExtension.java
+++ b/testing/src/test/java/io/stargate/it/driver/CqlSessionExtension.java
@@ -387,6 +387,8 @@ public class CqlSessionExtension
     config.put(TypedDriverOption.METADATA_SCHEMA_REQUEST_TIMEOUT, Duration.ofMinutes(3));
     config.put(TypedDriverOption.CONNECTION_INIT_QUERY_TIMEOUT, Duration.ofMinutes(3));
     config.put(TypedDriverOption.CONTROL_CONNECTION_TIMEOUT, Duration.ofMinutes(3));
+    config.put(TypedDriverOption.HEARTBEAT_TIMEOUT, Duration.ofMinutes(1));
+    config.put(TypedDriverOption.HEARTBEAT_INTERVAL, Duration.ofMinutes(1));
     config.put(TypedDriverOption.REQUEST_TRACE_INTERVAL, Duration.ofSeconds(5));
     config.put(TypedDriverOption.REQUEST_TRACE_ATTEMPTS, 180 / 5);
     config.put(TypedDriverOption.REQUEST_WARN_IF_SET_KEYSPACE, false);


### PR DESCRIPTION
... due to CI slowness