### PR TITLE
Do not pull schema from non-token ring members

### DIFF
--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/interceptors/DefaultQueryInterceptor.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/interceptors/DefaultQueryInterceptor.java
@@ -29,7 +29,6 @@ import org.apache.cassandra.gms.EndpointState;
 import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.gms.IEndpointStateChangeSubscriber;
 import org.apache.cassandra.gms.VersionedValue;
-import org.apache.cassandra.service.MigrationManager;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.transport.messages.ResultMessage;

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/interceptors/DefaultQueryInterceptor.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/interceptors/DefaultQueryInterceptor.java
@@ -240,10 +240,6 @@ public class DefaultQueryInterceptor implements QueryInterceptor, IEndpointState
         // for DDL queries to reach agreement before returning.
         StargateSystemKeyspace.updatePeerInfo(
             endpoint, "schema_version", StargateSystemKeyspace.SCHEMA_VERSION, executor);
-
-        // This fix schedules a schema pull for the non-member node and is required because
-        // `StorageService.onChange()` doesn't do this for non-member nodes.
-        MigrationManager.scheduleSchemaPull(endpoint, epState);
         break;
       case HOST_ID:
         StargateSystemKeyspace.updatePeerInfo(

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/interceptors/DefaultQueryInterceptor.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/interceptors/DefaultQueryInterceptor.java
@@ -27,7 +27,6 @@ import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.gms.IEndpointStateChangeSubscriber;
 import org.apache.cassandra.gms.VersionedValue;
 import org.apache.cassandra.locator.InetAddressAndPort;
-import org.apache.cassandra.schema.MigrationManager;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.QueryState;

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/interceptors/DefaultQueryInterceptor.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/interceptors/DefaultQueryInterceptor.java
@@ -253,10 +253,6 @@ public class DefaultQueryInterceptor implements QueryInterceptor, IEndpointState
         // for DDL queries to reach agreement before returning.
         StargateSystemKeyspace.updatePeerInfo(
             endpoint, "schema_version", StargateSystemKeyspace.SCHEMA_VERSION);
-
-        // This fix schedules a schema pull for the non-member node and is required because
-        // `StorageService.onChange()` doesn't do this for non-member nodes.
-        MigrationManager.instance.scheduleSchemaPull(endpoint, epState);
         break;
       case HOST_ID:
         StargateSystemKeyspace.updatePeerInfo(endpoint, "host_id", UUID.fromString(value.value));

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/interceptors/DefaultQueryInterceptor.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/interceptors/DefaultQueryInterceptor.java
@@ -238,12 +238,6 @@ public class DefaultQueryInterceptor implements QueryInterceptor, IEndpointState
       case NATIVE_TRANSPORT_PORT_SSL:
         updatePeer(endpoint, Integer.parseInt(value.value), StargatePeerInfo::setNativePortSsl);
         break;
-      case SCHEMA:
-        // This fix schedules a schema pull for the non-member node and is required because
-        // `StorageService.onChange()` doesn't do this for non-member nodes.
-        MigrationManager.instance.scheduleSchemaPull(
-            endpoint, epState, String.format("gossip schema version change to %s", value.value));
-        break;
       case STORAGE_PORT:
         updatePeer(endpoint, Integer.parseInt(value.value), StargatePeerInfo::setStoragePort);
         break;

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/interceptors/DefaultQueryInterceptor.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/interceptors/DefaultQueryInterceptor.java
@@ -28,7 +28,6 @@ import org.apache.cassandra.gms.EndpointState;
 import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.gms.IEndpointStateChangeSubscriber;
 import org.apache.cassandra.gms.VersionedValue;
-import org.apache.cassandra.schema.MigrationManager;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.transport.messages.ResultMessage;


### PR DESCRIPTION
In retrospect, it is a bug to pull schema from non-ring members and schema should only be pulled from the storage nodes. Pulling schema from ring members is handled in the`StorageService#onChange()` method.