### PR TITLE
GraphQL: Remove "__" prefix from "conversionWarnings" query name

### DIFF
--- a/graphqlapi/README.md
+++ b/graphqlapi/README.md
@@ -115,14 +115,14 @@ CREATE TABLE library.authors (
 
 If a GraphQL API is not generated for an existing CQL table schema then there might have been a
 failure with the conversion. The failure will create a warning that can be retrieved using the
-`__conversionWarnings` operation under the table's keyspace URL:
+`conversionWarnings` operation under the table's keyspace URL:
 `http://localhost/graphql/<keyspace>`. 
 
 To query the conversion warnings use:
 
 ```graphql
 query {
-  __conversionWarnings
+  conversionWarnings
 }
 ```
 

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/DmlSchemaBuilder.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/DmlSchemaBuilder.java
@@ -535,7 +535,7 @@ class DmlSchemaBuilder {
       }
     }
     return GraphQLFieldDefinition.newFieldDefinition()
-        .name("__conversionWarnings")
+        .name("conversionWarnings")
         .description(description.toString())
         .type(list(GraphQLString))
         .dataFetcher((d) -> warnings)

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/NameConversions.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/NameConversions.java
@@ -233,6 +233,7 @@ public class NameConversions {
           .put("TinyInt", "TinyInx74_")
           .put("Timestamp", "Timestamx70_")
           .put("Time", "Timx65_")
+          .put("conversionWarnings", "conversionWarningx73_")
           .build();
 
   private static ImmutableMap<String, String> RESERVED_PREFIXES =

--- a/testing/src/main/graphql/betterbotz/schema.json
+++ b/testing/src/main/graphql/betterbotz/schema.json
@@ -6641,7 +6641,7 @@
               "deprecationReason": "No longer supported. Use root type instead."
             },
             {
-              "name": "__conversionWarnings",
+              "name": "conversionWarnings",
               "description": "Warnings encountered during the CQL to GraphQL conversion.\nThis will return:\n- Table Tuples mapped as Tuplx65_s\n- Table TuplesPk mapped as Tuplx65_sPk",
               "args": [],
               "type": {


### PR DESCRIPTION
Fixes #615