### PR TITLE
Test whether schema argreement is achievable during the liveness check.

### DIFF
--- a/health-checker/src/main/java/io/stargate/health/CheckerResource.java
+++ b/health-checker/src/main/java/io/stargate/health/CheckerResource.java
@@ -1,6 +1,7 @@
 package io.stargate.health;
 
 import static io.stargate.health.HealthCheckerActivator.BUNDLES_CHECK_NAME;
+import static io.stargate.health.HealthCheckerActivator.SCHEMA_CHECK_NAME;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheck.Result;
@@ -51,11 +52,16 @@ public class CheckerResource {
     // Sufficient to just return a 200 OK since liveness just means "app is up and doesn't need
     // restarted"
     HealthCheck bundleHealthCheck = healthCheckRegistry.getHealthCheck(BUNDLES_CHECK_NAME);
-    if (bundleHealthCheck != null && bundleHealthCheck.execute().isHealthy()) {
-      return Response.status(Response.Status.OK).entity("UP").build();
+    if (bundleHealthCheck == null || !bundleHealthCheck.execute().isHealthy()) {
+      return Response.status(Response.Status.SERVICE_UNAVAILABLE).entity("DOWN").build();
     }
 
-    return Response.status(Response.Status.SERVICE_UNAVAILABLE).entity("DOWN").build();
+    HealthCheck schemaHealthCheck = healthCheckRegistry.getHealthCheck(SCHEMA_CHECK_NAME);
+    if (schemaHealthCheck == null || !schemaHealthCheck.execute().isHealthy()) {
+      return Response.status(Response.Status.SERVICE_UNAVAILABLE).entity("DOWN").build();
+    }
+
+    return Response.status(Response.Status.OK).entity("UP").build();
   }
 
   @GET

--- a/health-checker/src/main/java/io/stargate/health/HealthCheckerActivator.java
+++ b/health-checker/src/main/java/io/stargate/health/HealthCheckerActivator.java
@@ -16,6 +16,7 @@ public class HealthCheckerActivator extends BaseActivator {
 
   public static final String BUNDLES_CHECK_NAME = "bundles";
   public static final String DATASTORE_CHECK_NAME = "datastore";
+  public static final String SCHEMA_CHECK_NAME = "schema-agreement";
 
   private ServicePointer<Metrics> metrics = ServicePointer.create(Metrics.class);
   private ServicePointer<HealthCheckRegistry> healthCheckRegistry =
@@ -36,11 +37,9 @@ public class HealthCheckerActivator extends BaseActivator {
   protected ServiceAndProperties createService() {
     log.info("Starting healthchecker....");
     try {
-      BundleStateChecker bundleStateChecker = new BundleStateChecker(context);
-      healthCheckRegistry.get().register(BUNDLES_CHECK_NAME, bundleStateChecker);
-
-      DataStoreHealthChecker dataStoreHealthChecker = new DataStoreHealthChecker(context);
-      healthCheckRegistry.get().register(DATASTORE_CHECK_NAME, dataStoreHealthChecker);
+      healthCheckRegistry.get().register(BUNDLES_CHECK_NAME, new BundleStateChecker(context));
+      healthCheckRegistry.get().register(DATASTORE_CHECK_NAME, new DataStoreHealthChecker(context));
+      healthCheckRegistry.get().register(SCHEMA_CHECK_NAME, new SchemaAgreementChecker(context));
 
       WebImpl web = new WebImpl(context, metrics.get(), healthCheckRegistry.get());
       web.start();

--- a/health-checker/src/main/java/io/stargate/health/SchemaAgreementChecker.java
+++ b/health-checker/src/main/java/io/stargate/health/SchemaAgreementChecker.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.health;
+
+import com.codahale.metrics.health.HealthCheck;
+import io.stargate.db.Persistence;
+import java.util.Collection;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SchemaAgreementChecker extends HealthCheck {
+  private static final Logger logger = LoggerFactory.getLogger(SchemaAgreementChecker.class);
+
+  private static final String DB_PERSISTENCE_IDENTIFIER =
+      System.getProperty("stargate.persistence_id", "CassandraPersistence");
+  private static final String DB_PERSISTENCE_FILTER =
+      String.format("(Identifier=%s)", DB_PERSISTENCE_IDENTIFIER);
+
+  private final BundleContext context;
+
+  public SchemaAgreementChecker(BundleContext context) {
+    this.context = context;
+  }
+
+  @Override
+  protected Result check() {
+    try {
+      Collection<ServiceReference<Persistence>> services =
+          context.getServiceReferences(Persistence.class, DB_PERSISTENCE_FILTER);
+
+      // at most one persistence implementation is expected to be selected
+      for (ServiceReference<Persistence> service : services) {
+        Persistence persistence = context.getService(service);
+        try {
+          if (persistence.isInSchemaAgreement()) {
+            return Result.healthy("All schemas agree");
+          }
+
+          if (persistence.isSchemaAgreementAchievable()) {
+            return Result.healthy("Waiting for schema agreement");
+          }
+
+          return Result.unhealthy("Schema agreement is not achievable");
+        } finally {
+          context.ungetService(service);
+        }
+      }
+
+      return Result.healthy("Persistence is not initialized yet");
+
+    } catch (Exception e) {
+      logger.warn("Schema agreement check failed with {}", e.getMessage(), e);
+      return Result.unhealthy("Unable to check schema agreement: " + e);
+    }
+  }
+}

--- a/health-checker/src/test/java/io/stargate/health/SchemaAgreementCheckerTest.java
+++ b/health-checker/src/test/java/io/stargate/health/SchemaAgreementCheckerTest.java
@@ -1,0 +1,86 @@
+package io.stargate.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+import com.codahale.metrics.health.HealthCheck.Result;
+import io.stargate.db.Persistence;
+import java.util.Collection;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+class SchemaAgreementCheckerTest {
+
+  private BundleContext context;
+  private Persistence persistence;
+  private SchemaAgreementChecker checker;
+
+  @BeforeEach
+  public void setup() throws InvalidSyntaxException {
+    context = Mockito.mock(BundleContext.class);
+    persistence = Mockito.mock(Persistence.class);
+    checker = new SchemaAgreementChecker(context);
+
+    @SuppressWarnings("unchecked")
+    ServiceReference<Persistence> ref = Mockito.mock(ServiceReference.class);
+    Collection<ServiceReference<Persistence>> refs = Collections.singletonList(ref);
+    Mockito.when(context.getServiceReferences(eq(Persistence.class), any())).thenReturn(refs);
+
+    Mockito.when(context.getService(eq(ref))).thenReturn(persistence);
+  }
+
+  @Test
+  public void shouldSucceedWithNoPersistence() throws InvalidSyntaxException {
+    Mockito.when(context.getServiceReferences(eq(Persistence.class), any()))
+        .thenReturn(Collections.emptyList());
+    assertThat(checker.execute()).extracting(Result::isHealthy).isEqualTo(true);
+  }
+
+  @Test
+  public void shouldSucceedWhenSchemasAgree() {
+    Mockito.doReturn(true).when(persistence).isInSchemaAgreement();
+    assertThat(checker.execute()).extracting(Result::isHealthy).isEqualTo(true);
+  }
+
+  @Test
+  public void shouldSucceedWhenAgreementIsAchievable() {
+    Mockito.doReturn(false).when(persistence).isInSchemaAgreement();
+    Mockito.doReturn(true).when(persistence).isSchemaAgreementAchievable();
+    assertThat(checker.execute()).extracting(Result::isHealthy).isEqualTo(true);
+  }
+
+  @Test
+  public void shouldFailWhenAgreementIsNotAchievable() {
+    Mockito.doReturn(false).when(persistence).isInSchemaAgreement();
+    Mockito.doReturn(false).when(persistence).isSchemaAgreementAchievable();
+    assertThat(checker.execute()).extracting(Result::isHealthy).isEqualTo(false);
+  }
+
+  @Test
+  public void shouldFailOnException() throws InvalidSyntaxException {
+    Mockito.doThrow(new RuntimeException("test-exception")).when(persistence).isInSchemaAgreement();
+    assertThat(checker.execute()).extracting(Result::isHealthy).isEqualTo(false);
+  }
+}

--- a/persistence-api/src/main/java/io/stargate/db/Persistence.java
+++ b/persistence-api/src/main/java/io/stargate/db/Persistence.java
@@ -109,6 +109,14 @@ public interface Persistence {
   }
 
   /**
+   * Returns <code>false</code>> if the persistence implementation cannot reasonably expect to reach
+   * schema agreement with storage nodes assuming no external intervention.
+   */
+  default boolean isSchemaAgreementAchievable() {
+    return true;
+  }
+
+  /**
    * Persistence-specific CQL options to be returned in SUPPORTED response messages.
    *
    * <p><b>Important:</b> At a minimum, this must return the {@code "CQL_VERSION"} option.

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
@@ -308,9 +308,13 @@ public class CassandraPersistence
         <= 1;
   }
 
+  /**
+   * This method indicates whether storage nodes (i.e. excluding Stargate) agree on the
+   * schema version among themselves.
+   */
   private boolean isStorageInSchemaAgreement() {
     // See comment in isInSchemaAgreement()
-    // Here we also exclude Stargate nodes (isGossipOnlyMember)
+    // Here we also exclude Stargate nodes (by checking isGossipOnlyMember)
     return Gossiper.instance.getLiveMembers().stream()
             .filter(
                 ep -> {

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
@@ -35,8 +35,10 @@ import io.stargate.db.Statement;
 import io.stargate.db.cassandra.impl.interceptors.DefaultQueryInterceptor;
 import io.stargate.db.cassandra.impl.interceptors.QueryInterceptor;
 import io.stargate.db.datastore.common.AbstractCassandraPersistence;
+import io.stargate.db.datastore.common.util.SchemaAgreementAchievableCheck;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -88,6 +90,7 @@ import org.apache.cassandra.transport.messages.StartupMessage;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.MD5Digest;
+import org.apache.cassandra.utils.SystemTimeSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,6 +112,24 @@ public class CassandraPersistence
    */
   private static final int STARTUP_DELAY_MS =
       Integer.getInteger("stargate.startup_delay_ms", 3 * MigrationManager.MIGRATION_DELAY_IN_MS);
+
+  // SCHEMA_SYNC_GRACE_PERIOD should be longer than MigrationManager.MIGRATION_DELAY_IN_MS to allow
+  // the schema pull tasks to be initiated, plus some time for executing the pull requests plus
+  // some time to merge the responses. By default the pull task timeout is equal to
+  // DatabaseDescriptor.getRpcTimeout() (10 sec) and there are no retries. We assume that the merge
+  // operation should complete within the default MIGRATION_DELAY_IN_MS.
+  private static final Duration SCHEMA_SYNC_GRACE_PERIOD =
+      Duration.ofMillis(
+          Long.getLong(
+              "stargate.schema_sync_grace_period_ms",
+              2 * MigrationManager.MIGRATION_DELAY_IN_MS + 10_000));
+
+  private final SchemaAgreementAchievableCheck schemaCheck =
+      new SchemaAgreementAchievableCheck(
+          this::isInSchemaAgreement,
+          this::isStorageInSchemaAgreement,
+          SCHEMA_SYNC_GRACE_PERIOD,
+          new SystemTimeSource());
 
   private LocalAwareExecutorService executor;
 
@@ -183,6 +204,8 @@ public class CassandraPersistence
     // Use special gossip state "X10" to differentiate stargate nodes
     Gossiper.instance.addLocalApplicationState(
         ApplicationState.X10, StorageService.instance.valueFactory.releaseVersion("stargate"));
+
+    Gossiper.instance.register(schemaCheck);
 
     daemon.start();
 
@@ -283,6 +306,28 @@ public class CassandraPersistence
             .collect(Collectors.toSet())
             .size()
         <= 1;
+  }
+
+  private boolean isStorageInSchemaAgreement() {
+    // See comment in isInSchemaAgreement()
+    // Here we also exclude Stargate nodes (isGossipOnlyMember)
+    return Gossiper.instance.getLiveMembers().stream()
+            .filter(
+                ep -> {
+                  EndpointState epState = Gossiper.instance.getEndpointStateForEndpoint(ep);
+                  return epState != null
+                      && !Gossiper.instance.isDeadState(epState)
+                      && !Gossiper.instance.isGossipOnlyMember(ep);
+                })
+            .map(Gossiper.instance::getSchemaVersion)
+            .collect(Collectors.toSet())
+            .size()
+        <= 1;
+  }
+
+  @Override
+  public boolean isSchemaAgreementAchievable() {
+    return schemaCheck.check();
   }
 
   @Override

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
@@ -294,9 +294,13 @@ public class CassandraPersistence
         <= 1;
   }
 
+  /**
+   * This method indicates whether storage nodes (i.e. excluding Stargate) agree on the
+   * schema version among themselves.
+   */
   private boolean isStorageInSchemaAgreement() {
     // See comment in isInSchemaAgreement()
-    // Here we also exclude Stargate nodes (isGossipOnlyMember)
+    // Here we also exclude Stargate nodes (by checking isGossipOnlyMember)
     return Gossiper.instance.getLiveMembers().stream()
             .filter(
                 ep -> {

--- a/persistence-common/pom.xml
+++ b/persistence-common/pom.xml
@@ -30,5 +30,20 @@
       <version>2.8.8</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/persistence-common/src/main/java/io/stargate/db/datastore/common/util/HealthCheckWithGracePeriod.java
+++ b/persistence-common/src/main/java/io/stargate/db/datastore/common/util/HealthCheckWithGracePeriod.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.db.datastore.common.util;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.cassandra.utils.TimeSource;
+
+public abstract class HealthCheckWithGracePeriod {
+  protected final Duration gracePeriod;
+  private final AtomicLong failureTimestamp = new AtomicLong(-1);
+  private final TimeSource timeSource;
+
+  protected HealthCheckWithGracePeriod(Duration gracePeriod, TimeSource timeSource) {
+    this.gracePeriod = gracePeriod;
+    this.timeSource = timeSource;
+  }
+
+  protected abstract boolean isHealthy();
+
+  protected void reset() {
+    failureTimestamp.set(-1);
+  }
+
+  public boolean check() {
+    long timestamp = timeSource.currentTimeMillis();
+
+    boolean healthy = isHealthy();
+
+    if (healthy) {
+      reset();
+      return true;
+    }
+
+    if (failureTimestamp.compareAndSet(-1, timestamp)) {
+      // first failure after a healthy period - start grace period
+      return true;
+    }
+
+    long referenceTimestamp = failureTimestamp.get();
+    if (referenceTimestamp < 0) {
+      // there was a concurrent healthy check - ignore this failure
+      return true;
+    }
+
+    long graceMillis = gracePeriod.toMillis();
+    long deadline = referenceTimestamp + graceMillis;
+
+    return timestamp < deadline;
+  }
+}

--- a/persistence-common/src/main/java/io/stargate/db/datastore/common/util/HealthCheckWithGracePeriod.java
+++ b/persistence-common/src/main/java/io/stargate/db/datastore/common/util/HealthCheckWithGracePeriod.java
@@ -29,12 +29,27 @@ public abstract class HealthCheckWithGracePeriod {
     this.timeSource = timeSource;
   }
 
+  /**
+   * Executes the specific logic for determining whether the system is in a healthy state.
+   * This method need not deal with the grace period, which is handled by {@link #check()}.
+   * @return <code>true</code> if the system is healthy, <code>false</code> otherwise.
+   */
   protected abstract boolean isHealthy();
 
+  /**
+   * Resets the grace period marker. A new grace period will begin at the next failed health check.
+   */
   protected void reset() {
     failureTimestamp.set(-1);
   }
 
+  /**
+   * Executes the logic for determining whether the system is in a healthy state and returns the
+   * result.
+   * <p>Actual health checks are performed by {@link #isHealthy()}, this method additionally applies
+   * the grace period (as set in the constructor) to failed checks.</p>
+   * @return <code>true</code> if the system is healthy, <code>false</code> otherwise.
+   */
   public boolean check() {
     long timestamp = timeSource.currentTimeMillis();
 

--- a/persistence-common/src/main/java/io/stargate/db/datastore/common/util/HealthCheckWithGracePeriod.java
+++ b/persistence-common/src/main/java/io/stargate/db/datastore/common/util/HealthCheckWithGracePeriod.java
@@ -30,8 +30,9 @@ public abstract class HealthCheckWithGracePeriod {
   }
 
   /**
-   * Executes the specific logic for determining whether the system is in a healthy state.
-   * This method need not deal with the grace period, which is handled by {@link #check()}.
+   * Executes the specific logic for determining whether the system is in a healthy state. This
+   * method need not deal with the grace period, which is handled by {@link #check()}.
+   *
    * @return <code>true</code> if the system is healthy, <code>false</code> otherwise.
    */
   protected abstract boolean isHealthy();
@@ -46,8 +47,10 @@ public abstract class HealthCheckWithGracePeriod {
   /**
    * Executes the logic for determining whether the system is in a healthy state and returns the
    * result.
+   *
    * <p>Actual health checks are performed by {@link #isHealthy()}, this method additionally applies
-   * the grace period (as set in the constructor) to failed checks.</p>
+   * the grace period (as set in the constructor) to failed checks.
+   *
    * @return <code>true</code> if the system is healthy, <code>false</code> otherwise.
    */
   public boolean check() {

--- a/persistence-common/src/main/java/io/stargate/db/datastore/common/util/SchemaAgreementAchievableCheck.java
+++ b/persistence-common/src/main/java/io/stargate/db/datastore/common/util/SchemaAgreementAchievableCheck.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.db.datastore.common.util;
+
+import java.net.InetAddress;
+import java.time.Duration;
+import java.util.function.Supplier;
+import org.apache.cassandra.gms.ApplicationState;
+import org.apache.cassandra.gms.EndpointState;
+import org.apache.cassandra.gms.IEndpointStateChangeSubscriber;
+import org.apache.cassandra.gms.VersionedValue;
+import org.apache.cassandra.utils.TimeSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SchemaAgreementAchievableCheck extends HealthCheckWithGracePeriod
+    implements IEndpointStateChangeSubscriber {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(SchemaAgreementAchievableCheck.class);
+
+  private final Supplier<Boolean> isInSchemaAgreement;
+  private final Supplier<Boolean> isStorageInSchemaAgreement;
+
+  public SchemaAgreementAchievableCheck(
+      Supplier<Boolean> isInSchemaAgreement,
+      Supplier<Boolean> isStorageInSchemaAgreement,
+      Duration gracePeriod,
+      TimeSource timeSource) {
+    super(gracePeriod, timeSource);
+    this.isInSchemaAgreement = isInSchemaAgreement;
+    this.isStorageInSchemaAgreement = isStorageInSchemaAgreement;
+  }
+
+  @Override
+  protected boolean isHealthy() {
+    if (isInSchemaAgreement.get()) {
+      return true;
+    }
+
+    if (!isStorageInSchemaAgreement.get()) {
+      // Assume storage nodes are still disseminating schema data and will agree eventually.
+      // Note: isSchemaAgreementAchievable() is used to determine if the Stargate node should
+      // be restarted. In case storage nodes do not agree among themselves, restarting Stargate
+      // will not help, so there's no point returning false in this situation even if the
+      // schema disagreement at storage level is perpetual.
+      logger.debug("Storage nodes are not in schema agreement");
+      return true;
+    }
+
+    // Storage nodes agree on the schema version, but Stargate has a different schema.
+    // Fail the check and allow HealthCheckWithGracePeriod to apply the grace period during
+    // which schema pull requests are expected to complete and synchronize the local schema
+    // with storage nodes.
+    return false;
+  }
+
+  @Override
+  public boolean check() {
+    boolean result = super.check();
+    if (!result) {
+      logger.error("Schema agreement is not achievable with grace period {}", gracePeriod);
+    }
+
+    return result;
+  }
+
+  @Override
+  public void onChange(InetAddress endpoint, ApplicationState state, VersionedValue value) {
+    // Reset the schema sync grace period timeout on any schema change notifications
+    // even if there are not actual changes.
+    if (state == ApplicationState.SCHEMA) {
+      reset();
+    }
+  }
+
+  @Override
+  public void onJoin(InetAddress endpoint, EndpointState epState) {
+    // nop
+  }
+
+  @Override
+  public void beforeChange(
+      InetAddress endpoint,
+      EndpointState currentState,
+      ApplicationState newStateKey,
+      VersionedValue newValue) {
+    // nop
+  }
+
+  @Override
+  public void onAlive(InetAddress endpoint, EndpointState state) {
+    // nop
+  }
+
+  @Override
+  public void onDead(InetAddress endpoint, EndpointState state) {
+    // nop
+  }
+
+  @Override
+  public void onRemove(InetAddress endpoint) {
+    // nop
+  }
+
+  @Override
+  public void onRestart(InetAddress endpoint, EndpointState state) {
+    // nop
+  }
+}

--- a/persistence-common/src/main/java/io/stargate/db/datastore/common/util/SchemaAgreementAchievableCheck.java
+++ b/persistence-common/src/main/java/io/stargate/db/datastore/common/util/SchemaAgreementAchievableCheck.java
@@ -15,19 +15,13 @@
  */
 package io.stargate.db.datastore.common.util;
 
-import java.net.InetAddress;
 import java.time.Duration;
 import java.util.function.Supplier;
-import org.apache.cassandra.gms.ApplicationState;
-import org.apache.cassandra.gms.EndpointState;
-import org.apache.cassandra.gms.IEndpointStateChangeSubscriber;
-import org.apache.cassandra.gms.VersionedValue;
 import org.apache.cassandra.utils.TimeSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SchemaAgreementAchievableCheck extends HealthCheckWithGracePeriod
-    implements IEndpointStateChangeSubscriber {
+public class SchemaAgreementAchievableCheck extends HealthCheckWithGracePeriod {
 
   private static final Logger logger =
       LoggerFactory.getLogger(SchemaAgreementAchievableCheck.class);
@@ -76,48 +70,5 @@ public class SchemaAgreementAchievableCheck extends HealthCheckWithGracePeriod
     }
 
     return result;
-  }
-
-  @Override
-  public void onChange(InetAddress endpoint, ApplicationState state, VersionedValue value) {
-    // Reset the schema sync grace period timeout on any schema change notifications
-    // even if there are not actual changes.
-    if (state == ApplicationState.SCHEMA) {
-      reset();
-    }
-  }
-
-  @Override
-  public void onJoin(InetAddress endpoint, EndpointState epState) {
-    // nop
-  }
-
-  @Override
-  public void beforeChange(
-      InetAddress endpoint,
-      EndpointState currentState,
-      ApplicationState newStateKey,
-      VersionedValue newValue) {
-    // nop
-  }
-
-  @Override
-  public void onAlive(InetAddress endpoint, EndpointState state) {
-    // nop
-  }
-
-  @Override
-  public void onDead(InetAddress endpoint, EndpointState state) {
-    // nop
-  }
-
-  @Override
-  public void onRemove(InetAddress endpoint) {
-    // nop
-  }
-
-  @Override
-  public void onRestart(InetAddress endpoint, EndpointState state) {
-    // nop
   }
 }

--- a/persistence-common/src/test/java/io/stargate/db/datastore/common/util/HealthCheckWithGracePeriodTest.java
+++ b/persistence-common/src/test/java/io/stargate/db/datastore/common/util/HealthCheckWithGracePeriodTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.db.datastore.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.apache.cassandra.utils.TimeSource;
+import org.assertj.core.api.AbstractBooleanAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class HealthCheckWithGracePeriodTest {
+
+  private static final Duration TEST_GRACE_PERIOD = Duration.ofSeconds(5);
+  private HealthCheckWithGracePeriod check;
+  private TimeSource timeSource;
+  private boolean healthy;
+
+  @BeforeEach
+  public void setup() {
+    timeSource = Mockito.mock(TimeSource.class);
+    check =
+        new HealthCheckWithGracePeriod(TEST_GRACE_PERIOD, timeSource) {
+          @Override
+          protected boolean isHealthy() {
+            return healthy;
+          }
+        };
+  }
+
+  private AbstractBooleanAssert<?> assertThatCheck(long time, boolean healthy) {
+    this.healthy = healthy;
+    Mockito.doReturn(time).when(timeSource).currentTimeMillis();
+    return assertThat(check.check());
+  }
+
+  @Test
+  public void testSuccess() {
+    assertThatCheck(0, true).isTrue();
+    assertThatCheck(0, true).isTrue();
+
+    assertThatCheck(TEST_GRACE_PERIOD.toMillis() + 100, true).isTrue();
+    assertThatCheck(TEST_GRACE_PERIOD.toMillis() + 100, true).isTrue();
+  }
+
+  @Test
+  public void testFailWithinGracePeriod() {
+    assertThatCheck(0, false).isTrue();
+    assertThatCheck(TEST_GRACE_PERIOD.toMillis() - 1, false).isTrue();
+  }
+
+  @Test
+  public void testFailAfterGracePeriod() {
+    assertThatCheck(0, false).isTrue();
+    assertThatCheck(TEST_GRACE_PERIOD.toMillis() + 1, false).isFalse();
+    assertThatCheck(TEST_GRACE_PERIOD.toMillis() + 1, false).isFalse();
+  }
+
+  @Test
+  public void testRecoveryWithinGracePeriod() {
+    assertThatCheck(0, true).isTrue();
+    assertThatCheck(TEST_GRACE_PERIOD.toMillis() - 1, false).isTrue();
+    assertThatCheck(TEST_GRACE_PERIOD.toMillis() + 1, true).isTrue();
+    assertThatCheck(TEST_GRACE_PERIOD.toMillis() + 2, false).isTrue();
+  }
+
+  @Test
+  public void testFailAndRecover() {
+    assertThatCheck(0, true).isTrue();
+    assertThatCheck(100, false).isTrue();
+    assertThatCheck(101, false).isTrue();
+    assertThatCheck(100 + TEST_GRACE_PERIOD.toMillis() + 1, false).isFalse();
+    assertThatCheck(100 + TEST_GRACE_PERIOD.toMillis() + 2, true).isTrue();
+  }
+
+  @Test
+  public void testReset() {
+    assertThatCheck(0, false).isTrue();
+    check.reset();
+    assertThatCheck(TEST_GRACE_PERIOD.toMillis() + 1, false).isTrue();
+    assertThatCheck(2 * TEST_GRACE_PERIOD.toMillis() + 1, false).isFalse();
+    check.reset();
+    assertThatCheck(2 * TEST_GRACE_PERIOD.toMillis() + 1, false).isTrue();
+    assertThatCheck(3 * TEST_GRACE_PERIOD.toMillis() + 1, false).isFalse();
+  }
+}

--- a/persistence-common/src/test/java/io/stargate/db/datastore/common/util/SchemaAgreementAchievableCheckTest.java
+++ b/persistence-common/src/test/java/io/stargate/db/datastore/common/util/SchemaAgreementAchievableCheckTest.java
@@ -17,11 +17,7 @@ package io.stargate.db.datastore.common.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.time.Duration;
-import java.util.concurrent.atomic.AtomicLong;
-import org.apache.cassandra.gms.ApplicationState;
 import org.apache.cassandra.utils.SystemTimeSource;
 import org.assertj.core.api.AbstractBooleanAssert;
 import org.junit.jupiter.api.Test;
@@ -53,34 +49,5 @@ class SchemaAgreementAchievableCheckTest {
   @Test
   public void shouldNotBeHealthyWhenSchemaIsDifferentFromStorageSchema() {
     assertHealthy(false, true).isFalse();
-  }
-
-  @Test
-  public void shouldResetOnSchemaChange() throws UnknownHostException {
-    AtomicLong time = new AtomicLong(0);
-
-    SchemaAgreementAchievableCheck check =
-        new SchemaAgreementAchievableCheck(
-            () -> false,
-            () -> true,
-            Duration.ofMillis(5),
-            new SystemTimeSource() {
-              @Override
-              public long currentTimeMillis() {
-                return time.get();
-              }
-            });
-
-    assertThat(check.check()).isTrue();
-
-    check.onChange(InetAddress.getLocalHost(), ApplicationState.SCHEMA, null);
-    time.set(10);
-    assertThat(check.check()).isTrue();
-
-    time.set(20);
-    assertThat(check.check()).isFalse();
-
-    check.onChange(InetAddress.getLocalHost(), ApplicationState.SCHEMA, null);
-    assertThat(check.check()).isTrue();
   }
 }

--- a/persistence-common/src/test/java/io/stargate/db/datastore/common/util/SchemaAgreementAchievableCheckTest.java
+++ b/persistence-common/src/test/java/io/stargate/db/datastore/common/util/SchemaAgreementAchievableCheckTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.db.datastore.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.cassandra.gms.ApplicationState;
+import org.apache.cassandra.utils.SystemTimeSource;
+import org.assertj.core.api.AbstractBooleanAssert;
+import org.junit.jupiter.api.Test;
+
+class SchemaAgreementAchievableCheckTest {
+
+  private AbstractBooleanAssert<?> assertHealthy(
+      boolean schemasAgree, boolean storageSchemasAgree) {
+    SchemaAgreementAchievableCheck check =
+        new SchemaAgreementAchievableCheck(
+            () -> schemasAgree,
+            () -> storageSchemasAgree,
+            Duration.ofMillis(5),
+            new SystemTimeSource());
+    return assertThat(check.isHealthy());
+  }
+
+  @Test
+  public void shouldBeHealthyWhenSchemasAgree() {
+    assertHealthy(true, true).isTrue();
+    assertHealthy(true, false).isTrue();
+  }
+
+  @Test
+  public void shouldBeHealthyWhenStorageSchemasDisagree() {
+    assertHealthy(false, false).isTrue();
+  }
+
+  @Test
+  public void shouldNotBeHealthyWhenSchemaIsDifferentFromStorageSchema() {
+    assertHealthy(false, true).isFalse();
+  }
+
+  @Test
+  public void shouldResetOnSchemaChange() throws UnknownHostException {
+    AtomicLong time = new AtomicLong(0);
+
+    SchemaAgreementAchievableCheck check =
+        new SchemaAgreementAchievableCheck(
+            () -> false,
+            () -> true,
+            Duration.ofMillis(5),
+            new SystemTimeSource() {
+              @Override
+              public long currentTimeMillis() {
+                return time.get();
+              }
+            });
+
+    assertThat(check.check()).isTrue();
+
+    check.onChange(InetAddress.getLocalHost(), ApplicationState.SCHEMA, null);
+    time.set(10);
+    assertThat(check.check()).isTrue();
+
+    time.set(20);
+    assertThat(check.check()).isFalse();
+
+    check.onChange(InetAddress.getLocalHost(), ApplicationState.SCHEMA, null);
+    assertThat(check.check()).isTrue();
+  }
+}

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -271,8 +271,8 @@ public class DsePersistence
   }
 
   /**
-   * This method indicates whether storage nodes (i.e. excluding Stargate) agree on the
-   * schema version among themselves.
+   * This method indicates whether storage nodes (i.e. excluding Stargate) agree on the schema
+   * version among themselves.
    */
   private boolean isStorageInSchemaAgreement() {
     // See comment in isInSchemaAgreement()

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -270,9 +270,13 @@ public class DsePersistence
         <= 1;
   }
 
+  /**
+   * This method indicates whether storage nodes (i.e. excluding Stargate) agree on the
+   * schema version among themselves.
+   */
   private boolean isStorageInSchemaAgreement() {
     // See comment in isInSchemaAgreement()
-    // Here we also exclude Stargate nodes (isGossipOnlyMember)
+    // Here we also exclude Stargate nodes (by checking isGossipOnlyMember)
     return Gossiper.instance.getLiveMembers().stream()
             .filter(
                 ep -> {
@@ -589,13 +593,12 @@ public class DsePersistence
   }
 
   private static class PullRequestGetter {
-    private static final Field schedulerField;
     private static final Method nonCompletedPullRequestsMethod;
     private static final Object scheduler; // PullRequestScheduler
 
     static {
       try {
-        schedulerField = MigrationManager.class.getDeclaredField("scheduler");
+        Field schedulerField = MigrationManager.class.getDeclaredField("scheduler");
         schedulerField.setAccessible(true);
         scheduler = schedulerField.get(MigrationManager.instance);
         nonCompletedPullRequestsMethod =

--- a/persistence-test/src/main/java/io/stargate/it/PersistenceTest.java
+++ b/persistence-test/src/main/java/io/stargate/it/PersistenceTest.java
@@ -1406,4 +1406,9 @@ public abstract class PersistenceTest {
     assertThat(result.getWarnings()).hasSize(1);
     assertThat(result.getWarnings().get(0)).contains("exceeds maximum supported expiration");
   }
+
+  @Test
+  public void testSchemaAgreementAchievable() {
+    assertThat(persistence().isSchemaAgreementAchievable()).isTrue();
+  }
 }


### PR DESCRIPTION
Add a separate health check for verifying whether schema agreement is achievable.

Fixes #636