### PR TITLE
Make LogCollector wait for the expected number of messages.

### DIFF
--- a/testing/src/test/java/io/stargate/it/cql/AuthorizationCommandInterceptorTest.java
+++ b/testing/src/test/java/io/stargate/it/cql/AuthorizationCommandInterceptorTest.java
@@ -72,12 +72,12 @@ public class AuthorizationCommandInterceptorTest extends BaseOsgiIntegrationTest
 
   private List<String> addedMsgs(String cql) {
     session.execute(cql);
-    return log.filter(0, Pattern.compile(".+testing: addPermissions: (.+)"), 1);
+    return log.filter(0, Pattern.compile(".+testing: addPermissions: (.+)"), 1, 1);
   }
 
   private List<String> removedMsgs(String cql) {
     session.execute(cql);
-    return log.filter(0, Pattern.compile(".+testing: removePermissions: (.+)"), 1);
+    return log.filter(0, Pattern.compile(".+testing: removePermissions: (.+)"), 1, 1);
   }
 
   @Test

--- a/testing/src/test/java/io/stargate/it/storage/LogCollector.java
+++ b/testing/src/test/java/io/stargate/it/storage/LogCollector.java
@@ -16,6 +16,7 @@
 package io.stargate.it.storage;
 
 import io.stargate.it.exec.OutputListener;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -25,6 +26,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
 
 public class LogCollector implements OutputListener, Store.CloseableResource {
@@ -69,5 +71,12 @@ public class LogCollector implements OutputListener, Store.CloseableResource {
             })
         .filter(Objects::nonNull)
         .collect(Collectors.toList());
+  }
+
+  public List<String> filter(int node, Pattern pattern, int group, int numExpectedMessages) {
+    return Awaitility.await()
+        .atMost(Duration.ofMinutes(2))
+        .pollInterval(Duration.ofMillis(100))
+        .until(() -> filter(node, pattern, group), list -> list.size() >= numExpectedMessages);
   }
 }


### PR DESCRIPTION
This is necessary because the captured Stargate node's STDOUT
is pumped asynchronously, so messages are not guaranteed to show
up in LogCollector on time even if there's a strict happens-before
relationship between a log message and the completion of the related
test action.

Fixes #651