### PR TITLE
Add more CQL migration strategies

### DIFF
--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/AdminSchemaBuilder.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/AdminSchemaBuilder.java
@@ -22,6 +22,7 @@ import static graphql.schema.FieldCoordinates.coordinates;
 import static graphql.schema.GraphQLArgument.newArgument;
 import static graphql.schema.GraphQLCodeRegistry.newCodeRegistry;
 import static graphql.schema.GraphQLEnumType.newEnum;
+import static graphql.schema.GraphQLEnumValueDefinition.newEnumValueDefinition;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLInputObjectField.newInputObjectField;
 import static graphql.schema.GraphQLInputObjectType.newInputObject;
@@ -45,6 +46,7 @@ import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.graphql.schema.schemafirst.fetchers.admin.*;
+import io.stargate.graphql.schema.schemafirst.migration.MigrationStrategy;
 import io.stargate.graphql.web.resources.GraphqlResourceBase;
 import java.io.InputStream;
 
@@ -318,6 +320,60 @@ public class AdminSchemaBuilder {
           .type(nonNull(DROP_NAMESPACE_TYPE))
           .build();
 
+  public static final GraphQLEnumType MIGRATION_STRATEGY_ENUM =
+      newEnum()
+          .name("MigrationStrategy")
+          .description(
+              "What to do if the CQL schema doesn't match the provided GraphQL schema. "
+                  + "Note that a table will be considered matching even if it contains additional "
+                  + "columns not present in the GraphQL schema. In other words, a deploy "
+                  + "operation will never drop columns.")
+          .value(
+              newEnumValueDefinition()
+                  .name(MigrationStrategy.USE_EXISTING.name())
+                  .value(MigrationStrategy.USE_EXISTING)
+                  .description(
+                      "Don't do anything. All CQL tables and UDTs must match, otherwise the "
+                          + "deployment is aborted. This is the most conservative strategy.")
+                  .build())
+          .value(
+              newEnumValueDefinition()
+                  .name(MigrationStrategy.ADD_MISSING_TABLES.name())
+                  .value(MigrationStrategy.ADD_MISSING_TABLES)
+                  .description(
+                      "Create CQL tables and UDTs that don't already exist. "
+                          + "Those that exist must match, otherwise the deployment is aborted.")
+                  .build())
+          .value(
+              newEnumValueDefinition()
+                  .name(MigrationStrategy.ADD_MISSING_TABLES_AND_COLUMNS.name())
+                  .value(MigrationStrategy.ADD_MISSING_TABLES_AND_COLUMNS)
+                  .description(
+                      "Create CQL tables and UDTs that don't already exist. "
+                          + "For those that exist, add any missing columns (as long as they're "
+                          + "not marked as partition key or clustering). Note that this could "
+                          + "still fail if the column existed before with a different type.")
+                  .build())
+          .value(
+              newEnumValueDefinition()
+                  .name(MigrationStrategy.DROP_AND_RECREATE_ALL.name())
+                  .value(MigrationStrategy.DROP_AND_RECREATE_ALL)
+                  .description(
+                      "Drop and recreate all CQL tables and UDTs. "
+                          + "This is a destructive operation: any existing data will be lost.")
+                  .build())
+          .value(
+              newEnumValueDefinition()
+                  .name(MigrationStrategy.DROP_AND_RECREATE_IF_MISMATCH.name())
+                  .value(MigrationStrategy.DROP_AND_RECREATE_IF_MISMATCH)
+                  .description(
+                      "Drop and recreate only the CQL tables and UDTs that don't match. "
+                          + "This is a destructive operation: any existing data in those tables "
+                          + "will be lost (however, tables that didn't change will keep their "
+                          + "data).")
+                  .build())
+          .build();
+
   private static final GraphQLEnumType MESSAGE_CATEGORY_ENUM =
       newEnum()
           .name("MessageCategory")
@@ -351,7 +407,7 @@ public class AdminSchemaBuilder {
               newFieldDefinition()
                   .name("version")
                   .description("The new schema version that was created by this operation.")
-                  .type(nonNull(GraphQLString))
+                  .type(GraphQLString)
                   .build())
           .field(
               newFieldDefinition()
@@ -362,6 +418,14 @@ public class AdminSchemaBuilder {
                   // TODO add an argument to filter by category
                   // currently blocked by https://github.com/graphql-java/graphql-java/pull/2126
                   .type(list(MESSAGE_TYPE))
+                  .build())
+          .field(
+              newFieldDefinition()
+                  .name("cqlChanges")
+                  .description(
+                      "The queries that were executed to adapt the CQL data model to the new "
+                          + "schema.")
+                  .type(list(GraphQLString))
                   .build())
           .field(QUERY_FIELD)
           .build();
@@ -382,6 +446,24 @@ public class AdminSchemaBuilder {
                         + "or null if this is the first deployment.\n"
                         + "This is used to prevent concurrent updates.")
                 .type(GraphQLString)
+                .build())
+        .argument(
+            newArgument()
+                .name("migrationStrategy")
+                .description("The strategy to update the CQL schema if necessary.")
+                .type(nonNull(MIGRATION_STRATEGY_ENUM))
+                .defaultValue(MigrationStrategy.ADD_MISSING_TABLES_AND_COLUMNS)
+                .build())
+        .argument(
+            newArgument()
+                .name("dryRun")
+                .description(
+                    "Just parse and validate the schema, don't deploy it or apply any changes to "
+                        + "the database. This is useful in particular in conjunction with the "
+                        + "`cqlChanges` field in the result, to evaluate the impacts on the CQL "
+                        + "data model.")
+                .type(nonNull(GraphQLBoolean))
+                .defaultValue(false)
                 .build())
         .type(DEPLOY_SCHEMA_TYPE);
   }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/AddTableColumnQuery.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/AddTableColumnQuery.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.graphql.schema.schemafirst.migration;
+
+import io.stargate.db.datastore.DataStore;
+import io.stargate.db.query.builder.AbstractBound;
+import io.stargate.db.schema.Column;
+import io.stargate.db.schema.Table;
+
+public class AddTableColumnQuery extends MigrationQuery {
+
+  private final Table table;
+  private final Column column;
+
+  public AddTableColumnQuery(Table table, Column column) {
+    this.table = table;
+    this.column = column;
+  }
+
+  @Override
+  public AbstractBound<?> build(DataStore dataStore) {
+    return dataStore
+        .queryBuilder()
+        .alter()
+        .table(table.keyspace(), table.name())
+        .addColumn(column)
+        .build()
+        .bind();
+  }
+
+  @Override
+  public String getDescription() {
+    return String.format("Add column %s to table %s", column.name(), table.name());
+  }
+
+  @Override
+  public boolean addsReferenceTo(String udtName) {
+    return references(column.type(), udtName);
+  }
+
+  @Override
+  public boolean dropsReferenceTo(String udtName) {
+    return false;
+  }
+}

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/AddUdtFieldQuery.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/AddUdtFieldQuery.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.graphql.schema.schemafirst.migration;
+
+import io.stargate.db.datastore.DataStore;
+import io.stargate.db.query.builder.AbstractBound;
+import io.stargate.db.schema.Column;
+import io.stargate.db.schema.UserDefinedType;
+
+public class AddUdtFieldQuery extends MigrationQuery {
+
+  private final UserDefinedType type;
+  private final Column column;
+
+  public AddUdtFieldQuery(UserDefinedType type, Column column) {
+    this.type = type;
+    this.column = column;
+  }
+
+  @Override
+  public AbstractBound<?> build(DataStore dataStore) {
+    return dataStore
+        .queryBuilder()
+        .alter()
+        .type(type.keyspace(), type)
+        .addColumn(column)
+        .build()
+        .bind();
+  }
+
+  @Override
+  public String getDescription() {
+    return String.format("Add field %s to UDT %s", column.name(), type.name());
+  }
+
+  @Override
+  public boolean addsReferenceTo(String udtName) {
+    return references(column.type(), udtName);
+  }
+
+  @Override
+  public boolean dropsReferenceTo(String udtName) {
+    return false;
+  }
+}

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/CassandraMigrator.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/CassandraMigrator.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.graphql.schema.schemafirst.migration;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import graphql.GraphqlErrorException;
+import io.stargate.db.datastore.DataStore;
+import io.stargate.db.schema.Column;
+import io.stargate.db.schema.Schema;
+import io.stargate.db.schema.SchemaEntity;
+import io.stargate.db.schema.Table;
+import io.stargate.db.schema.UserDefinedType;
+import io.stargate.graphql.schema.schemafirst.migration.CassandraSchemaHelper.Difference;
+import io.stargate.graphql.schema.schemafirst.processor.EntityMappingModel;
+import io.stargate.graphql.schema.schemafirst.processor.MappingModel;
+import io.stargate.graphql.schema.schemafirst.util.DirectedGraph;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class CassandraMigrator {
+
+  private final DataStore dataStore;
+  private final MappingModel mappingModel;
+  private final MigrationStrategy strategy;
+
+  public CassandraMigrator(
+      DataStore dataStore, MappingModel mappingModel, MigrationStrategy strategy) {
+    this.dataStore = dataStore;
+    this.mappingModel = mappingModel;
+    this.strategy = strategy;
+  }
+
+  /** @throws GraphqlErrorException if the CQL data model can't be migrated */
+  public List<MigrationQuery> compute() {
+
+    Schema schema = dataStore.schema();
+
+    List<MigrationQuery> queries = new ArrayList<>();
+    List<String> errors = new ArrayList<>();
+
+    for (EntityMappingModel entity : mappingModel.getEntities().values()) {
+      switch (entity.getTarget()) {
+        case TABLE:
+          Table expectedTable = entity.getTableCqlSchema();
+          Table actualTable = schema.keyspace(entity.getKeyspaceName()).table(entity.getCqlName());
+          compute(
+              expectedTable,
+              actualTable,
+              CassandraSchemaHelper::compare,
+              CreateTableQuery::new,
+              DropTableQuery::new,
+              AddTableColumnQuery::new,
+              "table",
+              queries,
+              errors);
+          break;
+        case UDT:
+          UserDefinedType expectedType = entity.getUdtCqlSchema();
+          UserDefinedType actualType =
+              schema.keyspace(entity.getKeyspaceName()).userDefinedType(entity.getCqlName());
+          compute(
+              expectedType,
+              actualType,
+              CassandraSchemaHelper::compare,
+              CreateUdtQuery::new,
+              DropUdtQuery::new,
+              AddUdtFieldQuery::new,
+              "UDT",
+              queries,
+              errors);
+          break;
+        default:
+          throw new AssertionError("Unexpected target " + entity.getTarget());
+      }
+    }
+    if (!errors.isEmpty()) {
+      throw GraphqlErrorException.newErrorException()
+          .message(
+              String.format(
+                  "The schema you provided can't be mapped to the current CQL data model."
+                      + "Consider using a different migration strategy (current: %s). "
+                      + "See details in `extensions.migrationErrors` below.",
+                  strategy))
+          .extensions(ImmutableMap.of("migrationErrors", errors))
+          .build();
+    }
+    return sortForExecution(queries);
+  }
+
+  private <T extends SchemaEntity> void compute(
+      T expected,
+      T actual,
+      BiFunction<T, T, List<Difference>> comparator,
+      Function<T, MigrationQuery> createBuilder,
+      Function<T, MigrationQuery> dropBuilder,
+      BiFunction<T, Column, MigrationQuery> addColumnBuilder,
+      String entityType,
+      List<MigrationQuery> queries,
+      List<String> errors) {
+
+    switch (strategy) {
+      case USE_EXISTING:
+        if (actual == null) {
+          errors.add(String.format("Missing %s %s", entityType, expected.name()));
+        } else {
+          failIfMismatch(expected, actual, comparator, errors);
+        }
+        break;
+      case ADD_MISSING_TABLES:
+        if (actual == null) {
+          queries.add(createBuilder.apply(expected));
+        } else {
+          failIfMismatch(expected, actual, comparator, errors);
+        }
+        break;
+      case ADD_MISSING_TABLES_AND_COLUMNS:
+        if (actual == null) {
+          queries.add(createBuilder.apply(expected));
+        } else {
+          addMissingColumns(expected, actual, comparator, addColumnBuilder, queries, errors);
+        }
+        break;
+      case DROP_AND_RECREATE_ALL:
+        queries.add(dropBuilder.apply(expected));
+        queries.add(createBuilder.apply(expected));
+        break;
+      case DROP_AND_RECREATE_IF_MISMATCH:
+        if (actual == null) {
+          queries.add(createBuilder.apply(expected));
+        } else {
+          List<Difference> differences = comparator.apply(expected, actual);
+          if (!differences.isEmpty()) {
+            queries.add(dropBuilder.apply(expected));
+            queries.add(createBuilder.apply(expected));
+          }
+        }
+        break;
+      default:
+        throw new AssertionError("Unexpected strategy " + strategy);
+    }
+  }
+
+  private <T extends SchemaEntity> void failIfMismatch(
+      T expected, T actual, BiFunction<T, T, List<Difference>> comparator, List<String> errors) {
+    List<Difference> differences = comparator.apply(expected, actual);
+    if (!differences.isEmpty()) {
+      errors.addAll(
+          differences.stream().map(Difference::toGraphqlMessage).collect(Collectors.toList()));
+    }
+  }
+
+  private <T extends SchemaEntity> void addMissingColumns(
+      T expected,
+      T actual,
+      BiFunction<T, T, List<Difference>> comparator,
+      BiFunction<T, Column, MigrationQuery> addColumnBuilder,
+      List<MigrationQuery> queries,
+      List<String> errors) {
+    List<Difference> differences = comparator.apply(expected, actual);
+    if (!differences.isEmpty()) {
+      List<Difference> blockers =
+          differences.stream().filter(d -> !isAddableColumn(d)).collect(Collectors.toList());
+      if (blockers.isEmpty()) {
+        for (Difference difference : differences) {
+          assert isAddableColumn(difference);
+          queries.add(addColumnBuilder.apply(expected, difference.getColumn()));
+        }
+      } else {
+        errors.addAll(
+            blockers.stream().map(Difference::toGraphqlMessage).collect(Collectors.toList()));
+      }
+    }
+  }
+
+  private boolean isAddableColumn(Difference difference) {
+    return difference.getType() == CassandraSchemaHelper.DifferenceType.MISSING_COLUMN
+        && !difference.getColumn().isPartitionKey()
+        && !difference.getColumn().isClusteringKey();
+  }
+
+  @VisibleForTesting
+  static List<MigrationQuery> sortForExecution(List<MigrationQuery> queries) {
+    if (queries.size() < 2) {
+      return queries;
+    }
+    DirectedGraph<MigrationQuery> graph = new DirectedGraph<>(queries);
+    for (MigrationQuery query1 : queries) {
+      for (MigrationQuery query2 : queries) {
+        if (query1 != query2 && query1.mustRunBefore(query2)) {
+          graph.addEdge(query1, query2);
+        }
+      }
+    }
+    return graph.topologicalSort();
+  }
+}

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/CassandraSchemaHelper.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/CassandraSchemaHelper.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.graphql.schema.schemafirst.migration;
+
+import io.stargate.db.schema.Column;
+import io.stargate.db.schema.Table;
+import io.stargate.db.schema.UserDefinedType;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CassandraSchemaHelper {
+
+  /** @return a list of differences, or empty if the tables match. */
+  public static List<Difference> compare(Table expectedTable, Table actualTable) {
+
+    // Note: we deliberately avoid comparing the keyspaces, they might differ because of keyspace
+    // decoration.
+
+    String tableName = expectedTable.name();
+
+    if (!tableName.equals(actualTable.name())) {
+      throw new IllegalArgumentException(
+          "This should only be called for tables with the same name");
+    }
+
+    List<Difference> differences = new ArrayList<>();
+
+    for (Column expectedColumn : expectedTable.columns()) {
+      Column actualColumn = actualTable.column(expectedColumn.name());
+      compareColumn(expectedColumn, actualColumn, differences);
+    }
+    return differences;
+  }
+
+  private static void compareColumn(
+      Column expectedColumn, Column actualColumn, List<Difference> differences) {
+
+    Column.ColumnType columnType = expectedColumn.type();
+    assert columnType != null;
+
+    if (actualColumn == null) {
+      String description = null;
+      if (expectedColumn.isPartitionKey()) {
+        description = "it can't be added because it is marked as a partition key";
+      } else if (expectedColumn.isClusteringKey()) {
+        description = "it can't be added because it is marked as a clustering column";
+      }
+      differences.add(new Difference(expectedColumn, DifferenceType.MISSING_COLUMN, description));
+    } else if (!columnType.equals(actualColumn.type())) {
+      differences.add(
+          new Difference(
+              expectedColumn,
+              DifferenceType.WRONG_TYPE,
+              String.format(
+                  "expected %s, found %s",
+                  columnType.cqlDefinition(), actualColumn.type().cqlDefinition())));
+    } else if (expectedColumn.kind() != actualColumn.kind()) {
+      differences.add(
+          new Difference(
+              expectedColumn,
+              DifferenceType.WRONG_KIND,
+              String.format("expected %s, found %s", expectedColumn.kind(), actualColumn.kind())));
+    } else if (expectedColumn.kind() == Column.Kind.Clustering
+        && expectedColumn.order() != actualColumn.order()) {
+      differences.add(
+          new Difference(
+              expectedColumn,
+              DifferenceType.WRONG_CLUSTERING_ORDER,
+              String.format(
+                  "expected %s, found %s", expectedColumn.order(), actualColumn.order())));
+    }
+  }
+
+  /** @return a list of differences, or empty if the UDTs match. */
+  public static List<Difference> compare(UserDefinedType expectedType, UserDefinedType actualType) {
+
+    // Note: we deliberately avoid comparing the keyspaces, they might differ because of keyspace
+    // decoration.
+
+    String typeName = expectedType.name();
+
+    if (!typeName.equals(actualType.name())) {
+      throw new IllegalArgumentException("This should only be called for UDTs with the same name");
+    }
+
+    List<Difference> differences = new ArrayList<>();
+    for (Column expectedColumn : expectedType.columns()) {
+      Column actualColumn = actualType.columnMap().get(expectedColumn.name());
+      compareColumn(expectedColumn, actualColumn, differences);
+    }
+    return differences;
+  }
+
+  public enum DifferenceType {
+    MISSING_COLUMN,
+    WRONG_TYPE,
+    WRONG_KIND,
+    WRONG_CLUSTERING_ORDER,
+  }
+
+  public static class Difference {
+
+    private final Column column;
+    private final DifferenceType type;
+    private final String description;
+
+    public Difference(Column column, DifferenceType type, String description) {
+      this.column = column;
+      this.type = type;
+      this.description = description;
+    }
+
+    public Column getColumn() {
+      return column;
+    }
+
+    public DifferenceType getType() {
+      return type;
+    }
+
+    public String toGraphqlMessage() {
+      return String.format(
+          "[%s] %s.%s%s",
+          type, column.table(), column.name(), description == null ? "" : ": " + description);
+    }
+  }
+
+  private CassandraSchemaHelper() {}
+}

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/CreateTableQuery.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/CreateTableQuery.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.graphql.schema.schemafirst.migration;
+
+import io.stargate.db.datastore.DataStore;
+import io.stargate.db.query.builder.AbstractBound;
+import io.stargate.db.schema.Table;
+
+public class CreateTableQuery extends MigrationQuery {
+
+  private final Table table;
+
+  public CreateTableQuery(Table table) {
+    this.table = table;
+  }
+
+  @Override
+  public AbstractBound<?> build(DataStore dataStore) {
+    return dataStore
+        .queryBuilder()
+        .create()
+        .table(table.keyspace(), table.name())
+        .column(table.columns())
+        .build()
+        .bind();
+  }
+
+  @Override
+  public String getDescription() {
+    return "Create table " + table.name();
+  }
+
+  @Override
+  public boolean addsReferenceTo(String udtName) {
+    return table.columns().stream().anyMatch(c -> references(c.type(), udtName));
+  }
+
+  @Override
+  public boolean dropsReferenceTo(String udtName) {
+    return false;
+  }
+}

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/CreateUdtQuery.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/CreateUdtQuery.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.graphql.schema.schemafirst.migration;
+
+import io.stargate.db.datastore.DataStore;
+import io.stargate.db.query.builder.AbstractBound;
+import io.stargate.db.schema.UserDefinedType;
+
+public class CreateUdtQuery extends MigrationQuery {
+
+  private final UserDefinedType type;
+
+  public CreateUdtQuery(UserDefinedType type) {
+    this.type = type;
+  }
+
+  public UserDefinedType getType() {
+    return type;
+  }
+
+  @Override
+  public AbstractBound<?> build(DataStore dataStore) {
+    return dataStore.queryBuilder().create().type(type.keyspace(), type).build().bind();
+  }
+
+  @Override
+  public String getDescription() {
+    return "Create UDT " + type.name();
+  }
+
+  @Override
+  public boolean addsReferenceTo(String udtName) {
+    return type.columns().stream().anyMatch(c -> references(c.type(), udtName));
+  }
+
+  @Override
+  public boolean dropsReferenceTo(String udtName) {
+    return false;
+  }
+}

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/DropTableQuery.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/DropTableQuery.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.graphql.schema.schemafirst.migration;
+
+import io.stargate.db.datastore.DataStore;
+import io.stargate.db.query.builder.AbstractBound;
+import io.stargate.db.schema.Table;
+
+public class DropTableQuery extends MigrationQuery {
+
+  private final Table table;
+
+  public DropTableQuery(Table table) {
+    this.table = table;
+  }
+
+  @Override
+  public AbstractBound<?> build(DataStore dataStore) {
+    return dataStore
+        .queryBuilder()
+        .drop()
+        .table(table.keyspace(), table.name())
+        .ifExists()
+        .build()
+        .bind();
+  }
+
+  @Override
+  public String getDescription() {
+    return "Drop table " + table.name();
+  }
+
+  @Override
+  public boolean addsReferenceTo(String udtName) {
+    return false;
+  }
+
+  @Override
+  public boolean dropsReferenceTo(String udtName) {
+    return table.columns().stream().anyMatch(c -> references(c.type(), udtName));
+  }
+}

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/DropUdtQuery.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/DropUdtQuery.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.graphql.schema.schemafirst.migration;
+
+import io.stargate.db.datastore.DataStore;
+import io.stargate.db.query.builder.AbstractBound;
+import io.stargate.db.schema.UserDefinedType;
+
+public class DropUdtQuery extends MigrationQuery {
+
+  private final UserDefinedType type;
+
+  public DropUdtQuery(UserDefinedType type) {
+    this.type = type;
+  }
+
+  public UserDefinedType getType() {
+    return type;
+  }
+
+  @Override
+  public AbstractBound<?> build(DataStore dataStore) {
+    return dataStore.queryBuilder().drop().type(type.keyspace(), type).ifExists().build().bind();
+  }
+
+  @Override
+  public String getDescription() {
+    return "Drop UDT " + type.name();
+  }
+
+  @Override
+  public boolean addsReferenceTo(String udtName) {
+    return false;
+  }
+
+  @Override
+  public boolean dropsReferenceTo(String udtName) {
+    return type.columns().stream().anyMatch(c -> references(c.type(), udtName));
+  }
+}

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/MigrationQuery.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/MigrationQuery.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.graphql.schema.schemafirst.migration;
+
+import io.stargate.db.datastore.DataStore;
+import io.stargate.db.query.builder.AbstractBound;
+import io.stargate.db.schema.Column;
+import io.stargate.db.schema.ParameterizedType;
+import io.stargate.db.schema.UserDefinedType;
+
+/** A DDL query to be executed as part of a migration. */
+public abstract class MigrationQuery {
+
+  public abstract AbstractBound<?> build(DataStore dataStore);
+
+  public abstract String getDescription();
+
+  public boolean mustRunBefore(MigrationQuery that) {
+    if (this instanceof CreateUdtQuery) {
+      // A UDT must exist before we introduce a reference to it.
+      return that.addsReferenceTo(((CreateUdtQuery) this).getType().name());
+    } else if (that instanceof DropUdtQuery) {
+      // All references to a UDT must be dropped before we drop it.
+      return this.dropsReferenceTo(((DropUdtQuery) that).getType().name());
+    } else {
+      // In addition, we move all column additions as close to the beginning as possible. This is
+      // because these queries can fail unexpectedly if the column previously existed with a
+      // different type, and we have no way to check that beforehand. If this happens, we want to
+      // execute as few queries as possible before we find out.
+      return this instanceof AddTableColumnQuery
+          && !(that instanceof AddTableColumnQuery)
+          && !that.mustRunBefore(this);
+    }
+  }
+
+  /** Whether the query will introduce a new column/field that uses the given UDT. */
+  protected abstract boolean addsReferenceTo(String udtName);
+
+  /** Whether the query will remove a column/field that was using the given UDT. */
+  protected abstract boolean dropsReferenceTo(String udtName);
+
+  protected boolean references(Column.ColumnType type, String udtName) {
+    if (type instanceof UserDefinedType) {
+      return (type.name().equals(udtName))
+          || ((UserDefinedType) type)
+              .columns().stream().anyMatch(c -> references(c.type(), udtName));
+    } else if (type instanceof ParameterizedType) { // tuples and collections
+      return type.parameters().stream().anyMatch(subType -> references(subType, udtName));
+    } else { // primitives
+      return false;
+    }
+  }
+}

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/MigrationStrategy.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/MigrationStrategy.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.graphql.schema.schemafirst.migration;
+
+import io.stargate.graphql.schema.schemafirst.AdminSchemaBuilder;
+
+/** @see AdminSchemaBuilder#MIGRATION_STRATEGY_ENUM */
+public enum MigrationStrategy {
+  USE_EXISTING,
+  ADD_MISSING_TABLES,
+  ADD_MISSING_TABLES_AND_COLUMNS,
+  DROP_AND_RECREATE_ALL,
+  DROP_AND_RECREATE_IF_MISMATCH,
+  ;
+}

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/processor/FieldMappingModel.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/processor/FieldMappingModel.java
@@ -125,7 +125,6 @@ public class FieldMappingModel {
     // If the CQL type is explicitly provided, use that, otherwise use the best equivalent of the
     // GraphQL type.
     // TODO if the CQL type is provided, check that we know how to coerce to it
-    // TODO we should also consider the case where the table already exists
     Optional<Column.ColumnType> cqlType =
         directive
             .flatMap(d -> DirectiveHelper.getStringArgument(d, "type", context))

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/processor/ProcessedSchema.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/processor/ProcessedSchema.java
@@ -16,20 +16,23 @@
 package io.stargate.graphql.schema.schemafirst.processor;
 
 import graphql.GraphQL;
-import io.stargate.db.datastore.DataStore;
 import java.util.List;
 
 public class ProcessedSchema {
 
-  private final GraphQL graphql;
   private final MappingModel mappingModel;
+  private final GraphQL graphql;
   private final List<ProcessingMessage> messages;
 
   public ProcessedSchema(
-      GraphQL graphql, MappingModel mappingModel, List<ProcessingMessage> messages) {
-    this.graphql = graphql;
+      MappingModel mappingModel, GraphQL graphql, List<ProcessingMessage> messages) {
     this.mappingModel = mappingModel;
+    this.graphql = graphql;
     this.messages = messages;
+  }
+
+  public MappingModel getMappingModel() {
+    return mappingModel;
   }
 
   public GraphQL getGraphql() {
@@ -38,12 +41,5 @@ public class ProcessedSchema {
 
   public List<ProcessingMessage> getMessages() {
     return messages;
-  }
-
-  public void dropAndRecreateSchema(DataStore dataStore) throws Exception {
-    for (EntityMappingModel entity : mappingModel.getEntities().values()) {
-      dataStore.execute(entity.buildDropQuery(dataStore.queryBuilder())).get();
-      dataStore.execute(entity.buildCreateQuery(dataStore.queryBuilder())).get();
-    }
   }
 }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/processor/SchemaProcessor.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/processor/SchemaProcessor.java
@@ -101,7 +101,7 @@ public class SchemaProcessor {
 
     GraphQL graphql = buildGraphql(registry, mappingModel);
 
-    return new ProcessedSchema(graphql, mappingModel, context.getMessages());
+    return new ProcessedSchema(mappingModel, graphql, context.getMessages());
   }
 
   private void addGeneratedTypes(MappingModel mappingModel, TypeDefinitionRegistry registry) {

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/util/DirectedGraph.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/util/DirectedGraph.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.graphql.schema.schemafirst.util;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import net.jcip.annotations.NotThreadSafe;
+
+/** A basic directed graph implementation to perform topological sorts. */
+@NotThreadSafe
+public class DirectedGraph<VertexT> {
+
+  // We need to keep track of the predecessor count. For simplicity, use a map to store it
+  // alongside the vertices.
+  private final Map<VertexT, Integer> vertices;
+  private final Multimap<VertexT, VertexT> adjacencyList;
+  private boolean wasSorted;
+
+  public DirectedGraph(Collection<VertexT> vertices) {
+    this.vertices = Maps.newLinkedHashMapWithExpectedSize(vertices.size());
+    this.adjacencyList = LinkedHashMultimap.create();
+
+    for (VertexT vertex : vertices) {
+      this.vertices.put(vertex, 0);
+    }
+  }
+
+  @VisibleForTesting
+  @SafeVarargs
+  DirectedGraph(VertexT... vertices) {
+    this(Arrays.asList(vertices));
+  }
+
+  /**
+   * this assumes that {@code from} and {@code to} were part of the vertices passed to the
+   * constructor
+   */
+  public void addEdge(VertexT from, VertexT to) {
+    Preconditions.checkArgument(vertices.containsKey(from) && vertices.containsKey(to));
+    adjacencyList.put(from, to);
+    vertices.put(to, vertices.get(to) + 1);
+  }
+
+  /** one-time use only, calling this multiple times on the same graph won't work */
+  public List<VertexT> topologicalSort() {
+    Preconditions.checkState(!wasSorted);
+    wasSorted = true;
+
+    Queue<VertexT> queue = new ArrayDeque<>();
+
+    for (Map.Entry<VertexT, Integer> entry : vertices.entrySet()) {
+      if (entry.getValue() == 0) {
+        queue.add(entry.getKey());
+      }
+    }
+
+    List<VertexT> result = Lists.newArrayList();
+    while (!queue.isEmpty()) {
+      VertexT vertex = queue.remove();
+      result.add(vertex);
+      for (VertexT successor : adjacencyList.get(vertex)) {
+        if (decrementAndGetCount(successor) == 0) {
+          queue.add(successor);
+        }
+      }
+    }
+
+    if (result.size() != vertices.size()) {
+      throw new IllegalArgumentException("failed to perform topological sort, graph has a cycle");
+    }
+
+    return result;
+  }
+
+  private int decrementAndGetCount(VertexT vertex) {
+    Integer count = vertices.get(vertex);
+    count = count - 1;
+    vertices.put(vertex, count);
+    return count;
+  }
+}

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/schemafirst/migration/CassandraMigratorTest.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/schemafirst/migration/CassandraMigratorTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.graphql.schema.schemafirst.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import io.stargate.db.schema.Column;
+import io.stargate.db.schema.ImmutableColumn;
+import io.stargate.graphql.schema.SampleKeyspaces;
+import java.util.Collections;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class CassandraMigratorTest {
+
+  private static final MigrationQuery CREATE_AUTHORS =
+      new CreateTableQuery(SampleKeyspaces.LIBRARY.table("authors"));
+  private static final MigrationQuery ADD_BOOKS_PAGES =
+      new AddTableColumnQuery(
+          SampleKeyspaces.LIBRARY.table("books"),
+          ImmutableColumn.builder()
+              .keyspace("library")
+              .table("books")
+              .name("pages")
+              .type(Column.Type.Int)
+              .build());
+  private static final MigrationQuery ADD_BOOKS_EDITOR =
+      new AddTableColumnQuery(
+          SampleKeyspaces.LIBRARY.table("books"),
+          ImmutableColumn.builder()
+              .keyspace("library")
+              .table("books")
+              .name("editor")
+              .type(Column.Type.Text)
+              .build());
+
+  private static final MigrationQuery CREATE_UDT_A =
+      new CreateUdtQuery(SampleKeyspaces.UDTS.userDefinedType("A"));
+  private static final MigrationQuery CREATE_UDT_B =
+      new CreateUdtQuery(SampleKeyspaces.UDTS.userDefinedType("B"));
+  private static final MigrationQuery CREATE_TEST_TABLE =
+      new CreateTableQuery(SampleKeyspaces.UDTS.table("TestTable"));
+  private static final MigrationQuery ADD_TEST_TABLE_B =
+      new AddTableColumnQuery(
+          SampleKeyspaces.UDTS.table("TestTable"),
+          ImmutableColumn.builder()
+              .keyspace("udts")
+              .table("TestTable")
+              .name("b")
+              .type(SampleKeyspaces.UDTS.userDefinedType("B"))
+              .build());
+  private static final MigrationQuery DROP_UDT_A =
+      new DropUdtQuery(SampleKeyspaces.UDTS.userDefinedType("A"));
+  private static final MigrationQuery DROP_UDT_B =
+      new DropUdtQuery(SampleKeyspaces.UDTS.userDefinedType("B"));
+  private static final MigrationQuery DROP_TEST_TABLE =
+      new DropTableQuery(SampleKeyspaces.UDTS.table("TestTable"));
+
+  @Test
+  @DisplayName("Should sort queries when there are less than two")
+  public void sortZeroOrOneQuery() {
+    assertThat(CassandraMigrator.sortForExecution(Collections.emptyList())).isEmpty();
+    assertThat(CassandraMigrator.sortForExecution(ImmutableList.of(CREATE_AUTHORS)))
+        .containsExactly(CREATE_AUTHORS);
+  }
+
+  @Test
+  @DisplayName("Should sort UDT creations before their uses")
+  public void sortUdtCreations() {
+    assertThat(
+            CassandraMigrator.sortForExecution(
+                ImmutableList.of(CREATE_TEST_TABLE, CREATE_UDT_A, CREATE_UDT_B)))
+        .containsExactly(CREATE_UDT_B, CREATE_UDT_A, CREATE_TEST_TABLE);
+  }
+
+  @Test
+  @DisplayName("Should sort column additions first")
+  public void sortAddColumnFirst() {
+    assertThat(
+            CassandraMigrator.sortForExecution(
+                ImmutableList.of(CREATE_AUTHORS, ADD_BOOKS_PAGES, ADD_BOOKS_EDITOR)))
+        .containsExactly(ADD_BOOKS_PAGES, ADD_BOOKS_EDITOR, CREATE_AUTHORS);
+  }
+
+  @Test
+  @DisplayName("Should not sort column addition before creation of UDT it references")
+  public void sortAddColumnAfterUdt() {
+    // This is a bit contrived because TestTable already references B through A, but that doesn't
+    // affect the test, so reuse TestTable for simplicity.
+    assertThat(CassandraMigrator.sortForExecution(ImmutableList.of(ADD_TEST_TABLE_B, CREATE_UDT_B)))
+        .containsExactly(CREATE_UDT_B, ADD_TEST_TABLE_B);
+  }
+
+  @Test
+  @DisplayName("Should sort UDT drops before their uses")
+  public void sortUdtDrops() {
+    assertThat(
+            CassandraMigrator.sortForExecution(
+                ImmutableList.of(DROP_UDT_B, DROP_UDT_A, DROP_TEST_TABLE)))
+        .containsExactly(DROP_TEST_TABLE, DROP_UDT_A, DROP_UDT_B);
+  }
+}

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/schemafirst/util/DirectedGraphTest.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/schemafirst/util/DirectedGraphTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.graphql.schema.schemafirst.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class DirectedGraphTest {
+
+  @Test
+  @DisplayName("Should sort empty graph")
+  public void sortEmpty() {
+    DirectedGraph<String> g = new DirectedGraph<>();
+    assertThat(g.topologicalSort()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should sort graph with one node")
+  public void sortOneNode() {
+    DirectedGraph<String> g = new DirectedGraph<>("A");
+    assertThat(g.topologicalSort()).containsExactly("A");
+  }
+
+  @Test
+  @DisplayName("Should sort complex graph")
+  public void sortComplex() {
+    //         H   G
+    //        / \ /\
+    //       F   |  E
+    //        \ /  /
+    //         D  /
+    //        / \/
+    //        B  C
+    //        |
+    //        A
+    DirectedGraph<String> g = new DirectedGraph<>("A", "B", "C", "D", "E", "F", "G", "H");
+    g.addEdge("H", "F");
+    g.addEdge("G", "E");
+    g.addEdge("H", "D");
+    g.addEdge("F", "D");
+    g.addEdge("G", "D");
+    g.addEdge("D", "C");
+    g.addEdge("E", "C");
+    g.addEdge("D", "B");
+    g.addEdge("B", "A");
+
+    // The graph uses linked hash maps internally, so this order will be consistent across JVMs
+    assertThat(g.topologicalSort()).containsExactly("G", "H", "E", "F", "D", "C", "B", "A");
+  }
+
+  @Test
+  @DisplayName("Should fail to sort if graph has a cycle")
+  public void sortWithCycle() {
+    DirectedGraph<String> g = new DirectedGraph<>("A", "B", "C");
+    g.addEdge("A", "B");
+    g.addEdge("B", "C");
+    g.addEdge("C", "B");
+
+    assertThatThrownBy(g::topologicalSort).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("Should fail to sort if graph is cyclic")
+  public void sortCyclic() {
+    DirectedGraph<String> g = new DirectedGraph<>("A", "B", "C");
+    g.addEdge("A", "B");
+    g.addEdge("B", "C");
+    g.addEdge("C", "A");
+
+    assertThatThrownBy(g::topologicalSort).isInstanceOf(IllegalArgumentException.class);
+  }
+}


### PR DESCRIPTION
TODO:
- [x] topologically sort migration queries: we can't drop a UDT before any UDT/table that references it, etc.