### PR TITLE
fix some codacy warnings

### DIFF
--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/AdminSchemaBuilder.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/AdminSchemaBuilder.java
@@ -50,61 +50,6 @@ import java.io.InputStream;
 
 public class AdminSchemaBuilder {
 
-  private final AuthenticationService authenticationService;
-  private final AuthorizationService authorizationService;
-  private final DataStoreFactory dataStoreFactory;
-
-  public AdminSchemaBuilder(
-      AuthenticationService authenticationService,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    this.authenticationService = authenticationService;
-    this.authorizationService = authorizationService;
-    this.dataStoreFactory = dataStoreFactory;
-  }
-
-  public GraphQLSchema build() {
-    return newSchema()
-        .query(QUERY)
-        .mutation(MUTATION)
-        .codeRegistry(
-            newCodeRegistry()
-                .dataFetcher(
-                    coordinates(QUERY, NAMESPACES_QUERY),
-                    new AllNamespacesFetcher(
-                        authenticationService, authorizationService, dataStoreFactory))
-                .dataFetcher(
-                    coordinates(QUERY, NAMESPACE_QUERY),
-                    new SingleNamespaceFetcher(
-                        authenticationService, authorizationService, dataStoreFactory))
-                .dataFetcher(
-                    coordinates(QUERY, SCHEMA_QUERY),
-                    new SingleSchemaFetcher(
-                        authenticationService, authorizationService, dataStoreFactory))
-                .dataFetcher(
-                    coordinates(QUERY, SCHEMA_HISTORY_PER_NAMESPACE_QUERY),
-                    new AllSchemasFetcher(
-                        authenticationService, authorizationService, dataStoreFactory))
-                .dataFetcher(
-                    coordinates(MUTATION, CREATE_NAMESPACE_MUTATION),
-                    new CreateNamespaceFetcher(
-                        authenticationService, authorizationService, dataStoreFactory))
-                .dataFetcher(
-                    coordinates(MUTATION, DROP_NAMESPACE_MUTATION),
-                    new DropNamespaceFetcher(
-                        authenticationService, authorizationService, dataStoreFactory))
-                .dataFetcher(
-                    coordinates(MUTATION, DEPLOY_SCHEMA_MUTATION),
-                    new DeploySchemaFetcher(
-                        authenticationService, authorizationService, dataStoreFactory))
-                .dataFetcher(
-                    coordinates(MUTATION, DEPLOY_SCHEMA_FILE_MUTATION),
-                    new DeploySchemaFileFetcher(
-                        authenticationService, authorizationService, dataStoreFactory))
-                .build())
-        .build();
-  }
-
   private static final GraphQLObjectType DC_TYPE =
       newObject()
           .name("Datacenter")
@@ -473,6 +418,61 @@ public class AdminSchemaBuilder {
           .field(DEPLOY_SCHEMA_MUTATION)
           .field(DEPLOY_SCHEMA_FILE_MUTATION)
           .build();
+
+  private final AuthenticationService authenticationService;
+  private final AuthorizationService authorizationService;
+  private final DataStoreFactory dataStoreFactory;
+
+  public AdminSchemaBuilder(
+      AuthenticationService authenticationService,
+      AuthorizationService authorizationService,
+      DataStoreFactory dataStoreFactory) {
+    this.authenticationService = authenticationService;
+    this.authorizationService = authorizationService;
+    this.dataStoreFactory = dataStoreFactory;
+  }
+
+  public GraphQLSchema build() {
+    return newSchema()
+        .query(QUERY)
+        .mutation(MUTATION)
+        .codeRegistry(
+            newCodeRegistry()
+                .dataFetcher(
+                    coordinates(QUERY, NAMESPACES_QUERY),
+                    new AllNamespacesFetcher(
+                        authenticationService, authorizationService, dataStoreFactory))
+                .dataFetcher(
+                    coordinates(QUERY, NAMESPACE_QUERY),
+                    new SingleNamespaceFetcher(
+                        authenticationService, authorizationService, dataStoreFactory))
+                .dataFetcher(
+                    coordinates(QUERY, SCHEMA_QUERY),
+                    new SingleSchemaFetcher(
+                        authenticationService, authorizationService, dataStoreFactory))
+                .dataFetcher(
+                    coordinates(QUERY, SCHEMA_HISTORY_PER_NAMESPACE_QUERY),
+                    new AllSchemasFetcher(
+                        authenticationService, authorizationService, dataStoreFactory))
+                .dataFetcher(
+                    coordinates(MUTATION, CREATE_NAMESPACE_MUTATION),
+                    new CreateNamespaceFetcher(
+                        authenticationService, authorizationService, dataStoreFactory))
+                .dataFetcher(
+                    coordinates(MUTATION, DROP_NAMESPACE_MUTATION),
+                    new DropNamespaceFetcher(
+                        authenticationService, authorizationService, dataStoreFactory))
+                .dataFetcher(
+                    coordinates(MUTATION, DEPLOY_SCHEMA_MUTATION),
+                    new DeploySchemaFetcher(
+                        authenticationService, authorizationService, dataStoreFactory))
+                .dataFetcher(
+                    coordinates(MUTATION, DEPLOY_SCHEMA_FILE_MUTATION),
+                    new DeploySchemaFileFetcher(
+                        authenticationService, authorizationService, dataStoreFactory))
+                .build())
+        .build();
+  }
 
   /** See the multipart method in {@link GraphqlResourceBase}. */
   private static class InputStreamCoercing implements Coercing<InputStream, Void> {

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/fetchers/admin/DeploySchemaFetcherBase.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/fetchers/admin/DeploySchemaFetcherBase.java
@@ -122,6 +122,7 @@ abstract class DeploySchemaFetcherBase extends CassandraFetcher<Map<String, Obje
             .collect(Collectors.toList()));
   }
 
+  // todo why it is not used?
   private static TypeDefinitionRegistry parseSchema(String inputText) throws GraphqlErrorException {
     SchemaParser parser = new SchemaParser();
     try {

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/fetchers/admin/DeploySchemaFetcherBase.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/fetchers/admin/DeploySchemaFetcherBase.java
@@ -16,13 +16,8 @@
 package io.stargate.graphql.schema.schemafirst.fetchers.admin;
 
 import com.google.common.collect.ImmutableMap;
-import graphql.GraphQLError;
-import graphql.GraphqlErrorException;
 import graphql.GraphqlErrorHelper;
 import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.idl.SchemaParser;
-import graphql.schema.idl.TypeDefinitionRegistry;
-import graphql.schema.idl.errors.SchemaProblem;
 import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
@@ -38,7 +33,6 @@ import io.stargate.graphql.schema.schemafirst.processor.ProcessedSchema;
 import io.stargate.graphql.schema.schemafirst.processor.ProcessingMessage;
 import io.stargate.graphql.schema.schemafirst.processor.SchemaProcessor;
 import java.io.IOException;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
@@ -120,21 +114,5 @@ abstract class DeploySchemaFetcherBase extends CassandraFetcher<Map<String, Obje
         message.getLocations().stream()
             .map(GraphqlErrorHelper::location)
             .collect(Collectors.toList()));
-  }
-
-  // todo why it is not used?
-  private static TypeDefinitionRegistry parseSchema(String inputText) throws GraphqlErrorException {
-    SchemaParser parser = new SchemaParser();
-    try {
-      return parser.parse(inputText);
-    } catch (SchemaProblem schemaProblem) {
-      List<GraphQLError> schemaErrors = schemaProblem.getErrors();
-      throw GraphqlErrorException.newErrorException()
-          .message(
-              "Invalid GraphQL in schemaText/schemaFile. "
-                  + "See details in `extensions.schemaErrors` below.")
-          .extensions(ImmutableMap.of("schemaErrors", schemaErrors))
-          .build();
-    }
   }
 }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/fetchers/dynamic/InsertFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/fetchers/dynamic/InsertFetcher.java
@@ -66,7 +66,8 @@ public class InsertFetcher extends DynamicFetcher<Map<String, Object>> {
     Collection<ValueModifier> setters = new ArrayList<>();
     for (FieldMappingModel column : entityModel.getAllColumns()) {
       String graphqlName = column.getGraphqlName();
-      Object graphqlValue, cqlValue;
+      Object graphqlValue;
+      Object cqlValue;
       if (input.containsKey(graphqlName)) {
         graphqlValue = input.get(graphqlName);
         cqlValue = toCqlValue(graphqlValue, column);

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/processor/EntityMappingModel.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/processor/EntityMappingModel.java
@@ -36,6 +36,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class EntityMappingModel {
+  private static final Pattern NON_NESTED_FIELDS =
+      Pattern.compile("[_A-Za-z][_0-9A-Za-z]*(?:\\s+[_A-Za-z][_0-9A-Za-z]*)*");
+  private static final Splitter ON_SPACES = Splitter.onPattern("\\s+");
 
   private final String graphqlName;
   private final String keyspaceName;
@@ -194,6 +197,8 @@ public class EntityMappingModel {
           return Optional.empty();
         }
         break;
+      default:
+        throw new UnsupportedOperationException("Unsupported target type");
     }
 
     Optional<String> inputTypeName =
@@ -366,8 +371,4 @@ public class EntityMappingModel {
 
     abstract AbstractBound<?> buildDropQuery(QueryBuilder builder, EntityMappingModel entity);
   }
-
-  private static final Pattern NON_NESTED_FIELDS =
-      Pattern.compile("[_A-Za-z][_0-9A-Za-z]*(?:\\s+[_A-Za-z][_0-9A-Za-z]*)*");
-  private static final Splitter ON_SPACES = Splitter.onPattern("\\s+");
 }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/processor/SchemaProcessor.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/processor/SchemaProcessor.java
@@ -53,6 +53,20 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class SchemaProcessor {
+  // TODO make private
+  public static final TypeDefinitionRegistry CQL_DIRECTIVES =
+      new SchemaParser()
+          .parse(
+              new InputStreamReader(
+                  SchemaProcessor.class.getResourceAsStream("/schemafirst/cql_directives.graphql"),
+                  StandardCharsets.UTF_8));
+
+  private static final TypeDefinitionRegistry FEDERATION_DIRECTIVES =
+      new SchemaParser()
+          .parse(
+              new InputStreamReader(
+                  SchemaProcessor.class.getResourceAsStream("/schemafirst/federation.graphql"),
+                  StandardCharsets.UTF_8));
 
   private final AuthenticationService authenticationService;
   private final AuthorizationService authorizationService;
@@ -214,19 +228,4 @@ public class SchemaProcessor {
               }
             });
   }
-
-  // TODO make private
-  public static final TypeDefinitionRegistry CQL_DIRECTIVES =
-      new SchemaParser()
-          .parse(
-              new InputStreamReader(
-                  SchemaProcessor.class.getResourceAsStream("/schemafirst/cql_directives.graphql"),
-                  StandardCharsets.UTF_8));
-
-  private static final TypeDefinitionRegistry FEDERATION_DIRECTIVES =
-      new SchemaParser()
-          .parse(
-              new InputStreamReader(
-                  SchemaProcessor.class.getResourceAsStream("/schemafirst/federation.graphql"),
-                  StandardCharsets.UTF_8));
 }


### PR DESCRIPTION
@olim7t This is fixing the majority of Codancy errors on the `graphql-first` branch.
There are 3 problems left pending, please take a look:
- [ ] `Avoid really long methods.
` on `static Optional<EntityMappingModel> build(ObjectTypeDefinition type, ProcessingContext context) {
`. Please take a look and split if possible
- [x] `Avoid really long methods.` on `protected static void postMultipartJson`
- [x] `Avoid unused private methods such as 'parseSchema(String)'.` on
`private static TypeDefinitionRegistry parseSchema(String inputText) throws GraphqlErrorException`. This method is not used anywhere. Is it safe to remove?

