### PR TITLE
Do what filters we can in cassandra

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -925,17 +925,20 @@ public class DocumentService {
     if (inCassandraPaths.size() > 1 || inMemoryFilters.size() > 0) {
       // If the request involves more than one filter that could be handled by cassandra, or if
       // there is a combination of supported and unsupported filters, then we have to default to the
-      // I/O intensive
-      // in-memory filter.
-      inCassandraFilters = new ArrayList<>();
+      // I/O intensive in-memory filter because the relevant where clause wouldn't be supported in
+      // CQL (multiple C* filters would indirectly require an `OR` due to the document schema
+      // structure).
+      inCassandraFilters = Collections.emptyList();
       inMemoryFilters = filters;
     }
 
     ImmutablePair<List<Row>, ByteBuffer> page;
-    List<Row> leftoverRows = new ArrayList<>();
+    List<Row> leftoverRows = Collections.emptyList();
     ByteBuffer currentPageState = initialPagingState;
     List<String> path =
-        inCassandraFilters.isEmpty() ? new ArrayList<>() : inCassandraFilters.get(0).getPath();
+        inCassandraFilters.isEmpty()
+            ? Collections.emptyList()
+            : inCassandraFilters.get(0).getPath();
     do {
       page =
           searchRows(
@@ -943,13 +946,13 @@ public class DocumentService {
               collection,
               db,
               inCassandraFilters,
-              new ArrayList<>(),
+              Collections.emptyList(),
               path,
               false,
               null,
               pageSize,
               currentPageState);
-      List<Row> rowsResult = new ArrayList<>();
+      ArrayList<Row> rowsResult = new ArrayList<>();
       rowsResult.addAll(leftoverRows);
       rowsResult.addAll(page.left);
       leftoverRows =
@@ -986,7 +989,7 @@ public class DocumentService {
                   collection,
                   db,
                   inCassandraFilters,
-                  new ArrayList<>(),
+                  Collections.emptyList(),
                   path,
                   false,
                   null,

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/filter/FilterCondition.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/filter/FilterCondition.java
@@ -9,6 +9,8 @@ public interface FilterCondition {
 
   String getField();
 
+  String getPathString();
+
   String getFullFieldPath();
 
   List<String> getPath();

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/filter/ListFilterCondition.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/filter/ListFilterCondition.java
@@ -38,6 +38,7 @@ public class ListFilterCondition implements FilterCondition {
     return field;
   }
 
+  @Override
   public String getPathString() {
     return String.join(".", path);
   }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/filter/SingleFilterCondition.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/filter/SingleFilterCondition.java
@@ -66,6 +66,7 @@ public class SingleFilterCondition implements FilterCondition {
     return path;
   }
 
+  @Override
   public String getPathString() {
     return String.join(".", path);
   }


### PR DESCRIPTION
When doing the "full collection" search with a supported cassandra filter, execute it in cassandra rather than defaulting to in-memory. The in-memory approach will still have to be used for multiple filters and/or filters that are not supported by C* (in, nin, neq for instance)