### PR TITLE
Always login users into Persistence Connections

### DIFF
--- a/auth-table-based-service/src/test/java/io/stargate/auth/AuthenticationSubjectTest.java
+++ b/auth-table-based-service/src/test/java/io/stargate/auth/AuthenticationSubjectTest.java
@@ -93,4 +93,14 @@ class AuthenticationSubjectTest {
     assertThat(subject.isFromExternalAuth()).isEqualTo(true);
     assertThat(subject.customProperties()).isEmpty();
   }
+
+  @Test
+  public void convertToAuthenticatedUser() {
+    AuthenticatedUser user =
+        AuthenticationSubject.of("token1", "user2", true, ImmutableMap.of("p1", "v1")).asUser();
+    assertThat(user.token()).isEqualTo("token1");
+    assertThat(user.name()).isEqualTo("user2");
+    assertThat(user.isFromExternalAuth()).isEqualTo(true);
+    assertThat(user.customProperties()).isEqualTo(ImmutableMap.of("p1", "v1"));
+  }
 }

--- a/authnz/src/main/java/io/stargate/auth/AuthenticationSubject.java
+++ b/authnz/src/main/java/io/stargate/auth/AuthenticationSubject.java
@@ -33,6 +33,10 @@ public interface AuthenticationSubject {
 
   Map<String, String> customProperties();
 
+  default AuthenticatedUser asUser() {
+    return AuthenticatedUser.of(roleName(), token(), isFromExternalAuth(), customProperties());
+  }
+
   static AuthenticationSubject of(
       String token, String roleName, boolean fromExternalAuth, Map<String, String> properties) {
     return ImmutableAuthenticationSubject.builder()

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/CassandraFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/CassandraFetcher.java
@@ -50,15 +50,10 @@ public abstract class CassandraFetcher<ResultT> implements DataFetcher<ResultT> 
     DataStoreOptions dataStoreOptions =
         DataStoreOptions.builder()
             .putAllCustomProperties(httpAwareContext.getAllHeaders())
-            .putAllCustomProperties(authenticationSubject.customProperties())
             .defaultParameters(parameters)
             .alwaysPrepareQueries(true)
             .build();
-    DataStore dataStore =
-        dataStoreFactory.create(
-            authenticationSubject.roleName(),
-            authenticationSubject.isFromExternalAuth(),
-            dataStoreOptions);
+    DataStore dataStore = dataStoreFactory.create(authenticationSubject.asUser(), dataStoreOptions);
     return get(environment, dataStore, authenticationSubject);
   }
 

--- a/persistence-api/src/main/java/io/stargate/db/datastore/DataStoreFactory.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/DataStoreFactory.java
@@ -15,55 +15,26 @@
  */
 package io.stargate.db.datastore;
 
+import io.stargate.db.AuthenticatedUser;
 import io.stargate.db.ClientInfo;
 import io.stargate.db.Persistence;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 public interface DataStoreFactory {
 
   /**
-   * Creates a new DataStore on top of the provided persistence. If a username is provided then a
+   * Creates a new DataStore on top of the configured persistence. If the user has been authorized
+   * by the persistence itself (i.e. it is not {@link AuthenticatedUser#isFromExternalAuth()} then a
    * {@link ClientInfo} will be passed to {@link
    * Persistence#newConnection(io.stargate.db.ClientInfo)} causing the new connection to have an
-   * external ClientState thus causing authorization to be performed if enabled.
+   * external ClientState thus causing authorization to be performed at the persistence level (if
+   * enabled).
    *
-   * @param userName the user name to login for this store. For convenience, if it is {@code null}
-   *     or the empty string, no login attempt is performed (so no authentication must be setup).
+   * @param user the object representing the user to login for this store.
    * @param options the options for the create data store.
    * @return the created store.
    */
-  DataStore create(@Nullable String userName, @Nonnull DataStoreOptions options);
-
-  DataStore create(
-      @Nullable String userName, boolean isFromExternalAuth, @Nonnull DataStoreOptions options);
-
-  /**
-   * Creates a new DataStore on top of the provided persistence. If a username is provided then a
-   * {@link ClientInfo} will be passed to {@link
-   * Persistence#newConnection(io.stargate.db.ClientInfo)} causing the new connection to have an
-   * external ClientState thus causing authorization to be performed if enabled. ClientInfo
-   * clientInfo = null; if (!Strings.isNullOrEmpty(userName)) { // Must have a clientInfo so that an
-   * external ClientState is used in order for authorization // to be performed clientInfo = new
-   * ClientInfo(new InetSocketAddress("127.0.0.1", 0), null); }
-   *
-   * <p>return create(persistence, userName, Parameters.defaults(), clientInfo); Creates a new
-   * DataStore on top of the provided persistence.
-   *
-   * <p>A shortcut for {@link #create(DataStoreOptions)} with default options.
-   */
-  default DataStore create() {
-    return create(DataStoreOptions.defaults());
-  }
-
-  /**
-   * Creates a new DataStore on top of the provided persistence.
-   *
-   * <p>A shortcut for {@link #create(String, DataStoreOptions)} with a {@code null} userName.
-   */
-  default DataStore create(DataStoreOptions options) {
-    return create(null, options);
-  }
+  DataStore create(@Nonnull AuthenticatedUser user, @Nonnull DataStoreOptions options);
 
   /**
    * Creates a new internal DataStore on top of the provided persistence.

--- a/restapi/src/main/java/io/stargate/web/resources/Db.java
+++ b/restapi/src/main/java/io/stargate/web/resources/Db.java
@@ -72,12 +72,10 @@ public class Db {
         authenticationService.validateToken(token, headers);
     DataStore dataStore =
         dataStoreFactory.create(
-            authenticationSubject.roleName(),
-            authenticationSubject.isFromExternalAuth(),
+            authenticationSubject.asUser(),
             DataStoreOptions.builder()
                 .alwaysPrepareQueries(true)
                 .putAllCustomProperties(headers)
-                .putAllCustomProperties(authenticationSubject.customProperties())
                 .build());
 
     return new AuthenticatedDB(dataStore, authenticationSubject);
@@ -112,10 +110,8 @@ public class Db {
             .defaultParameters(parameters)
             .alwaysPrepareQueries(true)
             .putAllCustomProperties(headers)
-            .putAllCustomProperties(authenticationSubject.customProperties())
             .build();
-    return dataStoreFactory.create(
-        authenticationSubject.roleName(), authenticationSubject.isFromExternalAuth(), options);
+    return dataStoreFactory.create(authenticationSubject.asUser(), options);
   }
 
   private DocumentDB getDocDataStoreForTokenInternal(TokenAndHeaders tokenAndHeaders)


### PR DESCRIPTION
Even external users need to go through the Persistence.Connection.login() call.
Persistence implementations are prepared to deal with them. Moreover, external
users are already logged in when used in CQL connections.

Note: this commit makes considerable changes to the DataStoreFactory API,
however the removed methods were not used and conceptually should not be
used because DataStore clients should obtain user information from the
authentication services.

Also, it is worth noting that the removed methods had nullable user name
parameters, but actually using null user names would lead to runtime
exceptions because an AuthenticatedUser (created further down the call
path) cannot have a null name.

Fixes #683