### PR TITLE
Move schema table to a dedicated keyspace stargate_graphql

### DIFF
--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/fetchers/admin/AllSchemasFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/fetchers/admin/AllSchemasFetcher.java
@@ -55,7 +55,7 @@ public class AllSchemasFetcher extends SchemaFetcher<List<SchemaSource>> {
       throws Exception {
     String namespace = getNamespace(environment, dataStore);
 
-    authorize(authenticationSubject, namespace);
+    authorize(authenticationSubject);
 
     return schemaSourceDaoProvider.apply(dataStore).getSchemaHistory(namespace);
   }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/fetchers/admin/SchemaFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/fetchers/admin/SchemaFetcher.java
@@ -35,11 +35,11 @@ public abstract class SchemaFetcher<ResultT> extends CassandraFetcher<ResultT> {
     super(authenticationService, authorizationService, dataStoreFactory);
   }
 
-  protected void authorize(AuthenticationSubject authenticationSubject, String namespace)
+  protected void authorize(AuthenticationSubject authenticationSubject)
       throws UnauthorizedException {
     authorizationService.authorizeSchemaRead(
         authenticationSubject,
-        Collections.singletonList(namespace),
+        Collections.singletonList(SchemaSourceDao.KEYSPACE_NAME),
         Collections.singletonList(SchemaSourceDao.TABLE_NAME),
         SourceAPI.GRAPHQL);
   }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/fetchers/admin/SingleSchemaFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/fetchers/admin/SingleSchemaFetcher.java
@@ -56,7 +56,7 @@ public class SingleSchemaFetcher extends SchemaFetcher<SchemaSource> {
     Optional<UUID> version =
         Optional.ofNullable((String) environment.getArgument("version")).map(UUID::fromString);
 
-    authorize(authenticationSubject, namespace);
+    authorize(authenticationSubject);
 
     return schemaSourceDaoProvider.apply(dataStore).getByVersion(namespace, version);
   }

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/resources/schemafirst/FilesResource.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/resources/schemafirst/FilesResource.java
@@ -30,8 +30,6 @@ import io.stargate.graphql.web.RequestToHeadersMapper;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -87,7 +85,7 @@ public class FilesResource {
       @Context HttpServletRequest httpRequest)
       throws Exception {
 
-    if (!isAuthorized(token, namespace, httpRequest)) {
+    if (!isAuthorized(token, httpRequest)) {
       return Response.status(Response.Status.UNAUTHORIZED).build();
     }
 
@@ -144,32 +142,19 @@ public class FilesResource {
     }
   }
 
-  private boolean isAuthorized(String token, String namespace, HttpServletRequest httpRequest) {
+  private boolean isAuthorized(String token, HttpServletRequest httpRequest) {
     try {
       Map<String, String> headers = RequestToHeadersMapper.getAllHeaders(httpRequest);
       AuthenticationSubject authenticationSubject =
           authenticationService.validateToken(token, headers);
       authorizationService.authorizeSchemaRead(
           authenticationSubject,
-          Collections.singletonList(namespace),
+          Collections.singletonList(SchemaSourceDao.KEYSPACE_NAME),
           Collections.singletonList(SchemaSourceDao.TABLE_NAME),
           SourceAPI.GRAPHQL);
       return true;
     } catch (UnauthorizedException e) {
       return false;
     }
-  }
-
-  private static Map<String, String> getAllHeaders(HttpServletRequest request) {
-    if (request == null) {
-      return Collections.emptyMap();
-    }
-    Map<String, String> allHeaders = new HashMap<>();
-    Enumeration<String> headerNames = request.getHeaderNames();
-    while (headerNames.hasMoreElements()) {
-      String headerName = headerNames.nextElement();
-      allHeaders.put(headerName, request.getHeader(headerName));
-    }
-    return allHeaders;
   }
 }

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/resources/schemafirst/SchemaFirstCache.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/resources/schemafirst/SchemaFirstCache.java
@@ -124,7 +124,7 @@ public class SchemaFirstCache {
       try {
         source = schemaSourceDao.getLatest(namespace);
       } catch (Exception e) {
-        // The only way this can happen is if the graphql_schema table exists but with the wrong
+        // The only way this can happen is if the schema_source table exists but with the wrong
         // schema.
         LOG.debug(
             "Error while loading persisted schema for {} ({}).  Skipping for now, this will be "

--- a/graphqlapi/src/test/java/io/stargate/graphql/persistence/schemafirst/SchemaSourceDaoTest.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/persistence/schemafirst/SchemaSourceDaoTest.java
@@ -40,7 +40,7 @@ class SchemaSourceDaoTest {
     UUID versionId = Uuids.timeBased();
     String schemaContent = "some_schema";
     ResultSet resultSet = mockSchemaResultSet(versionId, schemaContent);
-    DataStore dataStore = mockDataStore(namespace, resultSet);
+    DataStore dataStore = mockDataStore(resultSet);
     SchemaSourceDao schemaSourceDao = new TestSchemaSourceDao(dataStore);
 
     // when
@@ -60,7 +60,7 @@ class SchemaSourceDaoTest {
     UUID versionId = Uuids.timeBased();
     String schemaContent = "some_schema";
     ResultSet resultSet = mockSchemaResultSet(versionId, schemaContent);
-    DataStore dataStore = mockDataStore(namespace, resultSet);
+    DataStore dataStore = mockDataStore(resultSet);
     SchemaSourceDao schemaSourceDao = new TestSchemaSourceDao(dataStore);
 
     // when
@@ -78,7 +78,7 @@ class SchemaSourceDaoTest {
     // given
     String namespace = "ns_1";
     ResultSet resultSet = mockNullResultSet();
-    DataStore dataStore = mockDataStore(namespace, resultSet);
+    DataStore dataStore = mockDataStore(resultSet);
     SchemaSourceDao schemaSourceDao = new TestSchemaSourceDao(dataStore);
 
     // when
@@ -98,7 +98,7 @@ class SchemaSourceDaoTest {
     String schemaContent2 = "some_schema_2";
     ResultSet resultSet =
         mockSchemaResultSetWithTwoRecords(versionId, schemaContent, versionId2, schemaContent2);
-    DataStore dataStore = mockDataStore(namespace, resultSet);
+    DataStore dataStore = mockDataStore(resultSet);
     SchemaSourceDao schemaSourceDao = new TestSchemaSourceDao(dataStore);
 
     // when
@@ -123,7 +123,7 @@ class SchemaSourceDaoTest {
     // given
     String namespace = "ns_1";
     ResultSet resultSet = mockNullResultSet();
-    DataStore dataStore = mockDataStore(namespace, resultSet);
+    DataStore dataStore = mockDataStore(resultSet);
     SchemaSourceDao schemaSourceDao = new TestSchemaSourceDao(dataStore);
 
     // when
@@ -133,30 +133,10 @@ class SchemaSourceDaoTest {
     assertThat(schema).isEmpty();
   }
 
-  private DataStore mockDataStore(String namespace, ResultSet resultSet) {
+  private DataStore mockDataStore(ResultSet resultSet) {
     DataStore dataStore = mock(DataStore.class);
-    ImmutableTable table =
-        ImmutableTable.builder()
-            .name(TABLE_NAME)
-            .keyspace(namespace)
-            .addColumns(
-                ImmutableColumn.create(
-                    KEY_COLUMN_NAME, Column.Kind.PartitionKey, Column.Type.Varchar))
-            .addColumns(
-                ImmutableColumn.create(
-                    VERSION_COLUMN_NAME,
-                    Column.Kind.Clustering,
-                    Column.Type.Timeuuid,
-                    Column.Order.DESC))
-            .addColumns(
-                ImmutableColumn.create(
-                    LATEST_VERSION_COLUMN_NAME, Column.Kind.Static, Column.Type.Timeuuid))
-            .addColumns(ImmutableColumn.create(CONTENTS_COLUMN_NAME, Column.Type.Varchar))
-            .addColumns(
-                ImmutableColumn.create(
-                    DEPLOYMENT_IN_PROGRESS_COLUMN_NAME, Column.Kind.Static, Column.Type.Boolean))
-            .build();
-    Keyspace keyspace = ImmutableKeyspace.builder().addTables(table).name(namespace).build();
+    Keyspace keyspace =
+        ImmutableKeyspace.builder().addTables(EXPECTED_TABLE).name(KEYSPACE_NAME).build();
     Schema schema = ImmutableSchema.create(Collections.singletonList(keyspace));
     when(dataStore.schema()).thenReturn(schema);
     when(dataStore.execute(any())).thenReturn(CompletableFuture.completedFuture(resultSet));

--- a/testing/src/test/java/io/stargate/it/http/graphql/graphfirst/DataTypesTest.java
+++ b/testing/src/test/java/io/stargate/it/http/graphql/graphfirst/DataTypesTest.java
@@ -23,7 +23,6 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.jayway.jsonpath.JsonPath;
-import io.stargate.it.BaseOsgiIntegrationTest;
 import io.stargate.it.driver.CqlSessionExtension;
 import io.stargate.it.driver.TestKeyspace;
 import io.stargate.it.http.RestUtils;
@@ -42,7 +41,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @ExtendWith(CqlSessionExtension.class)
-public class DataTypesTest extends BaseOsgiIntegrationTest {
+public class DataTypesTest extends GraphqlFirstTestBase {
 
   private static final UUID ID = UUID.randomUUID();
   private static GraphqlFirstClient CLIENT;
@@ -54,8 +53,8 @@ public class DataTypesTest extends BaseOsgiIntegrationTest {
   }
 
   @BeforeEach
-  public void resetKeyspace(CqlSession session) {
-    session.execute("DROP TABLE IF EXISTS graphql_schema");
+  public void cleanupDb(@TestKeyspace CqlIdentifier keyspaceId, CqlSession session) {
+    deleteAllGraphqlSchemas(keyspaceId.asInternal(), session);
     session.execute("DROP TABLE IF EXISTS \"Holder\"");
     session.execute("DROP TYPE IF EXISTS \"Location\"");
     session.execute("DROP TYPE IF EXISTS \"Address\"");

--- a/testing/src/test/java/io/stargate/it/http/graphql/graphfirst/GraphqlFirstTestBase.java
+++ b/testing/src/test/java/io/stargate/it/http/graphql/graphfirst/GraphqlFirstTestBase.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.it.http.graphql.graphfirst;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import io.stargate.it.BaseOsgiIntegrationTest;
+
+abstract class GraphqlFirstTestBase extends BaseOsgiIntegrationTest {
+  protected static void deleteAllGraphqlSchemas(String namespace, CqlSession session) {
+    session
+        .getMetadata()
+        .getKeyspace("stargate_graphql")
+        .flatMap(ks -> ks.getTable("schema_source"))
+        .ifPresent(
+            __ ->
+                session.execute(
+                    "DELETE FROM stargate_graphql.schema_source WHERE namespace = ?", namespace));
+  }
+}


### PR DESCRIPTION
Create the keyspace first if it does not exists (RF=1, users can alter
the replication settings later).

Use the namespace as the partition key instead of a fixed value.