### PR TITLE
move --bind-to-listen-address to starctl cmd

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -64,7 +64,7 @@ sudo ifconfig lo0 alias 127.0.0.2
 Start Stargate from the command line with
 
 ```
-./starctl --cluster-name stargate --cluster-seed 127.0.0.1 --cluster-version 3.11 --listen 127.0.0.2 --simple-snitch
+./starctl --cluster-name stargate --cluster-seed 127.0.0.1 --cluster-version 3.11 --listen 127.0.0.2 --bind-to-listen-address --simple-snitch
 
 # See all cli options with -h
 ```
@@ -77,7 +77,7 @@ docker pull stargateio/stargate-3_11:v0.0.2
 ```
 
 ```sh
-docker run --name stargate -d stargateio/stargate-3_11:v0.0.2 --cluster-name stargate --cluster-seed 127.0.0.1 --cluster-version 3.11 --listen 127.0.0.2 --bind-to-listen-address --simple-snitch
+docker run --name stargate -d stargateio/stargate-3_11:v0.0.2 --cluster-name stargate --cluster-seed 127.0.0.1 --cluster-version 3.11 --listen 127.0.0.2 --simple-snitch
 ```
 
 `starctl` respects the `JAVA_OPTS` environment variable.


### PR DESCRIPTION
#676 added --bind-to-listen-address to mitigate problems with binding
to a used address. The flag was added to a wrong command in DEV_GUIDE.md.
It was supposed to be added to starctl cmd.