### PR TITLE
Require authorization to read DML schemas

### DIFF
--- a/graphqlapi/src/main/java/io/stargate/graphql/web/DropwizardServer.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/DropwizardServer.java
@@ -103,6 +103,24 @@ public class DropwizardServer extends Application<Configuration> {
                 bind(FrameworkUtil.getBundle(GraphqlActivator.class)).to(Bundle.class);
               }
             });
+    environment
+        .jersey()
+        .register(
+            new AbstractBinder() {
+              @Override
+              protected void configure() {
+                bind(authenticationService).to(AuthenticationService.class);
+              }
+            });
+    environment
+        .jersey()
+        .register(
+            new AbstractBinder() {
+              @Override
+              protected void configure() {
+                bind(authorizationService).to(AuthorizationService.class);
+              }
+            });
 
     environment.jersey().register(GraphqlDmlResource.class);
     environment.jersey().register(GraphqlDdlResource.class);

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/resources/cqlfirst/GraphqlCache.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/resources/cqlfirst/GraphqlCache.java
@@ -99,6 +99,10 @@ public class GraphqlCache implements EventListener {
     return defaultKeyspace == null ? null : getDml(defaultKeyspace, Collections.emptyMap());
   }
 
+  public String getDefaultKeyspaceName() {
+    return defaultKeyspace;
+  }
+
   /** Populate a default keyspace to allow for omitting the keyspace from the path of requests. */
   private static String findDefaultKeyspace(DataStore dataStore) {
     if (DISABLE_DEFAULT_KEYSPACE) return null;


### PR DESCRIPTION
Motivation:

Unauthorized users were correctly prevented from executing data queries,
but they could still introspect the GraphQL schemas, which reveals
details about the CQL data model.

Modifications:

Perform an authorization check before we select the GraphQL schema to
use.

Result:

Unauthorized users will get a 401 for any GraphQL query, whether it's an
introspection query or one that goes to the backend.

Note that the DDL schema is not protected, it's a generic schema that is
the same for any Stargate installation, so exposing it doesn't reveal
any sensitive information.