### PR TITLE
Reduce Netty buffer memory usage for CQL transport

### DIFF
--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/CBUtil.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/CBUtil.java
@@ -375,15 +375,6 @@ public abstract class CBUtil {
     return ByteBuffer.wrap(readRawBytes(cb, length));
   }
 
-  public static ByteBuffer readValueNoCopy(ByteBuf cb) {
-    int length = cb.readInt();
-    if (length < 0) return null;
-
-    ByteBuffer buffer = cb.nioBuffer(cb.readerIndex(), length);
-    cb.skipBytes(length);
-    return buffer;
-  }
-
   public static ByteBuffer readBoundValue(ByteBuf cb, ProtocolVersion protocolVersion) {
     int length = cb.readInt();
     if (length < 0) {

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Frame.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Frame.java
@@ -28,8 +28,8 @@ import io.netty.util.Attribute;
 import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
-import org.apache.cassandra.metrics.ClientRequestSizeMetrics;
 import org.apache.cassandra.stargate.exceptions.InvalidRequestException;
+import org.apache.cassandra.stargate.metrics.ClientMetrics;
 import org.apache.cassandra.stargate.transport.ProtocolException;
 import org.apache.cassandra.stargate.transport.ProtocolVersion;
 import org.apache.cassandra.stargate.transport.internal.frame.FrameBodyTransformer;
@@ -207,8 +207,8 @@ public class Frame {
 
       if (buffer.readableBytes() < frameLength) return null;
 
-      ClientRequestSizeMetrics.totalBytesRead.inc(frameLength);
-      ClientRequestSizeMetrics.bytesRecievedPerFrame.update(frameLength);
+      ClientMetrics.instance.getTotalBytesRead().inc(frameLength);
+      ClientMetrics.instance.getBytesReceivedPerFrame().update(frameLength);
 
       // extract body
       ByteBuf body = buffer.slice(idx, bodyLength);
@@ -287,8 +287,8 @@ public class Frame {
       header.writeInt(frame.body.readableBytes());
 
       int messageSize = header.readableBytes() + frame.body.readableBytes();
-      ClientRequestSizeMetrics.totalBytesWritten.inc(messageSize);
-      ClientRequestSizeMetrics.bytesTransmittedPerFrame.update(messageSize);
+      ClientMetrics.instance.getTotalBytesWritten().inc(messageSize);
+      ClientMetrics.instance.getBytesTransmittedPerFrame().update(messageSize);
 
       results.add(header);
       results.add(frame.body);

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Message.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Message.java
@@ -365,6 +365,12 @@ public abstract class Message {
         // Remember the streamId
         throw ErrorMessage.wrap(ex, frame.header.streamId);
       } finally {
+        // Release the frame body {@link io.netty.buffer.ByteBuf}. All bytes have been copied into
+        // the decoded message. Keeping this around during the request execution and response flush
+        // can cause a pathological case where the cumulation buffer in {@link
+        // io.netty.handler.codec.ByteToMessageDecoder} grows significantly. See the logic in {@link
+        // io.netty.handler.codec.ByteToMessageDecoder#MERGE_CUMULATOR} where the buffer is expanded
+        // when the reference count of a buffer is greater than 0.
         frame.release();
       }
     }

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/QueryOptions.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/QueryOptions.java
@@ -190,9 +190,7 @@ public class QueryOptions {
       if (!flags.isEmpty()) {
         int pageSize = flags.contains(QueryOptions.Codec.Flag.PAGE_SIZE) ? body.readInt() : -1;
         ByteBuffer pagingState =
-            flags.contains(QueryOptions.Codec.Flag.PAGING_STATE)
-                ? CBUtil.readValueNoCopy(body)
-                : null;
+            flags.contains(QueryOptions.Codec.Flag.PAGING_STATE) ? CBUtil.readValue(body) : null;
         ConsistencyLevel serialConsistency =
             flags.contains(QueryOptions.Codec.Flag.SERIAL_CONSISTENCY)
                 ? CBUtil.readConsistencyLevel(body)

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/ResultMessage.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/ResultMessage.java
@@ -132,8 +132,7 @@ public class ResultMessage extends Message.Response {
             }
 
             ByteBuffer pagingState = null;
-            if (flags.contains(Result.Flag.HAS_MORE_PAGES))
-              pagingState = CBUtil.readValueNoCopy(body);
+            if (flags.contains(Result.Flag.HAS_MORE_PAGES)) pagingState = CBUtil.readValue(body);
 
             if (flags.contains(Result.Flag.NO_METADATA))
               return new Result.ResultMetadata(flags, columnCount, null, null, pagingState);


### PR DESCRIPTION
Request buffers were kept alive until responses are flushed to the
client. As far I can tell the request buffer is no longer used after
executing the request and can be safely deallocated before flushing the
response.

Request buffers tend to be oversized when requests are relatively small
and keeping these buffers around until the responses can be flushed can
result in substantial memory use relative to the size of the
requests/responses.

Also, ported some useful client metrics to use Prometheus.