### PR TITLE
Clean up GraphQL authentication (fixes #732)

### DIFF
--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/CassandraFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/CassandraFetcher.java
@@ -2,7 +2,6 @@ package io.stargate.graphql.schema;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.db.Parameters;
@@ -14,7 +13,6 @@ import org.apache.cassandra.stargate.db.ConsistencyLevel;
 
 /** Base class for fetchers that access the Cassandra backend. It also handles authentication. */
 public abstract class CassandraFetcher<ResultT> implements DataFetcher<ResultT> {
-  protected final AuthenticationService authenticationService;
   protected final AuthorizationService authorizationService;
   private final DataStoreFactory dataStoreFactory;
 
@@ -30,10 +28,7 @@ public abstract class CassandraFetcher<ResultT> implements DataFetcher<ResultT> 
           .build();
 
   public CassandraFetcher(
-      AuthenticationService authenticationService,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    this.authenticationService = authenticationService;
+      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
     this.authorizationService = authorizationService;
     this.dataStoreFactory = dataStoreFactory;
   }
@@ -42,9 +37,7 @@ public abstract class CassandraFetcher<ResultT> implements DataFetcher<ResultT> 
   public final ResultT get(DataFetchingEnvironment environment) throws Exception {
     HttpAwareContext httpAwareContext = environment.getContext();
 
-    String token = httpAwareContext.getAuthToken();
-    AuthenticationSubject authenticationSubject =
-        authenticationService.validateToken(token, httpAwareContext.getAllHeaders());
+    AuthenticationSubject authenticationSubject = httpAwareContext.getSubject();
 
     Parameters parameters = getDatastoreParameters(environment);
     DataStoreOptions dataStoreOptions =

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/SchemaFactory.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/SchemaFactory.java
@@ -16,7 +16,6 @@
 package io.stargate.graphql.schema.cqlfirst;
 
 import graphql.schema.GraphQLSchema;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.schema.Keyspace;
@@ -32,13 +31,10 @@ public class SchemaFactory {
    * <p>This is the API exposed at {@code /graphql/<keyspaceName>}.
    */
   public static GraphQLSchema newDmlSchema(
-      AuthenticationService authenticationService,
       AuthorizationService authorizationService,
       Keyspace keyspace,
       DataStoreFactory dataStoreFactory) {
-    return new DmlSchemaBuilder(
-            authenticationService, authorizationService, keyspace, dataStoreFactory)
-        .build();
+    return new DmlSchemaBuilder(authorizationService, keyspace, dataStoreFactory).build();
   }
 
   /**
@@ -48,10 +44,7 @@ public class SchemaFactory {
    * <p>This is the API exposed at {@code /graphql-schema}.
    */
   public static GraphQLSchema newDdlSchema(
-      AuthenticationService authenticationService,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    return new DdlSchemaBuilder(authenticationService, authorizationService, dataStoreFactory)
-        .build();
+      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
+    return new DdlSchemaBuilder(authorizationService, dataStoreFactory).build();
   }
 }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/DdlSchemaBuilder.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/DdlSchemaBuilder.java
@@ -30,7 +30,6 @@ import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLTypeReference;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.graphql.schema.cqlfirst.ddl.fetchers.AllKeyspacesFetcher;
@@ -51,16 +50,12 @@ public class DdlSchemaBuilder {
 
   private final HashMap<String, GraphQLType> objects;
   private final DataStoreFactory dataStoreFactory;
-  private final AuthenticationService authenticationService;
   private final AuthorizationService authorizationService;
 
   public DdlSchemaBuilder(
-      AuthenticationService authenticationService,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
+      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
     this.dataStoreFactory = dataStoreFactory;
     this.objects = new HashMap<>();
-    this.authenticationService = authenticationService;
     this.authorizationService = authorizationService;
   }
 
@@ -92,8 +87,7 @@ public class DdlSchemaBuilder {
         .argument(
             GraphQLArgument.newArgument().name("toAdd").type(nonNull(list(buildColumnInput()))))
         .type(Scalars.GraphQLBoolean)
-        .dataFetcher(
-            new AlterTableAddFetcher(authenticationService, authorizationService, dataStoreFactory))
+        .dataFetcher(new AlterTableAddFetcher(authorizationService, dataStoreFactory))
         .build();
   }
 
@@ -107,9 +101,7 @@ public class DdlSchemaBuilder {
         .argument(
             GraphQLArgument.newArgument().name("toDrop").type(nonNull(list(Scalars.GraphQLString))))
         .type(Scalars.GraphQLBoolean)
-        .dataFetcher(
-            new AlterTableDropFetcher(
-                authenticationService, authorizationService, dataStoreFactory))
+        .dataFetcher(new AlterTableDropFetcher(authorizationService, dataStoreFactory))
         .build();
   }
 
@@ -122,8 +114,7 @@ public class DdlSchemaBuilder {
             GraphQLArgument.newArgument().name("tableName").type(nonNull(Scalars.GraphQLString)))
         .argument(GraphQLArgument.newArgument().name("ifExists").type(Scalars.GraphQLBoolean))
         .type(Scalars.GraphQLBoolean)
-        .dataFetcher(
-            new DropTableFetcher(authenticationService, authorizationService, dataStoreFactory))
+        .dataFetcher(new DropTableFetcher(authorizationService, dataStoreFactory))
         .build();
   }
 
@@ -138,8 +129,7 @@ public class DdlSchemaBuilder {
             GraphQLArgument.newArgument().name("fields").type(nonNull(list(buildColumnInput()))))
         .argument(GraphQLArgument.newArgument().name("ifNotExists").type(Scalars.GraphQLBoolean))
         .type(Scalars.GraphQLBoolean)
-        .dataFetcher(
-            new CreateTypeFetcher(authenticationService, authorizationService, dataStoreFactory))
+        .dataFetcher(new CreateTypeFetcher(authorizationService, dataStoreFactory))
         .build();
   }
 
@@ -152,8 +142,7 @@ public class DdlSchemaBuilder {
             GraphQLArgument.newArgument().name("typeName").type(nonNull(Scalars.GraphQLString)))
         .argument(GraphQLArgument.newArgument().name("ifExists").type(Scalars.GraphQLBoolean))
         .type(Scalars.GraphQLBoolean)
-        .dataFetcher(
-            new DropTypeFetcher(authenticationService, authorizationService, dataStoreFactory))
+        .dataFetcher(new DropTypeFetcher(authorizationService, dataStoreFactory))
         .build();
   }
 
@@ -190,9 +179,7 @@ public class DdlSchemaBuilder {
                         + "You must specify either this or 'replicas', but not both.")
                 .build())
         .type(Scalars.GraphQLBoolean)
-        .dataFetcher(
-            new CreateKeyspaceFetcher(
-                authenticationService, authorizationService, dataStoreFactory))
+        .dataFetcher(new CreateKeyspaceFetcher(authorizationService, dataStoreFactory))
         .build();
   }
 
@@ -213,8 +200,7 @@ public class DdlSchemaBuilder {
                     "Whether the operation will succeed if the keyspace does not exist. "
                         + "Defaults to false if absent."))
         .type(Scalars.GraphQLBoolean)
-        .dataFetcher(
-            new DropKeyspaceFetcher(authenticationService, authorizationService, dataStoreFactory))
+        .dataFetcher(new DropKeyspaceFetcher(authorizationService, dataStoreFactory))
         .build();
   }
 
@@ -231,9 +217,7 @@ public class DdlSchemaBuilder {
         .name("keyspace")
         .argument(GraphQLArgument.newArgument().name("name").type(nonNull(Scalars.GraphQLString)))
         .type(buildKeyspace())
-        .dataFetcher(
-            new SingleKeyspaceFetcher(
-                authenticationService, authorizationService, dataStoreFactory))
+        .dataFetcher(new SingleKeyspaceFetcher(authorizationService, dataStoreFactory))
         .build();
   }
 
@@ -421,8 +405,7 @@ public class DdlSchemaBuilder {
     return GraphQLFieldDefinition.newFieldDefinition()
         .name("keyspaces")
         .type(list(buildKeyspace()))
-        .dataFetcher(
-            new AllKeyspacesFetcher(authenticationService, authorizationService, dataStoreFactory))
+        .dataFetcher(new AllKeyspacesFetcher(authorizationService, dataStoreFactory))
         .build();
   }
 
@@ -452,8 +435,7 @@ public class DdlSchemaBuilder {
         .argument(GraphQLArgument.newArgument().name("values").type(list(buildColumnInput())))
         .argument(GraphQLArgument.newArgument().name("ifNotExists").type(Scalars.GraphQLBoolean))
         .type(Scalars.GraphQLBoolean)
-        .dataFetcher(
-            new CreateTableFetcher(authenticationService, authorizationService, dataStoreFactory))
+        .dataFetcher(new CreateTableFetcher(authorizationService, dataStoreFactory))
         .build();
   }
 
@@ -485,8 +467,7 @@ public class DdlSchemaBuilder {
                         + " FULL (full index of a frozen collection)")
                 .type(buildIndexKind()))
         .type(Scalars.GraphQLBoolean)
-        .dataFetcher(
-            new CreateIndexFetcher(authenticationService, authorizationService, dataStoreFactory))
+        .dataFetcher(new CreateIndexFetcher(authorizationService, dataStoreFactory))
         .build();
   }
 
@@ -499,8 +480,7 @@ public class DdlSchemaBuilder {
             GraphQLArgument.newArgument().name("indexName").type(nonNull(Scalars.GraphQLString)))
         .argument(GraphQLArgument.newArgument().name("ifExists").type(Scalars.GraphQLBoolean))
         .type(Scalars.GraphQLBoolean)
-        .dataFetcher(
-            new DropIndexFetcher(authenticationService, authorizationService, dataStoreFactory))
+        .dataFetcher(new DropIndexFetcher(authorizationService, dataStoreFactory))
         .build();
   }
 

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/AllKeyspacesFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/AllKeyspacesFetcher.java
@@ -16,7 +16,6 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.SourceAPI;
@@ -35,10 +34,8 @@ public class AllKeyspacesFetcher extends CassandraFetcher<List<KeyspaceDto>> {
   private static final Logger LOG = LoggerFactory.getLogger(AllKeyspacesFetcher.class);
 
   public AllKeyspacesFetcher(
-      AuthenticationService authenticationService,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    super(authenticationService, authorizationService, dataStoreFactory);
+      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
+    super(authorizationService, dataStoreFactory);
   }
 
   @Override

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/AlterTableAddFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/AlterTableAddFetcher.java
@@ -16,7 +16,6 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.query.Query;
@@ -28,10 +27,8 @@ import java.util.Map;
 public class AlterTableAddFetcher extends TableFetcher {
 
   public AlterTableAddFetcher(
-      AuthenticationService authenticationService,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    super(authenticationService, authorizationService, dataStoreFactory);
+      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
+    super(authorizationService, dataStoreFactory);
   }
 
   @Override

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/AlterTableDropFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/AlterTableDropFetcher.java
@@ -16,7 +16,6 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.query.Query;
@@ -26,10 +25,8 @@ import java.util.List;
 public class AlterTableDropFetcher extends TableFetcher {
 
   public AlterTableDropFetcher(
-      AuthenticationService authenticationService,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    super(authenticationService, authorizationService, dataStoreFactory);
+      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
+    super(authorizationService, dataStoreFactory);
   }
 
   @Override

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/CreateIndexFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/CreateIndexFetcher.java
@@ -16,7 +16,6 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
 import io.stargate.db.datastore.DataStoreFactory;
@@ -27,10 +26,8 @@ import io.stargate.db.schema.ImmutableCollectionIndexingType;
 
 public class CreateIndexFetcher extends IndexFetcher {
   public CreateIndexFetcher(
-      AuthenticationService authenticationService,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    super(authenticationService, authorizationService, dataStoreFactory, Scope.CREATE);
+      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
+    super(authorizationService, dataStoreFactory, Scope.CREATE);
   }
 
   @Override

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/CreateKeyspaceFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/CreateKeyspaceFetcher.java
@@ -16,7 +16,6 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
@@ -33,10 +32,8 @@ import java.util.Map;
 public class CreateKeyspaceFetcher extends DdlQueryFetcher {
 
   public CreateKeyspaceFetcher(
-      AuthenticationService authenticationService,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    super(authenticationService, authorizationService, dataStoreFactory);
+      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
+    super(authorizationService, dataStoreFactory);
   }
 
   @Override

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/CreateTableFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/CreateTableFetcher.java
@@ -16,7 +16,6 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.query.Query;
@@ -29,10 +28,8 @@ import java.util.Map;
 public class CreateTableFetcher extends TableFetcher {
 
   public CreateTableFetcher(
-      AuthenticationService authenticationService,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    super(authenticationService, authorizationService, dataStoreFactory);
+      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
+    super(authorizationService, dataStoreFactory);
   }
 
   @Override

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/CreateTypeFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/CreateTypeFetcher.java
@@ -16,7 +16,6 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
@@ -35,10 +34,8 @@ import java.util.Map;
 public class CreateTypeFetcher extends DdlQueryFetcher {
 
   public CreateTypeFetcher(
-      AuthenticationService authenticationService,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    super(authenticationService, authorizationService, dataStoreFactory);
+      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
+    super(authorizationService, dataStoreFactory);
   }
 
   @Override

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DdlQueryFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DdlQueryFetcher.java
@@ -16,7 +16,6 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.UnauthorizedException;
@@ -42,10 +41,8 @@ import java.util.Map;
 public abstract class DdlQueryFetcher extends CassandraFetcher<Boolean> {
 
   protected DdlQueryFetcher(
-      AuthenticationService authenticationService,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    super(authenticationService, authorizationService, dataStoreFactory);
+      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
+    super(authorizationService, dataStoreFactory);
   }
 
   @Override

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DropIndexFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DropIndexFetcher.java
@@ -16,7 +16,6 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
 import io.stargate.db.datastore.DataStoreFactory;
@@ -26,10 +25,8 @@ import io.stargate.db.query.builder.QueryBuilder;
 public class DropIndexFetcher extends IndexFetcher {
 
   public DropIndexFetcher(
-      AuthenticationService authenticationService,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    super(authenticationService, authorizationService, dataStoreFactory, Scope.DROP);
+      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
+    super(authorizationService, dataStoreFactory, Scope.DROP);
   }
 
   @Override

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DropKeyspaceFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DropKeyspaceFetcher.java
@@ -16,7 +16,6 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
@@ -29,10 +28,8 @@ import io.stargate.db.query.builder.QueryBuilder;
 public class DropKeyspaceFetcher extends DdlQueryFetcher {
 
   public DropKeyspaceFetcher(
-      AuthenticationService authenticationService,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    super(authenticationService, authorizationService, dataStoreFactory);
+      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
+    super(authorizationService, dataStoreFactory);
   }
 
   @Override

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DropTableFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DropTableFetcher.java
@@ -16,7 +16,6 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.query.Query;
@@ -25,10 +24,8 @@ import io.stargate.db.query.builder.QueryBuilder;
 public class DropTableFetcher extends TableFetcher {
 
   public DropTableFetcher(
-      AuthenticationService authenticationService,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    super(authenticationService, authorizationService, dataStoreFactory);
+      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
+    super(authorizationService, dataStoreFactory);
   }
 
   @Override

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DropTypeFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DropTypeFetcher.java
@@ -16,7 +16,6 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
@@ -30,10 +29,8 @@ import io.stargate.db.schema.UserDefinedType;
 public class DropTypeFetcher extends DdlQueryFetcher {
 
   public DropTypeFetcher(
-      AuthenticationService authenticationService,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    super(authenticationService, authorizationService, dataStoreFactory);
+      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
+    super(authorizationService, dataStoreFactory);
   }
 
   @Override

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/IndexFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/IndexFetcher.java
@@ -3,7 +3,6 @@ package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 import static com.datastax.oss.driver.shaded.guava.common.base.Preconditions.checkNotNull;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
@@ -18,11 +17,8 @@ public abstract class IndexFetcher extends DdlQueryFetcher {
   protected final Scope scope;
 
   protected IndexFetcher(
-      AuthenticationService authenticationService,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory,
-      Scope scope) {
-    super(authenticationService, authorizationService, dataStoreFactory);
+      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory, Scope scope) {
+    super(authorizationService, dataStoreFactory);
 
     checkNotNull(scope, "No Scope provided");
     this.scope = scope;

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/SingleKeyspaceFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/SingleKeyspaceFetcher.java
@@ -16,7 +16,6 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.SourceAPI;
@@ -29,10 +28,8 @@ import java.util.Collections;
 public class SingleKeyspaceFetcher extends CassandraFetcher<KeyspaceDto> {
 
   public SingleKeyspaceFetcher(
-      AuthenticationService authenticationService,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    super(authenticationService, authorizationService, dataStoreFactory);
+      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
+    super(authorizationService, dataStoreFactory);
   }
 
   @Override

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/TableFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/TableFetcher.java
@@ -1,7 +1,6 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
@@ -14,10 +13,8 @@ import io.stargate.db.query.builder.QueryBuilder;
 public abstract class TableFetcher extends DdlQueryFetcher {
 
   protected TableFetcher(
-      AuthenticationService authenticationService,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    super(authenticationService, authorizationService, dataStoreFactory);
+      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
+    super(authorizationService, dataStoreFactory);
   }
 
   @Override

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/DmlSchemaBuilder.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/DmlSchemaBuilder.java
@@ -37,7 +37,6 @@ import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLTypeReference;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.schema.Column;
@@ -64,7 +63,6 @@ public class DmlSchemaBuilder {
 
   private static final Logger LOG = LoggerFactory.getLogger(DmlSchemaBuilder.class);
 
-  private final AuthenticationService authenticationService;
   private final AuthorizationService authorizationService;
   private final Map<Table, GraphQLOutputType> entityResultMap = new HashMap<>();
   private final List<String> warnings = new ArrayList<>();
@@ -85,12 +83,10 @@ public class DmlSchemaBuilder {
   }
 
   public DmlSchemaBuilder(
-      AuthenticationService authenticationService,
       AuthorizationService authorizationService,
       Keyspace keyspace,
       DataStoreFactory dataStoreFactory) {
 
-    this.authenticationService = authenticationService;
     this.authorizationService = authorizationService;
     this.keyspace = keyspace;
 
@@ -215,12 +211,7 @@ public class DmlSchemaBuilder {
                     .type(new GraphQLTypeReference("QueryOptions")))
             .type(buildEntityResultOutput(table))
             .dataFetcher(
-                new QueryFetcher(
-                    table,
-                    nameMapping,
-                    authenticationService,
-                    authorizationService,
-                    dataStoreFactory))
+                new QueryFetcher(table, nameMapping, authorizationService, dataStoreFactory))
             .build();
 
     GraphQLFieldDefinition filterQuery =
@@ -241,12 +232,7 @@ public class DmlSchemaBuilder {
                     .type(new GraphQLTypeReference("QueryOptions")))
             .type(buildEntityResultOutput(table))
             .dataFetcher(
-                new QueryFetcher(
-                    table,
-                    nameMapping,
-                    authenticationService,
-                    authorizationService,
-                    dataStoreFactory))
+                new QueryFetcher(table, nameMapping, authorizationService, dataStoreFactory))
             .build();
 
     return ImmutableList.of(query, filterQuery);
@@ -301,8 +287,7 @@ public class DmlSchemaBuilder {
         .argument(GraphQLArgument.newArgument().name("options").type(MUTATION_OPTIONS))
         .type(new GraphQLTypeReference(nameMapping.getGraphqlName(table) + "MutationResult"))
         .dataFetcher(
-            new UpdateMutationFetcher(
-                table, nameMapping, authenticationService, authorizationService, dataStoreFactory))
+            new UpdateMutationFetcher(table, nameMapping, authorizationService, dataStoreFactory))
         .build();
   }
 
@@ -323,8 +308,7 @@ public class DmlSchemaBuilder {
         .argument(GraphQLArgument.newArgument().name("options").type(MUTATION_OPTIONS))
         .type(new GraphQLTypeReference(nameMapping.getGraphqlName(table) + "MutationResult"))
         .dataFetcher(
-            new InsertMutationFetcher(
-                table, nameMapping, authenticationService, authorizationService, dataStoreFactory))
+            new InsertMutationFetcher(table, nameMapping, authorizationService, dataStoreFactory))
         .build();
   }
 
@@ -349,8 +333,7 @@ public class DmlSchemaBuilder {
         .argument(GraphQLArgument.newArgument().name("options").type(MUTATION_OPTIONS))
         .type(new GraphQLTypeReference(nameMapping.getGraphqlName(table) + "MutationResult"))
         .dataFetcher(
-            new DeleteMutationFetcher(
-                table, nameMapping, authenticationService, authorizationService, dataStoreFactory))
+            new DeleteMutationFetcher(table, nameMapping, authorizationService, dataStoreFactory))
         .build();
   }
 

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/DeleteMutationFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/DeleteMutationFetcher.java
@@ -1,7 +1,6 @@
 package io.stargate.graphql.schema.cqlfirst.dml.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
@@ -20,10 +19,9 @@ public class DeleteMutationFetcher extends MutationFetcher {
   public DeleteMutationFetcher(
       Table table,
       NameMapping nameMapping,
-      AuthenticationService authenticationService,
       AuthorizationService authorizationService,
       DataStoreFactory dataStoreFactory) {
-    super(table, nameMapping, authenticationService, authorizationService, dataStoreFactory);
+    super(table, nameMapping, authorizationService, dataStoreFactory);
   }
 
   @Override

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/DmlFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/DmlFetcher.java
@@ -2,7 +2,6 @@ package io.stargate.graphql.schema.cqlfirst.dml.fetchers;
 
 import com.google.common.collect.ImmutableList;
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.db.ImmutableParameters;
 import io.stargate.db.Parameters;
@@ -29,10 +28,9 @@ public abstract class DmlFetcher<ResultT> extends CassandraFetcher<ResultT> {
   protected DmlFetcher(
       Table table,
       NameMapping nameMapping,
-      AuthenticationService authenticationService,
       AuthorizationService authorizationService,
       DataStoreFactory dataStoreFactory) {
-    super(authenticationService, authorizationService, dataStoreFactory);
+    super(authorizationService, dataStoreFactory);
     this.table = table;
     this.nameMapping = nameMapping;
   }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/InsertMutationFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/InsertMutationFetcher.java
@@ -17,7 +17,6 @@ package io.stargate.graphql.schema.cqlfirst.dml.fetchers;
 
 import com.google.common.base.Preconditions;
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
@@ -41,10 +40,9 @@ public class InsertMutationFetcher extends MutationFetcher {
   public InsertMutationFetcher(
       Table table,
       NameMapping nameMapping,
-      AuthenticationService authenticationService,
       AuthorizationService authorizationService,
       DataStoreFactory dataStoreFactory) {
-    super(table, nameMapping, authenticationService, authorizationService, dataStoreFactory);
+    super(table, nameMapping, authorizationService, dataStoreFactory);
   }
 
   @Override

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/MutationFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/MutationFetcher.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableMap;
 import graphql.GraphQLException;
 import graphql.language.OperationDefinition;
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.db.datastore.DataStore;
@@ -37,10 +36,9 @@ public abstract class MutationFetcher extends DmlFetcher<CompletableFuture<Map<S
   protected MutationFetcher(
       Table table,
       NameMapping nameMapping,
-      AuthenticationService authenticationService,
       AuthorizationService authorizationService,
       DataStoreFactory dataStoreFactory) {
-    super(table, nameMapping, authenticationService, authorizationService, dataStoreFactory);
+    super(table, nameMapping, authorizationService, dataStoreFactory);
   }
 
   @Override

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/QueryFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/QueryFetcher.java
@@ -18,7 +18,6 @@ package io.stargate.graphql.schema.cqlfirst.dml.fetchers;
 import com.google.common.collect.ImmutableList;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.SelectedField;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.SourceAPI;
@@ -48,10 +47,9 @@ public class QueryFetcher extends DmlFetcher<Map<String, Object>> {
   public QueryFetcher(
       Table table,
       NameMapping nameMapping,
-      AuthenticationService authenticationService,
       AuthorizationService authorizationService,
       DataStoreFactory dataStoreFactory) {
-    super(table, nameMapping, authenticationService, authorizationService, dataStoreFactory);
+    super(table, nameMapping, authorizationService, dataStoreFactory);
   }
 
   @Override

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/UpdateMutationFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/UpdateMutationFetcher.java
@@ -1,7 +1,6 @@
 package io.stargate.graphql.schema.cqlfirst.dml.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
@@ -27,10 +26,9 @@ public class UpdateMutationFetcher extends MutationFetcher {
   public UpdateMutationFetcher(
       Table table,
       NameMapping nameMapping,
-      AuthenticationService authenticationService,
       AuthorizationService authorizationService,
       DataStoreFactory dataStoreFactory) {
-    super(table, nameMapping, authenticationService, authorizationService, dataStoreFactory);
+    super(table, nameMapping, authorizationService, dataStoreFactory);
   }
 
   @Override

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/DropwizardServer.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/DropwizardServer.java
@@ -28,6 +28,7 @@ import io.stargate.core.metrics.api.Metrics;
 import io.stargate.db.Persistence;
 import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.graphql.GraphqlActivator;
+import io.stargate.graphql.web.resources.AuthenticationFilter;
 import io.stargate.graphql.web.resources.PlaygroundResource;
 import io.stargate.graphql.web.resources.cqlfirst.GraphqlCache;
 import io.stargate.graphql.web.resources.cqlfirst.GraphqlDdlResource;
@@ -83,8 +84,7 @@ public class DropwizardServer extends Application<Configuration> {
   public void run(final Configuration config, final Environment environment) {
 
     GraphqlCache graphqlCache =
-        new GraphqlCache(
-            persistence, authenticationService, authorizationService, dataStoreFactory);
+        new GraphqlCache(persistence, authorizationService, dataStoreFactory);
     environment
         .jersey()
         .register(
@@ -103,15 +103,7 @@ public class DropwizardServer extends Application<Configuration> {
                 bind(FrameworkUtil.getBundle(GraphqlActivator.class)).to(Bundle.class);
               }
             });
-    environment
-        .jersey()
-        .register(
-            new AbstractBinder() {
-              @Override
-              protected void configure() {
-                bind(authenticationService).to(AuthenticationService.class);
-              }
-            });
+    environment.jersey().register(new AuthenticationFilter(authenticationService));
     environment
         .jersey()
         .register(

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/resources/Authenticated.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/resources/Authenticated.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.graphql.web.resources;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import javax.ws.rs.NameBinding;
+
+/** Annotates resources that we want filtered with {@link AuthenticationFilter}. */
+@NameBinding
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Authenticated {}

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/resources/AuthenticationFilter.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/resources/AuthenticationFilter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.graphql.web.resources;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.stargate.auth.AuthenticationService;
+import io.stargate.auth.AuthenticationSubject;
+import io.stargate.auth.UnauthorizedException;
+import io.stargate.graphql.web.RequestToHeadersMapper;
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Performs authentication before each GraphQL request. The subject is stored as a request attribute
+ * under {@link #SUBJECT_KEY}.
+ */
+@Provider
+@Authenticated
+public class AuthenticationFilter implements ContainerRequestFilter {
+
+  public static final String SUBJECT_KEY = AuthenticationSubject.class.getName();
+
+  private final AuthenticationService authenticationService;
+
+  public AuthenticationFilter(AuthenticationService authenticationService) {
+    this.authenticationService = authenticationService;
+  }
+
+  @Override
+  public void filter(ContainerRequestContext context) {
+    String token = context.getHeaderString("X-Cassandra-Token");
+    try {
+      AuthenticationSubject subject =
+          authenticationService.validateToken(token, deduplicate(context.getHeaders()));
+      context.setProperty(SUBJECT_KEY, subject);
+    } catch (UnauthorizedException e) {
+      context.abortWith(
+          Response.status(Response.Status.UNAUTHORIZED)
+              .entity(ImmutableMap.of("errors", ImmutableList.of("Authentication required")))
+              .build());
+    }
+  }
+
+  /** Same logic as {@link RequestToHeadersMapper}: only keep the first entry for each key. */
+  private Map<String, String> deduplicate(MultivaluedMap<String, String> multimap) {
+    Map<String, String> map = new HashMap<>();
+    for (String key : multimap.keySet()) {
+      map.put(key, multimap.getFirst(key));
+    }
+    return map;
+  }
+}

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/resources/cqlfirst/GraphqlCache.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/resources/cqlfirst/GraphqlCache.java
@@ -20,7 +20,6 @@ import com.google.errorprone.annotations.FormatString;
 import graphql.GraphQL;
 import graphql.execution.AsyncExecutionStrategy;
 import graphql.schema.GraphQLSchema;
-import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.db.EventListener;
 import io.stargate.db.Persistence;
@@ -54,7 +53,6 @@ public class GraphqlCache implements EventListener {
       Boolean.getBoolean("stargate.graphql.default_keyspace.disabled");
 
   private final Persistence persistence;
-  private final AuthenticationService authenticationService;
   private final AuthorizationService authorizationService;
   private final DataStoreFactory dataStoreFactory;
 
@@ -64,23 +62,17 @@ public class GraphqlCache implements EventListener {
 
   public GraphqlCache(
       Persistence persistence,
-      AuthenticationService authenticationService,
       AuthorizationService authorizationService,
       DataStoreFactory dataStoreFactory) {
     this.persistence = persistence;
-    this.authenticationService = authenticationService;
     this.authorizationService = authorizationService;
     this.dataStoreFactory = dataStoreFactory;
 
     this.ddlGraphql =
-        newGraphql(
-            SchemaFactory.newDdlSchema(
-                authenticationService, authorizationService, dataStoreFactory));
+        newGraphql(SchemaFactory.newDdlSchema(authorizationService, dataStoreFactory));
     DataStore dataStore = dataStoreFactory.createInternal();
     this.defaultKeyspace = findDefaultKeyspace(dataStore);
-    this.dmlGraphqls =
-        initDmlGraphqls(
-            persistence, dataStore, authenticationService, authorizationService, dataStoreFactory);
+    this.dmlGraphqls = initDmlGraphqls(dataStore, authorizationService, dataStoreFactory);
 
     persistence.registerEventListener(this);
   }
@@ -146,9 +138,7 @@ public class GraphqlCache implements EventListener {
   }
 
   private ConcurrentMap<String, DmlGraphqlReference> initDmlGraphqls(
-      Persistence persistence,
       DataStore dataStore,
-      AuthenticationService authenticationService,
       AuthorizationService authorizationService,
       DataStoreFactory dataStoreFactory) {
     ConcurrentMap<String, DmlGraphqlReference> map = new ConcurrentHashMap<>();
@@ -157,13 +147,7 @@ public class GraphqlCache implements EventListener {
       String keyspaceName = keyspace.name();
       LOG.debug("Prepare GraphQL schema for {}", keyspaceName);
       map.put(
-          keyspaceName,
-          new DmlGraphqlReference(
-              keyspace,
-              persistence,
-              authenticationService,
-              authorizationService,
-              dataStoreFactory));
+          keyspaceName, new DmlGraphqlReference(keyspace, authorizationService, dataStoreFactory));
     }
     return map;
   }
@@ -187,12 +171,7 @@ public class GraphqlCache implements EventListener {
       } else {
         dmlGraphqls.put(
             keyspaceName,
-            new DmlGraphqlReference(
-                keyspace,
-                persistence,
-                authenticationService,
-                authorizationService,
-                dataStoreFactory));
+            new DmlGraphqlReference(keyspace, authorizationService, dataStoreFactory));
       }
       LOG.debug("Done refreshing GraphQL schema for keyspace {}", keyspaceName);
     } catch (Exception e) {
@@ -301,8 +280,6 @@ public class GraphqlCache implements EventListener {
   static class DmlGraphqlReference {
 
     private final Keyspace keyspace;
-    private final Persistence persistence;
-    private final AuthenticationService authenticationService;
     private final AuthorizationService authorizationService;
     private final DataStoreFactory dataStoreFactory;
 
@@ -310,13 +287,9 @@ public class GraphqlCache implements EventListener {
 
     DmlGraphqlReference(
         Keyspace keyspace,
-        Persistence persistence,
-        AuthenticationService authenticationService,
         AuthorizationService authorizationService,
         DataStoreFactory dataStoreFactory) {
       this.keyspace = keyspace;
-      this.persistence = persistence;
-      this.authenticationService = authenticationService;
       this.authorizationService = authorizationService;
       this.dataStoreFactory = dataStoreFactory;
     }
@@ -331,8 +304,7 @@ public class GraphqlCache implements EventListener {
         if (graphql == null) {
           graphql =
               newGraphql(
-                  SchemaFactory.newDmlSchema(
-                      authenticationService, authorizationService, keyspace, dataStoreFactory));
+                  SchemaFactory.newDmlSchema(authorizationService, keyspace, dataStoreFactory));
         }
         return graphql;
       }

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/resources/cqlfirst/GraphqlDdlResource.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/resources/cqlfirst/GraphqlDdlResource.java
@@ -17,6 +17,7 @@ package io.stargate.graphql.web.resources.cqlfirst;
 
 import graphql.GraphQL;
 import io.stargate.graphql.web.models.GraphqlJsonBody;
+import io.stargate.graphql.web.resources.Authenticated;
 import io.stargate.graphql.web.resources.GraphqlResourceBase;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -33,6 +34,7 @@ import javax.ws.rs.core.MediaType;
 
 @Path("/graphql-schema")
 @Singleton
+@Authenticated
 public class GraphqlDdlResource extends GraphqlResourceBase {
 
   private final GraphQL graphql;

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/GraphQlTestBase.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/GraphQlTestBase.java
@@ -34,7 +34,6 @@ import io.stargate.db.schema.Schema;
 import io.stargate.graphql.web.HttpAwareContext;
 import io.stargate.graphql.web.HttpAwareContext.BatchContext;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -52,7 +51,6 @@ import org.mockito.junit.jupiter.MockitoSettings;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = LENIENT)
 public abstract class GraphQlTestBase {
-  private final String token = "mock token";
   protected GraphQL graphQl;
   protected GraphQLSchema graphQlSchema;
   @Mock protected AuthenticationService authenticationService;
@@ -74,8 +72,6 @@ public abstract class GraphQlTestBase {
     try {
       Schema schema = getCQLSchema();
       String roleName = "mock role name";
-      when(authenticationService.validateToken(token, Collections.emptyMap()))
-          .thenReturn(authenticationSubject);
       when(authenticationSubject.roleName()).thenReturn(roleName);
       when(authenticationSubject.asUser()).thenCallRealMethod();
       when(authorizationService.authorizedDataRead(
@@ -140,7 +136,7 @@ public abstract class GraphQlTestBase {
     // Use a dedicated batch executor per execution
     BatchContext batchContext = new BatchContext();
 
-    when(context.getAuthToken()).thenReturn(token);
+    when(context.getSubject()).thenReturn(authenticationSubject);
     when(context.getBatchContext()).thenReturn(batchContext);
     return graphQl.execute(ExecutionInput.newExecutionInput(query).context(context).build());
   }

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/cqlfirst/ddl/DdlTestBase.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/cqlfirst/ddl/DdlTestBase.java
@@ -8,7 +8,6 @@ public abstract class DdlTestBase extends GraphQlTestBase {
 
   @Override
   protected GraphQLSchema createGraphQlSchema() {
-    return SchemaFactory.newDdlSchema(
-        authenticationService, authorizationService, dataStoreFactory);
+    return SchemaFactory.newDdlSchema(authorizationService, dataStoreFactory);
   }
 }

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/cqlfirst/dml/DmlTestBase.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/cqlfirst/dml/DmlTestBase.java
@@ -17,10 +17,7 @@ public abstract class DmlTestBase extends GraphQlTestBase {
   @Override
   protected GraphQLSchema createGraphQlSchema() {
     return SchemaFactory.newDmlSchema(
-        authenticationService,
-        authorizationService,
-        getCQLSchema().keyspaces().iterator().next(),
-        dataStoreFactory);
+        authorizationService, getCQLSchema().keyspaces().iterator().next(), dataStoreFactory);
   }
 
   /** Creates a basic row suitable for faking result sets. */


### PR DESCRIPTION
Centralize auth in AuthenticationFilter, that will be applied before
every GraphQL REST resource annotated with `@Authenticated`.

Once we have the authentication subject, store it as a request
attribute, and later in the GraphQL context. We don't need to pass
the AuthenticationService into every fetcher anymore.