### PR TITLE
Add optimization for multiple filters in `where` for documents API

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentSearchPageState.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentSearchPageState.java
@@ -13,25 +13,63 @@ public class DocumentSearchPageState {
   @JsonProperty("internalPageState")
   String internalPageState;
 
+  @JsonIgnore ByteBuffer internalPageStateBuf;
+
+  @JsonIgnore boolean idFound;
+
+  @JsonIgnore boolean doneSkipping;
+
   @JsonCreator
   public DocumentSearchPageState(
       @JsonProperty("documentId") final String documentId,
       @JsonProperty("internalPageState") final String internalPageState) {
     this.documentId = documentId;
     this.internalPageState = internalPageState;
+    this.idFound = false;
+    this.doneSkipping = false;
+    if (internalPageState == null) {
+      throw new IllegalStateException("Malformed page state: parsed cassandra page state was null");
+    }
+    this.internalPageStateBuf =
+        internalPageState.isEmpty()
+            ? null
+            : ByteBuffer.wrap(Base64.getDecoder().decode(internalPageState));
   }
 
   public DocumentSearchPageState(final String documentId, final ByteBuffer internalPageStateBuf) {
     this.documentId = documentId;
-    this.internalPageState = Base64.getEncoder().encodeToString(internalPageStateBuf.array());
+    this.internalPageState =
+        internalPageStateBuf == null
+            ? ""
+            : Base64.getEncoder().encodeToString(internalPageStateBuf.array());
+    this.internalPageStateBuf = internalPageStateBuf;
+    this.idFound = false;
+    this.doneSkipping = false;
   }
 
   @JsonIgnore
   public ByteBuffer getPageState() {
-    if (internalPageState.isEmpty()) {
-      return null;
-    }
-    return ByteBuffer.wrap(Base64.getDecoder().decode(internalPageState));
+    return internalPageStateBuf;
+  }
+
+  @JsonIgnore
+  public boolean isIdFound() {
+    return idFound;
+  }
+
+  @JsonIgnore
+  public boolean isDoneSkipping() {
+    return doneSkipping;
+  }
+
+  @JsonIgnore
+  public void setIdFound(boolean val) {
+    this.idFound = val;
+  }
+
+  @JsonIgnore
+  public void setDoneSkipping(boolean val) {
+    this.doneSkipping = val;
   }
 
   @JsonIgnore

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentSearchPageState.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentSearchPageState.java
@@ -1,0 +1,41 @@
+package io.stargate.web.docsapi.dao;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+
+public class DocumentSearchPageState {
+  @JsonProperty("documentId")
+  String documentId;
+
+  @JsonProperty("internalPageState")
+  String internalPageState;
+
+  @JsonCreator
+  public DocumentSearchPageState(
+      @JsonProperty("documentId") final String documentId,
+      @JsonProperty("internalPageState") final String internalPageState) {
+    this.documentId = documentId;
+    this.internalPageState = internalPageState;
+  }
+
+  public DocumentSearchPageState(final String documentId, final ByteBuffer internalPageStateBuf) {
+    this.documentId = documentId;
+    this.internalPageState = Base64.getEncoder().encodeToString(internalPageStateBuf.array());
+  }
+
+  @JsonIgnore
+  public ByteBuffer getPageState() {
+    if (internalPageState.isEmpty()) {
+      return null;
+    }
+    return ByteBuffer.wrap(Base64.getDecoder().decode(internalPageState));
+  }
+
+  @JsonIgnore
+  public String getLastSeenDocId() {
+    return documentId;
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
@@ -793,30 +793,24 @@ public class DocumentResourceV2 {
           if (filters.isEmpty()) {
             results =
                 documentService.getFullDocuments(
-                    dbFactory,
                     db,
-                    authToken,
                     namespace,
                     collection,
                     selectionList,
                     pageState,
                     pageSize,
-                    Math.max(1, pageSizeParam),
-                    getAllHeaders(request));
+                    Math.max(1, pageSizeParam));
           } else {
             results =
                 documentService.getFullDocumentsFiltered(
-                    dbFactory,
                     db,
-                    authToken,
                     namespace,
                     collection,
                     filters,
                     selectionList,
                     pageState,
                     pageSize,
-                    Math.max(1, pageSizeParam),
-                    getAllHeaders(request));
+                    Math.max(1, pageSizeParam));
           }
 
           if (results == null) {

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -851,9 +851,9 @@ public class DocumentService {
     ImmutablePair<List<Row>, ByteBuffer> page = null;
     ByteBuffer currentPageState;
     boolean firstRequest = true;
-    boolean needsSkip = true;
     do {
-      currentPageState = getNextPageState(firstRequest, initialPagingState, page.right);
+      currentPageState =
+          getNextPageState(firstRequest, initialPagingState, page == null ? null : page.right);
 
       page =
           searchRows(
@@ -994,8 +994,7 @@ public class DocumentService {
               pageSize,
               initialPagingState,
               currentPageState,
-              candidates,
-              firstRequest);
+              candidates);
       candidates = candidateResult.left;
       nextPage = candidateResult.right;
 
@@ -1063,8 +1062,7 @@ public class DocumentService {
       int pageSize,
       DocumentSearchPageState initialPagingState,
       ByteBuffer pageState,
-      LinkedHashSet currentCandidateKeys,
-      boolean needsSkip)
+      LinkedHashSet currentCandidateKeys)
       throws UnauthorizedException {
     LinkedHashSet<String> candidatesThisPage = new LinkedHashSet<>();
     ImmutablePair<List<Row>, ByteBuffer> firstPage = null;

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -1049,9 +1049,9 @@ public class DocumentService {
           new HashSet<>(), rows, Collections.emptyList(), db.treatBooleansAsNumeric(), true);
     }
 
-    Set<String> docNames = candidates;
+    LinkedHashSet<String> docNames = candidates;
     if (candidates.size() > limit) {
-      docNames = new HashSet<>();
+      docNames = new LinkedHashSet<>();
       Iterator<String> iter = candidates.iterator();
       int i = 0;
       while (i < limit) {

--- a/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
@@ -210,7 +210,7 @@ public class DocumentResourceV2Test {
 
     Keyspace keyspaceMock = mock(Keyspace.class);
     Table tableMock = mock(Table.class);
-    when(dbFactoryMock.getDataStoreForToken(Mockito.eq(authToken), any()))
+    when(dbFactoryMock.getDataStoreForToken(Mockito.eq(authToken), anyObject()))
         .thenReturn(authenticatedDBMock);
     when(authenticatedDBMock.getKeyspace(keyspace)).thenReturn(keyspaceMock);
     when(keyspaceMock.table(collection)).thenReturn(tableMock);
@@ -260,7 +260,7 @@ public class DocumentResourceV2Test {
 
     Keyspace keyspaceMock = mock(Keyspace.class);
     Table tableMock = mock(Table.class);
-    when(dbFactoryMock.getDataStoreForToken(Mockito.eq(authToken), any()))
+    when(dbFactoryMock.getDataStoreForToken(Mockito.eq(authToken), anyObject()))
         .thenReturn(authenticatedDBMock);
     when(authenticatedDBMock.getKeyspace(keyspace)).thenReturn(keyspaceMock);
     when(keyspaceMock.table(collection)).thenReturn(tableMock);
@@ -323,7 +323,7 @@ public class DocumentResourceV2Test {
 
     Keyspace keyspaceMock = mock(Keyspace.class);
     Table tableMock = mock(Table.class);
-    when(dbFactoryMock.getDataStoreForToken(Mockito.eq(authToken), any()))
+    when(dbFactoryMock.getDataStoreForToken(Mockito.eq(authToken), anyObject()))
         .thenReturn(authenticatedDBMock);
     when(authenticatedDBMock.getKeyspace(keyspace)).thenReturn(keyspaceMock);
     when(keyspaceMock.table(collection)).thenReturn(tableMock);
@@ -374,7 +374,7 @@ public class DocumentResourceV2Test {
 
     Keyspace keyspaceMock = mock(Keyspace.class);
     Table tableMock = mock(Table.class);
-    when(dbFactoryMock.getDataStoreForToken(Mockito.eq(authToken), any()))
+    when(dbFactoryMock.getDataStoreForToken(Mockito.eq(authToken), anyObject()))
         .thenReturn(authenticatedDBMock);
     when(authenticatedDBMock.getKeyspace(keyspace)).thenReturn(keyspaceMock);
     when(keyspaceMock.table(collection)).thenReturn(tableMock);
@@ -424,7 +424,7 @@ public class DocumentResourceV2Test {
 
     Keyspace keyspaceMock = mock(Keyspace.class);
     Table tableMock = mock(Table.class);
-    when(dbFactoryMock.getDataStoreForToken(Mockito.eq(authToken), any()))
+    when(dbFactoryMock.getDataStoreForToken(Mockito.eq(authToken), anyObject()))
         .thenReturn(authenticatedDBMock);
     when(authenticatedDBMock.getKeyspace(keyspace)).thenReturn(keyspaceMock);
     when(keyspaceMock.table(collection)).thenReturn(tableMock);

--- a/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
@@ -476,7 +476,7 @@ public class DocumentResourceV2Test {
     String where = "";
     String fields = null;
     int pageSizeParam = 0;
-    String pageStateParam = "dmFsdWU=";
+    String pageStateParam = null;
     boolean raw = false;
 
     List<FilterCondition> conditions = new ArrayList<>();

--- a/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
@@ -1,7 +1,6 @@
 package io.stargate.web.docsapi.resources;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.anyObject;
@@ -493,16 +492,13 @@ public class DocumentResourceV2Test {
     Mockito.when(
             documentServiceMock.getFullDocumentsFiltered(
                 anyObject(),
-                anyObject(),
-                anyString(),
                 anyString(),
                 anyString(),
                 anyList(),
                 anyList(),
                 anyObject(),
                 anyInt(),
-                anyInt(),
-                any()))
+                anyInt()))
         .thenReturn(ImmutablePair.of(searchResult, null));
 
     Response r =
@@ -554,16 +550,13 @@ public class DocumentResourceV2Test {
     Mockito.when(
             documentServiceMock.getFullDocumentsFiltered(
                 anyObject(),
-                anyObject(),
-                anyString(),
                 anyString(),
                 anyString(),
                 anyList(),
                 anyList(),
                 anyObject(),
                 anyInt(),
-                anyInt(),
-                any()))
+                anyInt()))
         .thenReturn(ImmutablePair.of(searchResult, null));
 
     Response r =
@@ -615,16 +608,13 @@ public class DocumentResourceV2Test {
     Mockito.when(
             documentServiceMock.getFullDocumentsFiltered(
                 anyObject(),
-                anyObject(),
-                anyString(),
                 anyString(),
                 anyString(),
                 anyList(),
                 anyList(),
                 anyObject(),
                 anyInt(),
-                anyInt(),
-                any()))
+                anyInt()))
         .thenReturn(ImmutablePair.of(searchResult, null));
 
     Response r =
@@ -744,16 +734,7 @@ public class DocumentResourceV2Test {
 
     Mockito.when(
             documentServiceMock.getFullDocuments(
-                anyObject(),
-                anyObject(),
-                anyString(),
-                anyString(),
-                anyString(),
-                anyList(),
-                anyObject(),
-                anyInt(),
-                anyInt(),
-                any()))
+                anyObject(), anyString(), anyString(), anyList(), anyObject(), anyInt(), anyInt()))
         .thenReturn(ImmutablePair.of(searchResult, null));
 
     Response r =

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -176,6 +176,7 @@ public class DocumentServiceTest {
             List.class,
             List.class,
             List.class,
+            List.class,
             Boolean.class,
             String.class,
             int.class,
@@ -1238,7 +1239,7 @@ public class DocumentServiceTest {
         .thenCallRealMethod();
     Mockito.when(
             serviceMock.searchRows(
-                any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
         .thenReturn(ImmutablePair.of(new ArrayList<>(), null));
 
     List<FilterCondition> filters =
@@ -1260,7 +1261,7 @@ public class DocumentServiceTest {
         .thenCallRealMethod();
     Mockito.when(
             serviceMock.searchRows(
-                any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
         .thenReturn(ImmutablePair.of(makeInitialRowData(), null));
     Mockito.when(serviceMock.convertToJsonDoc(any(), anyBoolean(), anyBoolean()))
         .thenReturn(ImmutablePair.of(mapper.readTree("{\"a\": 1}"), new HashMap<>()));
@@ -1285,7 +1286,7 @@ public class DocumentServiceTest {
         .thenCallRealMethod();
     Mockito.when(
             serviceMock.searchRows(
-                any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
         .thenReturn(ImmutablePair.of(makeInitialRowData(), null));
     Mockito.when(serviceMock.convertToJsonDoc(any(), anyBoolean(), anyBoolean()))
         .thenReturn(ImmutablePair.of(mapper.readTree("{\"a\": 1}"), new HashMap<>()));
@@ -1323,7 +1324,7 @@ public class DocumentServiceTest {
     Mockito.when(dbFactoryMock.getDocDataStoreForToken(anyString(), any())).thenReturn(dbMock);
     Mockito.when(
             serviceMock.searchRows(
-                any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
         .thenReturn(ImmutablePair.of(makeInitialRowData(), null));
     Mockito.when(
             serviceMock.getFullDocuments(
@@ -1356,7 +1357,7 @@ public class DocumentServiceTest {
     Mockito.when(dbFactoryMock.getDocDataStoreForToken(anyString(), any())).thenReturn(dbMock);
     Mockito.when(
             serviceMock.searchRows(
-                any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
         .thenReturn(ImmutablePair.of(twoDocsRows, null));
     Mockito.when(
             serviceMock.getFullDocuments(
@@ -1407,6 +1408,7 @@ public class DocumentServiceTest {
                 "keyspace",
                 "collection",
                 dbMock,
+                new ArrayList<>(),
                 filters,
                 new ArrayList<>(),
                 ImmutableList.of("a,b", "*", "c"),
@@ -1425,6 +1427,7 @@ public class DocumentServiceTest {
                 "keyspace",
                 "collection",
                 dbMock,
+                new ArrayList<>(),
                 new ArrayList<>(),
                 new ArrayList<>(),
                 new ArrayList<>(),
@@ -1465,6 +1468,7 @@ public class DocumentServiceTest {
                     "keyspace",
                     "collection",
                     dbMock,
+                    new ArrayList<>(),
                     filters,
                     new ArrayList<>(),
                     ImmutableList.of("a,b", "*", "c"),

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -42,6 +42,7 @@ import io.stargate.db.query.builder.BuiltCondition;
 import io.stargate.db.schema.Column;
 import io.stargate.db.schema.Column.Type;
 import io.stargate.web.docsapi.dao.DocumentDB;
+import io.stargate.web.docsapi.dao.DocumentSearchPageState;
 import io.stargate.web.docsapi.exception.DocumentAPIRequestException;
 import io.stargate.web.docsapi.service.filter.FilterCondition;
 import io.stargate.web.docsapi.service.filter.ListFilterCondition;
@@ -127,7 +128,6 @@ public class DocumentServiceTest {
         DocumentService.class.getDeclaredMethod(
             "updateExistenceForMap",
             Set.class,
-            Map.class,
             List.class,
             List.class,
             boolean.class,
@@ -1310,12 +1310,9 @@ public class DocumentServiceTest {
   @Test
   public void updateExistenceForMap() throws InvocationTargetException, IllegalAccessException {
     Set<String> existenceByDoc = new HashSet<>();
-    Map<String, Integer> countsByDoc = new HashMap<>();
     List<Row> rows = makeInitialRowData();
-    updateExistenceForMap.invoke(
-        service, existenceByDoc, countsByDoc, rows, new ArrayList<>(), false, true);
+    updateExistenceForMap.invoke(service, existenceByDoc, rows, new ArrayList<>(), false, true);
     assertThat(existenceByDoc.contains("1")).isTrue();
-    assertThat(countsByDoc.get("1")).isEqualTo(3);
   }
 
   @Test
@@ -1345,7 +1342,7 @@ public class DocumentServiceTest {
     Mockito.when(serviceMock.convertToJsonDoc(any(), anyBoolean(), anyBoolean()))
         .thenReturn(ImmutablePair.of(mapper.readTree("{\"a\": 1}"), new HashMap<>()));
 
-    ImmutablePair<JsonNode, ByteBuffer> result =
+    ImmutablePair<JsonNode, DocumentSearchPageState> result =
         serviceMock.getFullDocuments(
             dbFactoryMock,
             dbMock,
@@ -1390,7 +1387,7 @@ public class DocumentServiceTest {
     Mockito.when(serviceMock.convertToJsonDoc(any(), anyBoolean(), anyBoolean()))
         .thenReturn(ImmutablePair.of(mapper.readTree("{\"a\": 1}"), new HashMap<>()));
 
-    ImmutablePair<JsonNode, ByteBuffer> result =
+    ImmutablePair<JsonNode, DocumentSearchPageState> result =
         serviceMock.getFullDocuments(
             dbFactoryMock,
             dbMock,
@@ -1402,7 +1399,7 @@ public class DocumentServiceTest {
             100,
             1,
             EMPTY_HEADERS);
-    assertThat(result.right).isNull();
+    assertThat(result.right.getPageState()).isNull();
     assertThat(result.left).isEqualTo(mapper.readTree("{\"1\": {\"a\": 1}}"));
   }
 

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -1328,15 +1328,12 @@ public class DocumentServiceTest {
     Mockito.when(
             serviceMock.getFullDocuments(
                 any(),
-                any(),
-                anyString(),
                 anyString(),
                 anyString(),
                 anyListOf(String.class),
                 any(),
                 anyInt(),
-                anyInt(),
-                any()))
+                anyInt()))
         .thenCallRealMethod();
     Mockito.doCallRealMethod().when(serviceMock).addRowsToMap(anyMap(), anyList());
     Mockito.when(serviceMock.convertToJsonDoc(any(), anyBoolean(), anyBoolean()))
@@ -1344,16 +1341,7 @@ public class DocumentServiceTest {
 
     ImmutablePair<JsonNode, DocumentSearchPageState> result =
         serviceMock.getFullDocuments(
-            dbFactoryMock,
-            dbMock,
-            "authToken",
-            "keyspace",
-            "collection",
-            new ArrayList<>(),
-            null,
-            100,
-            1,
-            EMPTY_HEADERS);
+            dbMock, "keyspace", "collection", new ArrayList<>(), null, 100, 1);
     assertThat(result.right).isNull();
     assertThat(result.left).isEqualTo(mapper.readTree("{\"1\": {\"a\": 1}}"));
   }
@@ -1373,15 +1361,12 @@ public class DocumentServiceTest {
     Mockito.when(
             serviceMock.getFullDocuments(
                 any(),
-                any(),
-                anyString(),
                 anyString(),
                 anyString(),
                 anyListOf(String.class),
                 any(),
                 anyInt(),
-                anyInt(),
-                any()))
+                anyInt()))
         .thenCallRealMethod();
     Mockito.doCallRealMethod().when(serviceMock).addRowsToMap(anyMap(), anyList());
     Mockito.when(serviceMock.convertToJsonDoc(any(), anyBoolean(), anyBoolean()))
@@ -1389,17 +1374,8 @@ public class DocumentServiceTest {
 
     ImmutablePair<JsonNode, DocumentSearchPageState> result =
         serviceMock.getFullDocuments(
-            dbFactoryMock,
-            dbMock,
-            "authToken",
-            "keyspace",
-            "collection",
-            new ArrayList<>(),
-            null,
-            100,
-            1,
-            EMPTY_HEADERS);
-    assertThat(result.right.getPageState()).isNull();
+            dbMock, "keyspace", "collection", new ArrayList<>(), null, 100, 1);
+    assertThat(result.right).isNull();
     assertThat(result.left).isEqualTo(mapper.readTree("{\"1\": {\"a\": 1}}"));
   }
 

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -1376,7 +1376,7 @@ public class DocumentServiceTest {
     ImmutablePair<JsonNode, DocumentSearchPageState> result =
         serviceMock.getFullDocuments(
             dbMock, "keyspace", "collection", new ArrayList<>(), null, 100, 1);
-    assertThat(result.right).isNull();
+    assertThat(result.right.getPageState()).isNull();
     assertThat(result.left).isEqualTo(mapper.readTree("{\"1\": {\"a\": 1}}"));
   }
 


### PR DESCRIPTION
This changes the format of the paging state for the documents API, implementing a "last seen" document ID that is used during search requests.

This allows us to optimize searches with multiple AND's a bit, whose implementation is in this PR.