### PR TITLE
Support geospacial types

### DIFF
--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/ColumnUtils.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/ColumnUtils.java
@@ -98,6 +98,12 @@ public class ColumnUtils {
           encodeType(t, dest, version);
         }
         break;
+      case Point: // Fallthrough intended
+      case Polygon: // Fallthrough intended
+      case LineString:
+        // For custom types the class name of the type follows the type ID (which is zero)
+        CBUtil.writeAsciiString(type.marshalTypeName(), dest);
+        break;
       default:
         // Nothing else to do for simple types
     }
@@ -130,6 +136,11 @@ public class ColumnUtils {
         for (Column.ColumnType t : tup.parameters()) {
           size += encodeSizeType(t, version);
         }
+        break;
+      case Point: // Fallthrough intended
+      case Polygon: // Fallthrough intended
+      case LineString:
+        size += CBUtil.sizeOfAsciiString(type.marshalTypeName());
         break;
       default: // fall though (simple types)
     }

--- a/persistence-api/src/main/java/io/stargate/db/schema/Column.java
+++ b/persistence-api/src/main/java/io/stargate/db/schema/Column.java
@@ -414,6 +414,23 @@ public abstract class Column implements SchemaEntity, Comparable<Column> {
 
     Varint(14, BigInteger.class, false, "Arbitrary-precision integer"),
 
+    // TODO: geo types have fake IDs, we need to fix that for proper metadata serialization in CQL
+    Point(
+        101,
+        io.stargate.db.schema.Point.class,
+        true,
+        "Contains two coordinate values for latitude and longitude"),
+    Polygon(
+        102,
+        io.stargate.db.schema.Polygon.class,
+        true,
+        "Contains three or more point values forming a polygon"),
+    LineString(
+        103,
+        io.stargate.db.schema.LineString.class,
+        true,
+        "Contains two or more point values forming a line"),
+
     UDT(
         48,
         UdtValue.class,

--- a/persistence-api/src/main/java/io/stargate/db/schema/LineString.java
+++ b/persistence-api/src/main/java/io/stargate/db/schema/LineString.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.stargate.db.schema;
+
+public class LineString {
+  // Placeholder for geospatial LineString values
+}

--- a/persistence-api/src/main/java/io/stargate/db/schema/Point.java
+++ b/persistence-api/src/main/java/io/stargate/db/schema/Point.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.stargate.db.schema;
+
+public class Point {
+  // Placeholder for geospatial Point values
+}

--- a/persistence-api/src/main/java/io/stargate/db/schema/Polygon.java
+++ b/persistence-api/src/main/java/io/stargate/db/schema/Polygon.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.stargate.db.schema;
+
+public class Polygon {
+  // Placeholder for geospatial Polygon values
+}

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
@@ -148,6 +148,9 @@ public class Conversion {
                   && ct != Column.Type.List
                   && ct != Column.Type.Map
                   && ct != Column.Type.Set
+                  && ct != Column.Type.Point
+                  && ct != Column.Type.Polygon
+                  && ct != Column.Type.LineString
                   && ct != Column.Type.UDT) {
                 types.put(ColumnUtils.toInternalType(ct).getClass(), ct);
               }

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
@@ -63,6 +63,9 @@ public class Conversion {
                   && ct != Column.Type.List
                   && ct != Column.Type.Map
                   && ct != Column.Type.Set
+                  && ct != Column.Type.Point
+                  && ct != Column.Type.Polygon
+                  && ct != Column.Type.LineString
                   && ct != Column.Type.UDT) {
                 types.put(ColumnUtils.toInternalType(ct).getClass(), ct);
               }

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/Conversion.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/Conversion.java
@@ -30,8 +30,11 @@ import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.cql3.ResultSet;
 import org.apache.cassandra.cql3.statements.BatchStatement;
 import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.LineStringType;
 import org.apache.cassandra.db.marshal.ListType;
 import org.apache.cassandra.db.marshal.MapType;
+import org.apache.cassandra.db.marshal.PointType;
+import org.apache.cassandra.db.marshal.PolygonType;
 import org.apache.cassandra.db.marshal.ReversedType;
 import org.apache.cassandra.db.marshal.SetType;
 import org.apache.cassandra.db.marshal.TupleType;
@@ -136,10 +139,18 @@ public class Conversion {
                   && ct != Column.Type.List
                   && ct != Column.Type.Map
                   && ct != Column.Type.Set
+                  && ct != Column.Type.Point
+                  && ct != Column.Type.Polygon
+                  && ct != Column.Type.LineString
                   && ct != Column.Type.UDT) {
                 types.put(ColumnUtils.toInternalType(ct).getClass(), ct);
               }
             });
+
+    types.put(PointType.class, Column.Type.Point);
+    types.put(PolygonType.class, Column.Type.Polygon);
+    types.put(LineStringType.class, Column.Type.LineString);
+
     TYPE_MAPPINGS = ImmutableMap.copyOf(types);
   }
 

--- a/testing/src/test/java/io/stargate/it/cql/TypeSample.java
+++ b/testing/src/test/java/io/stargate/it/cql/TypeSample.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.it.cql;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.data.TupleValue;
+import com.datastax.oss.driver.api.core.data.UdtValue;
+import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.driver.api.core.type.TupleType;
+import com.datastax.oss.driver.api.core.type.UserDefinedType;
+import com.datastax.oss.driver.api.core.type.reflect.GenericType;
+import com.datastax.oss.driver.internal.core.type.UserDefinedTypeBuilder;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TypeSample<JavaTypeT> {
+
+  private static final AtomicInteger COLUMN_COUNTER = new AtomicInteger();
+
+  final DataType cqlType;
+  final GenericType<JavaTypeT> javaType;
+  final JavaTypeT value;
+  final CqlIdentifier columnName;
+
+  private TypeSample(
+      DataType cqlType,
+      GenericType<JavaTypeT> javaType,
+      JavaTypeT value,
+      CqlIdentifier columnName) {
+    this.cqlType = cqlType;
+    this.javaType = javaType;
+    this.value = value;
+    this.columnName = columnName;
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", TypeSample.class.getSimpleName() + "[", "]")
+        .add("columnName=" + columnName)
+        .add("cqlType=" + cqlType)
+        .add("javaType=" + javaType)
+        .toString();
+  }
+
+  public static <JavaTypeT> TypeSample<JavaTypeT> typeSample(
+      DataType cqlType,
+      GenericType<JavaTypeT> javaType,
+      JavaTypeT value,
+      CqlIdentifier columnName) {
+    return new TypeSample<>(cqlType, javaType, value, columnName);
+  }
+
+  public static <JavaTypeT> TypeSample<JavaTypeT> typeSample(
+      DataType cqlType, GenericType<JavaTypeT> javaType, JavaTypeT value) {
+    return typeSample(cqlType, javaType, value, newColumnName());
+  }
+
+  public static <JavaTypeT> TypeSample<List<JavaTypeT>> listOf(TypeSample<JavaTypeT> type) {
+    return typeSample(
+        DataTypes.listOf(type.cqlType),
+        GenericType.listOf(type.javaType),
+        ImmutableList.of(type.value));
+  }
+
+  public static <JavaTypeT> TypeSample<Set<JavaTypeT>> setOf(TypeSample<JavaTypeT> type) {
+    return typeSample(
+        DataTypes.setOf(type.cqlType),
+        GenericType.setOf(type.javaType),
+        ImmutableSet.of(type.value));
+  }
+
+  public static <JavaTypeT> TypeSample<Map<Integer, JavaTypeT>> mapOfIntTo(
+      TypeSample<JavaTypeT> type) {
+    return typeSample(
+        DataTypes.mapOf(DataTypes.INT, type.cqlType),
+        GenericType.mapOf(GenericType.INTEGER, type.javaType),
+        ImmutableMap.of(1, type.value));
+  }
+
+  public static <JavaTypeT> TypeSample<Map<JavaTypeT, Integer>> mapToIntFrom(
+      TypeSample<JavaTypeT> type) {
+    return typeSample(
+        DataTypes.mapOf(type.cqlType, DataTypes.INT),
+        GenericType.mapOf(type.javaType, GenericType.INTEGER),
+        ImmutableMap.of(type.value, 1));
+  }
+
+  public static <JavaTypeT> TypeSample<TupleValue> tupleOfIntAnd(TypeSample<JavaTypeT> type) {
+    TupleType tupleType = DataTypes.tupleOf(DataTypes.INT, type.cqlType);
+    return typeSample(tupleType, GenericType.TUPLE_VALUE, tupleType.newValue(1, type.value));
+  }
+
+  public static <JavaTypeT> TypeSample<UdtValue> udtOfIntAnd(
+      TypeSample<JavaTypeT> type, CqlIdentifier keyspaceId) {
+    CqlIdentifier columnName = TypeSample.newColumnName();
+    UserDefinedType udtType =
+        new UserDefinedTypeBuilder(keyspaceId, CqlIdentifier.fromInternal(columnName + "Type"))
+            .withField("v1", DataTypes.INT)
+            .withField("v2", type.cqlType)
+            .build();
+    UdtValue udtValue = udtType.newValue(1, type.value);
+    return typeSample(udtType, GenericType.UDT_VALUE, udtValue, columnName);
+  }
+
+  public static CqlIdentifier newColumnName() {
+    return CqlIdentifier.fromCql("column" + COLUMN_COUNTER.getAndIncrement());
+  }
+}


### PR DESCRIPTION
This is to allow Stargate to process geo types and values when connected to DSE.

Note: CQL connections do not reinterpret geospacial value, these values go directly to the backend in encoded form. Stargate CQL does _encode_ and sent type information about the geospacial entities to CQL clients, though.