### PR TITLE
Execute DSE requests on TPC threads

### DIFF
--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -46,6 +46,7 @@ import org.apache.cassandra.auth.CassandraRoleManager;
 import org.apache.cassandra.auth.IAuthContext;
 import org.apache.cassandra.auth.RoleResource;
 import org.apache.cassandra.auth.user.UserRolesAndPermissions;
+import org.apache.cassandra.concurrent.TPC;
 import org.apache.cassandra.concurrent.TPCTaskType;
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
@@ -484,7 +485,7 @@ public class DsePersistence
         if (parameters.protocolVersion().isGreaterOrEqualTo(ProtocolVersion.V4))
           ClientWarn.instance.captureWarnings();
 
-        Single<QueryState> queryState = newQueryState();
+        Single<QueryState> queryState = newQueryState().subscribeOn(TPC.bestTPCScheduler());
         Request request = requestSupplier.get();
         if (parameters.tracingRequested()) {
           request.setTracingRequested();

--- a/testing/src/test/java/io/stargate/it/storage/StargateContainer.java
+++ b/testing/src/test/java/io/stargate/it/storage/StargateContainer.java
@@ -533,6 +533,7 @@ public class StargateContainer extends ExternalResource<StargateSpec, StargateCo
     @Override
     public Collection<String> commandArguments(ClusterConnectionInfo backend) {
       Collection<String> args = new ArrayList<>();
+      args.add("-ea");
       args.add("-jar");
       args.add(starterJar().getAbsolutePath());
       args.add("--cluster-seed");


### PR DESCRIPTION
This is mainly for CQL tracing to work properly.

In old code queries start on epoll or I/O threads this is where
the initial tracing thread-local state is set. Requests later jump
to TPC threads and the thread-local state is transferred to the
TPC thread. However, the tracing state on the initial thread remains.

There is risk of some other request reusing the tracing state from
the initial thread and braking that tracing session.

This commit forces all processing after establishing the query state
to be done on a TPC thread, including setting up tracing sessions.

Note: TPCRunnable automatically resets ExecutorLocals data (including
tracing) before running each task.

Note: this commit also enables assertions for integration tests to
validate proper thread-local handling.