### PR TITLE
Bump testcontainers to 1.15.2

### DIFF
--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -191,7 +191,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.15.0</version>
+      <version>1.15.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
I ran into testcontainers/testcontainers-java#3574 while running Keycloak-related tests on a new machine.
This fixes it.