### PR TITLE
Reset ExecutorLocals in DSE persistence requests

### DIFF
--- a/testing/src/test/java/io/stargate/it/storage/StargateContainer.java
+++ b/testing/src/test/java/io/stargate/it/storage/StargateContainer.java
@@ -533,6 +533,7 @@ public class StargateContainer extends ExternalResource<StargateSpec, StargateCo
     @Override
     public Collection<String> commandArguments(ClusterConnectionInfo backend) {
       Collection<String> args = new ArrayList<>();
+      args.add("-ea");
       args.add("-jar");
       args.add(starterJar().getAbsolutePath());
       args.add("--cluster-seed");


### PR DESCRIPTION
This is mainly for CQL tracing to work properly.

In old code queries start on epoll or I/O threads and this is where
the initial tracing thread-local state is set. Requests later jump
to TPC threads and the thread-local state is transferred to the
TPC thread. However, the tracing state on the initial thread remains.

There is risk of some other request reusing the tracing state from
the initial thread and breaking that tracing session.

This commit forces DSE ExecutorLocals to be reset (including resetting
tracing state) before invoking DSE request processing code.

Note: TPCRunnable automatically resets ExecutorLocals data (including
tracing) before running each task.

Note: this commit also enables assertions for integration tests to
validate proper thread-local handling.