### PR TITLE
Read auth tokens at CL == LOCAL_QUORUM

### DIFF
--- a/auth-table-based-service/src/main/java/io/stargate/auth/table/AuthnTableBasedService.java
+++ b/auth-table-based-service/src/main/java/io/stargate/auth/table/AuthnTableBasedService.java
@@ -247,7 +247,7 @@ public class AuthnTableBasedService implements AuthenticationService {
               .from(AUTH_KEYSPACE, AUTH_TABLE)
               .where("auth_token", Predicate.EQ, uuid)
               .build()
-              .execute()
+              .execute(ConsistencyLevel.LOCAL_QUORUM)
               .get();
 
       if (resultSet.hasNoMoreFetchedRows()) {


### PR DESCRIPTION
This is to ensure that a newly created token can be
used for authentication immediately.

Note that tokens are stored using LOCAL_QUORUM