### PR TITLE
Change the encoding of Pagination for Docs API

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentSearchPageState.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentSearchPageState.java
@@ -1,0 +1,41 @@
+package io.stargate.web.docsapi.dao;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+
+public class DocumentSearchPageState {
+  @JsonProperty("documentId")
+  String documentId;
+
+  @JsonProperty("internalPageState")
+  String internalPageState;
+
+  @JsonCreator
+  public DocumentSearchPageState(
+      @JsonProperty("documentId") final String documentId,
+      @JsonProperty("internalPageState") final String internalPageState) {
+    this.documentId = documentId;
+    this.internalPageState = internalPageState;
+  }
+
+  public DocumentSearchPageState(final String documentId, final ByteBuffer internalPageStateBuf) {
+    this.documentId = documentId;
+    this.internalPageState = Base64.getEncoder().encodeToString(internalPageStateBuf.array());
+  }
+
+  @JsonIgnore
+  public ByteBuffer getPageState() {
+    if (internalPageState.isEmpty()) {
+      return null;
+    }
+    return ByteBuffer.wrap(Base64.getDecoder().decode(internalPageState));
+  }
+
+  @JsonIgnore
+  public String getLastSeenDocId() {
+    return documentId;
+  }
+}

--- a/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
@@ -476,7 +476,7 @@ public class DocumentResourceV2Test {
     String where = "";
     String fields = null;
     int pageSizeParam = 0;
-    String pageStateParam = "dmFsdWU=";
+    String pageStateParam = null;
     boolean raw = false;
 
     List<FilterCondition> conditions = new ArrayList<>();

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -42,6 +42,7 @@ import io.stargate.db.query.builder.BuiltCondition;
 import io.stargate.db.schema.Column;
 import io.stargate.db.schema.Column.Type;
 import io.stargate.web.docsapi.dao.DocumentDB;
+import io.stargate.web.docsapi.dao.DocumentSearchPageState;
 import io.stargate.web.docsapi.exception.DocumentAPIRequestException;
 import io.stargate.web.docsapi.service.filter.FilterCondition;
 import io.stargate.web.docsapi.service.filter.ListFilterCondition;
@@ -127,7 +128,6 @@ public class DocumentServiceTest {
         DocumentService.class.getDeclaredMethod(
             "updateExistenceForMap",
             Set.class,
-            Map.class,
             List.class,
             List.class,
             boolean.class,
@@ -1310,12 +1310,9 @@ public class DocumentServiceTest {
   @Test
   public void updateExistenceForMap() throws InvocationTargetException, IllegalAccessException {
     Set<String> existenceByDoc = new HashSet<>();
-    Map<String, Integer> countsByDoc = new HashMap<>();
     List<Row> rows = makeInitialRowData();
-    updateExistenceForMap.invoke(
-        service, existenceByDoc, countsByDoc, rows, new ArrayList<>(), false, true);
+    updateExistenceForMap.invoke(service, existenceByDoc, rows, new ArrayList<>(), false, true);
     assertThat(existenceByDoc.contains("1")).isTrue();
-    assertThat(countsByDoc.get("1")).isEqualTo(3);
   }
 
   @Test
@@ -1345,7 +1342,7 @@ public class DocumentServiceTest {
     Mockito.when(serviceMock.convertToJsonDoc(any(), anyBoolean(), anyBoolean()))
         .thenReturn(ImmutablePair.of(mapper.readTree("{\"a\": 1}"), new HashMap<>()));
 
-    ImmutablePair<JsonNode, ByteBuffer> result =
+    ImmutablePair<JsonNode, DocumentSearchPageState> result =
         serviceMock.getFullDocuments(
             dbFactoryMock,
             dbMock,
@@ -1390,7 +1387,7 @@ public class DocumentServiceTest {
     Mockito.when(serviceMock.convertToJsonDoc(any(), anyBoolean(), anyBoolean()))
         .thenReturn(ImmutablePair.of(mapper.readTree("{\"a\": 1}"), new HashMap<>()));
 
-    ImmutablePair<JsonNode, ByteBuffer> result =
+    ImmutablePair<JsonNode, DocumentSearchPageState> result =
         serviceMock.getFullDocuments(
             dbFactoryMock,
             dbMock,
@@ -1402,7 +1399,7 @@ public class DocumentServiceTest {
             100,
             1,
             EMPTY_HEADERS);
-    assertThat(result.right).isNull();
+    assertThat(result.right.getPageState()).isNull();
     assertThat(result.left).isEqualTo(mapper.readTree("{\"1\": {\"a\": 1}}"));
   }
 


### PR DESCRIPTION
Because we are doing internal pagination (over cassandra) in the Docs API, but then are creating documents and making an extra layer of paging over that, this PR adds extra information into a DocsAPI-specific Paging State object. Essentially that object is just a Base64-encoded JSON blob with

```
{
 "documentId": XXX,
 "internalPageState": YYY
}
```

The documentId is the last document that was seen and returned to the user in the last request, and the internalPageState represents the _cassandra_ page that the document was on. So when you search using a Docs page state, it will start at the relevant C* page, and then fast-forward to just past the documentId that was last seen.

This should actually make searches better in two ways:
1) Pages will be definitely consistent/correct, even with mutliple nodes (which is a bit hard to test locally)
2) Search is expected to be a bit faster (there used to be a query with a particular page size that was done to determine the page state when the final document was mid-page, that no longer occurs)