### PR TITLE
DRAFT - Refactoring to Docs API

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -44,6 +44,7 @@ public class DocumentDB {
   private static final List<Column.ColumnType> allColumnTypes;
   private static final List<String> allPathColumnNames;
   private static final List<Column.ColumnType> allPathColumnTypes;
+  public static final int MAX_PAGE_SIZE = 20;
   public static final Integer MAX_DEPTH = Integer.getInteger("stargate.document_max_depth", 64);
   private Boolean useLoggedBatches;
   public static final Integer SEARCH_PAGE_SIZE =

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentSearchPageState.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentSearchPageState.java
@@ -3,6 +3,7 @@ package io.stargate.web.docsapi.dao;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.util.Strings;
 import java.nio.ByteBuffer;
 import java.util.Base64;
 
@@ -23,12 +24,14 @@ public class DocumentSearchPageState {
 
   public DocumentSearchPageState(final String documentId, final ByteBuffer internalPageStateBuf) {
     this.documentId = documentId;
-    this.internalPageState = Base64.getEncoder().encodeToString(internalPageStateBuf.array());
+    if (internalPageStateBuf != null) {
+      this.internalPageState = Base64.getEncoder().encodeToString(internalPageStateBuf.array());
+    }
   }
 
   @JsonIgnore
   public ByteBuffer getPageState() {
-    if (internalPageState.isEmpty()) {
+    if (Strings.isNullOrEmpty(internalPageState)) {
       return null;
     }
     return ByteBuffer.wrap(Base64.getDecoder().decode(internalPageState));

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/Paginator.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/Paginator.java
@@ -1,0 +1,117 @@
+package io.stargate.web.docsapi.dao;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.stargate.db.datastore.Row;
+import io.stargate.web.docsapi.exception.DocumentAPIRequestException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * This class is in charge of keeping the data of the Docs API pagination process.
+ * It's not only a stateful component, but a state machine with a initial state.
+ * It's created on the REST layer and passed through to the DocumentService that
+ * is in charge of its changes. After being populated its `documentPageState`
+ * can be passed by the REST layer to the client as a JSON string.
+ */
+public class Paginator {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  public final int dbPageSize;
+  public final int docPageSize;
+
+  private boolean initialState = true;
+  private ByteBuffer currentDbPageState; // keeps track of the DB page state while querying the DB
+  private DocumentSearchPageState documentPageState = null;
+
+  public Paginator(String pageStateParam, int pageSizeParam, int dbPageSize) throws IOException {
+    docPageSize = Math.max(1, pageSizeParam);
+    if (docPageSize > DocumentDB.MAX_PAGE_SIZE) {
+      throw new DocumentAPIRequestException("The parameter `page-size` is limited to 20.");
+    }
+
+    this.dbPageSize = dbPageSize;
+
+    if (pageStateParam != null) {
+      byte[] decodedBytes = Base64.getDecoder().decode(pageStateParam);
+      documentPageState = mapper.readValue(decodedBytes, DocumentSearchPageState.class);
+    }
+
+    this.currentDbPageState = (documentPageState != null) ? documentPageState.getPageState() : null;
+  }
+
+  public String getDocumentPageStateAsString() throws JsonProcessingException {
+    if (documentPageState != null) {
+      byte[] pagingJson = mapper.writeValueAsBytes(documentPageState);
+      return Base64.getEncoder().encodeToString(pagingJson);
+    }
+    return null;
+  }
+
+  public void clearDocumentPageState() {
+    this.documentPageState = null;
+  }
+
+  public void setCurrentDbPageState(ByteBuffer page) {
+    this.currentDbPageState = page;
+  }
+
+  public boolean hasDbPageState() {
+    return currentDbPageState != null;
+  }
+
+  public void setDocumentPageState(String lastIdSeen) {
+    documentPageState = new DocumentSearchPageState(lastIdSeen, currentDbPageState);
+  }
+
+  public ByteBuffer getCurrentDbPageState() {
+    return currentDbPageState;
+  }
+
+  private void leaveInitialState() {
+    initialState = false;
+  }
+
+  private boolean isInitialState() {
+    return initialState == true;
+  }
+
+  public List<Row> maybeSkipRows(List<Row> rows) {
+    List<Row> filteredRows = rows;
+    if (isInitialState()) {
+      filteredRows = skipSeenRows(documentPageState, rows);
+      leaveInitialState();
+    }
+    return filteredRows;
+  }
+
+  private List<Row> skipSeenRows(DocumentSearchPageState docPagingState, List<Row> rows) {
+    if (docPagingState == null) {
+      return rows;
+    }
+
+    String lastSeenId = docPagingState.getLastSeenDocId();
+    if (lastSeenId == null) {
+      return rows;
+    }
+
+    boolean found = false;
+    List<Row> filteredRows = new ArrayList<>();
+    for (Row row : rows) {
+      String docId = row.getString("key");
+      if (docId.equals(lastSeenId)) {
+        found = true;
+        continue;
+      }
+
+      if (found) {
+        filteredRows.add(row);
+      }
+    }
+    return filteredRows;
+  }
+}


### PR DESCRIPTION
@dimas-b @EricBorczuk This is a rough idea of what an alternative design/refactoring of the pagination portion. Basically, there's an (stateful) object (err... paginator) that groups all the relevant paging information. It's initially setup by the REST endpoint, but then DocumentService is in charge of changing its status. Some methods like `skipSeenRows` naturally migrated to this object. I also removed the need to return a pair of (Result, DocumentSearchPageState) on many methods. You have the result, if you wanna DocumentSearchPageState just ask the Paginator for the latest version of it. If you like the idea and think it's worth trying, we could incorporate this code into one of Eric's ongoing work, maybe. I am biased, but I think the code became more clear and succint. :) 


**I understand the priority is on solving the corner cases with pagination, but I am opening this PR just for your consideration in the future. This branch was based off Eric's `multiple-filter-performance`.**

