### PR TITLE
Fix #819 - contains and containsEntry with AND

### DIFF
--- a/restapi/src/main/java/io/stargate/web/resources/v2/RowsResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/RowsResource.java
@@ -120,12 +120,13 @@ public class RowsResource {
                       + "| $lte | Less Than Or Equal To | \n "
                       + "| $gt | Greater Than | \n "
                       + "| $gte | Greater Than Or Equal To | \n "
+                      + "| $eq | Equal To | \n "
                       + "| $ne | Not Equal To | \n "
                       + "| $in | Contained In | \n "
                       + "| $contains | Contains the given element (for lists or sets) or value (for maps) | \n "
                       + "| $containsKey | Contains the given key (for maps) | \n "
                       + "| $containsEntry | Contains the given key/value entry (for maps) | \n "
-                      + "| $exists | A value is set for the key | ",
+                      + "| $exists | Returns the rows whose column (boolean type) value is true | ",
               required = true)
           @QueryParam("where")
           final String where,

--- a/restapi/src/main/java/io/stargate/web/service/WhereParser.java
+++ b/restapi/src/main/java/io/stargate/web/service/WhereParser.java
@@ -96,6 +96,7 @@ public class WhereParser {
           default: // GT, GTE, LT, LTE, EQ, NE
             {
               addToCondition(conditions, context);
+              break;
             }
         }
       }

--- a/restapi/src/main/java/io/stargate/web/service/WhereParser.java
+++ b/restapi/src/main/java/io/stargate/web/service/WhereParser.java
@@ -79,7 +79,7 @@ public class WhereParser {
 
         switch (operator) {
           case $IN:
-            evaluateIN(conditions, context);
+            evaluateIn(conditions, context);
             break;
           case $EXISTS:
             evaluateExists(conditions, context);
@@ -233,7 +233,7 @@ public class WhereParser {
             mapValue));
   }
 
-  private static void evaluateIN(List<BuiltCondition> conditions, QueryContext context)
+  private static void evaluateIn(List<BuiltCondition> conditions, QueryContext context)
       throws IOException {
     if (!context.value.isArray()) {
       throw new IllegalArgumentException(

--- a/restapi/src/test/java/io/stargate/web/resources/WhereParserTest.java
+++ b/restapi/src/test/java/io/stargate/web/resources/WhereParserTest.java
@@ -145,7 +145,7 @@ public class WhereParserTest {
 
     assertThatThrownBy(() -> WhereParser.parseWhere(whereParam, table))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Unknown field name 'invalid_field' in where clause.");
+        .hasMessageContaining("Unknown field name 'invalid_field'");
   }
 
   @Test
@@ -165,6 +165,68 @@ public class WhereParserTest {
 
     List<BuiltCondition> where = WhereParser.parseWhere(whereParam, table);
 
+    assertThat(where).isEqualTo(whereExpected);
+  }
+
+  @Test
+  public void testDuplicateJsonKey() throws IOException {
+    String whereParam = "{\"text\": {\"$eq\": \"a\", \"$eq\": \"b\"}}";
+    ImmutableTable table =
+        ImmutableTable.builder()
+            .name("table")
+            .keyspace("keyspace")
+            .addColumns(ImmutableColumn.create("text", Column.Type.Text))
+            .build();
+
+    assertThatThrownBy(() -> WhereParser.parseWhere(whereParam, table))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Duplicate field '$eq'");
+  }
+
+  @Test
+  public void testParseMap() throws IOException {
+    ImmutableTable table =
+        ImmutableTable.builder()
+            .name("table")
+            .keyspace("keyspace")
+            .addColumns(
+                ImmutableColumn.create("text", Column.Type.Text),
+                ImmutableColumn.create("set", Column.Type.Set.of(Column.Type.Int)),
+                ImmutableColumn.create(
+                    "text_map", Column.Type.Map.of(Column.Type.Text, Column.Type.Text)))
+            .build();
+
+    String whereParam = "{\"text_map\": {\"$contains\": [\"a\", \"b\"]}}";
+    List<BuiltCondition> whereExpected =
+        asList(
+            BuiltCondition.of("text_map", Predicate.CONTAINS, "a"),
+            BuiltCondition.of("text_map", Predicate.CONTAINS, "b"));
+    List<BuiltCondition> where = WhereParser.parseWhere(whereParam, table);
+    assertThat(where).isEqualTo(whereExpected);
+
+    whereParam = "{\"set\": {\"$contains\": [76, 1]}}";
+    whereExpected =
+        asList(
+            BuiltCondition.of("set", Predicate.CONTAINS, 76),
+            BuiltCondition.of("set", Predicate.CONTAINS, 1));
+    where = WhereParser.parseWhere(whereParam, table);
+    assertThat(where).isEqualTo(whereExpected);
+
+    whereParam = "{\"set\": {\"$containskey\": [\"a\", \"b\"]}}";
+    whereExpected =
+        asList(
+            BuiltCondition.of("set", Predicate.CONTAINS_KEY, 76),
+            BuiltCondition.of("set", Predicate.CONTAINS_KEY, 1));
+    where = WhereParser.parseWhere(whereParam, table);
+    assertThat(where).isEqualTo(whereExpected);
+
+    whereParam =
+        "{\"set\": {\"$containsentry\": [{\"key\": \"a\", \"value\": \"1\"}, {\"key\": \"b\", \"value\": \"1\"}]}}";
+    whereExpected =
+        asList(
+            BuiltCondition.of("set", Predicate.CONTAINS, 76),
+            BuiltCondition.of("set", Predicate.CONTAINS, 1));
+    where = WhereParser.parseWhere(whereParam, table);
     assertThat(where).isEqualTo(whereExpected);
   }
 

--- a/restapi/src/test/java/io/stargate/web/resources/WhereParserTest.java
+++ b/restapi/src/test/java/io/stargate/web/resources/WhereParserTest.java
@@ -212,20 +212,21 @@ public class WhereParserTest {
     where = WhereParser.parseWhere(whereParam, table);
     assertThat(where).isEqualTo(whereExpected);
 
-    whereParam = "{\"set\": {\"$containskey\": [\"a\", \"b\"]}}";
+    whereParam = "{\"text_map\": {\"$containskey\": [\"a\", \"b\"]}}";
     whereExpected =
         asList(
-            BuiltCondition.of("set", Predicate.CONTAINS_KEY, 76),
-            BuiltCondition.of("set", Predicate.CONTAINS_KEY, 1));
+            BuiltCondition.of("text_map", Predicate.CONTAINS_KEY, "a"),
+            BuiltCondition.of("text_map", Predicate.CONTAINS_KEY, "b"));
     where = WhereParser.parseWhere(whereParam, table);
     assertThat(where).isEqualTo(whereExpected);
 
     whereParam =
-        "{\"set\": {\"$containsentry\": [{\"key\": \"a\", \"value\": \"1\"}, {\"key\": \"b\", \"value\": \"1\"}]}}";
+        "{\"text_map\": {\"$containsentry\": [{\"key\": \"a\", \"value\": \"1\"}, {\"key\": \"b\", \"value\": \"2\"}]}}";
+
     whereExpected =
         asList(
-            BuiltCondition.of("set", Predicate.CONTAINS, 76),
-            BuiltCondition.of("set", Predicate.CONTAINS, 1));
+            BuiltCondition.of(BuiltCondition.LHS.mapAccess("text_map", "a"), Predicate.EQ, "1"),
+            BuiltCondition.of(BuiltCondition.LHS.mapAccess("text_map", "b"), Predicate.EQ, "2"));
     where = WhereParser.parseWhere(whereParam, table);
     assertThat(where).isEqualTo(whereExpected);
   }

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -722,14 +722,6 @@ public class RestApiv2Test extends BaseOsgiIntegrationTest {
             getResponseWrapper.getData(), new TypeReference<List<Map<String, Object>>>() {});
     assertThat(data.get(0).get("id")).isEqualTo(rowIdentifier);
     assertThat(data.get(0).get("firstName")).isEqualTo("John");
-
-    whereClause = String.format("{\"id\":{\"$contains\":\"%s\"}}", rowIdentifier);
-    body =
-        RestUtils.get(
-            authToken,
-            String.format(
-                "%s:8082/v2/keyspaces/%s/%s?where=%s", host, keyspaceName, tableName, whereClause),
-            HttpStatus.SC_OK);
   }
 
   @Test
@@ -893,7 +885,7 @@ public class RestApiv2Test extends BaseOsgiIntegrationTest {
 
     assertThat(response.getCode()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
     assertThat(response.getDescription())
-        .isEqualTo("Bad request: Unknown field name 'invalid_field' in where clause.");
+        .isEqualTo("Bad request: Unknown field name 'invalid_field'.");
   }
 
   @Test

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -722,6 +722,14 @@ public class RestApiv2Test extends BaseOsgiIntegrationTest {
             getResponseWrapper.getData(), new TypeReference<List<Map<String, Object>>>() {});
     assertThat(data.get(0).get("id")).isEqualTo(rowIdentifier);
     assertThat(data.get(0).get("firstName")).isEqualTo("John");
+
+    whereClause = String.format("{\"id\":{\"$contains\":\"%s\"}}", rowIdentifier);
+    body =
+        RestUtils.get(
+            authToken,
+            String.format(
+                "%s:8082/v2/keyspaces/%s/%s?where=%s", host, keyspaceName, tableName, whereClause),
+            HttpStatus.SC_OK);
   }
 
   @Test


### PR DESCRIPTION
As discussed in #819, if we have expressions like `{{"text_map": {"$contains": "a"}, "text_map": {"$contains": "b"}}` then the second entry will override the first one and only `"text_map": {"$contains": "b"}` will effectively be sent to C*. 

This PR
1) defines a syntax like `{"text_map": {"$contains": ["a", "b"]}}` (also valid to $containsEntry, `$containsKey`, and even `$eq`) that will accept both a single object as well as an array as parameter to the operators cited. 

2) Fix a bug in $eq that didn't check for column existence during parsing of the expression;

3) Add more tests to the `WhereParser`;

4) Does a extensive refactoring of the `WhereParser`

5) Fixes #639 in the process.