### PR TITLE
Add directive to index fields

### DIFF
--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/CreateUdtQuery.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/migration/CreateUdtQuery.java
@@ -18,8 +18,18 @@ package io.stargate.graphql.schema.schemafirst.migration;
 import io.stargate.db.datastore.DataStore;
 import io.stargate.db.query.builder.AbstractBound;
 import io.stargate.db.schema.UserDefinedType;
+import java.util.Collections;
+import java.util.List;
 
 public class CreateUdtQuery extends MigrationQuery {
+
+  /**
+   * This method only exist to mirror {@link CreateTableQuery#createTableAndIndexes} (there is some
+   * common code that abstracts over both).
+   */
+  public static List<MigrationQuery> createUdt(UserDefinedType type) {
+    return Collections.singletonList(new CreateUdtQuery(type));
+  }
 
   private final UserDefinedType type;
 

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/processor/FieldModel.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/processor/FieldModel.java
@@ -29,6 +29,7 @@ public class FieldModel {
   private final ColumnType cqlType;
   private final boolean partitionKey;
   private final Optional<Order> clusteringOrder;
+  private final Optional<IndexModel> index;
 
   FieldModel(
       String graphqlName,
@@ -36,13 +37,15 @@ public class FieldModel {
       String cqlName,
       ColumnType cqlType,
       boolean partitionKey,
-      Optional<Order> clusteringOrder) {
+      Optional<Order> clusteringOrder,
+      Optional<IndexModel> index) {
     this.graphqlName = graphqlName;
     this.graphqlType = graphqlType;
     this.cqlName = cqlName;
     this.cqlType = cqlType;
     this.partitionKey = partitionKey;
     this.clusteringOrder = clusteringOrder;
+    this.index = index;
   }
 
   public String getGraphqlName() {
@@ -71,7 +74,7 @@ public class FieldModel {
   }
 
   public FieldModel asPartitionKey() {
-    return new FieldModel(graphqlName, graphqlType, cqlName, cqlType, true, clusteringOrder);
+    return new FieldModel(graphqlName, graphqlType, cqlName, cqlType, true, clusteringOrder, index);
   }
 
   public Optional<Order> getClusteringOrder() {
@@ -84,5 +87,9 @@ public class FieldModel {
 
   public boolean isPrimaryKey() {
     return partitionKey || clusteringOrder.isPresent();
+  }
+
+  public Optional<IndexModel> getIndex() {
+    return index;
   }
 }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/processor/IndexModel.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/processor/IndexModel.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.graphql.schema.schemafirst.processor;
+
+import io.stargate.db.schema.CollectionIndexingType;
+import java.util.Map;
+import java.util.Optional;
+
+public class IndexModel {
+
+  private final String name;
+  private final Optional<String> indexClass;
+  private final CollectionIndexingType indexingType;
+  private final Map<String, String> options;
+
+  IndexModel(
+      String name,
+      Optional<String> indexClass,
+      CollectionIndexingType indexingType,
+      Map<String, String> options) {
+    this.name = name;
+    this.indexClass = indexClass;
+    this.indexingType = indexingType;
+    this.options = options;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Optional<String> getIndexClass() {
+    return indexClass;
+  }
+
+  public CollectionIndexingType getIndexingType() {
+    return indexingType;
+  }
+
+  public Map<String, String> getOptions() {
+    return options;
+  }
+}

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/processor/IndexModelBuilder.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/processor/IndexModelBuilder.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.graphql.schema.schemafirst.processor;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Splitter;
+import graphql.language.Directive;
+import io.stargate.db.schema.CollectionIndexingType;
+import io.stargate.db.schema.Column;
+import io.stargate.db.schema.ImmutableCollectionIndexingType;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+class IndexModelBuilder extends ModelBuilderBase<IndexModel> {
+
+  private static final Splitter.MapSplitter OPTIONS_SPLITTER =
+      Splitter.on(',').withKeyValueSeparator(Splitter.on(':').trimResults(CharMatcher.anyOf("' ")));
+  private static final ImmutableCollectionIndexingType NO_INDEXING_TYPE =
+      ImmutableCollectionIndexingType.builder().build();
+  private static final ImmutableCollectionIndexingType VALUES_INDEXING_TYPE =
+      ImmutableCollectionIndexingType.builder().indexValues(true).build();
+
+  private final Directive cqlIndexDirective;
+  private final String parentCqlName;
+  private final String columnCqlName;
+  private final Column.ColumnType cqlType;
+  private final String messagePrefix;
+
+  IndexModelBuilder(
+      Directive cqlIndexDirective,
+      String parentCqlName,
+      String columnCqlName,
+      Column.ColumnType cqlType,
+      String messagePrefix,
+      ProcessingContext context) {
+    super(context, cqlIndexDirective.getSourceLocation());
+    this.cqlIndexDirective = cqlIndexDirective;
+    this.parentCqlName = parentCqlName;
+    this.columnCqlName = columnCqlName;
+    this.cqlType = cqlType;
+    this.messagePrefix = messagePrefix;
+  }
+
+  @Override
+  IndexModel build() {
+    Optional<String> indexClass =
+        DirectiveHelper.getStringArgument(cqlIndexDirective, "class", context);
+
+    String indexName =
+        DirectiveHelper.getStringArgument(cqlIndexDirective, "name", context)
+            .orElse(parentCqlName + '_' + columnCqlName + "_idx");
+    CollectionIndexingType indexingType =
+        DirectiveHelper.getEnumArgument(cqlIndexDirective, "target", IndexTarget.class, context)
+            .filter(this::validateTarget)
+            .map(IndexTarget::toIndexingType)
+            .orElse(cqlType.isCollection() ? VALUES_INDEXING_TYPE : NO_INDEXING_TYPE);
+    Map<String, String> indexOptions =
+        DirectiveHelper.getStringArgument(cqlIndexDirective, "options", context)
+            .flatMap(this::convertOptions)
+            .orElse(Collections.emptyMap());
+
+    return new IndexModel(indexName, indexClass, indexingType, indexOptions);
+  }
+
+  private boolean validateTarget(IndexTarget indexTarget) {
+    switch (indexTarget) {
+      case KEYS:
+      case ENTRIES:
+        if (!cqlType.isMap()) {
+          invalidMapping(
+              "%s: index target %s can only be used for map columns", messagePrefix, indexTarget);
+          return false;
+        }
+        break;
+      case VALUES:
+        if (!cqlType.isCollection() || cqlType.isFrozen()) {
+          invalidMapping(
+              "%s: index target %s can only be used for non-frozen collection columns",
+              messagePrefix, indexTarget);
+          return false;
+        }
+        break;
+      case FULL:
+        if (!cqlType.isCollection() || !cqlType.isFrozen()) {
+          invalidMapping(
+              "%s: index target %s can only be used for frozen collection columns",
+              messagePrefix, indexTarget);
+          return false;
+        }
+        break;
+      default:
+        throw new AssertionError("Unsupported target " + indexTarget);
+    }
+    return true;
+  }
+
+  private Optional<Map<String, String>> convertOptions(String rawOptions) {
+    try {
+      return Optional.of(OPTIONS_SPLITTER.split(rawOptions));
+    } catch (IllegalArgumentException e) {
+      invalidMapping(
+          "%s: invalid format for options. Expected 'option1':'value1','option2','value2'...",
+          messagePrefix);
+      return Optional.empty();
+    }
+  }
+}

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/processor/IndexTarget.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/schemafirst/processor/IndexTarget.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.graphql.schema.schemafirst.processor;
+
+import io.stargate.db.schema.CollectionIndexingType;
+import io.stargate.db.schema.ImmutableCollectionIndexingType;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum IndexTarget {
+  KEYS(ImmutableCollectionIndexingType.builder().indexKeys(true).build()),
+  VALUES(ImmutableCollectionIndexingType.builder().indexValues(true).build()),
+  ENTRIES(ImmutableCollectionIndexingType.builder().indexEntries(true).build()),
+  FULL(ImmutableCollectionIndexingType.builder().indexFull(true).build()),
+  ;
+
+  private static final Map<CollectionIndexingType, IndexTarget> BY_TYPE =
+      Arrays.stream(values())
+          .collect(Collectors.toMap(IndexTarget::toIndexingType, Function.identity()));
+
+  private final CollectionIndexingType indexingType;
+
+  IndexTarget(CollectionIndexingType indexingType) {
+    this.indexingType = indexingType;
+  }
+
+  public CollectionIndexingType toIndexingType() {
+    return indexingType;
+  }
+
+  public static IndexTarget fromIndexingType(CollectionIndexingType indexingType) {
+    IndexTarget value = BY_TYPE.get(indexingType);
+    if (value == null) {
+      throw new IllegalArgumentException("Invalid value " + indexingType);
+    }
+    return value;
+  }
+}

--- a/graphqlapi/src/main/resources/schemafirst/cql_directives.graphql
+++ b/graphqlapi/src/main/resources/schemafirst/cql_directives.graphql
@@ -62,6 +62,59 @@ directive @cql_column(
 
 ) on FIELD_DEFINITION
 
+
+"Which part of a collection field will be indexed."
+enum IndexTarget {
+
+    """
+    Indexes the values of a list field.
+    This is only allowed if the CQL type is not frozen.
+    """
+    VALUES
+
+    """
+    Indexes the full collection for a list, set or map column.
+    This is only allowed if the CQL type is frozen.
+    """
+    FULL
+}
+
+
+"""
+Requests the creation of a CQL index for a GraphQL object field.
+
+This is only allowed for objects that map to CQL tables, and only for non-partition-key fields (in
+other words, fields that have neither `@cql_column.partitionKey` nor `@cql_column.clusteringOrder`
+set).
+"""
+directive @cql_index (
+
+    """
+    A custom name for the index. If not specified, one will be generated.
+    """
+    name: String
+
+    """
+    If the index is custom, the name of the index class to use. If not specified, this will be a
+    regular secondary index.
+    """
+    class: String
+
+    """
+    (Only used with list fields) Which part of the field to index. If not specified, this will
+    default to `VALUES`.
+    """
+    target: IndexTarget
+
+    """
+    Any custom options to pass to the index, in the format: `'option1': 'value1', 'option2':
+    'value2'...`
+    """
+    options: String
+
+) on FIELD_DEFINITION
+
+
 """
 Provides additional options to the CQL SELECT generated for a query.
 This is only required if you pass arguments to the directive. Otherwise, GraphQL queries are always

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/schemafirst/processor/QueryMappingModelTest.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/schemafirst/processor/QueryMappingModelTest.java
@@ -137,7 +137,7 @@ class QueryMappingModelTest {
         .isInstanceOf(GraphqlErrorException.class)
         .extracting(ex -> extractMappingErrors((GraphqlErrorException) ex))
         .isEqualTo(
-            "Operation foo: every partition key field of type Foo must be present (expected: pk1, pk2)");
+            "Operation foo: every partition key field of type Foo must be present (expected: pk1, pk2).");
   }
 
   @Test

--- a/testing/src/main/java/io/stargate/it/http/graphql/schemafirst/CreateIndexTest.java
+++ b/testing/src/main/java/io/stargate/it/http/graphql/schemafirst/CreateIndexTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.it.http.graphql.schemafirst;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.metadata.schema.IndexKind;
+import com.datastax.oss.driver.api.core.metadata.schema.IndexMetadata;
+import io.stargate.it.driver.CqlSessionExtension;
+import io.stargate.it.driver.TestKeyspace;
+import io.stargate.it.http.RestUtils;
+import io.stargate.it.storage.StargateConnectionInfo;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(CqlSessionExtension.class)
+public class CreateIndexTest extends GraphqlFirstTestBase {
+
+  private static GraphqlFirstClient CLIENT;
+  private static final CqlIdentifier USER_TABLE_ID = CqlIdentifier.fromInternal("User");
+
+  @BeforeAll
+  public static void setup(StargateConnectionInfo cluster) {
+    String host = cluster.seedAddress();
+    CLIENT = new GraphqlFirstClient(host, RestUtils.getAuthToken(host));
+  }
+
+  @AfterEach
+  public void cleanup(@TestKeyspace CqlIdentifier keyspaceId, CqlSession session) {
+    deleteAllGraphqlSchemas(keyspaceId.asInternal(), session);
+    session.execute("DROP TABLE IF EXISTS \"User\"");
+  }
+
+  @Test
+  @DisplayName("Should create regular index with default name")
+  public void createRegularIndexDefaultName(
+      @TestKeyspace CqlIdentifier keyspaceId, CqlSession session) {
+
+    String schema =
+        "type User {\n"
+            + "  id: ID!\n"
+            + "  name: String @cql_index\n"
+            + "}\n"
+            + "type Query { user(id: ID!): User }";
+    CqlIdentifier indexId = CqlIdentifier.fromInternal("User_name_idx");
+    IndexMetadata index = deploySchemaAndGetIndex(keyspaceId, schema, indexId, session);
+
+    assertThat(index.getTarget()).isEqualTo("name");
+    assertThat(index.getKind()).isEqualTo(IndexKind.COMPOSITES);
+    assertThat(index.getClassName()).isEmpty();
+    assertThat(index.getOptions()).hasSize(1).containsEntry("target", "name");
+  }
+
+  @Test
+  @DisplayName("Should create regular index with custom name")
+  public void createRegularIndexCustomName(
+      @TestKeyspace CqlIdentifier keyspaceId, CqlSession session) {
+
+    String schema =
+        "type User {\n"
+            + "  id: ID!\n"
+            + "  name: String @cql_index(name: \"myIndex\")\n"
+            + "}\n"
+            + "type Query { user(id: ID!): User }";
+    CqlIdentifier indexId = CqlIdentifier.fromInternal("myIndex");
+    IndexMetadata index = deploySchemaAndGetIndex(keyspaceId, schema, indexId, session);
+
+    assertThat(index.getTarget()).isEqualTo("name");
+    assertThat(index.getKind()).isEqualTo(IndexKind.COMPOSITES);
+    assertThat(index.getClassName()).isEmpty();
+    assertThat(index.getOptions()).hasSize(1).containsEntry("target", "name");
+  }
+
+  @Test
+  @DisplayName("Should create custom index")
+  public void createCustomIndex(@TestKeyspace CqlIdentifier keyspaceId, CqlSession session) {
+    // TODO remove this when we figure out how to enable SAI indexes in Cassandra 4
+    assumeThat(isCassandra4())
+        .as(
+            "Disabled because it is currently not possible to enable SAI indexes "
+                + "on a Cassandra 4 backend")
+        .isFalse();
+
+    String schema =
+        "type User {\n"
+            + "  id: ID!\n"
+            + "  name: String @cql_index(class: \"org.apache.cassandra.index.sasi.SASIIndex\""
+            + "                          options: \"'mode': 'CONTAINS'\")\n"
+            + "}\n"
+            + "type Query { user(id: ID!): User }";
+    CqlIdentifier indexId = CqlIdentifier.fromInternal("User_name_idx");
+    IndexMetadata index = deploySchemaAndGetIndex(keyspaceId, schema, indexId, session);
+
+    assertThat(index.getTarget()).isEqualTo("name");
+    assertThat(index.getKind()).isEqualTo(IndexKind.CUSTOM);
+    assertThat(index.getClassName()).contains("org.apache.cassandra.index.sasi.SASIIndex");
+    assertThat(index.getOptions())
+        .hasSize(3)
+        .containsEntry("target", "name")
+        .containsEntry("class_name", "org.apache.cassandra.index.sasi.SASIIndex")
+        .containsEntry("mode", "CONTAINS");
+  }
+
+  @Test
+  @DisplayName("Should create VALUES index on a list field")
+  public void createListValuesIndex(@TestKeyspace CqlIdentifier keyspaceId, CqlSession session) {
+    String schema =
+        "type User {\n"
+            + "  id: ID!\n"
+            + "  names: [String] @cql_index(target: VALUES)\n"
+            + "}\n"
+            + "type Query { user(id: ID!): User }";
+    CqlIdentifier indexId = CqlIdentifier.fromInternal("User_names_idx");
+    IndexMetadata index = deploySchemaAndGetIndex(keyspaceId, schema, indexId, session);
+
+    assertThat(index.getTarget()).isEqualTo("values(names)");
+    assertThat(index.getKind()).isEqualTo(IndexKind.COMPOSITES);
+    assertThat(index.getClassName()).isEmpty();
+    assertThat(index.getOptions()).hasSize(1).containsEntry("target", "values(names)");
+  }
+
+  @Test
+  @DisplayName("Should fail to create VALUES index if field is not a list")
+  public void createValuesIndexNotAList(@TestKeyspace CqlIdentifier keyspaceId) {
+    String schema =
+        "type User {\n"
+            + "  id: ID!\n"
+            + "  name: String @cql_index(target: VALUES)\n"
+            + "}\n"
+            + "type Query { user(id: ID!): User }";
+    String error = CLIENT.getDeploySchemaError(keyspaceId.asInternal(), null, schema);
+    assertThat(error).contains("The GraphQL schema that you provided contains CQL mapping errors");
+  }
+
+  @Test
+  @DisplayName("Should create index on existing table")
+  public void createIndexExistingTable(@TestKeyspace CqlIdentifier keyspaceId, CqlSession session) {
+    UUID version1 =
+        CLIENT.deploySchema(
+            keyspaceId.asInternal(),
+            "type User {\n"
+                + "  id: ID!\n"
+                + "  name: String\n"
+                + "}\n"
+                + "type Query { user(id: ID!): User }");
+
+    String newSchema =
+        "type User {\n"
+            + "  id: ID!\n"
+            + "  name: String @cql_index\n"
+            + "}\n"
+            + "type Query { user(id: ID!): User }";
+    CqlIdentifier indexId = CqlIdentifier.fromInternal("User_name_idx");
+    IndexMetadata index =
+        deploySchemaAndGetIndex(keyspaceId, version1, newSchema, indexId, session);
+
+    assertThat(index.getTarget()).isEqualTo("name");
+    assertThat(index.getKind()).isEqualTo(IndexKind.COMPOSITES);
+    assertThat(index.getClassName()).isEmpty();
+    assertThat(index.getOptions()).hasSize(1).containsEntry("target", "name");
+  }
+
+  private IndexMetadata deploySchemaAndGetIndex(
+      CqlIdentifier keyspaceId, String schema, CqlIdentifier indexId, CqlSession session) {
+    return deploySchemaAndGetIndex(keyspaceId, null, schema, indexId, session);
+  }
+
+  private IndexMetadata deploySchemaAndGetIndex(
+      CqlIdentifier keyspaceId,
+      UUID expectedVersion,
+      String schema,
+      CqlIdentifier indexId,
+      CqlSession session) {
+    CLIENT.deploySchema(
+        keyspaceId.asInternal(),
+        expectedVersion == null ? null : expectedVersion.toString(),
+        schema);
+    return session
+        .refreshSchema()
+        .getKeyspace(keyspaceId)
+        .flatMap(k -> k.getTable(USER_TABLE_ID))
+        .flatMap(
+            t -> {
+              return t.getIndex(indexId);
+            })
+        .orElseThrow(AssertionError::new);
+  }
+}


### PR DESCRIPTION
TODO:
- [x] only allow `FULL` indexes on frozen collections
- [x] only allow `VALUES` indexes on non-frozen collections
- [x] move index parameters to a separate `@cql_index` directive (to allow multiple indexes in the future)