### PR TITLE
Support custom paging positions

### DIFF
--- a/persistence-api/src/main/java/io/stargate/db/PagingPosition.java
+++ b/persistence-api/src/main/java/io/stargate/db/PagingPosition.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.stargate.db;
+
+import io.stargate.db.Result.ResultMetadata;
+import io.stargate.db.datastore.Row;
+import org.immutables.value.Value;
+
+/**
+ * Represents a custom paging position for requesting data from paginated queries. The difference
+ * from the normal {@link ResultMetadata#pagingState paging state} is that this position may be set
+ * based on a row in the middle of a page returned by the previous query execution.
+ */
+@Value.Immutable
+public interface PagingPosition {
+
+  static ImmutablePagingPosition.Builder builder() {
+    return ImmutablePagingPosition.builder();
+  }
+
+  /** The reference row for the paging state. */
+  Row currentRow();
+
+  /** Defines how to resume paging relative to the {@link #currentRow() reference row}. */
+  ResumeMode resumeFrom();
+
+  /**
+   * The maximum number of rows to be returned by the query execution requests using this paging
+   * position.
+   *
+   * <p>Note: since the custom paging position may be chosen arbitrarily, the caller is responsible
+   * for tracking query limits and calculating the number of rows remaining.
+   */
+  @Value.Default
+  default int remainingRows() {
+    return Integer.MAX_VALUE;
+  }
+
+  /**
+   * The maximum number of rows to be returned for next data partition in the query execution
+   * requests using this paging position.
+   *
+   * <p>Note: since the custom paging position may be chosen arbitrarily, the caller is responsible
+   * for tracking per-partition query limits and calculating the number of rows remaining in next
+   * partition.
+   *
+   * <p>Note: if {@link ResumeMode#NEXT_PARTITION} is used, this parameter does not have to be set
+   * (the per-partition limit will be inherited from the query).
+   */
+  @Value.Default
+  default int remainingRowsInPartition() {
+    return Integer.MAX_VALUE;
+  }
+
+  enum ResumeMode {
+    /**
+     * Paging is resumed from the first row of the partition following the partition of the {@link
+     * #currentRow() reference row}.
+     */
+    NEXT_PARTITION,
+  }
+}

--- a/persistence-api/src/main/java/io/stargate/db/Parameters.java
+++ b/persistence-api/src/main/java/io/stargate/db/Parameters.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.stargate.db;
 
 import static java.lang.String.format;

--- a/persistence-api/src/main/java/io/stargate/db/Persistence.java
+++ b/persistence-api/src/main/java/io/stargate/db/Persistence.java
@@ -226,5 +226,15 @@ public interface Persistence {
 
     /** Adds properties to be used by persistence backend (if supported) */
     default void setCustomProperties(Map<String, String> customProperties) {}
+
+    /**
+     * Converts a custom paging position to a persistence-specific paging state.
+     *
+     * @param position identifies desired paging position
+     * @param parameters request execution parameters (these should generally be the same or
+     *     compatible to what will be used for executing the query with the returned paging state).
+     * @see Parameters#pagingState()
+     */
+    ByteBuffer makePagingState(PagingPosition position, Parameters parameters);
   }
 }

--- a/persistence-api/src/main/java/io/stargate/db/RateLimitingPersistence.java
+++ b/persistence-api/src/main/java/io/stargate/db/RateLimitingPersistence.java
@@ -174,5 +174,10 @@ public class RateLimitingPersistence implements Persistence {
     public void setCustomProperties(Map<String, String> customProperties) {
       connection.setCustomProperties(customProperties);
     }
+
+    @Override
+    public ByteBuffer makePagingState(PagingPosition position, Parameters parameters) {
+      return connection.makePagingState(position, parameters);
+    }
   }
 }

--- a/persistence-api/src/main/java/io/stargate/db/datastore/PersistenceBackedResultSet.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/PersistenceBackedResultSet.java
@@ -1,6 +1,7 @@
 package io.stargate.db.datastore;
 
 import com.datastax.oss.driver.api.core.ProtocolVersion;
+import io.stargate.db.PagingPosition;
 import io.stargate.db.Parameters;
 import io.stargate.db.Persistence;
 import io.stargate.db.Persistence.Connection;
@@ -238,6 +239,11 @@ class PersistenceBackedResultSet implements ResultSet {
   @Override
   public ByteBuffer getPagingState() {
     return nextPagingState;
+  }
+
+  @Override
+  public ByteBuffer makePagingState(PagingPosition position) {
+    return connection.makePagingState(position, parameters);
   }
 
   @Override

--- a/persistence-api/src/main/java/io/stargate/db/datastore/ResultSet.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/ResultSet.java
@@ -15,6 +15,7 @@
  */
 package io.stargate.db.datastore;
 
+import io.stargate.db.PagingPosition;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Iterator;
@@ -72,6 +73,11 @@ public interface ResultSet extends Iterable<Row> {
     }
 
     @Override
+    public ByteBuffer makePagingState(PagingPosition position) {
+      return null;
+    }
+
+    @Override
     public boolean waitedForSchemaAgreement() {
       return waitedForSchemaAgreement;
     }
@@ -115,6 +121,12 @@ public interface ResultSet extends Iterable<Row> {
   boolean hasNoMoreFetchedRows();
 
   ByteBuffer getPagingState();
+
+  /**
+   * Creates a paging state from a custom paging position for fetching more data from the query that
+   * returned this {@link ResultSet}.
+   */
+  ByteBuffer makePagingState(PagingPosition position);
 
   /** Returns true of this request waited for schema agreement. */
   default boolean waitedForSchemaAgreement() {

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
@@ -28,6 +28,7 @@ import io.stargate.db.Batch;
 import io.stargate.db.BoundStatement;
 import io.stargate.db.ClientInfo;
 import io.stargate.db.EventListener;
+import io.stargate.db.PagingPosition;
 import io.stargate.db.Parameters;
 import io.stargate.db.Persistence;
 import io.stargate.db.Result;
@@ -522,6 +523,11 @@ public class CassandraPersistence
             }
             return new BatchMessage(internalBatchType, queryOrIdList, allValues, options);
           });
+    }
+
+    @Override
+    public ByteBuffer makePagingState(PagingPosition position, Parameters parameters) {
+      return Conversion.toPagingState(position, parameters);
     }
 
     private Object queryOrId(Statement statement) {

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
@@ -19,9 +19,12 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import io.stargate.db.BatchType;
+import io.stargate.db.PagingPosition;
+import io.stargate.db.PagingPosition.ResumeMode;
 import io.stargate.db.Parameters;
 import io.stargate.db.Result;
 import io.stargate.db.Result.Flag;
+import io.stargate.db.datastore.Row;
 import io.stargate.db.datastore.common.util.ColumnUtils;
 import io.stargate.db.schema.Column;
 import io.stargate.db.schema.ImmutableColumn;
@@ -36,12 +39,17 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.cassandra.config.CFMetaData;
+import org.apache.cassandra.config.Schema;
 import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.cql3.statements.BatchStatement;
 import org.apache.cassandra.cql3.statements.ParsedStatement;
+import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.ListType;
 import org.apache.cassandra.db.marshal.MapType;
@@ -81,6 +89,7 @@ import org.apache.cassandra.transport.Event;
 import org.apache.cassandra.transport.ProtocolVersionLimit;
 import org.apache.cassandra.transport.messages.ResultMessage;
 import org.apache.cassandra.utils.NoSpamLogger;
+import org.apache.cassandra.utils.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -156,6 +165,58 @@ public class Conversion {
               }
             });
     TYPE_MAPPINGS = ImmutableMap.copyOf(types);
+  }
+
+  public static ByteBuffer toPagingState(PagingPosition pos, Parameters parameters) {
+    Row row = pos.currentRow();
+    Set<Pair<String, String>> tables =
+        row.columns().stream()
+            .map(c -> Pair.create(c.keyspace(), c.table()))
+            .collect(Collectors.toSet());
+
+    if (tables.isEmpty()) {
+      throw new IllegalArgumentException("Missing table information in custom paging request.");
+    }
+
+    if (tables.size() > 1) {
+      throw new IllegalArgumentException("Too many tables are referenced: " + tables);
+    }
+
+    Pair<String, String> table = tables.iterator().next();
+    CFMetaData cfm = Schema.instance.getCFMetaData(table.left, table.right);
+    if (cfm == null) {
+      throw new IllegalStateException("Table not found: " + table);
+    }
+
+    Object[] pkValues =
+        cfm.partitionKeyColumns().stream()
+            .map(
+                c -> {
+                  ByteBuffer value = row.getBytesUnsafe(c.name.toCQLString());
+
+                  if (value == null) {
+                    throw new IllegalArgumentException(
+                        String.format(
+                            "Partition key value is not present in current row (table: %s, column: %s)",
+                            table, c.name.toCQLString()));
+                  }
+
+                  return value;
+                })
+            .toArray();
+    Clustering clustering = cfm.getKeyValidatorAsClusteringComparator().make(pkValues);
+
+    if (pos.resumeFrom() != ResumeMode.NEXT_PARTITION) {
+      throw new UnsupportedOperationException("Unsupported paging mode: " + pos.resumeFrom());
+    }
+
+    ByteBuffer serializedKey = CFMetaData.serializePartitionKey(clustering);
+    PagingState pagingState =
+        new PagingState(serializedKey, null, pos.remainingRows(), pos.remainingRowsInPartition());
+
+    org.apache.cassandra.transport.ProtocolVersion protocolVersion =
+        toInternal(parameters.protocolVersion());
+    return pagingState.serialize(protocolVersion);
   }
 
   public static QueryOptions toInternal(

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
@@ -13,6 +13,7 @@ import io.stargate.db.Batch;
 import io.stargate.db.BoundStatement;
 import io.stargate.db.ClientInfo;
 import io.stargate.db.EventListener;
+import io.stargate.db.PagingPosition;
 import io.stargate.db.Parameters;
 import io.stargate.db.Persistence;
 import io.stargate.db.Result;
@@ -511,6 +512,11 @@ public class CassandraPersistence
             }
             return new BatchMessage(internalBatchType, queryOrIdList, allValues, options);
           });
+    }
+
+    @Override
+    public ByteBuffer makePagingState(PagingPosition position, Parameters parameters) {
+      return Conversion.toPagingState(position, parameters);
     }
 
     private Object queryOrId(Statement statement) {

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
@@ -4,8 +4,11 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import io.stargate.db.BatchType;
+import io.stargate.db.PagingPosition;
+import io.stargate.db.PagingPosition.ResumeMode;
 import io.stargate.db.Parameters;
 import io.stargate.db.Result;
+import io.stargate.db.datastore.Row;
 import io.stargate.db.datastore.common.util.ColumnUtils;
 import io.stargate.db.schema.Column;
 import io.stargate.db.schema.ImmutableColumn;
@@ -17,12 +20,15 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.cql3.QueryHandler;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.cql3.statements.BatchStatement;
+import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.ListType;
 import org.apache.cassandra.db.marshal.MapType;
@@ -32,6 +38,8 @@ import org.apache.cassandra.db.marshal.TupleType;
 import org.apache.cassandra.db.marshal.UserType;
 import org.apache.cassandra.exceptions.CassandraException;
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.schema.Schema;
+import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.pager.PagingState;
 import org.apache.cassandra.stargate.cql3.functions.FunctionName;
 import org.apache.cassandra.stargate.db.ConsistencyLevel;
@@ -44,6 +52,7 @@ import org.apache.cassandra.stargate.utils.MD5Digest;
 import org.apache.cassandra.transport.Event;
 import org.apache.cassandra.transport.messages.ResultMessage;
 import org.apache.cassandra.utils.NoSpamLogger;
+import org.apache.cassandra.utils.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,6 +80,56 @@ public class Conversion {
               }
             });
     TYPE_MAPPINGS = ImmutableMap.copyOf(types);
+  }
+
+  public static ByteBuffer toPagingState(PagingPosition pos, Parameters parameters) {
+    Row row = pos.currentRow();
+    Set<Pair<String, String>> tables =
+        row.columns().stream()
+            .map(c -> Pair.create(c.keyspace(), c.table()))
+            .collect(Collectors.toSet());
+
+    if (tables.isEmpty()) {
+      throw new IllegalArgumentException("Missing table information in custom paging request.");
+    }
+
+    if (tables.size() > 1) {
+      throw new IllegalArgumentException("Too many tables are referenced: " + tables);
+    }
+
+    Pair<String, String> tableName = tables.iterator().next();
+    TableMetadata table = Schema.instance.validateTable(tableName.left, tableName.right);
+
+    Object[] pkValues =
+        table.partitionKeyColumns().stream()
+            .map(
+                c -> {
+                  ByteBuffer value = row.getBytesUnsafe(c.name.toCQLString());
+
+                  if (value == null) {
+                    throw new IllegalArgumentException(
+                        String.format(
+                            "Partition key value is not present in current row (table: %s, column: %s)",
+                            table, c.name.toCQLString()));
+                  }
+
+                  return value;
+                })
+            .toArray();
+    Clustering<?> clustering = table.partitionKeyAsClusteringComparator().make(pkValues);
+
+    if (pos.resumeFrom() != ResumeMode.NEXT_PARTITION) {
+      throw new UnsupportedOperationException("Unsupported paging mode: " + pos.resumeFrom());
+    }
+
+    ByteBuffer serializedKey = clustering.serializeAsPartitionKey();
+
+    PagingState pagingState =
+        new PagingState(serializedKey, null, pos.remainingRows(), pos.remainingRowsInPartition());
+
+    org.apache.cassandra.transport.ProtocolVersion protocolVersion =
+        toInternal(parameters.protocolVersion());
+    return pagingState.serialize(protocolVersion);
   }
 
   public static QueryOptions toInternal(

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/Conversion.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/Conversion.java
@@ -4,8 +4,11 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import io.stargate.db.BatchType;
+import io.stargate.db.PagingPosition;
+import io.stargate.db.PagingPosition.ResumeMode;
 import io.stargate.db.Parameters;
 import io.stargate.db.Result;
+import io.stargate.db.datastore.Row;
 import io.stargate.db.datastore.common.util.ColumnUtils;
 import io.stargate.db.schema.Column;
 import io.stargate.db.schema.ImmutableColumn;
@@ -19,7 +22,9 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.cql3.PageSize;
@@ -29,6 +34,7 @@ import org.apache.cassandra.cql3.QueryOptions.PagingOptions;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.cql3.ResultSet;
 import org.apache.cassandra.cql3.statements.BatchStatement;
+import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.LineStringType;
 import org.apache.cassandra.db.marshal.ListType;
@@ -40,6 +46,8 @@ import org.apache.cassandra.db.marshal.SetType;
 import org.apache.cassandra.db.marshal.TupleType;
 import org.apache.cassandra.db.marshal.UserType;
 import org.apache.cassandra.exceptions.CassandraException;
+import org.apache.cassandra.schema.SchemaManager;
+import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.pager.PagingState;
 import org.apache.cassandra.stargate.cql3.functions.FunctionName;
 import org.apache.cassandra.stargate.db.ConsistencyLevel;
@@ -72,6 +80,7 @@ import org.apache.cassandra.transport.Event;
 import org.apache.cassandra.transport.messages.ResultMessage;
 import org.apache.cassandra.utils.Flags;
 import org.apache.cassandra.utils.NoSpamLogger;
+import org.apache.cassandra.utils.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -152,6 +161,56 @@ public class Conversion {
     types.put(LineStringType.class, Column.Type.LineString);
 
     TYPE_MAPPINGS = ImmutableMap.copyOf(types);
+  }
+
+  public static ByteBuffer toPagingState(PagingPosition pos, Parameters parameters) {
+    Row row = pos.currentRow();
+    Set<Pair<String, String>> tables =
+        row.columns().stream()
+            .map(c -> Pair.create(c.keyspace(), c.table()))
+            .collect(Collectors.toSet());
+
+    if (tables.isEmpty()) {
+      throw new IllegalArgumentException("Missing table information in custom paging request.");
+    }
+
+    if (tables.size() > 1) {
+      throw new IllegalArgumentException("Too many tables are referenced: " + tables);
+    }
+
+    Pair<String, String> tableName = tables.iterator().next();
+    TableMetadata table = SchemaManager.instance.validateTable(tableName.left, tableName.right);
+
+    Object[] pkValues =
+        table.partitionKeyColumns().stream()
+            .map(
+                c -> {
+                  ByteBuffer value = row.getBytesUnsafe(c.name.toCQLString());
+
+                  if (value == null) {
+                    throw new IllegalArgumentException(
+                        String.format(
+                            "Partition key value is not present in current row (table: %s, column: %s)",
+                            table, c.name.toCQLString()));
+                  }
+
+                  return value;
+                })
+            .toArray();
+    Clustering clustering = table.partitionKeyAsClusteringComparator().make(pkValues);
+
+    if (pos.resumeFrom() != ResumeMode.NEXT_PARTITION) {
+      throw new UnsupportedOperationException("Unsupported paging mode: " + pos.resumeFrom());
+    }
+
+    ByteBuffer serializedKey = clustering.serializeAsPartitionKey();
+    PagingState pagingState =
+        new PagingState(
+            serializedKey, null, pos.remainingRows(), pos.remainingRowsInPartition(), false);
+
+    org.apache.cassandra.transport.ProtocolVersion protocolVersion =
+        toInternal(parameters.protocolVersion());
+    return pagingState.serialize(protocolVersion);
   }
 
   public static QueryOptions toInternal(

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -16,6 +16,7 @@ import io.stargate.db.Batch;
 import io.stargate.db.BoundStatement;
 import io.stargate.db.ClientInfo;
 import io.stargate.db.EventListener;
+import io.stargate.db.PagingPosition;
 import io.stargate.db.Parameters;
 import io.stargate.db.Persistence;
 import io.stargate.db.Result;
@@ -621,6 +622,11 @@ public class DsePersistence
             }
             return new BatchMessage(internalBatchType, queryOrIdList, allValues, options);
           });
+    }
+
+    @Override
+    public ByteBuffer makePagingState(PagingPosition position, Parameters parameters) {
+      return Conversion.toPagingState(position, parameters);
     }
 
     private Object queryOrId(Statement statement) {


### PR DESCRIPTION
Allow resuming data fetching from paged queries at
a custom position (not necessarily at the end of the
last page returned from the previous execution).