### PR TITLE
fixes #843: better responses for the mutation queries

### DIFF
--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/MutationFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/MutationFetcher.java
@@ -90,10 +90,8 @@ public abstract class MutationFetcher extends DmlFetcher<CompletableFuture<Map<S
       // if we have no rows means that we got no information back from query execution, return
       // original value to the user and applied true to denote that query was accepted
       // not matter if the underlying data is not changed
-      ImmutableMap.Builder<String, Object> resultBuilder = ImmutableMap.builder();
-      resultBuilder.put("value", originalValue);
-      resultBuilder.put("applied", true);
-      return resultBuilder.build();
+      return ImmutableMap.of("value", originalValue, "applied", true);
+
     } else {
       // otherwise check what can we get from the results
       // mutation target only one row
@@ -103,10 +101,7 @@ public abstract class MutationFetcher extends DmlFetcher<CompletableFuture<Map<S
 
       // if applied we can return the original value, otherwise use database state
       Object finalValue = applied ? originalValue : value;
-      ImmutableMap.Builder<String, Object> resultBuilder = ImmutableMap.builder();
-      resultBuilder.put("value", finalValue);
-      resultBuilder.put("applied", applied);
-      return resultBuilder.build();
+      return ImmutableMap.of("value", finalValue, "applied", applied);
     }
   }
 

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/MutationFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/MutationFetcher.java
@@ -25,10 +25,13 @@ import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.db.datastore.DataStore;
 import io.stargate.db.datastore.DataStoreFactory;
+import io.stargate.db.datastore.ResultSet;
+import io.stargate.db.datastore.Row;
 import io.stargate.db.query.BoundQuery;
 import io.stargate.db.schema.Table;
 import io.stargate.graphql.schema.cqlfirst.dml.NameMapping;
 import io.stargate.graphql.web.HttpAwareContext;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -74,9 +77,33 @@ public abstract class MutationFetcher extends DmlFetcher<CompletableFuture<Map<S
     }
 
     // Execute as a single statement
-    return dataStore
-        .execute(query)
-        .thenApply(rs -> ImmutableMap.of("value", environment.getArgument("value")));
+    return dataStore.execute(query).thenApply(rs -> toMutationResult(rs, environment));
+  }
+
+  private Map<String, Object> toMutationResult(
+      ResultSet resultSet, DataFetchingEnvironment environment) {
+
+    List<Row> rows = resultSet.currentPageRows();
+    Object originalValue = environment.getArgument("value");
+
+    if (rows.isEmpty()) {
+      // if we have no rows means that we got no information back from query execution, return
+      // original value to the user
+      return ImmutableMap.of("value", originalValue);
+    } else {
+      // otherwise check what can we get from the results
+      // mutation target only one row
+      Row row = rows.iterator().next();
+      boolean applied = row.getBoolean("[applied]");
+      Map<String, Object> value = DataTypeMapping.toGraphQLValue(nameMapping, table, row);
+
+      // return value from query, if given or not applied, fallback to the original
+      Object finalValue = !value.isEmpty() || !applied ? value : originalValue;
+      ImmutableMap.Builder<String, Object> mutationResultMapBuilder = ImmutableMap.builder();
+      mutationResultMapBuilder.put("value", finalValue);
+      mutationResultMapBuilder.put("applied", applied);
+      return mutationResultMapBuilder.build();
+    }
   }
 
   private CompletableFuture<Map<String, Object>> executeAsBatch(


### PR DESCRIPTION
I fixed the response we send back for all mutation queries in case when `ifExist` or `ifNotExists` is set to `true`. Basically I am doing a generic handling here and only changing what we return back in case I get non-empty rows from Cassandra. 

I am also asking myself if we should actually return the input back in case we have no rows. If we are going to mirror the Cassandra behavior then we should maybe not do that. Not sure.

I added tests and added cleanup of the inserted products as they affect the `io.stargate.it.http.GraphqlTest#queryWithPaging` test if those inserts run before it.