### PR TITLE
Use custom paging positions in Docs API

### DIFF
--- a/persistence-api/src/main/java/io/stargate/db/datastore/PersistenceBackedResultSet.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/PersistenceBackedResultSet.java
@@ -106,6 +106,11 @@ class PersistenceBackedResultSet implements ResultSet {
     return processed;
   }
 
+  @Override
+  public List<Column> columns() {
+    return columns;
+  }
+
   private static @Nullable Column columnInSchema(Schema schema, Column toFind) {
     Keyspace ks = schema.keyspace(toFind.keyspace());
     if (ks == null) return null;

--- a/persistence-api/src/main/java/io/stargate/db/datastore/ResultSet.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/ResultSet.java
@@ -16,6 +16,7 @@
 package io.stargate.db.datastore;
 
 import io.stargate.db.PagingPosition;
+import io.stargate.db.schema.Column;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Iterator;
@@ -40,6 +41,11 @@ public interface ResultSet extends Iterable<Row> {
     @Override
     public ResultSet withRowInspector(Predicate<Row> authzFilter) {
       return this;
+    }
+
+    @Override
+    public List<Column> columns() {
+      return Collections.emptyList();
     }
 
     @Override
@@ -93,6 +99,8 @@ public interface ResultSet extends Iterable<Row> {
   static ResultSet empty() {
     return EMPTY_NO_SCHEMA_AGREEMENT;
   }
+
+  List<Column> columns();
 
   @NotNull
   @Override

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
@@ -24,7 +24,6 @@ import io.stargate.db.PagingPosition.ResumeMode;
 import io.stargate.db.Parameters;
 import io.stargate.db.Result;
 import io.stargate.db.Result.Flag;
-import io.stargate.db.datastore.Row;
 import io.stargate.db.datastore.common.util.ColumnUtils;
 import io.stargate.db.schema.Column;
 import io.stargate.db.schema.ImmutableColumn;
@@ -168,9 +167,8 @@ public class Conversion {
   }
 
   public static ByteBuffer toPagingState(PagingPosition pos, Parameters parameters) {
-    Row row = pos.currentRow();
     Set<Pair<String, String>> tables =
-        row.columns().stream()
+        pos.currentRow().keySet().stream()
             .map(c -> Pair.create(c.keyspace(), c.table()))
             .collect(Collectors.toSet());
 
@@ -192,7 +190,7 @@ public class Conversion {
         cfm.partitionKeyColumns().stream()
             .map(
                 c -> {
-                  ByteBuffer value = row.getBytesUnsafe(c.name.toCQLString());
+                  ByteBuffer value = pos.currentRowValuesByColumnName().get(c.name.toCQLString());
 
                   if (value == null) {
                     throw new IllegalArgumentException(

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
@@ -8,7 +8,6 @@ import io.stargate.db.PagingPosition;
 import io.stargate.db.PagingPosition.ResumeMode;
 import io.stargate.db.Parameters;
 import io.stargate.db.Result;
-import io.stargate.db.datastore.Row;
 import io.stargate.db.datastore.common.util.ColumnUtils;
 import io.stargate.db.schema.Column;
 import io.stargate.db.schema.ImmutableColumn;
@@ -83,9 +82,8 @@ public class Conversion {
   }
 
   public static ByteBuffer toPagingState(PagingPosition pos, Parameters parameters) {
-    Row row = pos.currentRow();
     Set<Pair<String, String>> tables =
-        row.columns().stream()
+        pos.currentRow().keySet().stream()
             .map(c -> Pair.create(c.keyspace(), c.table()))
             .collect(Collectors.toSet());
 
@@ -104,7 +102,7 @@ public class Conversion {
         table.partitionKeyColumns().stream()
             .map(
                 c -> {
-                  ByteBuffer value = row.getBytesUnsafe(c.name.toCQLString());
+                  ByteBuffer value = pos.currentRowValuesByColumnName().get(c.name.toCQLString());
 
                   if (value == null) {
                     throw new IllegalArgumentException(

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/Conversion.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/Conversion.java
@@ -8,7 +8,6 @@ import io.stargate.db.PagingPosition;
 import io.stargate.db.PagingPosition.ResumeMode;
 import io.stargate.db.Parameters;
 import io.stargate.db.Result;
-import io.stargate.db.datastore.Row;
 import io.stargate.db.datastore.common.util.ColumnUtils;
 import io.stargate.db.schema.Column;
 import io.stargate.db.schema.ImmutableColumn;
@@ -164,9 +163,8 @@ public class Conversion {
   }
 
   public static ByteBuffer toPagingState(PagingPosition pos, Parameters parameters) {
-    Row row = pos.currentRow();
     Set<Pair<String, String>> tables =
-        row.columns().stream()
+        pos.currentRow().keySet().stream()
             .map(c -> Pair.create(c.keyspace(), c.table()))
             .collect(Collectors.toSet());
 
@@ -185,7 +183,7 @@ public class Conversion {
         table.partitionKeyColumns().stream()
             .map(
                 c -> {
-                  ByteBuffer value = row.getBytesUnsafe(c.name.toCQLString());
+                  ByteBuffer value = pos.currentRowValuesByColumnName().get(c.name.toCQLString());
 
                   if (value == null) {
                     throw new IllegalArgumentException(

--- a/persistence-test/src/main/java/io/stargate/it/PersistenceTest.java
+++ b/persistence-test/src/main/java/io/stargate/it/PersistenceTest.java
@@ -1704,8 +1704,7 @@ public abstract class PersistenceTest {
 
     ByteBuffer pagingState =
         rs.makePagingState(
-            PagingPosition.builder()
-                .currentRow(row2)
+            PagingPosition.ofCurrentRow(row2)
                 .resumeFrom(ResumeMode.NEXT_PARTITION)
                 .remainingRows(7) // not inherited from the query
                 .build());

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/Paginator.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/Paginator.java
@@ -1,14 +1,15 @@
 package io.stargate.web.docsapi.dao;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.stargate.db.datastore.Row;
+import io.stargate.db.PagingPosition;
+import io.stargate.db.PagingPosition.ResumeMode;
+import io.stargate.db.datastore.DataStore;
+import io.stargate.db.datastore.ResultSet;
+import io.stargate.db.schema.Column;
+import io.stargate.db.schema.Column.Type;
 import io.stargate.web.docsapi.exception.DocumentAPIRequestException;
-import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Base64;
-import java.util.List;
 
 /**
  * This class is in charge of keeping the data of the Docs API pagination process. It's not only a
@@ -18,15 +19,16 @@ import java.util.List;
  */
 public class Paginator {
 
-  private final ObjectMapper mapper = new ObjectMapper();
-
+  private final DataStore dataStore;
   public final int dbPageSize;
   public final int docPageSize;
 
   private ByteBuffer currentDbPageState; // keeps track of the DB page state while querying the DB
-  private DocumentSearchPageState documentPageState = null;
+  private String lastDocumentId;
+  private ResultSet resultSet;
 
-  public Paginator(String pageState, int pageSize, int dbPageSize) throws IOException {
+  public Paginator(DataStore dataStore, String pageState, int pageSize, int dbPageSize) {
+    this.dataStore = dataStore;
     docPageSize = Math.max(1, pageSize);
     if (docPageSize > DocumentDB.MAX_PAGE_SIZE) {
       throw new DocumentAPIRequestException("The parameter `page-size` is limited to 20.");
@@ -36,49 +38,44 @@ public class Paginator {
 
     if (pageState != null) {
       byte[] decodedBytes = Base64.getDecoder().decode(pageState);
-      documentPageState = mapper.readValue(decodedBytes, DocumentSearchPageState.class);
+      this.currentDbPageState = ByteBuffer.wrap(decodedBytes);
     }
-
-    this.currentDbPageState = (documentPageState != null) ? documentPageState.getPageState() : null;
   }
 
-  // Some parts of the document API use bytes that correspond directly to cassandra page states,
-  // rather than DocumentSearchPageState which is only used for collections search.
-  public Paginator(String pageState, int pageSize, int dbPageSize, boolean raw) throws IOException {
-    docPageSize = Math.max(1, pageSize);
-    if (docPageSize > DocumentDB.MAX_PAGE_SIZE) {
-      throw new DocumentAPIRequestException("The parameter `page-size` is limited to 20.");
-    }
+  public void useResultSet(ResultSet resultSet) {
+    this.resultSet = resultSet;
+    this.currentDbPageState = resultSet.getPagingState();
+  }
 
-    this.dbPageSize = dbPageSize;
+  public String makeExternalPagingState() throws JsonProcessingException {
+    ByteBuffer pagingState;
 
-    if (pageState != null) {
-      byte[] decodedBytes = Base64.getDecoder().decode(pageState);
-      if (raw) {
-        this.currentDbPageState = ByteBuffer.wrap(decodedBytes);
-      } else {
-        documentPageState = mapper.readValue(decodedBytes, DocumentSearchPageState.class);
-        this.currentDbPageState = documentPageState.getPageState();
-      }
+    if (lastDocumentId != null && resultSet != null) {
+      ByteBuffer keyValue = dataStore.valueCodec().encode(Type.Text, lastDocumentId);
+      Column keyColumn =
+          resultSet.columns().stream()
+              .filter(c -> c.name().equals("key"))
+              .findFirst()
+              .orElseThrow(() -> new IllegalStateException("key column not selected"));
+      PagingPosition position =
+          PagingPosition.builder()
+              .putCurrentRow(keyColumn, keyValue)
+              .resumeFrom(ResumeMode.NEXT_PARTITION)
+              .build();
+      pagingState = resultSet.makePagingState(position);
     } else {
-      this.currentDbPageState = null;
+      pagingState = currentDbPageState;
     }
-  }
 
-  public String getDocumentPageStateAsString() throws JsonProcessingException {
-    if (documentPageState != null) {
-      byte[] pagingJson = mapper.writeValueAsBytes(documentPageState);
-      return Base64.getEncoder().encodeToString(pagingJson);
+    if (pagingState == null) {
+      return null;
     }
-    return null;
+
+    return Base64.getEncoder().encodeToString(pagingState.array());
   }
 
   public void clearDocumentPageState() {
-    this.documentPageState = null;
-  }
-
-  public void setCurrentDbPageState(ByteBuffer page) {
-    this.currentDbPageState = page;
+    this.lastDocumentId = null;
   }
 
   public boolean hasDbPageState() {
@@ -86,51 +83,10 @@ public class Paginator {
   }
 
   public void setDocumentPageState(String lastIdSeen) {
-    documentPageState = new DocumentSearchPageState(lastIdSeen, currentDbPageState);
+    this.lastDocumentId = lastIdSeen;
   }
 
   public ByteBuffer getCurrentDbPageState() {
     return currentDbPageState;
-  }
-
-  // Only used to get the internal Cassandra paging state
-  public String getCurrentDbPageStateAsString() {
-    if (currentDbPageState != null) {
-      return Base64.getEncoder().encodeToString(currentDbPageState.array());
-    }
-    return null;
-  }
-
-  public List<Row> maybeSkipRows(List<Row> rows) {
-    return skipSeenRows(documentPageState, rows);
-  }
-
-  private List<Row> skipSeenRows(DocumentSearchPageState docPagingState, List<Row> rows) {
-    if (docPagingState == null) {
-      return rows;
-    }
-
-    String lastSeenId = docPagingState.getLastSeenDocId();
-    if (lastSeenId == null) {
-      return rows;
-    }
-
-    boolean idFound = docPagingState.isIdFound();
-    List<Row> filteredRows = new ArrayList<>();
-    for (Row row : rows) {
-      String docId = row.getString("key");
-      if (docId.equals(lastSeenId)) {
-        idFound = true;
-        continue;
-      }
-
-      if (idFound) {
-        filteredRows.add(row);
-      }
-    }
-
-    docPagingState.setIdFound(idFound);
-
-    return filteredRows;
   }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
@@ -672,10 +672,10 @@ public class DocumentResourceV2 {
           } else {
             final Paginator paginator =
                 new Paginator(
+                    dbFactory.getDataStore(),
                     pageStateParam,
                     pageSizeParam,
-                    pageSizeParam > 0 ? pageSizeParam : DEFAULT_PAGE_SIZE,
-                    true);
+                    pageSizeParam > 0 ? pageSizeParam : DEFAULT_PAGE_SIZE);
             DocumentDB db = dbFactory.getDocDataStoreForToken(authToken, getAllHeaders(request));
             JsonNode result =
                 documentService.searchDocumentsV2(
@@ -688,7 +688,7 @@ public class DocumentResourceV2 {
             String json;
 
             if (raw == null || !raw) {
-              String pagingStateStr = paginator.getCurrentDbPageStateAsString();
+              String pagingStateStr = paginator.makeExternalPagingState();
               json =
                   mapper.writeValueAsString(
                       new DocumentResponseWrapper<>(id, pagingStateStr, result));
@@ -773,7 +773,8 @@ public class DocumentResourceV2 {
           DocumentDB db = dbFactory.getDocDataStoreForToken(authToken, getAllHeaders(request));
 
           final Paginator paginator =
-              new Paginator(pageStateParam, pageSizeParam, DEFAULT_PAGE_SIZE);
+              new Paginator(
+                  dbFactory.getDataStore(), pageStateParam, pageSizeParam, DEFAULT_PAGE_SIZE);
 
           JsonNode results;
 
@@ -799,7 +800,7 @@ public class DocumentResourceV2 {
             json =
                 mapper.writeValueAsString(
                     new DocumentResponseWrapper<>(
-                        null, paginator.getDocumentPageStateAsString(), results));
+                        null, paginator.makeExternalPagingState(), results));
           } else {
             json = mapper.writeValueAsString(results);
           }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -766,7 +766,6 @@ public class DocumentService {
               false,
               null,
               paginator);
-      rows = paginator.maybeSkipRows(rows);
       addRowsToMap(rowsByDoc, rows);
     } while (rowsByDoc.keySet().size() <= paginator.docPageSize && paginator.hasDbPageState());
 
@@ -940,9 +939,7 @@ public class DocumentService {
                 null,
                 paginator);
         candidatesThisPage = new LinkedHashSet<>();
-        List<Row> rows = page;
-        rows = paginator.maybeSkipRows(rows);
-        for (Row row : rows) {
+        for (Row row : page) {
           candidatesThisPage.add(row.getString("key"));
         }
       } else {
@@ -1000,8 +997,7 @@ public class DocumentService {
               paginator);
       ArrayList<Row> rowsResult = new ArrayList<>();
       rowsResult.addAll(leftoverRows);
-      List<Row> rows = paginator.maybeSkipRows(page);
-      rowsResult.addAll(rows);
+      rowsResult.addAll(page);
       leftoverRows =
           updateExistenceForMap(
               existsByDoc,
@@ -1179,8 +1175,7 @@ public class DocumentService {
 
     List<Row> rows = r.currentPageRows();
 
-    // this is the only place that currently updates C* page state property
-    paginator.setCurrentDbPageState(r.getPagingState());
+    paginator.useResultSet(r);
 
     if (documentKey != null) {
       rows =

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -36,6 +36,7 @@ import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.UnauthorizedException;
 import io.stargate.db.datastore.ArrayListBackedRow;
+import io.stargate.db.datastore.DataStore;
 import io.stargate.db.datastore.ResultSet;
 import io.stargate.db.datastore.Row;
 import io.stargate.db.query.builder.BuiltCondition;
@@ -71,6 +72,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class DocumentServiceTest {
+  private final DataStore dataStore = Mockito.mock(DataStore.class);
   private DocumentService service;
   private Method convertToBracketedPath;
   private Method leftPadTo6;
@@ -1240,7 +1242,8 @@ public class DocumentServiceTest {
                 any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(new ArrayList<>());
     int pageSizeParam = 0;
-    Paginator paginator = new Paginator(null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
+    Paginator paginator =
+        new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
 
     List<FilterCondition> filters =
         ImmutableList.of(
@@ -1264,7 +1267,8 @@ public class DocumentServiceTest {
     Mockito.when(serviceMock.convertToJsonDoc(any(), anyBoolean(), anyBoolean()))
         .thenReturn(ImmutablePair.of(mapper.readTree("{\"a\": 1}"), new HashMap<>()));
     int pageSizeParam = 0;
-    Paginator paginator = new Paginator(null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
+    Paginator paginator =
+        new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
 
     List<FilterCondition> filters =
         ImmutableList.of(
@@ -1292,7 +1296,8 @@ public class DocumentServiceTest {
         ImmutableList.of(
             new SingleFilterCondition(ImmutableList.of("a", "b", "c"), "$exists", true));
     int pageSizeParam = 0;
-    Paginator paginator = new Paginator(null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
+    Paginator paginator =
+        new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
     JsonNode result =
         serviceMock.searchDocumentsV2(
             dbMock, "keyspace", "collection", filters, ImmutableList.of("field"), null, paginator);
@@ -1334,7 +1339,8 @@ public class DocumentServiceTest {
     Mockito.when(serviceMock.convertToJsonDoc(any(), anyBoolean(), anyBoolean()))
         .thenReturn(ImmutablePair.of(mapper.readTree("{\"a\": 1}"), new HashMap<>()));
     int pageSizeParam = 0;
-    Paginator paginator = new Paginator(null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
+    Paginator paginator =
+        new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
 
     JsonNode result =
         serviceMock.getFullDocuments(
@@ -1363,7 +1369,8 @@ public class DocumentServiceTest {
     Mockito.when(serviceMock.convertToJsonDoc(any(), anyBoolean(), anyBoolean()))
         .thenReturn(ImmutablePair.of(mapper.readTree("{\"a\": 1}"), new HashMap<>()));
     int pageSizeParam = 0;
-    Paginator paginator = new Paginator(null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
+    Paginator paginator =
+        new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
 
     JsonNode result =
         serviceMock.getFullDocuments(
@@ -1394,7 +1401,8 @@ public class DocumentServiceTest {
         ImmutableList.of(new SingleFilterCondition(ImmutableList.of("a,b", "*", "c"), "$eq", true));
 
     int pageSizeParam = 0;
-    Paginator paginator = new Paginator(null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
+    Paginator paginator =
+        new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
 
     List<Row> result =
         (List<Row>)
@@ -1414,7 +1422,7 @@ public class DocumentServiceTest {
     assertThat(paginator.getCurrentDbPageState()).isNull();
     assertThat(result).isEqualTo(rows);
 
-    paginator = new Paginator(null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
+    paginator = new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
     result =
         (List<Row>)
             searchRows.invoke(
@@ -1452,7 +1460,8 @@ public class DocumentServiceTest {
     when(rsMock.getPagingState()).thenReturn(ByteBuffer.wrap(new byte[0]));
 
     int pageSizeParam = 0;
-    Paginator paginator = new Paginator(null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
+    Paginator paginator =
+        new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
 
     List<FilterCondition> filters =
         ImmutableList.of(new SingleFilterCondition(ImmutableList.of("a,b", "*", "c"), "$ne", true));


### PR DESCRIPTION
Rely on the Persistence to provide the next partition based on
"last seen" document ID (partition key) rather that on client
side logic for skipping "previously seen" rows.