### PR TITLE
Upgrade jetty version because of vulnerability

### DIFF
--- a/config-store-yaml/pom.xml
+++ b/config-store-yaml/pom.xml
@@ -41,7 +41,7 @@
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-graphite</artifactId>
-        <version>4.1.2</version>
+        <version>${dropwizard.metrics.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/config-store-yaml/pom.xml
+++ b/config-store-yaml/pom.xml
@@ -35,11 +35,6 @@
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
-        <artifactId>metrics-ganglia</artifactId>
-        <version>3.2.6</version>
-      </dependency>
-      <dependency>
-        <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-graphite</artifactId>
         <version>${dropwizard.metrics.version}</version>
       </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,17 +16,17 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>4.1.11</version>
+            <version>${dropwizard.metrics.version}</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-healthchecks</artifactId>
-            <version>4.1.11</version>
+            <version>${dropwizard.metrics.version}</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jvm</artifactId>
-            <version>4.1.11</version>
+            <version>${dropwizard.metrics.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/cql/pom.xml
+++ b/cql/pom.xml
@@ -51,12 +51,12 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-jvm</artifactId>
-      <version>3.1.5</version>
+      <version>${dropwizard.metrics.version}</version>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-      <version>3.1.5</version>
+      <version>${dropwizard.metrics.version}</version>
     </dependency>
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>

--- a/graphqlapi/pom.xml
+++ b/graphqlapi/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-servlet</artifactId>
-      <version>4.1.9</version>
+      <version>${dropwizard.metrics.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-healthchecks</artifactId>
-      <version>4.1.11</version>
+      <version>${dropwizard.metrics.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/health-checker/pom.xml
+++ b/health-checker/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-healthchecks</artifactId>
-      <version>4.1.11</version>
+      <version>${dropwizard.metrics.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/persistence-cassandra-3.11/pom.xml
+++ b/persistence-cassandra-3.11/pom.xml
@@ -54,11 +54,6 @@
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-ganglia</artifactId>
-      <version>3.2.6</version>
-    </dependency>
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>
       <version>${dropwizard.metrics.version}</version>
     </dependency>

--- a/persistence-cassandra-3.11/pom.xml
+++ b/persistence-cassandra-3.11/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>
-      <version>4.1.2</version>
+      <version>${dropwizard.metrics.version}</version>
     </dependency>
     <dependency>
       <groupId>com.github.akarnokd</groupId>

--- a/persistence-cassandra-4.0/pom.xml
+++ b/persistence-cassandra-4.0/pom.xml
@@ -54,11 +54,6 @@
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-ganglia</artifactId>
-      <version>3.2.6</version>
-    </dependency>
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>
       <version>${dropwizard.metrics.version}</version>
     </dependency>

--- a/persistence-cassandra-4.0/pom.xml
+++ b/persistence-cassandra-4.0/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>
-      <version>4.1.2</version>
+      <version>${dropwizard.metrics.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.auto.factory</groupId>

--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -112,11 +112,6 @@
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-ganglia</artifactId>
-      <version>3.2.6</version>
-    </dependency>
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>
       <version>${dropwizard.metrics.version}</version>
     </dependency>

--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -118,7 +118,7 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>
-      <version>4.1.2</version>
+      <version>${dropwizard.metrics.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.auto.factory</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <doclint>none</doclint>
     <driver.version>4.9.0</driver.version>
     <xml-format.skip>true</xml-format.skip>
-    <dropwizard.version>2.0.12</dropwizard.version>
+    <dropwizard.version>2.0.21</dropwizard.version>
     <!--
       Note that this is currently aligned with the Jetty version that DropWizard transitively depends on.
       It's probably a good idea to keep the two versions in sync.

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
       Note that this is currently aligned with the Jetty version that DropWizard transitively depends on.
       It's probably a good idea to keep the two versions in sync.
     -->
-    <jetty.version>9.4.30.v20200611</jetty.version>
+    <jetty.version>9.4.40.v20210413</jetty.version>
     <slf4j.version>1.7.30</slf4j.version>
     <logback.version>1.2.3</logback.version>
     <!-- Make sure micrometer and prometheus versions are in sync  -->

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,11 @@
     <xml-format.skip>true</xml-format.skip>
     <dropwizard.version>2.0.21</dropwizard.version>
     <!--
+      Note that this is currently aligned with the metrics version that DropWizard transitively depends on.
+      It's probably a good idea to keep the two versions in sync.
+    -->
+    <dropwizard.metrics.version>4.1.19</dropwizard.metrics.version>
+    <!--
       Note that this is currently aligned with the Jetty version that DropWizard transitively depends on.
       It's probably a good idea to keep the two versions in sync.
     -->

--- a/restapi/pom.xml
+++ b/restapi/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-healthchecks</artifactId>
-      <version>4.1.11</version>
+      <version>${dropwizard.metrics.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Resolves: https://github.com/stargate/stargate/security/dependabot/pom.xml/org.eclipse.jetty:jetty-io/open

Dependabot kept upgrading to a major version which breaks our code so I've manually created a PR to resolve the issue.