### PR TITLE
Fixes #815 - Enable SASI indexes on C* 4 backends in test

### DIFF
--- a/cql/pom.xml
+++ b/cql/pom.xml
@@ -12,7 +12,7 @@
     <dependency>
       <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-all</artifactId>
-      <version>4.0-rc1</version>
+      <version>4.0-alpha4</version>
       <exclusions>
         <exclusion>
           <groupId>org.gridkit.jvmtool</groupId>

--- a/cql/pom.xml
+++ b/cql/pom.xml
@@ -12,7 +12,7 @@
     <dependency>
       <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-all</artifactId>
-      <version>4.0-alpha4</version>
+      <version>4.0-rc1</version>
       <exclusions>
         <exclusion>
           <groupId>org.gridkit.jvmtool</groupId>

--- a/persistence-api/pom.xml
+++ b/persistence-api/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-all</artifactId>
-      <version>4.0-alpha4</version>
+      <version>4.0-rc1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/persistence-cassandra-4.0/pom.xml
+++ b/persistence-cassandra-4.0/pom.xml
@@ -9,7 +9,7 @@
   <groupId>io.stargate.db.cassandra</groupId>
   <artifactId>persistence-cassandra-4.0</artifactId>
   <properties>
-    <cassandra.version>4.0-beta4</cassandra.version>
+    <cassandra.version>4.0-rc1</cassandra.version>
   </properties>
   <dependencies>
     <dependency>

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/CassandraPersistenceActivator.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/CassandraPersistenceActivator.java
@@ -130,7 +130,7 @@ public class CassandraPersistenceActivator extends BaseActivator {
     c.storage_port = listenPort;
     c.listen_address = listenAddress;
     c.broadcast_address = broadcastAddress;
-    c.enable_sasi_indexes = true;
+    c.enable_sasi_indexes = false;
     c.seed_provider =
         new ParameterizedClass(
             StargateSeedProvider.class.getName(), Collections.singletonMap("seeds", seedList));

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/CassandraPersistenceActivator.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/CassandraPersistenceActivator.java
@@ -130,6 +130,7 @@ public class CassandraPersistenceActivator extends BaseActivator {
     c.storage_port = listenPort;
     c.listen_address = listenAddress;
     c.broadcast_address = broadcastAddress;
+    c.enable_sasi_indexes = true;
     c.seed_provider =
         new ParameterizedClass(
             StargateSeedProvider.class.getName(), Collections.singletonMap("seeds", seedList));

--- a/persistence-cassandra-4.0/src/test/resources/cassandra.yaml
+++ b/persistence-cassandra-4.0/src/test/resources/cassandra.yaml
@@ -1394,7 +1394,7 @@ enable_materialized_views: false
 
 # Enables SASI index creation on this node.
 # SASI indexes are considered experimental and are not recommended for production use.
-enable_sasi_indexes: false
+enable_sasi_indexes: true
 
 # Enables creation of transiently replicated keyspaces on this node.
 # Transient replication is experimental and is not recommended for production use.

--- a/persistence-test/src/main/java/io/stargate/it/PersistenceTest.java
+++ b/persistence-test/src/main/java/io/stargate/it/PersistenceTest.java
@@ -49,7 +49,6 @@ import static io.stargate.db.schema.Column.Type.Uuid;
 import static io.stargate.db.schema.Column.Type.Varchar;
 import static io.stargate.db.schema.Column.Type.Varint;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.assertj.core.api.Fail.fail;
 
 import com.datastax.oss.driver.api.core.ProtocolVersion;
@@ -546,12 +545,6 @@ public abstract class PersistenceTest {
 
   @Test
   public void testSecondaryIndexes() throws ExecutionException, InterruptedException {
-    // TODO remove this when we figure out how to enable SAI indexes in Cassandra 4
-    assumeThat(isCassandra4())
-        .as(
-            "Disabled because it is currently not possible to enable SAI indexes "
-                + "on a Cassandra 4 backend")
-        .isFalse();
     createKeyspace();
     dataStore
         .queryBuilder()

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -16,7 +16,6 @@
 package io.stargate.it.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.Row;
@@ -449,13 +448,6 @@ public class RestApiv2Test extends BaseOsgiIntegrationTest {
 
   @Test
   public void createCustomIndex(CqlSession session) throws IOException {
-    // TODO remove this when we figure out how to enable SAI indexes in Cassandra 4
-    assumeThat(isCassandra4())
-        .as(
-            "Disabled because it is currently not possible to enable SAI indexes "
-                + "on a Cassandra 4 backend")
-        .isFalse();
-
     createKeyspace(keyspaceName);
     tableName = "tbl_createtable_" + System.currentTimeMillis();
     createTestTable(


### PR DESCRIPTION
Updates C* version to 4.0-rc1, that solves two bugs related to indexing, and re-enable the SASI tests on C* 4.0. 