### PR TITLE
Json Conversion Refactor: Part 2

### DIFF
--- a/restapi/pom.xml
+++ b/restapi/pom.xml
@@ -151,6 +151,11 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-junit-jupiter</artifactId>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
@@ -5,7 +5,6 @@ import static io.stargate.web.docsapi.resources.RequestToHeadersMapper.getAllHea
 import com.datastax.oss.driver.api.core.NoNodeAvailableException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.annotations.VisibleForTesting;
 import io.stargate.auth.UnauthorizedException;
 import io.stargate.db.schema.Keyspace;
 import io.stargate.db.schema.Table;
@@ -63,18 +62,8 @@ public class DocumentResourceV2 {
   @Inject private Db dbFactory;
   private static final Logger logger = LoggerFactory.getLogger(DocumentResourceV2.class);
   private static final ObjectMapper mapper = new ObjectMapper();
-  private final DocumentService documentService;
+  @Inject private DocumentService documentService;
   private final int DEFAULT_PAGE_SIZE = DocumentDB.SEARCH_PAGE_SIZE;
-
-  public DocumentResourceV2() {
-    documentService = new DocumentService();
-  }
-
-  @VisibleForTesting
-  DocumentResourceV2(Db dbFactory, DocumentService documentService) {
-    this.dbFactory = dbFactory;
-    this.documentService = documentService;
-  }
 
   @POST
   @ManagedAsync

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
@@ -14,6 +14,7 @@ import io.stargate.web.docsapi.examples.WriteDocResponse;
 import io.stargate.web.docsapi.exception.DocumentAPIRequestException;
 import io.stargate.web.docsapi.exception.ResourceNotFoundException;
 import io.stargate.web.docsapi.models.DocumentResponseWrapper;
+import io.stargate.web.docsapi.service.DocsApiConfiguration;
 import io.stargate.web.docsapi.service.DocumentService;
 import io.stargate.web.docsapi.service.filter.FilterCondition;
 import io.stargate.web.models.Error;
@@ -61,9 +62,9 @@ import org.slf4j.LoggerFactory;
 public class DocumentResourceV2 {
   @Inject private Db dbFactory;
   private static final Logger logger = LoggerFactory.getLogger(DocumentResourceV2.class);
-  private static final ObjectMapper mapper = new ObjectMapper();
+  @Inject private ObjectMapper mapper;
   @Inject private DocumentService documentService;
-  private final int DEFAULT_PAGE_SIZE = DocumentDB.SEARCH_PAGE_SIZE;
+  @Inject private DocsApiConfiguration docsApiConfiguration;
 
   @POST
   @ManagedAsync
@@ -664,7 +665,7 @@ public class DocumentResourceV2 {
                     dbFactory.getDataStore(),
                     pageStateParam,
                     pageSizeParam,
-                    pageSizeParam > 0 ? pageSizeParam : DEFAULT_PAGE_SIZE);
+                    pageSizeParam > 0 ? pageSizeParam : docsApiConfiguration.getSearchPageSize());
             DocumentDB db = dbFactory.getDocDataStoreForToken(authToken, getAllHeaders(request));
             JsonNode result =
                 documentService.searchDocumentsV2(
@@ -763,7 +764,10 @@ public class DocumentResourceV2 {
 
           final Paginator paginator =
               new Paginator(
-                  dbFactory.getDataStore(), pageStateParam, pageSizeParam, DEFAULT_PAGE_SIZE);
+                  dbFactory.getDataStore(),
+                  pageStateParam,
+                  pageSizeParam,
+                  docsApiConfiguration.getSearchPageSize());
 
           JsonNode results;
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocsApiComponentsBinder.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocsApiComponentsBinder.java
@@ -1,0 +1,21 @@
+package io.stargate.web.docsapi.service;
+
+import io.dropwizard.setup.Environment;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+
+public class DocsApiComponentsBinder extends AbstractBinder {
+  private final Environment environment;
+
+  public DocsApiComponentsBinder(Environment environment) {
+    this.environment = environment;
+  }
+
+  protected void configure() {
+    DocsApiConfiguration conf = DocsApiConfiguration.DEFAULT;
+    JsonConverter jsonConverter = new JsonConverter(environment.getObjectMapper(), conf);
+    bind(conf).to(DocsApiConfiguration.class);
+    bind(jsonConverter).to(JsonConverter.class);
+    bind(new DocumentService(environment.getObjectMapper(), jsonConverter, conf))
+        .to(DocumentService.class);
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocsApiConfiguration.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocsApiConfiguration.java
@@ -4,6 +4,7 @@ import io.stargate.web.docsapi.dao.DocumentDB;
 
 public interface DocsApiConfiguration {
   DocsApiConfiguration DEFAULT = new DocsApiConfiguration() {};
+
   default int getMaxPageSize() {
     return DocumentDB.MAX_PAGE_SIZE;
   }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocsApiConfiguration.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocsApiConfiguration.java
@@ -1,0 +1,22 @@
+package io.stargate.web.docsapi.service;
+
+import io.stargate.web.docsapi.dao.DocumentDB;
+
+public interface DocsApiConfiguration {
+  DocsApiConfiguration DEFAULT = new DocsApiConfiguration() {};
+  default int getMaxPageSize() {
+    return DocumentDB.MAX_PAGE_SIZE;
+  }
+
+  default int getSearchPageSize() {
+    return DocumentDB.SEARCH_PAGE_SIZE;
+  }
+
+  default int getMaxDepth() {
+    return DocumentDB.MAX_DEPTH;
+  }
+
+  default int getMaxArrayLength() {
+    return DocumentDB.MAX_ARRAY_LENGTH;
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -35,7 +35,6 @@ import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import javax.inject.Inject;
 import javax.ws.rs.core.PathSegment;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableObject;
@@ -58,7 +57,10 @@ public class DocumentService {
   private JsonConverter jsonConverterService;
   private ObjectMapper mapper;
 
-  public DocumentService(ObjectMapper mapper, JsonConverter jsonConverterService, DocsApiConfiguration docsApiConfiguration) {
+  public DocumentService(
+      ObjectMapper mapper,
+      JsonConverter jsonConverterService,
+      DocsApiConfiguration docsApiConfiguration) {
     this.mapper = mapper;
     this.jsonConverterService = jsonConverterService;
     this.docsApiConfiguration = docsApiConfiguration;

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -36,8 +36,6 @@ import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import javax.inject.Inject;
-import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.PathSegment;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableObject;
@@ -57,9 +55,13 @@ public class DocumentService {
   private static final Splitter PAIR_SPLITTER = Splitter.on('=');
   private static final Splitter PATH_SPLITTER = Splitter.on('/');
 
-  @Inject @NotNull @VisibleForTesting JsonConverter jsonConverterService;
+  private JsonConverter jsonConverterService;
+  private ObjectMapper mapper;
 
-  @Inject @VisibleForTesting ObjectMapper mapper;
+  public DocumentService(ObjectMapper mapper, JsonConverter jsonConverterService) {
+    this.mapper = mapper;
+    this.jsonConverterService = jsonConverterService;
+  }
 
   /*
    * Converts a JSON path string (e.g. "$.a.b.c[0]") into a JSON path string

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/JsonConverter.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/JsonConverter.java
@@ -110,17 +110,6 @@ public class JsonConverter {
         JsonNode childRef;
 
         if (isArray && !writeAllPathsAsObjects) {
-          if (!ref.isArray()) {
-            if (i == 0) {
-              doc = mapper.createArrayNode();
-              ref = doc;
-            } else {
-              markObjectAtPathAsDead(ref, parentPath, collector);
-              ref = changeCurrentNodeToArray(row, parentRef, i);
-            }
-            pathWriteTimes.put(parentPath, rowWriteTime);
-          }
-
           int index = Integer.parseInt(p.substring(1, p.length() - 1));
 
           ArrayNode arrayRef = (ArrayNode) ref;

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/JsonConverter.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/JsonConverter.java
@@ -8,7 +8,7 @@ import io.stargate.db.schema.Column;
 import io.stargate.web.docsapi.dao.DocumentDB;
 import io.stargate.web.docsapi.service.json.DeadLeafCollector;
 import io.stargate.web.docsapi.service.json.ImmutableDeadLeaf;
-import io.stargate.web.docsapi.service.json.ImmutableDeadLeafCollectorNoOp;
+import io.stargate.web.docsapi.service.json.ImmutableDeadLeafCollector;
 import java.util.*;
 import javax.inject.Inject;
 
@@ -38,7 +38,7 @@ public class JsonConverter {
   public JsonNode convertToJsonDoc(
       List<Row> rows, boolean writeAllPathsAsObjects, boolean numericBooleans) {
     return convertToJsonDoc(
-        rows, ImmutableDeadLeafCollectorNoOp.of(), writeAllPathsAsObjects, numericBooleans);
+        rows, ImmutableDeadLeafCollector.of(), writeAllPathsAsObjects, numericBooleans);
   }
 
   public JsonNode convertToJsonDoc(

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/JsonConverter.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/JsonConverter.java
@@ -7,8 +7,8 @@ import io.stargate.db.datastore.Row;
 import io.stargate.db.schema.Column;
 import io.stargate.web.docsapi.dao.DocumentDB;
 import io.stargate.web.docsapi.service.json.DeadLeafCollector;
-import io.stargate.web.docsapi.service.json.DeadLeafCollectorNoOp;
 import io.stargate.web.docsapi.service.json.ImmutableDeadLeaf;
+import io.stargate.web.docsapi.service.json.ImmutableDeadLeafCollectorNoOp;
 import java.util.*;
 import javax.inject.Inject;
 
@@ -38,7 +38,7 @@ public class JsonConverter {
   public JsonNode convertToJsonDoc(
       List<Row> rows, boolean writeAllPathsAsObjects, boolean numericBooleans) {
     return convertToJsonDoc(
-        rows, DeadLeafCollectorNoOp.INSTANCE, writeAllPathsAsObjects, numericBooleans);
+        rows, ImmutableDeadLeafCollectorNoOp.of(), writeAllPathsAsObjects, numericBooleans);
   }
 
   public JsonNode convertToJsonDoc(

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/JsonConverter.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/JsonConverter.java
@@ -3,7 +3,6 @@ package io.stargate.web.docsapi.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.*;
-import com.google.common.annotations.VisibleForTesting;
 import io.stargate.db.datastore.Row;
 import io.stargate.db.schema.Column;
 import io.stargate.web.docsapi.dao.DocumentDB;
@@ -13,7 +12,15 @@ import java.util.*;
 import javax.inject.Inject;
 
 public class JsonConverter {
-  @Inject @VisibleForTesting ObjectMapper mapper;
+  private ObjectMapper mapper;
+
+  @Inject
+  public JsonConverter(ObjectMapper mapper) {
+    if (mapper == null) {
+      throw new IllegalStateException("JsonConverter requires a non-null ObjectMapper");
+    }
+    this.mapper = mapper;
+  }
 
   // TODO find a place to refactor this to, along with DocumentService#getBooleanFromRow
   private static Boolean getBooleanFromRow(Row row, String colName, boolean numericBooleans) {

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/json/DeadLeafCollector.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/json/DeadLeafCollector.java
@@ -1,11 +1,13 @@
 package io.stargate.web.docsapi.service.json;
 
 public interface DeadLeafCollector {
-  void addLeaf(String path, DeadLeaf leaf);
+  default void addLeaf(String path, DeadLeaf leaf) {}
 
-  void addArray(String path);
+  default void addArray(String path) {}
 
-  void addAll(String path);
+  default void addAll(String path) {}
 
-  boolean isEmpty();
+  default boolean isEmpty() {
+    return true;
+  }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/json/DeadLeafCollector.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/json/DeadLeafCollector.java
@@ -1,5 +1,8 @@
 package io.stargate.web.docsapi.service.json;
 
+import org.immutables.value.Value;
+
+@Value.Immutable(singleton = true)
 public interface DeadLeafCollector {
   default void addLeaf(String path, DeadLeaf leaf) {}
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/json/DeadLeafCollectorImpl.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/json/DeadLeafCollectorImpl.java
@@ -9,18 +9,21 @@ public class DeadLeafCollectorImpl implements DeadLeafCollector {
     deadPaths = new HashMap<>();
   }
 
+  @Override
   public void addLeaf(String path, DeadLeaf leaf) {
     Set<DeadLeaf> leavesAtPath = deadPaths.getOrDefault(path, new HashSet<>());
     leavesAtPath.add(leaf);
     deadPaths.put(path, leavesAtPath);
   }
 
+  @Override
   public void addArray(String path) {
     Set<DeadLeaf> leavesAtPath = deadPaths.getOrDefault(path, new HashSet<>());
     leavesAtPath.add(DeadLeaf.ARRAYLEAF);
     deadPaths.put(path, leavesAtPath);
   }
 
+  @Override
   public void addAll(String path) {
     Set<DeadLeaf> leavesAtPath = new HashSet<>();
     leavesAtPath.add(DeadLeaf.STARLEAF);
@@ -31,6 +34,7 @@ public class DeadLeafCollectorImpl implements DeadLeafCollector {
     return deadPaths;
   }
 
+  @Override
   public boolean isEmpty() {
     return deadPaths.isEmpty();
   }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/json/DeadLeafCollectorNoOp.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/json/DeadLeafCollectorNoOp.java
@@ -1,19 +1,6 @@
 package io.stargate.web.docsapi.service.json;
 
-public enum DeadLeafCollectorNoOp implements DeadLeafCollector {
-  INSTANCE;
+import org.immutables.value.Value;
 
-  @Override
-  public void addLeaf(String path, DeadLeaf leaf) {}
-
-  @Override
-  public void addArray(String path) {}
-
-  @Override
-  public void addAll(String path) {}
-
-  @Override
-  public boolean isEmpty() {
-    return true;
-  }
-}
+@Value.Immutable(singleton = true)
+public interface DeadLeafCollectorNoOp extends DeadLeafCollector {}

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/json/DeadLeafCollectorNoOp.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/json/DeadLeafCollectorNoOp.java
@@ -1,12 +1,18 @@
 package io.stargate.web.docsapi.service.json;
 
-public class DeadLeafCollectorNoOp implements DeadLeafCollector {
+public enum DeadLeafCollectorNoOp implements DeadLeafCollector {
+  INSTANCE;
+
+  @Override
   public void addLeaf(String path, DeadLeaf leaf) {}
 
+  @Override
   public void addArray(String path) {}
 
+  @Override
   public void addAll(String path) {}
 
+  @Override
   public boolean isEmpty() {
     return true;
   }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/json/DeadLeafCollectorNoOp.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/json/DeadLeafCollectorNoOp.java
@@ -1,6 +1,0 @@
-package io.stargate.web.docsapi.service.json;
-
-import org.immutables.value.Value;
-
-@Value.Immutable(singleton = true)
-public interface DeadLeafCollectorNoOp extends DeadLeafCollector {}

--- a/restapi/src/main/java/io/stargate/web/impl/Server.java
+++ b/restapi/src/main/java/io/stargate/web/impl/Server.java
@@ -36,6 +36,7 @@ import io.stargate.web.config.ApplicationConfiguration;
 import io.stargate.web.docsapi.resources.CollectionsResource;
 import io.stargate.web.docsapi.resources.DocumentResourceV2;
 import io.stargate.web.docsapi.resources.NamespacesResource;
+import io.stargate.web.docsapi.service.DocumentService;
 import io.stargate.web.docsapi.service.JsonConverter;
 import io.stargate.web.resources.ColumnResource;
 import io.stargate.web.resources.Db;
@@ -134,27 +135,20 @@ public class Server extends Application<ApplicationConfiguration> {
     environment.jersey().register(IndexesResource.class);
 
     // Documents API
-    final JsonConverter jsonConverter = new JsonConverter();
-    final ObjectMapper mapper = new ObjectMapper();
+    JsonConverter jsonConverter = new JsonConverter(environment.getObjectMapper());
+
     environment
         .jersey()
         .register(
             new AbstractBinder() {
               @Override
               protected void configure() {
-                bind(jsonConverter).to(JsonConverter.class);
-              }
-            });
-    environment
-        .jersey()
-        .register(
-            new AbstractBinder() {
-              @Override
-              protected void configure() {
-                bind(mapper).to(ObjectMapper.class);
+                bind(new DocumentService(environment.getObjectMapper(), jsonConverter))
+                    .to(DocumentService.class);
               }
             });
     environment.jersey().register(DocumentResourceV2.class);
+
     environment.jersey().register(CollectionsResource.class);
     environment.jersey().register(NamespacesResource.class);
 

--- a/restapi/src/main/java/io/stargate/web/impl/Server.java
+++ b/restapi/src/main/java/io/stargate/web/impl/Server.java
@@ -36,8 +36,7 @@ import io.stargate.web.config.ApplicationConfiguration;
 import io.stargate.web.docsapi.resources.CollectionsResource;
 import io.stargate.web.docsapi.resources.DocumentResourceV2;
 import io.stargate.web.docsapi.resources.NamespacesResource;
-import io.stargate.web.docsapi.service.DocumentService;
-import io.stargate.web.docsapi.service.JsonConverter;
+import io.stargate.web.docsapi.service.DocsApiComponentsBinder;
 import io.stargate.web.resources.ColumnResource;
 import io.stargate.web.resources.Db;
 import io.stargate.web.resources.HealthResource;
@@ -123,6 +122,15 @@ public class Server extends Application<ApplicationConfiguration> {
                 bind(db).to(Db.class);
               }
             });
+    environment
+        .jersey()
+        .register(
+            new AbstractBinder() {
+              @Override
+              protected void configure() {
+                bind(environment.getObjectMapper()).to(ObjectMapper.class);
+              }
+            });
     environment.jersey().register(KeyspaceResource.class);
     environment.jersey().register(TableResource.class);
     environment.jersey().register(RowResource.class);
@@ -135,18 +143,7 @@ public class Server extends Application<ApplicationConfiguration> {
     environment.jersey().register(IndexesResource.class);
 
     // Documents API
-    JsonConverter jsonConverter = new JsonConverter(environment.getObjectMapper());
-
-    environment
-        .jersey()
-        .register(
-            new AbstractBinder() {
-              @Override
-              protected void configure() {
-                bind(new DocumentService(environment.getObjectMapper(), jsonConverter))
-                    .to(DocumentService.class);
-              }
-            });
+    environment.jersey().register(new DocsApiComponentsBinder(environment));
     environment.jersey().register(DocumentResourceV2.class);
 
     environment.jersey().register(CollectionsResource.class);

--- a/restapi/src/main/java/io/stargate/web/impl/Server.java
+++ b/restapi/src/main/java/io/stargate/web/impl/Server.java
@@ -36,6 +36,7 @@ import io.stargate.web.config.ApplicationConfiguration;
 import io.stargate.web.docsapi.resources.CollectionsResource;
 import io.stargate.web.docsapi.resources.DocumentResourceV2;
 import io.stargate.web.docsapi.resources.NamespacesResource;
+import io.stargate.web.docsapi.service.JsonConverter;
 import io.stargate.web.resources.ColumnResource;
 import io.stargate.web.resources.Db;
 import io.stargate.web.resources.HealthResource;
@@ -133,6 +134,26 @@ public class Server extends Application<ApplicationConfiguration> {
     environment.jersey().register(IndexesResource.class);
 
     // Documents API
+    final JsonConverter jsonConverter = new JsonConverter();
+    final ObjectMapper mapper = new ObjectMapper();
+    environment
+        .jersey()
+        .register(
+            new AbstractBinder() {
+              @Override
+              protected void configure() {
+                bind(jsonConverter).to(JsonConverter.class);
+              }
+            });
+    environment
+        .jersey()
+        .register(
+            new AbstractBinder() {
+              @Override
+              protected void configure() {
+                bind(mapper).to(ObjectMapper.class);
+              }
+            });
     environment.jersey().register(DocumentResourceV2.class);
     environment.jersey().register(CollectionsResource.class);
     environment.jersey().register(NamespacesResource.class);

--- a/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.stargate.auth.UnauthorizedException;
 import io.stargate.db.schema.Keyspace;
 import io.stargate.db.schema.Table;
+import io.stargate.web.docsapi.service.DocsApiConfiguration;
 import io.stargate.web.docsapi.service.DocumentService;
 import io.stargate.web.docsapi.service.filter.FilterCondition;
 import io.stargate.web.docsapi.service.filter.SingleFilterCondition;
@@ -34,22 +35,22 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 public class DocumentResourceV2Test {
-  private static final ObjectMapper mapper = new ObjectMapper();
   private final AuthenticatedDB authenticatedDBMock = mock(AuthenticatedDB.class);
   @InjectMocks private DocumentResourceV2 documentResourceV2;
   @Mock private DocumentService documentServiceMock;
   @Mock private Db dbFactoryMock;
+  @Spy private ObjectMapper mapper = new ObjectMapper();
+  @Spy private DocsApiConfiguration conf;
   private HttpServletRequest httpServletRequest;
 
   @BeforeEach
   public void setup() {
-    MockitoAnnotations.initMocks(this);
     httpServletRequest = mock(HttpServletRequest.class);
     when(httpServletRequest.getHeaderNames()).thenReturn(Collections.emptyEnumeration());
   }
@@ -630,8 +631,6 @@ public class DocumentResourceV2Test {
     conditions.add(
         new SingleFilterCondition(ImmutableList.of("a", "b", "c", "field1"), "$eq", "value"));
 
-    Mockito.when(documentServiceMock.convertToFilterOps(anyList(), anyObject()))
-        .thenReturn(conditions);
     Mockito.when(documentServiceMock.convertToSelectionList(anyObject()))
         .thenReturn(ImmutableList.of("field1"));
 

--- a/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
@@ -34,19 +34,22 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 public class DocumentResourceV2Test {
   private static final ObjectMapper mapper = new ObjectMapper();
-  private final DocumentService documentServiceMock = mock(DocumentService.class);
-  private final Db dbFactoryMock = mock(Db.class);
   private final AuthenticatedDB authenticatedDBMock = mock(AuthenticatedDB.class);
-  private DocumentResourceV2 documentResourceV2;
+  @InjectMocks private DocumentResourceV2 documentResourceV2;
+  @Mock private DocumentService documentServiceMock;
+  @Mock private Db dbFactoryMock;
   private HttpServletRequest httpServletRequest;
 
   @BeforeEach
   public void setup() {
-    documentResourceV2 = new DocumentResourceV2(dbFactoryMock, documentServiceMock);
+    MockitoAnnotations.initMocks(this);
     httpServletRequest = mock(HttpServletRequest.class);
     when(httpServletRequest.getHeaderNames()).thenReturn(Collections.emptyEnumeration());
   }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -70,6 +70,7 @@ public class DocumentServiceTest {
   private final DataStore dataStore = Mockito.mock(DataStore.class);
   @InjectMocks DocumentService service;
   @Mock JsonConverter jsonConverter;
+  @Spy ObjectMapper serviceMapper;
 
   private Method convertToBracketedPath;
   private Method leftPadTo6;
@@ -89,14 +90,13 @@ public class DocumentServiceTest {
   private Method checkGtOp;
   private Method checkLtOp;
   private Method searchRows;
+
   private static final ObjectMapper mapper = new ObjectMapper();
   private static final Map<String, String> EMPTY_HEADERS = Collections.emptyMap();
 
   @BeforeEach
   public void setup() throws NoSuchMethodException {
     MockitoAnnotations.initMocks(this);
-    jsonConverter.mapper = mapper;
-    service.mapper = mapper;
 
     convertToBracketedPath =
         DocumentService.class.getDeclaredMethod("convertToBracketedPath", String.class);

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/JsonConverterTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/JsonConverterTest.java
@@ -21,7 +21,7 @@ public class JsonConverterTest {
 
   @BeforeEach
   public void setup() {
-    service = new JsonConverter(mapper);
+    service = new JsonConverter(mapper, DocsApiConfiguration.DEFAULT);
   }
 
   @Test

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/JsonConverterTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/JsonConverterTest.java
@@ -1,4 +1,4 @@
-package io.stargate.web.docsapi.service.json;
+package io.stargate.web.docsapi.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.stargate.db.datastore.Row;
-import io.stargate.web.docsapi.service.DocumentServiceTest;
+import io.stargate.web.docsapi.service.json.DeadLeaf;
+import io.stargate.web.docsapi.service.json.DeadLeafCollectorImpl;
+import io.stargate.web.docsapi.service.json.ImmutableDeadLeaf;
 import java.util.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,6 +22,7 @@ public class JsonConverterTest {
   @BeforeEach
   public void setup() {
     service = new JsonConverter();
+    service.mapper = mapper;
   }
 
   @Test

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/JsonConverterTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/JsonConverterTest.java
@@ -26,7 +26,7 @@ public class JsonConverterTest {
 
   @Test
   public void convertToJsonDoc_testDeadLeaves() throws JsonProcessingException {
-    List<Row> initial = DocumentServiceTest.makeInitialRowData();
+    List<Row> initial = DocumentServiceTest.makeInitialRowData(false);
     initial.sort(
         (row1, row2) ->
             (Objects.requireNonNull(row1.getString("p0"))
@@ -54,7 +54,7 @@ public class JsonConverterTest {
     assertThat(collector.isEmpty()).isTrue();
 
     collector = new DeadLeafCollectorImpl();
-    initial.addAll(DocumentServiceTest.makeSecondRowData());
+    initial.addAll(DocumentServiceTest.makeSecondRowData(false));
     initial.sort(
         (row1, row2) ->
             (Objects.requireNonNull(row1.getString("p0"))
@@ -75,10 +75,11 @@ public class JsonConverterTest {
         .isEqualTo(
             mapper
                 .readTree(
-                    "{\"a\": {\"b\": {\"c\": {\"d\": \"replaced\"}}}, \"d\": {\"e\": [3]}, \"f\": \"abc\"}")
+                    "{\"a\":{\"b\":{\"c\":{\"d\":\"replaced\"}}},\"d\":{\"e\":{\"f\":{\"g\":\"replaced\"}}},\"f\":\"abc\"}")
                 .toString());
 
-    // This state should have 1 dead leaf, since $.a.b.c was changed from `true` to an object
+    // This state should have 2 dead leaves, since $.a.b.c was changed from `true` to an object,
+    // And $.d.e was changed from an array to an object
     Map<String, List<JsonNode>> expected = new HashMap<>();
     List<JsonNode> list = new ArrayList<>();
     ObjectNode node = mapper.createObjectNode();
@@ -86,14 +87,18 @@ public class JsonConverterTest {
     list.add(node);
     expected.put("$.a.b.c", list);
     Map<String, Set<DeadLeaf>> deadLeaves = collector.getLeaves();
-    assertThat(deadLeaves.keySet().size()).isEqualTo(1);
+    assertThat(deadLeaves.keySet().size()).isEqualTo(2);
     assertThat(deadLeaves.containsKey("$.a.b.c")).isTrue();
+    assertThat(deadLeaves.containsKey("$.d.e")).isTrue();
     Set<DeadLeaf> leaves = deadLeaves.get("$.a.b.c");
     assertThat(leaves.size()).isEqualTo(1);
     assertThat(leaves.contains(ImmutableDeadLeaf.builder().name("").build())).isTrue();
+    leaves = deadLeaves.get("$.d.e");
+    assertThat(leaves.size()).isEqualTo(1);
+    assertThat(leaves.contains(DeadLeaf.ARRAYLEAF)).isTrue();
 
     collector = new DeadLeafCollectorImpl();
-    initial.addAll(DocumentServiceTest.makeThirdRowData());
+    initial.addAll(DocumentServiceTest.makeThirdRowData(false));
     initial.sort(
         (row1, row2) ->
             (Objects.requireNonNull(row1.getString("p0"))
@@ -128,5 +133,154 @@ public class JsonConverterTest {
     leaves = deadLeaves.get("$.f");
     assertThat(leaves.size()).isEqualTo(1);
     assertThat(leaves.contains(DeadLeaf.STARLEAF)).isTrue();
+  }
+
+  @Test
+  public void convertToJsonDoc_testDeadLeaves_numericBools() throws JsonProcessingException {
+    List<Row> initial = DocumentServiceTest.makeInitialRowData(true);
+    initial.sort(
+        (row1, row2) ->
+            (Objects.requireNonNull(row1.getString("p0"))
+                        .compareTo(Objects.requireNonNull(row2.getString("p0")))
+                    * 100000
+                + Objects.requireNonNull(row1.getString("p1"))
+                        .compareTo(Objects.requireNonNull(row2.getString("p1")))
+                    * 10000
+                + Objects.requireNonNull(row1.getString("p2"))
+                        .compareTo(Objects.requireNonNull(row2.getString("p2")))
+                    * 1000
+                + Objects.requireNonNull(row1.getString("p3"))
+                        .compareTo(Objects.requireNonNull(row2.getString("p3")))
+                    * 100));
+    DeadLeafCollectorImpl collector = new DeadLeafCollectorImpl();
+    JsonNode result = service.convertToJsonDoc(initial, collector, false, true);
+
+    assertThat(result.toString())
+        .isEqualTo(
+            mapper
+                .readTree("{\"a\": {\"b\": {\"c\": true}}, \"d\": {\"e\": [3]}, \"f\": \"abc\"}")
+                .toString());
+
+    // This state should have no dead leaves, as it's the initial write
+    assertThat(collector.isEmpty()).isTrue();
+
+    collector = new DeadLeafCollectorImpl();
+    initial.addAll(DocumentServiceTest.makeSecondRowData(true));
+    initial.sort(
+        (row1, row2) ->
+            (Objects.requireNonNull(row1.getString("p0"))
+                        .compareTo(Objects.requireNonNull(row2.getString("p0")))
+                    * 100000
+                + Objects.requireNonNull(row1.getString("p1"))
+                        .compareTo(Objects.requireNonNull(row2.getString("p1")))
+                    * 10000
+                + Objects.requireNonNull(row1.getString("p2"))
+                        .compareTo(Objects.requireNonNull(row2.getString("p2")))
+                    * 1000
+                + Objects.requireNonNull(row1.getString("p3"))
+                        .compareTo(Objects.requireNonNull(row2.getString("p3")))
+                    * 100));
+    result = service.convertToJsonDoc(initial, collector, false, true);
+
+    assertThat(result.toString())
+        .isEqualTo(
+            mapper
+                .readTree(
+                    "{\"a\":{\"b\":{\"c\":{\"d\":\"replaced\"}}},\"d\":{\"e\":{\"f\":{\"g\":\"replaced\"}}},\"f\":\"abc\"}")
+                .toString());
+
+    // This state should have 2 dead leaves, since $.a.b.c was changed from `true` to an object,
+    // And $.d.e was changed from an array to an object
+    Map<String, List<JsonNode>> expected = new HashMap<>();
+    List<JsonNode> list = new ArrayList<>();
+    ObjectNode node = mapper.createObjectNode();
+    node.set("", BooleanNode.valueOf(true));
+    list.add(node);
+    expected.put("$.a.b.c", list);
+    Map<String, Set<DeadLeaf>> deadLeaves = collector.getLeaves();
+    assertThat(deadLeaves.keySet().size()).isEqualTo(2);
+    assertThat(deadLeaves.containsKey("$.a.b.c")).isTrue();
+    assertThat(deadLeaves.containsKey("$.d.e")).isTrue();
+    Set<DeadLeaf> leaves = deadLeaves.get("$.a.b.c");
+    assertThat(leaves.size()).isEqualTo(1);
+    assertThat(leaves.contains(ImmutableDeadLeaf.builder().name("").build())).isTrue();
+    leaves = deadLeaves.get("$.d.e");
+    assertThat(leaves.size()).isEqualTo(1);
+    assertThat(leaves.contains(DeadLeaf.ARRAYLEAF)).isTrue();
+
+    collector = new DeadLeafCollectorImpl();
+    initial.addAll(DocumentServiceTest.makeThirdRowData(true));
+    initial.sort(
+        (row1, row2) ->
+            (Objects.requireNonNull(row1.getString("p0"))
+                        .compareTo(Objects.requireNonNull(row2.getString("p0")))
+                    * 100000
+                + Objects.requireNonNull(row1.getString("p1"))
+                        .compareTo(Objects.requireNonNull(row2.getString("p1")))
+                    * 10000
+                + Objects.requireNonNull(row1.getString("p2"))
+                        .compareTo(Objects.requireNonNull(row2.getString("p2")))
+                    * 1000
+                + Objects.requireNonNull(row1.getString("p3"))
+                        .compareTo(Objects.requireNonNull(row2.getString("p3")))
+                    * 100));
+    result = service.convertToJsonDoc(initial, collector, false, true);
+
+    assertThat(result.toString()).isEqualTo(mapper.readTree("[\"replaced\"]").toString());
+
+    // This state should have 3 dead branches representing keys a, d, and f, since everything was
+    // blown away by the latest change
+    deadLeaves = collector.getLeaves();
+    assertThat(deadLeaves.keySet().size()).isEqualTo(3);
+    assertThat(deadLeaves.containsKey("$.a")).isTrue();
+    assertThat(deadLeaves.containsKey("$.d")).isTrue();
+    assertThat(deadLeaves.containsKey("$.f")).isTrue();
+    leaves = deadLeaves.get("$.a");
+    assertThat(leaves.size()).isEqualTo(1);
+    assertThat(leaves.contains(DeadLeaf.STARLEAF)).isTrue();
+    leaves = deadLeaves.get("$.d");
+    assertThat(leaves.size()).isEqualTo(1);
+    assertThat(leaves.contains(DeadLeaf.STARLEAF)).isTrue();
+    leaves = deadLeaves.get("$.f");
+    assertThat(leaves.size()).isEqualTo(1);
+    assertThat(leaves.contains(DeadLeaf.STARLEAF)).isTrue();
+  }
+
+  @Test
+  public void convertToJsonDoc_noOpBaseCases() throws JsonProcessingException {
+    List<Row> initial = DocumentServiceTest.makeInitialRowData(false);
+    initial.sort(
+        (row1, row2) ->
+            (Objects.requireNonNull(row1.getString("p0"))
+                        .compareTo(Objects.requireNonNull(row2.getString("p0")))
+                    * 100000
+                + Objects.requireNonNull(row1.getString("p1"))
+                        .compareTo(Objects.requireNonNull(row2.getString("p1")))
+                    * 10000
+                + Objects.requireNonNull(row1.getString("p2"))
+                        .compareTo(Objects.requireNonNull(row2.getString("p2")))
+                    * 1000
+                + Objects.requireNonNull(row1.getString("p3"))
+                        .compareTo(Objects.requireNonNull(row2.getString("p3")))
+                    * 100));
+    JsonNode result = service.convertToJsonDoc(initial, false, false);
+
+    assertThat(result.toString())
+        .isEqualTo(
+            mapper
+                .readTree("{\"a\": {\"b\": {\"c\": true}}, \"d\": {\"e\": [3]}, \"f\": \"abc\"}")
+                .toString());
+
+    result = service.convertToJsonDoc(new ArrayList<>(), false, false);
+    assertThat(result.toString()).isEqualTo(mapper.readTree("{}").toString());
+  }
+
+  @Test
+  public void convertToJsonDoc_arrayConversion() throws JsonProcessingException {
+    List<Row> initial = DocumentServiceTest.makeMultipleReplacements();
+    JsonNode result = service.convertToJsonDoc(initial, false, false);
+
+    assertThat(result.toString())
+        .isEqualTo(mapper.readTree("{\"a\":{\"b\":{\"c\":{}}}}").toString());
   }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/JsonConverterTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/JsonConverterTest.java
@@ -21,8 +21,7 @@ public class JsonConverterTest {
 
   @BeforeEach
   public void setup() {
-    service = new JsonConverter();
-    service.mapper = mapper;
+    service = new JsonConverter(mapper);
   }
 
   @Test


### PR DESCRIPTION
- [x] Use DI to inject JsonConverter and ObjectMapper to DocumentService
- [x] Reformat DocumentServiceTest to no longer spy on DocumentService
- [x] Couple of small revisions from previous PR w.r.t convertToJsonDoc
- [x] Add unit tests to cover more behavior in JsonConverter