### PR TITLE
Never enable debug in Stargate nodes in test

### DIFF
--- a/testing/src/main/java/io/stargate/it/storage/StargateContainer.java
+++ b/testing/src/main/java/io/stargate/it/storage/StargateContainer.java
@@ -16,7 +16,6 @@
 package io.stargate.it.storage;
 
 import static io.stargate.starter.Starter.STARTED_MESSAGE;
-import static java.lang.management.ManagementFactory.getRuntimeMXBean;
 
 import com.datastax.oss.driver.api.core.Version;
 import io.stargate.it.exec.OutputListener;
@@ -214,11 +213,6 @@ public class StargateContainer extends ExternalResource<StargateSpec, StargateCo
     throw new IllegalStateException("Unknown parameter: " + pc);
   }
 
-  private static boolean isDebug() {
-    String args = getRuntimeMXBean().getInputArguments().toString();
-    return args.contains("-agentlib:jdwp") || args.contains("-Xrunjdwp");
-  }
-
   protected static class Container extends ExternalResource.Holder
       implements StargateEnvironmentInfo, AutoCloseable {
 
@@ -381,14 +375,6 @@ public class StargateContainer extends ExternalResource<StargateSpec, StargateCo
 
       for (Entry<String, String> e : params.systemProperties().entrySet()) {
         cmd.addArgument("-D" + e.getKey() + "=" + e.getValue());
-      }
-
-      if (isDebug()) {
-        int debuggerPort = 5100 + nodeIndex;
-        cmd.addArgument(
-            "-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,"
-                + "address=localhost:"
-                + debuggerPort);
       }
 
       for (String arg : args(backend)) {


### PR DESCRIPTION
It's currently impossible to debug an integration test that starts a Stargate node. The node fails with this error:
```
ERROR [Exec Stream Pumper] 2021-04-28 09:45:12,329 ProcessRunner.java:85 - stargate0-0> ERROR: transport error 202: connect failed: Connection refused
ERROR [Exec Stream Pumper] 2021-04-28 09:45:12,329 ProcessRunner.java:85 - stargate0-0> ERROR: JDWP Transport dt_socket failed to initialize, TRANSPORT_INIT(510)
ERROR [Exec Stream Pumper] 2021-04-28 09:45:12,329 ProcessRunner.java:85 - stargate0-0> JDWP exit error AGENT_ERROR_TRANSPORT_INIT(197): No transports initialized [debugInit.c:750]
```
I'm not sure exactly why this happens, but the whole idea of starting the nodes with debug sounds dubious to me:
* ~~if you are debugging the test, you already have a debugging session in the IDE. How would you start another one?~~
* ~~how do you deal with `suspend=y` when there are multiple Stargate nodes?~~

edit: you _can_ run multiple parallel debugging sessions in IDEA I guess... Still I'm not sure I often I would use that in practice.

I propose we remove the options altogether. At least that will give us the ability to set breakpoints in the test code, and observe the behavior of the the Stargate process from the client POV.
To debug the Stargate code, you'll need to start a standalone instance and execute the scenario manually.