### PR TITLE
resolve possible request not flushed in metrics tests

### DIFF
--- a/testing/src/main/java/io/stargate/it/http/MetricsTest.java
+++ b/testing/src/main/java/io/stargate/it/http/MetricsTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import net.jcip.annotations.NotThreadSafe;
 import okhttp3.*;
-import org.apache.commons.lang.mutable.MutableInt;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeAll;
@@ -68,13 +67,7 @@ public class MetricsTest extends BaseOsgiIntegrationTest {
             .addHeader(TagMeHttpMetricsTagProvider.TAG_ME_HEADER, "test-value")
             .build();
 
-    MutableInt status = new MutableInt();
-    try (Response execute = client.newCall(request).execute()) {
-      assertThat(execute.body()).isNotNull();
-      assertThat(execute.code()).isNotZero();
-      status.setValue(execute.code());
-    }
-
+    int status = execute(client, request);
     String result = RestUtils.get("", String.format("%s:8084/metrics", host), HttpStatus.SC_OK);
 
     List<String> lines =
@@ -89,7 +82,7 @@ public class MetricsTest extends BaseOsgiIntegrationTest {
                     .contains("method=\"GET\"")
                     .contains("module=\"restapi\"")
                     .contains("uri=\"/v1/keyspaces\"")
-                    .contains(String.format("status=\"%d\"", status.intValue()))
+                    .contains(String.format("status=\"%d\"", status))
                     .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY + "=\"test-value\""));
   }
 
@@ -105,13 +98,7 @@ public class MetricsTest extends BaseOsgiIntegrationTest {
             .addHeader(TagMeHttpMetricsTagProvider.TAG_ME_HEADER, "test-value")
             .build();
 
-    MutableInt status = new MutableInt();
-    try (Response execute = client.newCall(request).execute()) {
-      assertThat(execute.body()).isNotNull();
-      assertThat(execute.code()).isNotZero();
-      status.setValue(execute.code());
-    }
-
+    int status = execute(client, request);
     String result = RestUtils.get("", String.format("%s:8084/metrics", host), HttpStatus.SC_OK);
 
     List<String> lines =
@@ -126,7 +113,7 @@ public class MetricsTest extends BaseOsgiIntegrationTest {
                     .contains("method=\"GET\"")
                     .contains("module=\"graphqlapi\"")
                     .contains("uri=\"/graphql\"")
-                    .contains(String.format("status=\"%d\"", status.intValue()))
+                    .contains(String.format("status=\"%d\"", status))
                     .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY + "=\"test-value\""));
   }
 
@@ -142,13 +129,7 @@ public class MetricsTest extends BaseOsgiIntegrationTest {
             .addHeader(TagMeHttpMetricsTagProvider.TAG_ME_HEADER, "test-value")
             .build();
 
-    MutableInt status = new MutableInt();
-    try (Response execute = client.newCall(request).execute()) {
-      assertThat(execute.body()).isNotNull();
-      assertThat(execute.code()).isNotZero();
-      status.setValue(execute.code());
-    }
-
+    int status = execute(client, request);
     String result = RestUtils.get("", String.format("%s:8084/metrics", host), HttpStatus.SC_OK);
 
     List<String> lines =
@@ -163,7 +144,7 @@ public class MetricsTest extends BaseOsgiIntegrationTest {
                     .contains("method=\"POST\"")
                     .contains("module=\"authapi\"")
                     .contains("uri=\"/v1/auth\"")
-                    .contains(String.format("status=\"%d\"", status.intValue()))
+                    .contains(String.format("status=\"%d\"", status))
                     .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY + "=\"test-value\""));
   }
 
@@ -203,5 +184,13 @@ public class MetricsTest extends BaseOsgiIntegrationTest {
             .collect(Collectors.toList());
 
     assertThat(lines).isNotEmpty();
+  }
+
+  private int execute(OkHttpClient client, Request request) throws IOException {
+    try (Response execute = client.newCall(request).execute()) {
+      assertThat(execute.body()).isNotNull();
+      assertThat(execute.code()).isNotZero();
+      return execute.code();
+    }
   }
 }

--- a/testing/src/main/java/io/stargate/it/http/MetricsTest.java
+++ b/testing/src/main/java/io/stargate/it/http/MetricsTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import net.jcip.annotations.NotThreadSafe;
 import okhttp3.*;
+import org.apache.commons.lang.mutable.MutableInt;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeAll;
@@ -66,7 +67,13 @@ public class MetricsTest extends BaseOsgiIntegrationTest {
             .get()
             .addHeader(TagMeHttpMetricsTagProvider.TAG_ME_HEADER, "test-value")
             .build();
-    Response execute = client.newCall(request).execute();
+
+    MutableInt status = new MutableInt();
+    try (Response execute = client.newCall(request).execute()) {
+      assertThat(execute.body()).isNotNull();
+      assertThat(execute.code()).isNotZero();
+      status.setValue(execute.code());
+    }
 
     String result = RestUtils.get("", String.format("%s:8084/metrics", host), HttpStatus.SC_OK);
 
@@ -82,7 +89,7 @@ public class MetricsTest extends BaseOsgiIntegrationTest {
                     .contains("method=\"GET\"")
                     .contains("module=\"restapi\"")
                     .contains("uri=\"/v1/keyspaces\"")
-                    .contains(String.format("status=\"%d\"", execute.code()))
+                    .contains(String.format("status=\"%d\"", status.intValue()))
                     .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY + "=\"test-value\""));
   }
 
@@ -97,7 +104,13 @@ public class MetricsTest extends BaseOsgiIntegrationTest {
             .get()
             .addHeader(TagMeHttpMetricsTagProvider.TAG_ME_HEADER, "test-value")
             .build();
-    Response execute = client.newCall(request).execute();
+
+    MutableInt status = new MutableInt();
+    try (Response execute = client.newCall(request).execute()) {
+      assertThat(execute.body()).isNotNull();
+      assertThat(execute.code()).isNotZero();
+      status.setValue(execute.code());
+    }
 
     String result = RestUtils.get("", String.format("%s:8084/metrics", host), HttpStatus.SC_OK);
 
@@ -113,7 +126,7 @@ public class MetricsTest extends BaseOsgiIntegrationTest {
                     .contains("method=\"GET\"")
                     .contains("module=\"graphqlapi\"")
                     .contains("uri=\"/graphql\"")
-                    .contains(String.format("status=\"%d\"", execute.code()))
+                    .contains(String.format("status=\"%d\"", status.intValue()))
                     .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY + "=\"test-value\""));
   }
 
@@ -128,7 +141,13 @@ public class MetricsTest extends BaseOsgiIntegrationTest {
             .post(RequestBody.create("{}", MediaType.parse("application/json")))
             .addHeader(TagMeHttpMetricsTagProvider.TAG_ME_HEADER, "test-value")
             .build();
-    Response execute = client.newCall(request).execute();
+
+    MutableInt status = new MutableInt();
+    try (Response execute = client.newCall(request).execute()) {
+      assertThat(execute.body()).isNotNull();
+      assertThat(execute.code()).isNotZero();
+      status.setValue(execute.code());
+    }
 
     String result = RestUtils.get("", String.format("%s:8084/metrics", host), HttpStatus.SC_OK);
 
@@ -144,7 +163,7 @@ public class MetricsTest extends BaseOsgiIntegrationTest {
                     .contains("method=\"POST\"")
                     .contains("module=\"authapi\"")
                     .contains("uri=\"/v1/auth\"")
-                    .contains(String.format("status=\"%d\"", execute.code()))
+                    .contains(String.format("status=\"%d\"", status.intValue()))
                     .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY + "=\"test-value\""));
   }
 


### PR DESCRIPTION
OK I figured out what could be causing the problem.. The call to the `client.newCall(request).execute()` seems not to guarantee that the request has been fully done on the other side:

```
Note that transport-layer success (receiving a HTTP response code, headers and body) does not necessarily indicate application-layer success: response may still indicate an unhappy HTTP response code like 404 or 500.
```

Thus I guess we can end up in the situation where the call is not yet registered in the metrics.. I fixed that by asserting on the status and body, closing the resources as well.

I am sorry I caused trouble in everyone's PRs.