### PR TITLE
Don't get all the candidates if you're only returning a few of them

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -906,14 +906,6 @@ public class DocumentService {
 
     // Either we've reached the end of all rows in the collection, or we have enough rows
     // in memory to build the final result.
-    if (rows == null) {
-      BuiltCondition candidatesPredicate =
-          BuiltCondition.of("key", Predicate.IN, new ArrayList<>(candidates));
-      rows = db.executeSelect(keyspace, collection, ImmutableList.of(candidatesPredicate)).rows();
-      updateExistenceForMap(
-          new HashSet<>(), rows, Collections.emptyList(), db.treatBooleansAsNumeric(), true);
-    }
-
     Set<String> docNames = candidates;
     if (candidates.size() > paginator.docPageSize) {
       docNames = new HashSet<>();
@@ -926,6 +918,14 @@ public class DocumentService {
       paginator.setDocumentPageState(lastSeenId);
     } else {
       paginator.clearDocumentPageState();
+    }
+
+    if (rows == null) {
+      BuiltCondition candidatesPredicate =
+          BuiltCondition.of("key", Predicate.IN, new ArrayList<>(docNames));
+      rows = db.executeSelect(keyspace, collection, ImmutableList.of(candidatesPredicate)).rows();
+      updateExistenceForMap(
+          new HashSet<>(), rows, Collections.emptyList(), db.treatBooleansAsNumeric(), true);
     }
 
     Map<String, List<Row>> rowsByDoc = new HashMap<>();


### PR DESCRIPTION
Fixes https://github.com/stargate/stargate/issues/905

By reversing the order of two crucial steps, I was automatically taking all of the candidates in the filtering process and hydrating them all (via IN query) to get all the document rows out. This means that if in the first C* page there were 300 candidates, and the user requested only page-size of 20, the other 280 documents' rows would be fetched and then immediately discarded.

A summary of the latency measurements before and after:
For a database with 100k documents, ~10 fields each:
pre-changes:
```
[READ], AverageLatency(us), 401343.4944
[READ], MinLatency(us), 164352
[READ], MaxLatency(us), 2215935
[READ], 95thPercentileLatency(us), 491007
[READ], 99thPercentileLatency(us), 559103
```
post-changes:
```
[READ], AverageLatency(us), 114754.9432
[READ], MinLatency(us), 21904
[READ], MaxLatency(us), 720383
[READ], 95thPercentileLatency(us), 155903
[READ], 99thPercentileLatency(us), 190207
```