### PR TITLE
Fix issue with last document not being registered in pagination

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -1033,13 +1033,10 @@ public class DocumentService {
       ArrayList<Row> rowsResult = new ArrayList<>();
       rowsResult.addAll(leftoverRows);
       rowsResult.addAll(page);
+      boolean endOfResult = !paginator.hasDbPageState();
       leftoverRows =
           updateExistenceForMap(
-              existsByDoc,
-              rowsResult,
-              inMemoryFilters,
-              db.treatBooleansAsNumeric(),
-              paginator.hasDbPageState());
+              existsByDoc, rowsResult, inMemoryFilters, db.treatBooleansAsNumeric(), endOfResult);
     } while (existsByDoc.size() <= paginator.docPageSize && paginator.hasDbPageState());
 
     // Either we've reached the end of all rows in the collection, or we have enough rows


### PR DESCRIPTION
During refactor, there was a boolean that got flipped...

To avoid this happening again, I added a small test case that ensures that documents that fit within a page, while using limited support filters, will both get returned.