### PR TITLE
generic constructor for ServiceAndProperties

### DIFF
--- a/core/src/main/java/io/stargate/core/activator/BaseActivator.java
+++ b/core/src/main/java/io/stargate/core/activator/BaseActivator.java
@@ -280,15 +280,15 @@ public abstract class BaseActivator implements BundleActivator {
 
     private final Hashtable<String, String> properties;
 
-    public ServiceAndProperties(
-        Object service, Class<?> targetServiceClass, Hashtable<String, String> properties) {
+    public <T, E extends T> ServiceAndProperties(
+        E service, Class<T> targetServiceClass, Hashtable<String, String> properties) {
       this.service = service;
       this.targetServiceClass = targetServiceClass;
       this.properties = properties;
     }
 
     @SuppressWarnings("JdkObsolete")
-    public ServiceAndProperties(Object service, Class<?> targetServiceClass) {
+    public <T, E extends T> ServiceAndProperties(E service, Class<T> targetServiceClass) {
       this(service, targetServiceClass, new Hashtable<>());
     }
   }

--- a/core/src/main/java/io/stargate/core/activator/BaseActivator.java
+++ b/core/src/main/java/io/stargate/core/activator/BaseActivator.java
@@ -280,15 +280,15 @@ public abstract class BaseActivator implements BundleActivator {
 
     private final Hashtable<String, String> properties;
 
-    public <T, E extends T> ServiceAndProperties(
-        E service, Class<T> targetServiceClass, Hashtable<String, String> properties) {
+    public <T> ServiceAndProperties(
+        T service, Class<? super T> targetServiceClass, Hashtable<String, String> properties) {
       this.service = service;
       this.targetServiceClass = targetServiceClass;
       this.properties = properties;
     }
 
     @SuppressWarnings("JdkObsolete")
-    public <T, E extends T> ServiceAndProperties(E service, Class<T> targetServiceClass) {
+    public <T> ServiceAndProperties(T service, Class<? super T> targetServiceClass) {
       this(service, targetServiceClass, new Hashtable<>());
     }
   }


### PR DESCRIPTION
I was actually able to compile code that supplies to the `ServiceAndProperties` an object that is not instance of a class passed.. Seems that this is allowed, not sure when and how it fails later on, but I think it would be fine to already prevent this in the compile time?