### PR TITLE
Break up searchRows into more reasonable parts

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/Paginator.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/Paginator.java
@@ -1,6 +1,5 @@
 package io.stargate.web.docsapi.dao;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.stargate.db.PagingPosition;
 import io.stargate.db.PagingPosition.ResumeMode;
 import io.stargate.db.datastore.DataStore;
@@ -31,7 +30,8 @@ public class Paginator {
     this.dataStore = dataStore;
     docPageSize = Math.max(1, pageSize);
     if (docPageSize > DocumentDB.MAX_PAGE_SIZE) {
-      throw new DocumentAPIRequestException("The parameter `page-size` is limited to 20.");
+      throw new DocumentAPIRequestException(
+          String.format("The parameter `page-size` is limited to %d.", DocumentDB.MAX_PAGE_SIZE));
     }
 
     this.dbPageSize = dbPageSize;
@@ -47,7 +47,7 @@ public class Paginator {
     this.currentDbPageState = resultSet.getPagingState();
   }
 
-  public String makeExternalPagingState() throws JsonProcessingException {
+  public String makeExternalPagingState() {
     ByteBuffer pagingState;
 
     if (lastDocumentId != null && resultSet != null) {

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
@@ -668,8 +668,8 @@ public class DocumentResourceV2 {
                     pageSizeParam > 0 ? pageSizeParam : docsApiConfiguration.getSearchPageSize());
             DocumentDB db = dbFactory.getDocDataStoreForToken(authToken, getAllHeaders(request));
             JsonNode result =
-                documentService.searchDocumentsV2(
-                    db, namespace, collection, filters, selectionList, id, paginator);
+                documentService.searchWithinDocument(
+                    db, namespace, collection, id, filters, selectionList, paginator);
 
             if (result == null) {
               return Response.noContent().build();

--- a/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
@@ -307,13 +307,13 @@ public class DocumentResourceV2Test {
     mockedReturn.set("someData", BooleanNode.valueOf(true));
 
     Mockito.when(
-            documentServiceMock.searchDocumentsV2(
+            documentServiceMock.searchWithinDocument(
                 anyObject(),
                 anyString(),
                 anyString(),
-                anyList(),
-                anyList(),
                 anyString(),
+                anyList(),
+                anyList(),
                 anyObject()))
         .thenReturn(mockedReturn);
 


### PR DESCRIPTION
Before this change, searchRows was doing far too much - so I broke it up into 3 reasonable parts.

1) getUnfilteredRows - selects the next page from cassandra
2) getRowsForDocument - selects a page of rows for a particular document
3) getCandidateRows - selects rows for the "candidacy filtering" algorithm we use for evaluating search filters with AND

The common parts of these 3 functions were also refactored (most of them have to do with converting data into C* predicates)