### PR TITLE
Standardize use of Paginator limits

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/Paginator.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/Paginator.java
@@ -1,6 +1,5 @@
 package io.stargate.web.docsapi.dao;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.stargate.db.PagingPosition;
 import io.stargate.db.PagingPosition.ResumeMode;
 import io.stargate.db.datastore.DataStore;
@@ -54,7 +53,7 @@ public class Paginator {
     this.currentDbPageState = resultSet.getPagingState();
   }
 
-  public String makeExternalPagingState() throws JsonProcessingException {
+  public String makeExternalPagingState() {
     ByteBuffer pagingState;
 
     if (lastDocumentId != null && resultSet != null) {

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/Paginator.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/Paginator.java
@@ -6,7 +6,6 @@ import io.stargate.db.datastore.DataStore;
 import io.stargate.db.datastore.ResultSet;
 import io.stargate.db.schema.Column;
 import io.stargate.db.schema.Column.Type;
-import io.stargate.web.docsapi.exception.DocumentAPIRequestException;
 import java.nio.ByteBuffer;
 import java.util.Base64;
 
@@ -31,10 +30,6 @@ public class Paginator {
     docPageSize = pageSize;
     if (docPageSize < 1) {
       throw new IllegalStateException("Document page size cannot be less than 1.");
-    }
-
-    if (docPageSize > DocumentDB.MAX_PAGE_SIZE) {
-      throw new DocumentAPIRequestException("The parameter `page-size` is limited to 20.");
     }
 
     this.dbPageSize = dbPageSize;

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/Paginator.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/Paginator.java
@@ -29,12 +29,19 @@ public class Paginator {
 
   public Paginator(DataStore dataStore, String pageState, int pageSize, int dbPageSize) {
     this.dataStore = dataStore;
-    docPageSize = Math.max(1, pageSize);
+    docPageSize = pageSize;
+    if (docPageSize < 1) {
+      throw new IllegalStateException("Document page size cannot be less than 1.");
+    }
+
     if (docPageSize > DocumentDB.MAX_PAGE_SIZE) {
       throw new DocumentAPIRequestException("The parameter `page-size` is limited to 20.");
     }
 
     this.dbPageSize = dbPageSize;
+    if (this.dbPageSize < 1) {
+      throw new IllegalStateException("Database page size cannot be less than 1.");
+    }
 
     if (pageState != null) {
       byte[] decodedBytes = Base64.getDecoder().decode(pageState);

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
@@ -660,12 +660,13 @@ public class DocumentResourceV2 {
             logger.debug(json);
             return Response.ok(json).build();
           } else {
+            int pageSize = Math.max(1, pageSizeParam);
             final Paginator paginator =
                 new Paginator(
                     dbFactory.getDataStore(),
                     pageStateParam,
-                    pageSizeParam,
-                    pageSizeParam > 0 ? pageSizeParam : docsApiConfiguration.getSearchPageSize());
+                    pageSize,
+                    pageSize);
             DocumentDB db = dbFactory.getDocDataStoreForToken(authToken, getAllHeaders(request));
             JsonNode result =
                 documentService.searchDocumentsV2(
@@ -766,14 +767,11 @@ public class DocumentResourceV2 {
               new Paginator(
                   dbFactory.getDataStore(),
                   pageStateParam,
-                  pageSizeParam,
+                  Math.max(1, pageSizeParam),
                   docsApiConfiguration.getSearchPageSize());
 
           JsonNode results;
 
-          if (pageSizeParam > 20) {
-            throw new DocumentAPIRequestException("The parameter `page-size` is limited to 20.");
-          }
           if (filters.isEmpty()) {
             results =
                 documentService.getFullDocuments(

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
@@ -506,7 +506,7 @@ public class DocumentResourceV2 {
           String fields,
       @ApiParam(
               value = "the max number of results to return, if `where` is defined.",
-              defaultValue = "100")
+              defaultValue = "1")
           @QueryParam("page-size")
           int pageSizeParam,
       @ApiParam(
@@ -584,7 +584,7 @@ public class DocumentResourceV2 {
           String fields,
       @ApiParam(
               value = "the max number of results to return, if `where` is defined",
-              defaultValue = "100")
+              defaultValue = "1")
           @QueryParam("page-size")
           int pageSizeParam,
       @ApiParam(
@@ -662,11 +662,7 @@ public class DocumentResourceV2 {
           } else {
             int pageSize = Math.max(1, pageSizeParam);
             final Paginator paginator =
-                new Paginator(
-                    dbFactory.getDataStore(),
-                    pageStateParam,
-                    pageSize,
-                    pageSize);
+                new Paginator(dbFactory.getDataStore(), pageStateParam, pageSize, pageSize);
             DocumentDB db = dbFactory.getDocDataStoreForToken(authToken, getAllHeaders(request));
             JsonNode result =
                 documentService.searchDocumentsV2(

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
@@ -759,12 +759,17 @@ public class DocumentResourceV2 {
 
           DocumentDB db = dbFactory.getDocDataStoreForToken(authToken, getAllHeaders(request));
 
+          int docPageSize = Math.max(1, pageSizeParam);
           final Paginator paginator =
               new Paginator(
                   dbFactory.getDataStore(),
                   pageStateParam,
-                  Math.max(1, pageSizeParam),
+                  docPageSize,
                   docsApiConfiguration.getSearchPageSize());
+
+          if (docPageSize > DocumentDB.MAX_PAGE_SIZE) {
+            throw new DocumentAPIRequestException("The parameter `page-size` is limited to 20.");
+          }
 
           JsonNode results;
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -1084,10 +1084,6 @@ public class DocumentService {
    * Cassandra for any data that matches `path` and then does matching of the selection set and
    * filtering in memory.
    *
-   * <p>A major restriction: if `fields` is non-empty or `filters` includes a filter that has
-   * "limited support" ($nin, $in, $ne), then the result set MUST fit in a single page. A requester
-   * could alter `page-size` up to a limit of 1000 to attempt to achieve this.
-   *
    * @param keyspace the keyspace (document namespace) where the table lives
    * @param collection the table (document collection)
    * @param db the DB utility
@@ -1215,11 +1211,6 @@ public class DocumentService {
           rows.stream()
               .filter(row -> row.getString("key").equals(documentKey))
               .collect(Collectors.toList());
-    }
-
-    if (!inMemoryFilters.isEmpty() && paginator.hasDbPageState()) {
-      throw new DocumentAPIRequestException(
-          "The results as requested must fit in one page, try increasing the `page-size` parameter.");
     }
 
     rows = filterToSelectionSet(rows, fields, path);

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -1346,43 +1346,6 @@ public class DocumentServiceTest {
   }
 
   @Test
-  public void searchRows_invalid() throws UnauthorizedException {
-    DocumentDB dbMock = mock(DocumentDB.class);
-    ResultSet rsMock = mock(ResultSet.class);
-    when(dbMock.executeSelect(anyString(), anyString(), any(), anyBoolean(), anyInt(), any()))
-        .thenReturn(rsMock);
-    when(rsMock.getPagingState()).thenReturn(ByteBuffer.wrap(new byte[0]));
-
-    int pageSizeParam = 1;
-    Paginator paginator =
-        new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
-
-    List<FilterCondition> filters =
-        ImmutableList.of(new SingleFilterCondition(ImmutableList.of("a,b", "*", "c"), "$ne", true));
-
-    Throwable thrown =
-        catchThrowable(
-            () ->
-                searchRows.invoke(
-                    service,
-                    "keyspace",
-                    "collection",
-                    dbMock,
-                    new ArrayList<>(),
-                    filters,
-                    new ArrayList<>(),
-                    ImmutableList.of("a,b", "*", "c"),
-                    null,
-                    null,
-                    paginator));
-
-    assertThat(thrown.getCause())
-        .isInstanceOf(DocumentAPIRequestException.class)
-        .hasMessage(
-            "The results as requested must fit in one page, try increasing the `page-size` parameter.");
-  }
-
-  @Test
   public void getParentPathFromRow() throws InvocationTargetException, IllegalAccessException {
     Row row = makeInitialRowData(false).get(1);
     String result = (String) getParentPathFromRow.invoke(service, row);

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyListOf;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyList;

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -1166,14 +1166,13 @@ public class DocumentServiceTest {
   public void searchDocumentsV2_emptyResult() throws Exception {
     DocumentDB dbMock = Mockito.mock(DocumentDB.class);
     DocumentService serviceMock = Mockito.mock(DocumentService.class);
-    JsonConverter jsonConverterServiceMock = mock(JsonConverter.class, CALLS_REAL_METHODS);
     Mockito.when(serviceMock.searchDocumentsV2(any(), any(), any(), any(), any(), any(), any()))
         .thenCallRealMethod();
     Mockito.when(
             serviceMock.searchRows(
                 any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(new ArrayList<>());
-    int pageSizeParam = 0;
+    int pageSizeParam = 1;
     Paginator paginator =
         new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
 
@@ -1195,7 +1194,7 @@ public class DocumentServiceTest {
     when(dbMock.executeSelect(anyString(), anyString(), any(), anyBoolean(), anyInt(), any()))
         .thenReturn(rsMock);
     when(rsMock.currentPageRows()).thenReturn(rows);
-    int pageSizeParam = 0;
+    int pageSizeParam = 1;
     Paginator paginator =
         new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
 
@@ -1222,7 +1221,7 @@ public class DocumentServiceTest {
     List<FilterCondition> filters =
         ImmutableList.of(
             new SingleFilterCondition(ImmutableList.of("a", "b", "c"), "$exists", true));
-    int pageSizeParam = 0;
+    int pageSizeParam = 1;
     Paginator paginator =
         new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
     JsonNode result =
@@ -1258,7 +1257,7 @@ public class DocumentServiceTest {
     when(rsMock.currentPageRows()).thenReturn(rows);
     Mockito.when(jsonConverter.convertToJsonDoc(anyList(), anyBoolean(), anyBoolean()))
         .thenReturn(mapper.readTree("{\"a\": 1}"));
-    int pageSizeParam = 0;
+    int pageSizeParam = 1;
     Paginator paginator =
         new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
 
@@ -1280,7 +1279,7 @@ public class DocumentServiceTest {
     twoDocsRows.addAll(makeRowDataForSecondDoc(false));
     Mockito.when(jsonConverter.convertToJsonDoc(anyList(), anyBoolean(), anyBoolean()))
         .thenReturn(mapper.readTree("{\"a\": 1}"));
-    int pageSizeParam = 0;
+    int pageSizeParam = 1;
     Paginator paginator =
         new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
 
@@ -1305,7 +1304,7 @@ public class DocumentServiceTest {
     List<FilterCondition> filters =
         ImmutableList.of(new SingleFilterCondition(ImmutableList.of("a,b", "*", "c"), "$eq", true));
 
-    int pageSizeParam = 0;
+    int pageSizeParam = 1;
     Paginator paginator =
         new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
 
@@ -1355,7 +1354,7 @@ public class DocumentServiceTest {
         .thenReturn(rsMock);
     when(rsMock.getPagingState()).thenReturn(ByteBuffer.wrap(new byte[0]));
 
-    int pageSizeParam = 0;
+    int pageSizeParam = 1;
     Paginator paginator =
         new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
 

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -1412,7 +1412,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.food.*.price\": {\"$lte\": 600}}&page-size=20",
+                + "/collections/collection/cool-search-id?where={\"products.food.*.price\": {\"$lte\": 600}}&page-size=100",
             200);
 
     searchResultStr =
@@ -1483,7 +1483,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.electronics.Pixel_3a.price\": {\"$eq\": 600}}&page-size=20&fields=[\"name\", \"price\", \"model\", \"manufacturer\"]",
+                + "/collections/collection/cool-search-id?where={\"products.electronics.Pixel_3a.price\": {\"$eq\": 600}}&page-size=100&fields=[\"name\", \"price\", \"model\", \"manufacturer\"]",
             200);
 
     String searchResultStr =
@@ -1498,7 +1498,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.food.*.price\": {\"$lt\": 600}}&fields=[\"name\", \"price\", \"model\"]&page-size=2&raw=true",
+                + "/collections/collection/cool-search-id?where={\"products.food.*.price\": {\"$lt\": 600}}&fields=[\"name\", \"price\", \"model\"]&page-size=100&raw=true",
             200);
 
     searchResultStr =
@@ -1583,7 +1583,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$ne\": \"3a\"}}&page-size=20",
+                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$ne\": \"3a\"}}&page-size=100",
             200);
 
     String searchResultStr =
@@ -1598,7 +1598,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"quiz.nests.q1.options.[3].this\": {\"$ne\": false}}",
+                + "/collections/collection/cool-search-id?where={\"quiz.nests.q1.options.[3].this\": {\"$ne\": false}}&page-size=100",
             200);
 
     searchResultStr =
@@ -1716,7 +1716,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$in\": [\"11\", \"3a\"]}}&page-size=20",
+                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$in\": [\"11\", \"3a\"]}}&page-size=100",
             200);
 
     String searchResultStr =
@@ -1731,7 +1731,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$in\": [600, 900]}}&page-size=2",
+                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$in\": [600, 900]}}&page-size=100",
             200);
 
     searchResultStr =
@@ -1786,7 +1786,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$nin\": [\"12\"]}}&page-size=20",
+                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$nin\": [\"12\"]}}&page-size=100",
             200);
 
     String searchResultStr =
@@ -1801,7 +1801,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$nin\": [600, 900]}}&page-size=2",
+                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$nin\": [600, 900]}}&page-size=100",
             200);
 
     searchResultStr =
@@ -1856,7 +1856,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$nin\": [\"11\"], \"$gt\": \"\"}}&page-size=20",
+                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$nin\": [\"11\"], \"$gt\": \"\"}}&page-size=100",
             200);
 
     String searchResultStr =
@@ -1871,7 +1871,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$in\": [\"11\", \"3a\"], \"$ne\": \"11\"}}",
+                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$in\": [\"11\", \"3a\"], \"$ne\": \"11\"}}&page-size=100",
             200);
 
     searchResultStr = "[{\"products\": {\"electronics\": { \"Pixel_3a\": {\"model\": \"3a\"}}}}]";
@@ -2077,7 +2077,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"quiz.nests.q1,q2.options.[0]\": {\"$eq\": \"nest\"}}&page-size=2&raw=true",
+                + "/collections/collection/cool-search-id?where={\"quiz.nests.q1,q2.options.[0]\": {\"$eq\": \"nest\"}}&page-size=100&raw=true",
             200);
     searchResultStr =
         "["
@@ -2117,7 +2117,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?page-size=20&where={\"*.value\": {\"$gt\": 0}}",
+                + "/collections/collection/cool-search-id?page-size=100&where={\"*.value\": {\"$gt\": 0}}",
             200);
     JsonNode responseBody1 = objectMapper.readTree(r);
 
@@ -2130,7 +2130,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?page-size=20&where={\"*.value\": {\"$gt\": 0}}&page-state="
+                + "/collections/collection/cool-search-id?page-size=100&where={\"*.value\": {\"$gt\": 0}}&page-state="
                 + URLEncoder.encode(pageState, "UTF-8"),
             200);
     JsonNode responseBody2 = objectMapper.readTree(r);

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -1398,7 +1398,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.food.*.price\": {\"$lt\": 600}}&raw=true",
+                + "/collections/collection/cool-search-id?where={\"products.food.*.price\": {\"$lt\": 600}}&page-size=2&raw=true",
             200);
 
     searchResultStr =
@@ -1412,7 +1412,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.food.*.price\": {\"$lte\": 600}}",
+                + "/collections/collection/cool-search-id?where={\"products.food.*.price\": {\"$lte\": 600}}&page-size=2",
             200);
 
     searchResultStr =
@@ -1440,7 +1440,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.price\": {\"$gte\": 600}}&raw=true",
+                + "/collections/collection/cool-search-id?where={\"products.electronics.*.price\": {\"$gte\": 600}}&page-size=2&raw=true",
             200);
 
     searchResultStr =
@@ -1454,7 +1454,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$exists\": true}}&raw=true",
+                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$exists\": true}}&page-size=4&raw=true",
             200);
     searchResultStr =
         "["
@@ -1498,7 +1498,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.food.*.price\": {\"$lt\": 600}}&fields=[\"name\", \"price\", \"model\"]&raw=true",
+                + "/collections/collection/cool-search-id?where={\"products.food.*.price\": {\"$lt\": 600}}&fields=[\"name\", \"price\", \"model\"]&page-size=2&raw=true",
             200);
 
     searchResultStr =
@@ -1512,7 +1512,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.food.*.price\": {\"$lte\": 600}}&fields=[\"price\", \"sku\"]",
+                + "/collections/collection/cool-search-id?where={\"products.food.*.price\": {\"$lte\": 600}}&page-size=2&fields=[\"price\", \"sku\"]",
             200);
 
     searchResultStr =
@@ -1540,7 +1540,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.price\": {\"$gte\": 600}}&fields=[\"price\"]&raw=true",
+                + "/collections/collection/cool-search-id?where={\"products.electronics.*.price\": {\"$gte\": 600}}&page-size=2&fields=[\"price\"]&raw=true",
             200);
 
     searchResultStr =
@@ -1554,7 +1554,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$exists\": true}}&fields=[\"price\", \"name\", \"manufacturer\", \"model\", \"sku\"]&raw=true",
+                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$exists\": true}}&page-size=4&fields=[\"price\", \"name\", \"manufacturer\", \"model\", \"sku\"]&raw=true",
             200);
     searchResultStr =
         "["
@@ -1716,7 +1716,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$in\": [\"11\", \"3a\"]}}",
+                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$in\": [\"11\", \"3a\"]}}&page-size=2",
             200);
 
     String searchResultStr =
@@ -1731,7 +1731,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$in\": [600, 900]}}",
+                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$in\": [600, 900]}}&page-size=2",
             200);
 
     searchResultStr =
@@ -1746,7 +1746,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$in\": [0.99, 0.89]}}",
+                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$in\": [0.99, 0.89]}}&page-size=2",
             200);
 
     searchResultStr =
@@ -1786,7 +1786,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$nin\": [\"12\"]}}",
+                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$nin\": [\"12\"]}}&page-size=2",
             200);
 
     String searchResultStr =
@@ -1801,7 +1801,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$nin\": [600, 900]}}",
+                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$nin\": [600, 900]}}&page-size=2",
             200);
 
     searchResultStr =
@@ -1816,7 +1816,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$nin\": [0.99, 0.89]}}",
+                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$nin\": [0.99, 0.89]}}&page-size=2",
             200);
 
     searchResultStr =
@@ -2077,7 +2077,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"quiz.nests.q1,q2.options.[0]\": {\"$eq\": \"nest\"}}&raw=true",
+                + "/collections/collection/cool-search-id?where={\"quiz.nests.q1,q2.options.[0]\": {\"$eq\": \"nest\"}}&page-size=2&raw=true",
             200);
     searchResultStr =
         "["

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -1375,7 +1375,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.electronics.Pixel_3a.price\": {\"$eq\": 600}}",
+                + "/collections/collection/cool-search-id?where={\"products.electronics.Pixel_3a.price\": {\"$eq\": 600}}&page-size=2",
             200);
 
     String searchResultStr =
@@ -1412,7 +1412,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.food.*.price\": {\"$lte\": 600}}&page-size=2",
+                + "/collections/collection/cool-search-id?where={\"products.food.*.price\": {\"$lte\": 600}}&page-size=20",
             200);
 
     searchResultStr =
@@ -1483,7 +1483,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.electronics.Pixel_3a.price\": {\"$eq\": 600}}&fields=[\"name\", \"price\", \"model\", \"manufacturer\"]",
+                + "/collections/collection/cool-search-id?where={\"products.electronics.Pixel_3a.price\": {\"$eq\": 600}}&page-size=20&fields=[\"name\", \"price\", \"model\", \"manufacturer\"]",
             200);
 
     String searchResultStr =
@@ -1583,7 +1583,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$ne\": \"3a\"}}",
+                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$ne\": \"3a\"}}&page-size=20",
             200);
 
     String searchResultStr =
@@ -1716,7 +1716,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$in\": [\"11\", \"3a\"]}}&page-size=2",
+                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$in\": [\"11\", \"3a\"]}}&page-size=20",
             200);
 
     String searchResultStr =
@@ -1786,7 +1786,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$nin\": [\"12\"]}}&page-size=2",
+                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$nin\": [\"12\"]}}&page-size=20",
             200);
 
     String searchResultStr =
@@ -1856,7 +1856,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$nin\": [\"11\"], \"$gt\": \"\"}}",
+                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$nin\": [\"11\"], \"$gt\": \"\"}}&page-size=20",
             200);
 
     String searchResultStr =
@@ -2751,29 +2751,6 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(r)
         .isEqualTo(
             "{\"description\":\"Bad request: The parameter `page-size` is limited to 20.\",\"code\":400}");
-  }
-
-  @Test
-  public void testPaginationDisallowedLimitedSupport() throws IOException {
-    JsonNode doc1 =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("longSearch.json"));
-    RestUtils.put(
-        authToken,
-        hostWithPort + "/v2/namespaces/" + keyspace + "/collections/collection/1",
-        doc1.toString(),
-        200);
-
-    String r =
-        RestUtils.get(
-            authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + keyspace
-                + "/collections/collection/1?where={\"*.value\":{\"$nin\": [3]}}&page-size=5",
-            400);
-    assertThat(r)
-        .isEqualTo(
-            "{\"description\":\"Bad request: The results as requested must fit in one page, try increasing the `page-size` parameter.\",\"code\":400}");
   }
 
   // Below are "namespace" tests that should match the REST Api's keyspace tests


### PR DESCRIPTION
The "search within a document" functionality now properly honors the page-size default of 1. That default could change in the future, but is now shared with the "search across collections" functionality.

Note that In order to do this, the db page size actually had to be set to be equal to the doc page size when performing search within a document.  This is so that no rows are discarded in memory after querying and the pagination state is maintained properly.