### PR TITLE
Add checks for document table validity before querying

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -284,8 +284,13 @@ public class DocumentDB {
    * @param tableName The name of the table.
    */
   public boolean isDocumentsTable(String keyspaceName, String tableName) {
-    List<Column> columns = dataStore.schema().keyspace(keyspaceName).table(tableName).columns();
-    return columns.stream().allMatch(column -> allColumnNames.contains(column.name()));
+    List<String> columnNames =
+        dataStore.schema().keyspace(keyspaceName).table(tableName).columns().stream()
+            .map(Column::name)
+            .collect(Collectors.toList());
+    if (columnNames.size() != allColumnNames.size()) return false;
+    columnNames.removeAll(allColumnNames);
+    return columnNames.isEmpty();
   }
 
   private void createDefaultIndexes(String keyspaceName, String tableName)

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -274,6 +274,20 @@ public class DocumentDB {
     }
   }
 
+  /**
+   * Checks that a table in a particular keyspace has the schema of a Documents collection. This is
+   * done by checking that the table has all of the columns required.
+   *
+   * <p>Does not check that the table and keyspace exist.
+   *
+   * @param keyspaceName The name of the keyspace.
+   * @param tableName The name of the table.
+   */
+  public boolean isDocumentsTable(String keyspaceName, String tableName) {
+    List<Column> columns = dataStore.schema().keyspace(keyspaceName).table(tableName).columns();
+    return columns.stream().allMatch(column -> allColumnNames.contains(column.name()));
+  }
+
   private void createDefaultIndexes(String keyspaceName, String tableName)
       throws InterruptedException, ExecutionException {
     for (String name : VALUE_COLUMN_NAMES) {

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -23,6 +23,7 @@ import io.stargate.db.schema.Column;
 import io.stargate.db.schema.Column.Kind;
 import io.stargate.db.schema.Column.Type;
 import io.stargate.db.schema.Keyspace;
+import io.stargate.db.schema.Table;
 import io.stargate.web.docsapi.exception.ErrorCode;
 import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
 import io.stargate.web.docsapi.service.json.DeadLeaf;
@@ -291,6 +292,22 @@ public class DocumentDB {
     if (columnNames.size() != allColumnNames.size()) return false;
     columnNames.removeAll(allColumnNames);
     return columnNames.isEmpty();
+  }
+
+  public void tableExists(String keyspaceName, String tableName) {
+    Keyspace keyspace = dataStore.schema().keyspace(keyspaceName);
+
+    if (null == keyspace) {
+      throw new ErrorCodeRuntimeException(
+          ErrorCode.DATASTORE_KEYSPACE_DOES_NOT_EXIST,
+          String.format("Namespace %s does not exist.", keyspaceName));
+    }
+    Table table = keyspace.table(tableName);
+    if (null == table) {
+      throw new ErrorCodeRuntimeException(
+          ErrorCode.DATASTORE_TABLE_DOES_NOT_EXIST,
+          String.format("Collection %s does not exist.", tableName));
+    }
   }
 
   private void createDefaultIndexes(String keyspaceName, String tableName)

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -23,6 +23,7 @@ import io.stargate.db.schema.Column;
 import io.stargate.db.schema.Column.Kind;
 import io.stargate.db.schema.Column.Type;
 import io.stargate.db.schema.Keyspace;
+import io.stargate.db.schema.Schema;
 import io.stargate.db.schema.Table;
 import io.stargate.web.docsapi.exception.ErrorCode;
 import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
@@ -158,6 +159,10 @@ public class DocumentDB {
 
   public QueryBuilder builder() {
     return dataStore.queryBuilder();
+  }
+
+  public Schema schema() {
+    return dataStore.schema();
   }
 
   /**

--- a/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
@@ -37,7 +37,7 @@ public enum ErrorCode {
   /** Document API. */
   DOCS_API_TABLE_NOT_A_COLLECTION(
       Response.Status.BAD_REQUEST,
-      "The requested Cassandra table is not a Documents API Collection."),
+      "The requested database table is not a Documents API Collection."),
   DOCS_API_GENERAL_ARRAY_LENGTH_EXCEEDED(
       Response.Status.BAD_REQUEST,
       String.format(

--- a/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
@@ -35,6 +35,9 @@ public enum ErrorCode {
       "The table name contains invalid characters. Valid characters are alphanumeric and underscores."),
 
   /** Document API. */
+  DOCS_API_TABLE_NOT_A_COLLECTION(
+      Response.Status.BAD_REQUEST,
+      "The requested Cassandra table is not a Documents API Collection."),
   DOCS_API_GENERAL_ARRAY_LENGTH_EXCEEDED(
       Response.Status.BAD_REQUEST,
       String.format(

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
@@ -655,7 +655,6 @@ public class DocumentResourceV2 {
                     pageStateParam,
                     pageSizeParam,
                     pageSizeParam > 0 ? pageSizeParam : docsApiConfiguration.getSearchPageSize());
-            db = dbFactory.getDocDataStoreForToken(authToken, getAllHeaders(request));
             JsonNode result =
                 documentService.searchDocumentsV2(
                     db, namespace, collection, filters, selectionList, id, paginator);

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
@@ -6,8 +6,6 @@ import com.datastax.oss.driver.api.core.NoNodeAvailableException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.stargate.auth.UnauthorizedException;
-import io.stargate.db.schema.Keyspace;
-import io.stargate.db.schema.Table;
 import io.stargate.web.docsapi.dao.DocumentDB;
 import io.stargate.web.docsapi.dao.Paginator;
 import io.stargate.web.docsapi.examples.WriteDocResponse;
@@ -15,10 +13,10 @@ import io.stargate.web.docsapi.exception.ErrorCode;
 import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
 import io.stargate.web.docsapi.models.DocumentResponseWrapper;
 import io.stargate.web.docsapi.service.DocsApiConfiguration;
+import io.stargate.web.docsapi.service.DocsSchemaChecker;
 import io.stargate.web.docsapi.service.DocumentService;
 import io.stargate.web.docsapi.service.filter.FilterCondition;
 import io.stargate.web.models.Error;
-import io.stargate.web.resources.AuthenticatedDB;
 import io.stargate.web.resources.Db;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -65,6 +63,7 @@ public class DocumentResourceV2 {
   @Inject private ObjectMapper mapper;
   @Inject private DocumentService documentService;
   @Inject private DocsApiConfiguration docsApiConfiguration;
+  @Inject private DocsSchemaChecker schemaChecker;
 
   @POST
   @ManagedAsync
@@ -630,23 +629,11 @@ public class DocumentResourceV2 {
           }
 
           // check first that namespace and table exist
-          AuthenticatedDB authenticatedDB = dbFactory.getDataStoreForToken(authToken, allHeaders);
-          Keyspace keyspace = authenticatedDB.getKeyspace(namespace);
-          if (null == keyspace) {
-            String message = String.format("Namespace %s does not exist.", namespace);
-            throw new ErrorCodeRuntimeException(
-                ErrorCode.DATASTORE_KEYSPACE_DOES_NOT_EXIST, message);
-          }
-          Table table = keyspace.table(collection);
-          if (null == table) {
-            String message = String.format("Collection %s does not exist.", collection);
-            throw new ErrorCodeRuntimeException(ErrorCode.DATASTORE_TABLE_DOES_NOT_EXIST, message);
-          }
+          DocumentDB db = dbFactory.getDocDataStoreForToken(authToken, allHeaders);
+          schemaChecker.checkValidity(namespace, collection, db);
 
           JsonNode node;
           if (filters.isEmpty()) {
-
-            DocumentDB db = dbFactory.getDocDataStoreForToken(authToken, allHeaders);
             node = documentService.getJsonAtPath(db, namespace, collection, id, path);
             if (node == null) {
               return Response.noContent().build();
@@ -668,7 +655,7 @@ public class DocumentResourceV2 {
                     pageStateParam,
                     pageSizeParam,
                     pageSizeParam > 0 ? pageSizeParam : docsApiConfiguration.getSearchPageSize());
-            DocumentDB db = dbFactory.getDocDataStoreForToken(authToken, getAllHeaders(request));
+            db = dbFactory.getDocDataStoreForToken(authToken, getAllHeaders(request));
             JsonNode result =
                 documentService.searchDocumentsV2(
                     db, namespace, collection, filters, selectionList, id, paginator);
@@ -763,6 +750,7 @@ public class DocumentResourceV2 {
           }
 
           DocumentDB db = dbFactory.getDocDataStoreForToken(authToken, getAllHeaders(request));
+          schemaChecker.checkValidity(namespace, collection, db);
 
           final Paginator paginator =
               new Paginator(

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocsApiComponentsBinder.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocsApiComponentsBinder.java
@@ -13,9 +13,11 @@ public class DocsApiComponentsBinder extends AbstractBinder {
   protected void configure() {
     DocsApiConfiguration conf = DocsApiConfiguration.DEFAULT;
     JsonConverter jsonConverter = new JsonConverter(environment.getObjectMapper(), conf);
+    DocsSchemaChecker schemaChecker = new DocsSchemaChecker();
     bind(conf).to(DocsApiConfiguration.class);
     bind(jsonConverter).to(JsonConverter.class);
-    bind(new DocumentService(environment.getObjectMapper(), jsonConverter, conf))
+    bind(schemaChecker).to(DocsSchemaChecker.class);
+    bind(new DocumentService(environment.getObjectMapper(), jsonConverter, conf, schemaChecker))
         .to(DocumentService.class);
   }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocsSchemaChecker.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocsSchemaChecker.java
@@ -1,60 +1,41 @@
 package io.stargate.web.docsapi.service;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+import io.stargate.db.schema.Schema;
 import io.stargate.web.docsapi.dao.DocumentDB;
 import io.stargate.web.docsapi.exception.ErrorCode;
 import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
-import java.util.Objects;
+import io.stargate.web.docsapi.service.util.ImmutableKeyspaceAndTable;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A helper class for checking that particular keyspace/table combinations exist and are valid
  * document API collections.
  */
 public class DocsSchemaChecker {
-  public static class KeyspaceAndTable {
-    private String keyspace;
-    private String table;
+  private Schema lastCheckedSchema;
 
-    public KeyspaceAndTable(String keyspace, String table) {
-      this.keyspace = keyspace;
-      this.table = table;
+  private final ConcurrentHashMap<ImmutableKeyspaceAndTable, Boolean> validatedDocCollections =
+      new ConcurrentHashMap<>();
+
+  private void clearCacheOnSchemaChange(DocumentDB db) {
+    if (!db.schema().equals(lastCheckedSchema)) {
+      validatedDocCollections.clear();
+      this.lastCheckedSchema = db.schema();
     }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      KeyspaceAndTable that = (KeyspaceAndTable) o;
-      return keyspace.equals(that.keyspace) && table.equals(that.table);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(keyspace, table);
-    }
-  }
-
-  private final Cache<KeyspaceAndTable, Boolean> validatedDocCollections =
-      Caffeine.newBuilder().maximumSize(10_000).build();
-
-  public void checkTableExists(String keyspace, String table, DocumentDB db) {
-    db.tableExists(keyspace, table);
-  }
-
-  public boolean isDocumentsTable(String keyspace, String table, DocumentDB db) {
-    KeyspaceAndTable keyspaceAndTable = new KeyspaceAndTable(keyspace, table);
-    Boolean valid = validatedDocCollections.getIfPresent(keyspaceAndTable);
-    if (valid == null) {
-      valid = db.isDocumentsTable(keyspace, table);
-      validatedDocCollections.put(keyspaceAndTable, valid);
-    }
-    return valid;
   }
 
   public void checkValidity(String keyspace, String table, DocumentDB db) {
-    checkTableExists(keyspace, table, db);
-    boolean isDocsTable = isDocumentsTable(keyspace, table, db);
+    ImmutableKeyspaceAndTable keyspaceAndTable =
+        ImmutableKeyspaceAndTable.builder().keyspace(keyspace).table(table).build();
+    clearCacheOnSchemaChange(db);
+    validatedDocCollections.computeIfAbsent(keyspaceAndTable, ks -> performValidityCheck(ks, db));
+  }
+
+  private boolean performValidityCheck(ImmutableKeyspaceAndTable keyspaceAndTable, DocumentDB db) {
+    String keyspace = keyspaceAndTable.getKeyspace();
+    String table = keyspaceAndTable.getTable();
+    db.tableExists(keyspace, table);
+    boolean isDocsTable = db.isDocumentsTable(keyspace, table);
     if (!isDocsTable) {
       throw new ErrorCodeRuntimeException(
           ErrorCode.DOCS_API_TABLE_NOT_A_COLLECTION,
@@ -62,5 +43,6 @@ public class DocsSchemaChecker {
               "The Cassandra table %s.%s is not a Documents collection. Accessing arbitrary tables via the Documents API is not permitted.",
               keyspace, table));
     }
+    return true;
   }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocsSchemaChecker.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocsSchemaChecker.java
@@ -40,7 +40,7 @@ public class DocsSchemaChecker {
       throw new ErrorCodeRuntimeException(
           ErrorCode.DOCS_API_TABLE_NOT_A_COLLECTION,
           String.format(
-              "The Cassandra table %s.%s is not a Documents collection. Accessing arbitrary tables via the Documents API is not permitted.",
+              "The database table %s.%s is not a Documents collection. Accessing arbitrary tables via the Documents API is not permitted.",
               keyspace, table));
     }
     return true;

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocsSchemaChecker.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocsSchemaChecker.java
@@ -1,0 +1,66 @@
+package io.stargate.web.docsapi.service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.stargate.web.docsapi.dao.DocumentDB;
+import io.stargate.web.docsapi.exception.ErrorCode;
+import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
+import java.util.Objects;
+
+/**
+ * A helper class for checking that particular keyspace/table combinations exist and are valid
+ * document API collections.
+ */
+public class DocsSchemaChecker {
+  public static class KeyspaceAndTable {
+    private String keyspace;
+    private String table;
+
+    public KeyspaceAndTable(String keyspace, String table) {
+      this.keyspace = keyspace;
+      this.table = table;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      KeyspaceAndTable that = (KeyspaceAndTable) o;
+      return keyspace.equals(that.keyspace) && table.equals(that.table);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(keyspace, table);
+    }
+  }
+
+  private final Cache<KeyspaceAndTable, Boolean> validatedDocCollections =
+      Caffeine.newBuilder().maximumSize(10_000).build();
+
+  public void checkTableExists(String keyspace, String table, DocumentDB db) {
+    db.tableExists(keyspace, table);
+  }
+
+  public boolean isDocumentsTable(String keyspace, String table, DocumentDB db) {
+    KeyspaceAndTable keyspaceAndTable = new KeyspaceAndTable(keyspace, table);
+    Boolean valid = validatedDocCollections.getIfPresent(keyspaceAndTable);
+    if (valid == null) {
+      valid = db.isDocumentsTable(keyspace, table);
+      validatedDocCollections.put(keyspaceAndTable, valid);
+    }
+    return valid;
+  }
+
+  public void checkValidity(String keyspace, String table, DocumentDB db) {
+    checkTableExists(keyspace, table, db);
+    boolean isDocsTable = isDocumentsTable(keyspace, table, db);
+    if (!isDocsTable) {
+      throw new ErrorCodeRuntimeException(
+          ErrorCode.DOCS_API_TABLE_NOT_A_COLLECTION,
+          String.format(
+              "The Cassandra table %s.%s is not a Documents collection. Accessing arbitrary tables via the Documents API is not permitted.",
+              keyspace, table));
+    }
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/util/KeyspaceAndTable.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/util/KeyspaceAndTable.java
@@ -1,0 +1,10 @@
+package io.stargate.web.docsapi.service.util;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface KeyspaceAndTable {
+  String getKeyspace();
+
+  String getTable();
+}

--- a/restapi/src/main/java/io/stargate/web/impl/Server.java
+++ b/restapi/src/main/java/io/stargate/web/impl/Server.java
@@ -147,7 +147,6 @@ public class Server extends Application<ApplicationConfiguration> {
     // Documents API
     environment.jersey().register(new DocsApiComponentsBinder(environment));
     environment.jersey().register(DocumentResourceV2.class);
-
     environment.jersey().register(CollectionsResource.class);
     environment.jersey().register(NamespacesResource.class);
 

--- a/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
@@ -15,9 +15,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.collect.ImmutableList;
 import io.stargate.auth.UnauthorizedException;
-import io.stargate.db.schema.Keyspace;
-import io.stargate.db.schema.Table;
 import io.stargate.web.docsapi.service.DocsApiConfiguration;
+import io.stargate.web.docsapi.service.DocsSchemaChecker;
 import io.stargate.web.docsapi.service.DocumentService;
 import io.stargate.web.docsapi.service.filter.FilterCondition;
 import io.stargate.web.docsapi.service.filter.SingleFilterCondition;
@@ -45,6 +44,7 @@ public class DocumentResourceV2Test {
   @InjectMocks private DocumentResourceV2 documentResourceV2;
   @Mock private DocumentService documentServiceMock;
   @Mock private Db dbFactoryMock;
+  @Mock private DocsSchemaChecker schemaCheckerMock;
   @Spy private ObjectMapper mapper = new ObjectMapper();
   @Spy private DocsApiConfiguration conf;
   private HttpServletRequest httpServletRequest;
@@ -210,13 +210,6 @@ public class DocumentResourceV2Test {
                 anyObject(), anyString(), anyString(), anyString(), anyObject()))
         .thenReturn(mockedReturn);
 
-    Keyspace keyspaceMock = mock(Keyspace.class);
-    Table tableMock = mock(Table.class);
-    when(dbFactoryMock.getDataStoreForToken(Mockito.eq(authToken), anyObject()))
-        .thenReturn(authenticatedDBMock);
-    when(authenticatedDBMock.getKeyspace(keyspace)).thenReturn(keyspaceMock);
-    when(keyspaceMock.table(collection)).thenReturn(tableMock);
-
     Response r =
         documentResourceV2.getDoc(
             headers,
@@ -237,9 +230,7 @@ public class DocumentResourceV2Test {
   }
 
   @Test
-  public void getDocPath_rawTrue()
-      throws ExecutionException, InterruptedException, JsonProcessingException,
-          UnauthorizedException {
+  public void getDocPath_rawTrue() throws JsonProcessingException, UnauthorizedException {
     HttpHeaders headers = mock(HttpHeaders.class);
     UriInfo ui = mock(UriInfo.class);
     String authToken = "auth_token";
@@ -259,13 +250,6 @@ public class DocumentResourceV2Test {
             documentServiceMock.getJsonAtPath(
                 anyObject(), anyString(), anyString(), anyString(), anyObject()))
         .thenReturn(mockedReturn);
-
-    Keyspace keyspaceMock = mock(Keyspace.class);
-    Table tableMock = mock(Table.class);
-    when(dbFactoryMock.getDataStoreForToken(Mockito.eq(authToken), anyObject()))
-        .thenReturn(authenticatedDBMock);
-    when(authenticatedDBMock.getKeyspace(keyspace)).thenReturn(keyspaceMock);
-    when(keyspaceMock.table(collection)).thenReturn(tableMock);
 
     Response r =
         documentResourceV2.getDocPath(
@@ -288,9 +272,7 @@ public class DocumentResourceV2Test {
   }
 
   @Test
-  public void getDocPath_whereAndFields()
-      throws ExecutionException, InterruptedException, JsonProcessingException,
-          UnauthorizedException {
+  public void getDocPath_whereAndFields() throws JsonProcessingException, UnauthorizedException {
     HttpHeaders headers = mock(HttpHeaders.class);
     UriInfo ui = mock(UriInfo.class);
     String authToken = "auth_token";
@@ -322,13 +304,6 @@ public class DocumentResourceV2Test {
 
     Mockito.when(documentServiceMock.convertToSelectionList(anyObject())).thenCallRealMethod();
 
-    Keyspace keyspaceMock = mock(Keyspace.class);
-    Table tableMock = mock(Table.class);
-    when(dbFactoryMock.getDataStoreForToken(Mockito.eq(authToken), anyObject()))
-        .thenReturn(authenticatedDBMock);
-    when(authenticatedDBMock.getKeyspace(keyspace)).thenReturn(keyspaceMock);
-    when(keyspaceMock.table(collection)).thenReturn(tableMock);
-
     Response r =
         documentResourceV2.getDocPath(
             headers,
@@ -350,9 +325,7 @@ public class DocumentResourceV2Test {
   }
 
   @Test
-  public void getDocPath_rawFalse()
-      throws ExecutionException, InterruptedException, JsonProcessingException,
-          UnauthorizedException {
+  public void getDocPath_rawFalse() throws JsonProcessingException, UnauthorizedException {
     HttpHeaders headers = mock(HttpHeaders.class);
     UriInfo ui = mock(UriInfo.class);
     String authToken = "auth_token";
@@ -372,13 +345,6 @@ public class DocumentResourceV2Test {
             documentServiceMock.getJsonAtPath(
                 anyObject(), anyString(), anyString(), anyString(), anyObject()))
         .thenReturn(mockedReturn);
-
-    Keyspace keyspaceMock = mock(Keyspace.class);
-    Table tableMock = mock(Table.class);
-    when(dbFactoryMock.getDataStoreForToken(Mockito.eq(authToken), anyObject()))
-        .thenReturn(authenticatedDBMock);
-    when(authenticatedDBMock.getKeyspace(keyspace)).thenReturn(keyspaceMock);
-    when(keyspaceMock.table(collection)).thenReturn(tableMock);
 
     Response r =
         documentResourceV2.getDocPath(
@@ -404,8 +370,7 @@ public class DocumentResourceV2Test {
   }
 
   @Test
-  public void getDocPath_emptyResult()
-      throws ExecutionException, InterruptedException, UnauthorizedException {
+  public void getDocPath_emptyResult() throws UnauthorizedException {
     HttpHeaders headers = mock(HttpHeaders.class);
     UriInfo ui = mock(UriInfo.class);
     String authToken = "auth_token";
@@ -422,13 +387,6 @@ public class DocumentResourceV2Test {
             documentServiceMock.getJsonAtPath(
                 anyObject(), anyString(), anyString(), anyString(), anyObject()))
         .thenReturn(null);
-
-    Keyspace keyspaceMock = mock(Keyspace.class);
-    Table tableMock = mock(Table.class);
-    when(dbFactoryMock.getDataStoreForToken(Mockito.eq(authToken), anyObject()))
-        .thenReturn(authenticatedDBMock);
-    when(authenticatedDBMock.getKeyspace(keyspace)).thenReturn(keyspaceMock);
-    when(keyspaceMock.table(collection)).thenReturn(tableMock);
 
     Response r =
         documentResourceV2.getDocPath(

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyListOf;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyList;
@@ -926,6 +925,7 @@ public class DocumentServiceTest {
     Db dbFactoryMock = mock(Db.class);
     when(dbFactoryMock.getDocDataStoreForToken(anyString(), any())).thenReturn(dbMock);
     when(dbMock.newBindMap(any())).thenCallRealMethod();
+    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
 
     service.putAtPath(
         "authToken",
@@ -952,6 +952,7 @@ public class DocumentServiceTest {
     Db dbFactoryMock = mock(Db.class);
     when(dbFactoryMock.getDocDataStoreForToken(anyString(), any())).thenReturn(dbMock);
     when(dbMock.newBindMap(any())).thenCallRealMethod();
+    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
 
     service.putAtPath(
         "authToken",
@@ -977,6 +978,7 @@ public class DocumentServiceTest {
     DocumentDB dbMock = mock(DocumentDB.class);
     Db dbFactoryMock = mock(Db.class);
     when(dbFactoryMock.getDocDataStoreForToken(anyString(), any())).thenReturn(dbMock);
+    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
 
     Throwable thrown =
         catchThrowable(
@@ -1006,6 +1008,7 @@ public class DocumentServiceTest {
     ResultSet rsMock = mock(ResultSet.class);
     when(dbMock.executeSelect(anyString(), anyString(), anyListOf(BuiltCondition.class)))
         .thenReturn(rsMock);
+    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
     when(rsMock.rows()).thenReturn(new ArrayList<>());
 
     List<PathSegment> path = smallPath();
@@ -1020,6 +1023,7 @@ public class DocumentServiceTest {
     ResultSet rsMock = mock(ResultSet.class);
     when(dbMock.executeSelect(anyString(), anyString(), anyListOf(BuiltCondition.class)))
         .thenReturn(rsMock);
+    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
 
     List<Row> rows = makeInitialRowData(false);
     when(rsMock.rows()).thenReturn(rows);
@@ -1040,6 +1044,7 @@ public class DocumentServiceTest {
     ResultSet rsMock = mock(ResultSet.class);
     when(dbMock.executeSelect(anyString(), anyString(), anyListOf(BuiltCondition.class)))
         .thenReturn(rsMock);
+    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
 
     List<Row> rows = makeInitialRowData(false);
     when(rsMock.rows()).thenReturn(rows);
@@ -1181,7 +1186,7 @@ public class DocumentServiceTest {
   public void searchDocumentsV2_emptyResult() throws Exception {
     DocumentDB dbMock = Mockito.mock(DocumentDB.class);
     DocumentService serviceMock = Mockito.mock(DocumentService.class);
-    JsonConverter jsonConverterServiceMock = mock(JsonConverter.class, CALLS_REAL_METHODS);
+    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
     Mockito.when(serviceMock.searchDocumentsV2(any(), any(), any(), any(), any(), any(), any()))
         .thenCallRealMethod();
     Mockito.when(
@@ -1209,6 +1214,7 @@ public class DocumentServiceTest {
     List<Row> rows = makeInitialRowData(false);
     when(dbMock.executeSelect(anyString(), anyString(), any(), anyBoolean(), anyInt(), any()))
         .thenReturn(rsMock);
+    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
     when(rsMock.currentPageRows()).thenReturn(rows);
     int pageSizeParam = 0;
     Paginator paginator =
@@ -1232,6 +1238,7 @@ public class DocumentServiceTest {
     List<Row> rows = makeInitialRowData(false);
     when(dbMock.executeSelect(anyString(), anyString(), any(), anyBoolean(), anyInt(), any()))
         .thenReturn(rsMock);
+    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
     when(rsMock.currentPageRows()).thenReturn(rows);
 
     List<FilterCondition> filters =
@@ -1270,6 +1277,7 @@ public class DocumentServiceTest {
     ResultSet rsMock = mock(ResultSet.class);
     List<Row> rows = makeInitialRowData(false);
     when(dbMock.executeSelectAll(anyString(), anyString(), anyInt(), any())).thenReturn(rsMock);
+    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
     when(rsMock.currentPageRows()).thenReturn(rows);
     Mockito.when(jsonConverter.convertToJsonDoc(anyList(), anyBoolean(), anyBoolean()))
         .thenReturn(mapper.readTree("{\"a\": 1}"));
@@ -1290,6 +1298,7 @@ public class DocumentServiceTest {
     ResultSet rsMock = mock(ResultSet.class);
     List<Row> rows = makeInitialRowData(false);
     when(dbMock.executeSelectAll(anyString(), anyString(), anyInt(), any())).thenReturn(rsMock);
+    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
     when(rsMock.currentPageRows()).thenReturn(rows);
     List<Row> twoDocsRows = makeInitialRowData(false);
     twoDocsRows.addAll(makeRowDataForSecondDoc(false));

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -68,6 +68,7 @@ public class DocumentServiceTest {
   private final DataStore dataStore = Mockito.mock(DataStore.class);
   @InjectMocks DocumentService service;
   @Mock JsonConverter jsonConverter;
+  @Mock DocsSchemaChecker schemaChecker;
   @Spy ObjectMapper serviceMapper;
   @Spy DocsApiConfiguration docsConfig;
 
@@ -925,7 +926,6 @@ public class DocumentServiceTest {
     Db dbFactoryMock = mock(Db.class);
     when(dbFactoryMock.getDocDataStoreForToken(anyString(), any())).thenReturn(dbMock);
     when(dbMock.newBindMap(any())).thenCallRealMethod();
-    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
 
     service.putAtPath(
         "authToken",
@@ -952,7 +952,6 @@ public class DocumentServiceTest {
     Db dbFactoryMock = mock(Db.class);
     when(dbFactoryMock.getDocDataStoreForToken(anyString(), any())).thenReturn(dbMock);
     when(dbMock.newBindMap(any())).thenCallRealMethod();
-    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
 
     service.putAtPath(
         "authToken",
@@ -978,7 +977,6 @@ public class DocumentServiceTest {
     DocumentDB dbMock = mock(DocumentDB.class);
     Db dbFactoryMock = mock(Db.class);
     when(dbFactoryMock.getDocDataStoreForToken(anyString(), any())).thenReturn(dbMock);
-    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
 
     Throwable thrown =
         catchThrowable(
@@ -1008,7 +1006,6 @@ public class DocumentServiceTest {
     ResultSet rsMock = mock(ResultSet.class);
     when(dbMock.executeSelect(anyString(), anyString(), anyListOf(BuiltCondition.class)))
         .thenReturn(rsMock);
-    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
     when(rsMock.rows()).thenReturn(new ArrayList<>());
 
     List<PathSegment> path = smallPath();
@@ -1023,7 +1020,6 @@ public class DocumentServiceTest {
     ResultSet rsMock = mock(ResultSet.class);
     when(dbMock.executeSelect(anyString(), anyString(), anyListOf(BuiltCondition.class)))
         .thenReturn(rsMock);
-    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
 
     List<Row> rows = makeInitialRowData(false);
     when(rsMock.rows()).thenReturn(rows);
@@ -1044,7 +1040,6 @@ public class DocumentServiceTest {
     ResultSet rsMock = mock(ResultSet.class);
     when(dbMock.executeSelect(anyString(), anyString(), anyListOf(BuiltCondition.class)))
         .thenReturn(rsMock);
-    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
 
     List<Row> rows = makeInitialRowData(false);
     when(rsMock.rows()).thenReturn(rows);
@@ -1186,7 +1181,6 @@ public class DocumentServiceTest {
   public void searchDocumentsV2_emptyResult() throws Exception {
     DocumentDB dbMock = Mockito.mock(DocumentDB.class);
     DocumentService serviceMock = Mockito.mock(DocumentService.class);
-    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
     Mockito.when(serviceMock.searchDocumentsV2(any(), any(), any(), any(), any(), any(), any()))
         .thenCallRealMethod();
     Mockito.when(
@@ -1214,7 +1208,6 @@ public class DocumentServiceTest {
     List<Row> rows = makeInitialRowData(false);
     when(dbMock.executeSelect(anyString(), anyString(), any(), anyBoolean(), anyInt(), any()))
         .thenReturn(rsMock);
-    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
     when(rsMock.currentPageRows()).thenReturn(rows);
     int pageSizeParam = 0;
     Paginator paginator =
@@ -1238,7 +1231,6 @@ public class DocumentServiceTest {
     List<Row> rows = makeInitialRowData(false);
     when(dbMock.executeSelect(anyString(), anyString(), any(), anyBoolean(), anyInt(), any()))
         .thenReturn(rsMock);
-    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
     when(rsMock.currentPageRows()).thenReturn(rows);
 
     List<FilterCondition> filters =
@@ -1277,7 +1269,6 @@ public class DocumentServiceTest {
     ResultSet rsMock = mock(ResultSet.class);
     List<Row> rows = makeInitialRowData(false);
     when(dbMock.executeSelectAll(anyString(), anyString(), anyInt(), any())).thenReturn(rsMock);
-    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
     when(rsMock.currentPageRows()).thenReturn(rows);
     Mockito.when(jsonConverter.convertToJsonDoc(anyList(), anyBoolean(), anyBoolean()))
         .thenReturn(mapper.readTree("{\"a\": 1}"));
@@ -1298,7 +1289,6 @@ public class DocumentServiceTest {
     ResultSet rsMock = mock(ResultSet.class);
     List<Row> rows = makeInitialRowData(false);
     when(dbMock.executeSelectAll(anyString(), anyString(), anyInt(), any())).thenReturn(rsMock);
-    when(dbMock.isDocumentsTable(anyString(), anyString())).thenReturn(true);
     when(rsMock.currentPageRows()).thenReturn(rows);
     List<Row> twoDocsRows = makeInitialRowData(false);
     twoDocsRows.addAll(makeRowDataForSecondDoc(false));

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -206,7 +206,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     String errorMessage =
         String.format(
-            "{\"description\":\"The Cassandra table %s.not_docs is not a Documents collection. Accessing arbitrary tables via the Documents API is not permitted.\",\"code\":400}",
+            "{\"description\":\"The database table %s.not_docs is not a Documents collection. Accessing arbitrary tables via the Documents API is not permitted.\",\"code\":400}",
             keyspace);
 
     String resp =

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -195,11 +195,12 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   }
 
   @Test
-  public void testAccessArbitraryTableDisallowed() throws IOException {
+  public void testAccessArbitraryTableDisallowed(CqlSession session) throws IOException {
     assertThat(
             session
                 .execute(
-                    String.format("create table %s.not_docs(x text primary key, y text)", keyspace))
+                    String.format(
+                        "create table \"%s\".not_docs(x text primary key, y text)", keyspace))
                 .wasApplied())
         .isTrue();
 
@@ -1974,17 +1975,9 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
 
   @Test
   public void testInvalidFullDocPageSize() throws IOException {
-    RestUtils.post(
-            authToken,
-            collectionPath,
-            "{\"doc\" : \"doc\"}",
-            200);
+    RestUtils.post(authToken, collectionPath, "{\"doc\" : \"doc\"}", 201);
 
-    String r =
-        RestUtils.get(
-            authToken,
-            collectionPath + "?page-size=21",
-            400);
+    String r = RestUtils.get(authToken, collectionPath + "?page-size=21", 400);
     assertThat(r)
         .isEqualTo(
             "{\"description\":\"The parameter `page-size` is limited to 20.\",\"code\":400}");

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -205,7 +205,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     String errorMessage =
         String.format(
-            "{\"description\":\"Bad request: The Cassandra table %s.not_docs is not a Documents collection. Accessing arbitrary tables via the Documents API is not permitted.\",\"code\":400}",
+            "{\"description\":\"The Cassandra table %s.not_docs is not a Documents collection. Accessing arbitrary tables via the Documents API is not permitted.\",\"code\":400}",
             keyspace);
 
     String resp =
@@ -1974,7 +1974,17 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
 
   @Test
   public void testInvalidFullDocPageSize() throws IOException {
-    String r = RestUtils.get(authToken, collectionPath + "?page-size=21", 400);
+    RestUtils.post(
+            authToken,
+            collectionPath,
+            "{\"doc\" : \"doc\"}",
+            200);
+
+    String r =
+        RestUtils.get(
+            authToken,
+            collectionPath + "?page-size=21",
+            400);
     assertThat(r)
         .isEqualTo(
             "{\"description\":\"The parameter `page-size` is limited to 20.\",\"code\":400}");

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -198,7 +198,8 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   public void testAccessArbitraryTableDisallowed() throws IOException {
     assertThat(
             session
-                .execute(String.format("create table not_docs(x text primary key, y text)"))
+                .execute(
+                    String.format("create table %s.not_docs(x text primary key, y text)", keyspace))
                 .wasApplied())
         .isTrue();
 


### PR DESCRIPTION
Instead of throwing a schema-related exception and returning a 500 when someone tries to use the docs API to access a non-docs table, give them a better error message and a 400