### PR TITLE
Refactor docs api pagination

### DIFF
--- a/restapi/pom.xml
+++ b/restapi/pom.xml
@@ -151,6 +151,16 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.reactivex.rxjava2</groupId>
+      <artifactId>rxjava</artifactId>
+      <version>2.2.15</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.akarnokd</groupId>
+      <artifactId>rxjava2-extensions</artifactId>
+      <version>0.20.10</version>
+    </dependency>
       <dependency>
           <groupId>org.mockito</groupId>
           <artifactId>mockito-junit-jupiter</artifactId>

--- a/restapi/pom.xml
+++ b/restapi/pom.xml
@@ -152,14 +152,14 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.reactivex.rxjava2</groupId>
+      <groupId>io.reactivex.rxjava3</groupId>
       <artifactId>rxjava</artifactId>
-      <version>2.2.15</version>
+      <version>3.0.12</version>
     </dependency>
     <dependency>
       <groupId>com.github.akarnokd</groupId>
-      <artifactId>rxjava2-extensions</artifactId>
-      <version>0.20.10</version>
+      <artifactId>rxjava3-extensions</artifactId>
+      <version>3.0.1</version>
     </dependency>
       <dependency>
           <groupId>org.mockito</groupId>

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -4,6 +4,7 @@ import com.datastax.oss.driver.api.core.servererrors.AlreadyExistsException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import io.reactivex.Flowable;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
@@ -16,6 +17,7 @@ import io.stargate.db.datastore.ResultSet;
 import io.stargate.db.query.BoundQuery;
 import io.stargate.db.query.Predicate;
 import io.stargate.db.query.TypedValue;
+import io.stargate.db.query.builder.AbstractBound;
 import io.stargate.db.query.builder.BuiltCondition;
 import io.stargate.db.query.builder.QueryBuilder;
 import io.stargate.db.query.builder.ValueModifier;
@@ -27,6 +29,8 @@ import io.stargate.db.schema.Schema;
 import io.stargate.db.schema.Table;
 import io.stargate.web.docsapi.exception.ErrorCode;
 import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
+import io.stargate.web.docsapi.service.QueryExecutor;
+import io.stargate.web.docsapi.service.RawDocument;
 import io.stargate.web.docsapi.service.json.DeadLeaf;
 import java.nio.ByteBuffer;
 import java.time.Instant;
@@ -70,6 +74,7 @@ public class DocumentDB {
   final DataStore dataStore;
   private final AuthorizationService authorizationService;
   private final AuthenticationSubject authenticationSubject;
+  private final QueryExecutor executor;
 
   static {
     allColumns = new ArrayList<>();
@@ -123,6 +128,8 @@ public class DocumentDB {
     if (!dataStore.supportsSAI() && !dataStore.supportsSecondaryIndex()) {
       throw new IllegalStateException("Backend does not support any known index types.");
     }
+
+    executor = new QueryExecutor(dataStore);
   }
 
   public AuthorizationService getAuthorizationService() {
@@ -373,63 +380,42 @@ public class DocumentDB {
     }
   }
 
-  public ResultSet executeSelect(
-      String keyspace, String collection, List<BuiltCondition> predicates)
-      throws UnauthorizedException {
+  public void authorizeSelect(String keyspace, String collection) throws UnauthorizedException {
     // Run generic authorizeDataRead for now
     getAuthorizationService()
         .authorizeDataRead(getAuthenticationSubject(), keyspace, collection, SourceAPI.REST);
-    return this.builder()
-        .select()
-        .column(DocumentDB.allColumns())
-        .writeTimeColumn("leaf")
-        .from(keyspace, collection)
-        .where(predicates)
-        .build()
-        .execute()
-        .join();
   }
 
-  public ResultSet executeSelect(
+  public Flowable<RawDocument> executeSelect(
       String keyspace,
       String collection,
       List<BuiltCondition> predicates,
       int pageSize,
-      ByteBuffer pageState)
+      ByteBuffer pagingState)
       throws UnauthorizedException {
     // Run generic authorizeDataRead for now
     getAuthorizationService()
         .authorizeDataRead(getAuthenticationSubject(), keyspace, collection, SourceAPI.REST);
-    UnaryOperator<Parameters> parametersModifier =
-        p -> ImmutableParameters.builder().pageSize(pageSize).pagingState(pageState).build();
-    return this.builder()
-        .select()
-        .column(DocumentDB.allColumns())
-        .writeTimeColumn("leaf")
-        .from(keyspace, collection)
-        .where(predicates)
-        .build()
-        .execute(parametersModifier)
-        .join();
+    AbstractBound<?> query =
+        this.builder()
+            .select()
+            .column(DocumentDB.allColumns())
+            .writeTimeColumn("leaf")
+            .from(keyspace, collection)
+            .where(predicates)
+            .build()
+            .bind();
+    return executor.queryDocs(query, pageSize, pagingState);
   }
 
-  public ResultSet executeSelect(
-      String keyspace, String collection, List<BuiltCondition> predicates, boolean allowFiltering)
-      throws UnauthorizedException {
-    // Run generic authorizeDataRead for now
-    getAuthorizationService()
-        .authorizeDataRead(getAuthenticationSubject(), keyspace, collection, SourceAPI.REST);
+  public Flowable<RawDocument> executeSelect(
+      AbstractBound<?> query, int pageSize, ByteBuffer pagingState) {
+    return executor.queryDocs(query, pageSize, pagingState);
+  }
 
-    return this.builder()
-        .select()
-        .column(DocumentDB.allColumns())
-        .writeTimeColumn("leaf")
-        .from(keyspace, collection)
-        .where(predicates)
-        .allowFiltering(allowFiltering)
-        .build()
-        .execute()
-        .join();
+  public Flowable<RawDocument> executeSelect(
+      int keyDepth, AbstractBound<?> query, int pageSize, ByteBuffer pagingState) {
+    return executor.queryDocs(keyDepth, query, pageSize, pagingState);
   }
 
   public ResultSet executeSelect(
@@ -460,22 +446,6 @@ public class DocumentDB {
         .allowFiltering(allowFiltering)
         .build()
         .execute(parametersModifier)
-        .join();
-  }
-
-  public ResultSet executeSelectAll(String keyspace, String collection)
-      throws UnauthorizedException {
-    // Run generic authorizeDataRead for now
-    getAuthorizationService()
-        .authorizeDataRead(getAuthenticationSubject(), keyspace, collection, SourceAPI.REST);
-
-    return this.builder()
-        .select()
-        .column(DocumentDB.allColumns())
-        .writeTimeColumn("leaf")
-        .from(keyspace, collection)
-        .build()
-        .execute()
         .join();
   }
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -4,7 +4,7 @@ import com.datastax.oss.driver.api.core.servererrors.AlreadyExistsException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
-import io.reactivex.Flowable;
+import io.reactivex.rxjava3.core.Flowable;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocsApiComponentsBinder.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocsApiComponentsBinder.java
@@ -13,6 +13,7 @@ public class DocsApiComponentsBinder extends AbstractBinder {
   protected void configure() {
     DocsApiConfiguration conf = DocsApiConfiguration.DEFAULT;
     bind(conf).to(DocsApiConfiguration.class);
+    bind(TimeSource.SYSTEM).to(TimeSource.class);
 
     bindAsContract(JsonConverter.class);
     bindAsContract(DocsSchemaChecker.class);

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -15,8 +15,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import io.reactivex.Flowable;
-import io.reactivex.FlowableTransformer;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.FlowableTransformer;
 import io.stargate.auth.UnauthorizedException;
 import io.stargate.db.datastore.Row;
 import io.stargate.db.query.Predicate;
@@ -469,7 +469,7 @@ public class DocumentService {
     }
 
     List<RawDocument> docs =
-        db.executeSelect(keyspace, collection, predicates, 0, null).limit(1).toList().blockingGet();
+        db.executeSelect(keyspace, collection, predicates, 0, null).take(1).toList().blockingGet();
 
     if (docs.isEmpty()) {
       return null;
@@ -718,7 +718,7 @@ public class DocumentService {
     List<RawDocument> docs =
         db.executeSelect(keyDepth, mainQuery, dbPageSize, paginator.getCurrentDbPageState())
             .compose(filterInMemory(db, inMemoryFilters))
-            .limit(paginator.docPageSize)
+            .take(paginator.docPageSize)
             .toList()
             .blockingGet();
 
@@ -795,7 +795,7 @@ public class DocumentService {
                 ImmutableList.of(),
                 docsApiConfiguration.getSearchPageSize(),
                 paginator.getCurrentDbPageState())
-            .limit(paginator.docPageSize)
+            .take(paginator.docPageSize)
             .toList()
             .blockingGet();
 
@@ -859,7 +859,7 @@ public class DocumentService {
                           keyspace, collection, ImmutableList.of(keyPredicate), 0, null));
                 })
             .compose(filterInMemory(db, inMemoryFilters))
-            .limit(paginator.docPageSize)
+            .take(paginator.docPageSize)
             .toList()
             .blockingGet();
 
@@ -920,7 +920,7 @@ public class DocumentService {
 
                 // If the nested query finds any docs, return the input doc to preserve
                 // the paging order of the main query
-                return db.executeSelect(nestedQuery, 1, null).limit(1).map(nested -> d);
+                return db.executeSelect(nestedQuery, 1, null).take(1).map(nested -> d);
               });
     }
 
@@ -945,7 +945,7 @@ public class DocumentService {
                 docsApiConfiguration.getSearchPageSize(),
                 paginator.getCurrentDbPageState())
             .compose(filterInMemory(db, inMemoryFilters))
-            .limit(paginator.docPageSize)
+            .take(paginator.docPageSize)
             .toList()
             .blockingGet();
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -1,5 +1,7 @@
 package io.stargate.web.docsapi.service;
 
+import static io.stargate.web.docsapi.dao.DocumentDB.MAX_DEPTH;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -8,16 +10,17 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import io.reactivex.Flowable;
+import io.reactivex.FlowableTransformer;
 import io.stargate.auth.UnauthorizedException;
-import io.stargate.db.datastore.ResultSet;
 import io.stargate.db.datastore.Row;
 import io.stargate.db.query.Predicate;
+import io.stargate.db.query.builder.AbstractBound;
 import io.stargate.db.query.builder.BuiltCondition;
 import io.stargate.web.docsapi.dao.DocumentDB;
 import io.stargate.web.docsapi.dao.Paginator;
@@ -30,16 +33,12 @@ import io.stargate.web.docsapi.service.filter.ListFilterCondition;
 import io.stargate.web.docsapi.service.filter.SingleFilterCondition;
 import io.stargate.web.docsapi.service.json.DeadLeafCollectorImpl;
 import io.stargate.web.resources.Db;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.*;
-import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.ws.rs.core.PathSegment;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.mutable.MutableObject;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.jsfr.json.JsonSurfer;
 import org.jsfr.json.JsonSurferGson;
@@ -55,6 +54,7 @@ public class DocumentService {
   private static final Splitter FORM_SPLITTER = Splitter.on('&');
   private static final Splitter PAIR_SPLITTER = Splitter.on('=');
   private static final Splitter PATH_SPLITTER = Splitter.on('/');
+  private TimeSource timeSource;
   private DocsApiConfiguration docsApiConfiguration;
   private JsonConverter jsonConverterService;
   private ObjectMapper mapper;
@@ -62,10 +62,12 @@ public class DocumentService {
 
   @Inject
   public DocumentService(
+      TimeSource timeSource,
       ObjectMapper mapper,
       JsonConverter jsonConverterService,
       DocsApiConfiguration docsApiConfiguration,
       DocsSchemaChecker schemaChecker) {
+    this.timeSource = timeSource;
     this.mapper = mapper;
     this.jsonConverterService = jsonConverterService;
     this.docsApiConfiguration = docsApiConfiguration;
@@ -436,7 +438,7 @@ public class DocumentService {
 
     logger.debug("Bind {}", bindVariableList.size());
 
-    long now = ChronoUnit.MICROS.between(Instant.EPOCH, Instant.now());
+    long now = timeSource.currentTimeMicros();
     if (patching) {
       db.deletePatchedPathsThenInsertBatch(
           keyspace, collection, id, bindVariableList, convertedPath, firstLevelKeys, now);
@@ -466,15 +468,17 @@ public class DocumentService {
       }
     }
 
-    ResultSet r = db.executeSelect(keyspace, collection, predicates);
-    List<Row> rows = r.rows();
+    List<RawDocument> docs =
+        db.executeSelect(keyspace, collection, predicates, 0, null).limit(1).toList().blockingGet();
 
-    if (rows.isEmpty()) {
+    if (docs.isEmpty()) {
       return null;
     }
+    RawDocument rawDoc = docs.get(0);
     DeadLeafCollectorImpl collector = new DeadLeafCollectorImpl();
     JsonNode result =
-        jsonConverterService.convertToJsonDoc(rows, collector, false, db.treatBooleansAsNumeric());
+        jsonConverterService.convertToJsonDoc(
+            rawDoc.rows(), collector, false, db.treatBooleansAsNumeric());
     if (!collector.isEmpty()) {
       logger.info(String.format("Deleting %d dead leaves", collector.getLeaves().size()));
       db.deleteDeadLeaves(keyspace, collection, id, collector.getLeaves());
@@ -628,9 +632,26 @@ public class DocumentService {
       String pathStr = pathSegment.getPath();
       convertedPath.add(convertArrayPath(pathStr));
     }
-    Long now = ChronoUnit.MICROS.between(Instant.EPOCH, Instant.now());
+
+    long now = timeSource.currentTimeMicros();
 
     db.delete(keyspace, collection, id, convertedPath, now);
+  }
+
+  private FlowableTransformer<RawDocument, RawDocument> filterInMemory(
+      DocumentDB db, List<FilterCondition> filters) {
+    if (filters.isEmpty()) {
+      return flowable -> flowable;
+    }
+
+    Set<String> filterFieldPaths =
+        filters.stream().map(FilterCondition::getFullFieldPath).collect(Collectors.toSet());
+
+    return flowable ->
+        flowable.filter(
+            document ->
+                matchesFilters(
+                    filters, db.treatBooleansAsNumeric(), filterFieldPaths, document.rows()));
   }
 
   public JsonNode searchDocumentsV2(
@@ -642,76 +663,80 @@ public class DocumentService {
       String documentId,
       Paginator paginator)
       throws UnauthorizedException {
+    db.authorizeSelect(keyspace, collection);
     FilterCondition first = filters.get(0);
     List<String> path = first.getPath();
 
-    List<Row> rows =
-        searchRows(
-            keyspace,
-            collection,
-            db,
-            Collections.emptyList(),
-            filters,
-            fields,
-            path,
-            false,
-            documentId,
-            paginator);
-    if (rows.isEmpty()) {
-      return null;
-    }
+    List<BuiltCondition> conditions = new ArrayList<>();
+    conditions.add(BuiltCondition.of("key", Predicate.EQ, documentId));
 
-    JsonNode docsResult = mapper.createObjectNode();
-
+    int dbPageSize;
+    List<FilterCondition> inMemoryFilters;
     if (fields.isEmpty()) {
-      Map<String, List<Row>> rowsByDoc = new HashMap<>();
+      conditions.add(BuiltCondition.of("leaf", Predicate.EQ, first.getField()));
 
-      for (Row row : rows) {
-        String key = row.getString("key");
-        List<Row> rowsAtKey = rowsByDoc.getOrDefault(key, new ArrayList<>());
-        rowsAtKey.add(row);
-        rowsByDoc.put(key, rowsAtKey);
+      // Assume all filters apply to the same row - this is expected to be enforced by callers
+      dbPageSize = paginator.docPageSize;
+      List<FilterCondition> inCassandraFilters =
+          filters.stream()
+              .filter(f -> !FilterOp.LIMITED_SUPPORT_FILTERS.contains(f.getFilterOp()))
+              .collect(Collectors.toList());
+      inMemoryFilters =
+          filters.stream()
+              .filter(f -> FilterOp.LIMITED_SUPPORT_FILTERS.contains(f.getFilterOp()))
+              .collect(Collectors.toList());
+
+      collectNestedElementConditions(conditions, first.getPath());
+
+      if (!inCassandraFilters.isEmpty()) {
+        collectFieldConditions(conditions, inCassandraFilters.get(0));
       }
 
-      for (Map.Entry<String, List<Row>> entry : rowsByDoc.entrySet()) {
-        ArrayNode ref = mapper.createArrayNode();
-        if (documentId == null) {
-          ((ObjectNode) docsResult).set(entry.getKey(), ref);
-        } else {
-          docsResult = ref;
-        }
-        List<Row> docRows = entry.getValue();
-        for (Row row : docRows) {
-          JsonNode jsonDoc =
-              jsonConverterService.convertToJsonDoc(
-                  Collections.singletonList(row), true, db.treatBooleansAsNumeric());
-          ref.add(jsonDoc);
-        }
+      for (FilterCondition filter : inCassandraFilters) {
+        collectValueConditions(conditions, filter, db.treatBooleansAsNumeric());
       }
     } else {
-      if (documentId != null) {
-        docsResult = mapper.createArrayNode();
-      }
-      for (List<Row> chunk : Lists.partition(rows, fields.size())) {
-        String key = chunk.get(0).getString("key");
-        if (!docsResult.has(key) && documentId == null) {
-          ((ObjectNode) docsResult).set(key, mapper.createArrayNode());
-        }
+      dbPageSize = docsApiConfiguration.getSearchPageSize();
+      inMemoryFilters = filters;
 
-        List<Row> nonNull = chunk.stream().filter(x -> x != null).collect(Collectors.toList());
-        JsonNode jsonDoc =
-            jsonConverterService.convertToJsonDoc(nonNull, true, db.treatBooleansAsNumeric());
-
-        if (documentId == null) {
-          ((ArrayNode) docsResult.get(key)).add(jsonDoc);
-        } else {
-          ((ArrayNode) docsResult).add(jsonDoc);
-        }
-      }
+      collectNestedElementConditions(conditions, path);
     }
 
-    if (docsResult.isMissingNode() || (docsResult.isObject() && docsResult.isEmpty())) {
+    AbstractBound<?> mainQuery =
+        db.builder()
+            .select()
+            .column(DocumentDB.allColumns())
+            .writeTimeColumn("leaf")
+            .from(keyspace, collection)
+            .where(conditions)
+            .allowFiltering()
+            .build()
+            .bind();
+
+    // Use `key` plus some of the clustering columns (path elements) for grouping query results
+    int keyDepth = first.getPath().size() + 1; // +1 for the partition key
+    List<RawDocument> docs =
+        db.executeSelect(keyDepth, mainQuery, dbPageSize, paginator.getCurrentDbPageState())
+            .compose(filterInMemory(db, inMemoryFilters))
+            .limit(paginator.docPageSize)
+            .toList()
+            .blockingGet();
+
+    if (docs.isEmpty()) {
       return null;
+    }
+
+    paginator.setDocumentPageState(docs);
+
+    ArrayNode docsResult = mapper.createArrayNode();
+
+    for (RawDocument doc : docs) {
+      List<Row> rows = filterToSelectionSet(doc.rows(), fields, path);
+      rows = rows.stream().filter(Objects::nonNull).collect(Collectors.toList());
+      JsonNode jsonDoc =
+          jsonConverterService.convertToJsonDoc(rows, true, db.treatBooleansAsNumeric());
+
+      docsResult.add(jsonDoc);
     }
 
     return docsResult;
@@ -727,44 +752,30 @@ public class DocumentService {
     }
   }
 
-  private List<Row> updateExistenceForMap(
-      Set<String> existsByDoc,
-      List<Row> rows,
-      List<FilterCondition> filters,
-      boolean booleansStoredAsTinyint,
-      boolean endOfResults) {
-    LinkedHashMap<String, List<Row>> documentChunks = new LinkedHashMap<>();
-    for (int i = 0; i < rows.size(); i++) {
-      Row row = rows.get(i);
-      String key = row.getString("key");
-      List<Row> chunk = documentChunks.getOrDefault(key, new ArrayList<>());
-      chunk.add(row);
-      documentChunks.put(key, chunk);
-    }
-
-    List<List<Row>> chunksList = new ArrayList<>(documentChunks.values());
-
-    for (int i = 0; i < chunksList.size() - (endOfResults ? 0 : 1); i++) {
-      List<Row> chunk = chunksList.get(i);
-      String key = chunk.get(0).getString("key");
-      List<Row> filteredRows =
-          applyInMemoryFilters(chunk, filters, chunk.size(), booleansStoredAsTinyint);
-      if (!filteredRows.isEmpty()) {
-        existsByDoc.add(key);
-      }
-    }
-
-    if (!chunksList.isEmpty() && !endOfResults) {
-      return chunksList.get(chunksList.size() - 1);
-    }
-    return Collections.emptyList();
-  }
-
   private boolean fieldMatchesRowPath(Row row, String field) {
     String rowPath = getFieldPathFromRow(row);
     return rowPath.startsWith(field)
         && (rowPath.substring(field.length()).isEmpty()
             || rowPath.substring(field.length()).startsWith("."));
+  }
+
+  private void addToJsonMap(
+      DocumentDB db, ObjectNode docsResult, List<RawDocument> docs, List<String> fields) {
+    for (RawDocument doc : docs) {
+      List<Row> rows;
+      if (fields.isEmpty()) {
+        rows = doc.rows();
+      } else {
+        rows =
+            doc.rows().stream()
+                .filter(row -> fields.stream().anyMatch(field -> fieldMatchesRowPath(row, field)))
+                .collect(Collectors.toList());
+      }
+
+      docsResult.set(
+          doc.id(),
+          jsonConverterService.convertToJsonDoc(rows, false, db.treatBooleansAsNumeric()));
+    }
   }
 
   /**
@@ -776,72 +787,22 @@ public class DocumentService {
       DocumentDB db, String keyspace, String collection, List<String> fields, Paginator paginator)
       throws UnauthorizedException {
     ObjectNode docsResult = mapper.createObjectNode();
-    LinkedHashMap<String, List<Row>> rowsByDoc = new LinkedHashMap<>();
-    do {
 
-      List<Row> rows =
-          searchRows(
-              keyspace,
-              collection,
-              db,
-              new ArrayList<>(),
-              new ArrayList<>(),
-              new ArrayList<>(),
-              new ArrayList<>(),
-              false,
-              null,
-              paginator);
-      addRowsToMap(rowsByDoc, rows);
-    } while (rowsByDoc.keySet().size() <= paginator.docPageSize && paginator.hasDbPageState());
+    List<RawDocument> docs =
+        db.executeSelect(
+                keyspace,
+                collection,
+                ImmutableList.of(),
+                docsApiConfiguration.getSearchPageSize(),
+                paginator.getCurrentDbPageState())
+            .limit(paginator.docPageSize)
+            .toList()
+            .blockingGet();
 
-    // Either we've reached the end of all rows in the collection, or we have enough rows
-    // in memory to build the final result.
-    if (rowsByDoc.keySet().size() > paginator.docPageSize) {
-      MutableObject<String> lastIdSeen = new MutableObject<>();
-      rowsByDoc.entrySet().stream()
-          .limit(paginator.docPageSize)
-          .forEach(
-              e -> {
-                List<Row> rows =
-                    e.getValue().stream()
-                        .map(
-                            row -> {
-                              lastIdSeen.setValue(row.getString("key"));
-                              return row;
-                            })
-                        .filter(
-                            row ->
-                                fields.isEmpty()
-                                    || fields.stream()
-                                        .anyMatch(
-                                            field -> getFieldPathFromRow(row).startsWith(field)))
-                        .collect(Collectors.toList());
-                docsResult.set(
-                    e.getKey(),
-                    jsonConverterService.convertToJsonDoc(
-                        rows, false, db.treatBooleansAsNumeric()));
-              });
+    paginator.setDocumentPageState(docs);
 
-      paginator.setDocumentPageState(lastIdSeen.getValue());
-    } else {
-      rowsByDoc.entrySet().stream()
-          .forEach(
-              e -> {
-                List<Row> rows =
-                    e.getValue().stream()
-                        .filter(
-                            row ->
-                                fields.isEmpty()
-                                    || fields.stream()
-                                        .anyMatch(field -> fieldMatchesRowPath(row, field)))
-                        .collect(Collectors.toList());
-                docsResult.set(
-                    e.getKey(),
-                    jsonConverterService.convertToJsonDoc(
-                        rows, false, db.treatBooleansAsNumeric()));
-              });
-      paginator.clearDocumentPageState();
-    }
+    addToJsonMap(db, docsResult, docs, fields);
+
     return docsResult;
   }
 
@@ -886,128 +847,84 @@ public class DocumentService {
       Paginator paginator)
       throws UnauthorizedException {
     ObjectNode docsResult = mapper.createObjectNode();
-    LinkedHashSet<String> candidates = new LinkedHashSet<>();
-    List<Row> rows = null;
 
-    do {
-      LinkedHashSet<String> candidateResult =
-          getCandidatesForPage(db, keyspace, collection, inCassandraFilters, candidates, paginator);
-      candidates = candidateResult;
+    List<RawDocument> docs =
+        getCandidatesForPage(db, keyspace, collection, inCassandraFilters, paginator)
+            .concatMapSingle(
+                d -> {
+                  // TODO: revisit fetching doc rows in batches using IN on `key`
+                  BuiltCondition keyPredicate = BuiltCondition.of("key", Predicate.EQ, d.id());
+                  return d.populateFrom(
+                      db.executeSelect(
+                          keyspace, collection, ImmutableList.of(keyPredicate), 0, null));
+                })
+            .compose(filterInMemory(db, inMemoryFilters))
+            .limit(paginator.docPageSize)
+            .toList()
+            .blockingGet();
 
-      // Do an in-memory filter if there are non-cassandra filters
-      if (!inMemoryFilters.isEmpty()) {
-        BuiltCondition candidatesPredicate =
-            BuiltCondition.of("key", Predicate.IN, new ArrayList<>(candidates));
-        rows = db.executeSelect(keyspace, collection, ImmutableList.of(candidatesPredicate)).rows();
-        candidates.clear();
-        updateExistenceForMap(candidates, rows, inMemoryFilters, db.treatBooleansAsNumeric(), true);
-      }
-    } while (candidates.size() <= paginator.docPageSize && paginator.hasDbPageState());
+    paginator.setDocumentPageState(docs);
 
-    // Either we've reached the end of all rows in the collection, or we have enough rows
-    // in memory to build the final result.
-    Set<String> docNames = candidates;
-    if (candidates.size() > paginator.docPageSize) {
-      docNames = new HashSet<>();
-      Iterator<String> iter = candidates.iterator();
-      String lastSeenId = null;
-      for (int i = 0; i < paginator.docPageSize; i++) {
-        lastSeenId = iter.next();
-        docNames.add(lastSeenId);
-      }
-      paginator.setDocumentPageState(lastSeenId);
-    } else {
-      paginator.clearDocumentPageState();
-    }
-
-    if (rows == null) {
-      BuiltCondition candidatesPredicate =
-          BuiltCondition.of("key", Predicate.IN, new ArrayList<>(docNames));
-      rows = db.executeSelect(keyspace, collection, ImmutableList.of(candidatesPredicate)).rows();
-      updateExistenceForMap(
-          new HashSet<>(), rows, Collections.emptyList(), db.treatBooleansAsNumeric(), true);
-    }
-
-    Map<String, List<Row>> rowsByDoc = new HashMap<>();
-    for (Row row : rows) {
-      String key = row.getString("key");
-      if (docNames.contains(key)) {
-        List<Row> rowsAtKey = rowsByDoc.getOrDefault(key, new ArrayList<>());
-        if (fields.isEmpty()
-            || fields.stream().anyMatch(field -> fieldMatchesRowPath(row, field))) {
-          rowsAtKey.add(row);
-        }
-        rowsByDoc.put(key, rowsAtKey);
-      }
-    }
-
-    for (Map.Entry<String, List<Row>> entry : rowsByDoc.entrySet()) {
-      docsResult.set(
-          entry.getKey(),
-          jsonConverterService.convertToJsonDoc(
-              entry.getValue(), false, db.treatBooleansAsNumeric()));
-    }
+    addToJsonMap(db, docsResult, docs, fields);
 
     return docsResult;
   }
 
-  private LinkedHashSet<String> getCandidatesForPage(
+  private Flowable<RawDocument> getCandidatesForPage(
       DocumentDB db,
       String keyspace,
       String collection,
       List<FilterCondition> inCassandraFilters,
-      LinkedHashSet currentCandidateKeys,
       Paginator paginator)
       throws UnauthorizedException {
-    LinkedHashSet<String> candidatesThisPage = new LinkedHashSet<>();
-    List<Row> page;
-    for (int i = 0; i < inCassandraFilters.size(); i++) {
-      FilterCondition condition = inCassandraFilters.get(i);
-      List<String> path = condition.getPath();
+    db.authorizeSelect(keyspace, collection);
 
-      if (i == 0) {
-        page =
-            searchRows(
-                keyspace,
-                collection,
-                db,
-                Collections.emptyList(),
-                ImmutableList.of(condition),
-                Collections.emptyList(),
-                path,
-                false,
-                null,
-                paginator);
-        candidatesThisPage = new LinkedHashSet<>();
-        for (Row row : page) {
-          candidatesThisPage.add(row.getString("key"));
-        }
-      } else {
-        LinkedHashSet<String> tempCandidates = new LinkedHashSet<>();
-        for (String candidate : candidatesThisPage) {
-          BuiltCondition candidateCondition = BuiltCondition.of("key", Predicate.EQ, candidate);
-          page =
-              searchRows(
-                  keyspace,
-                  collection,
-                  db,
-                  ImmutableList.of(candidateCondition),
-                  ImmutableList.of(condition),
-                  Collections.emptyList(),
-                  path,
-                  false,
-                  null,
-                  paginator);
-          if (!page.isEmpty()) {
-            tempCandidates.add(candidate);
-          }
-        }
-        candidatesThisPage = tempCandidates;
-      }
+    Iterator<FilterCondition> it = inCassandraFilters.iterator();
+    FilterCondition pagingCondition = it.next(); // assume at least one condition
+
+    AbstractBound<?> mainQuery =
+        db.builder()
+            .select()
+            .column("key")
+            .column("leaf")
+            .from(keyspace, collection)
+            .where(buildConditions(pagingCondition, db.treatBooleansAsNumeric()))
+            .allowFiltering()
+            .build()
+            .bind();
+
+    Flowable<RawDocument> docs =
+        db.executeSelect(
+            mainQuery, docsApiConfiguration.getSearchPageSize(), paginator.getCurrentDbPageState());
+
+    while (it.hasNext()) {
+      FilterCondition nestedCondition = it.next();
+
+      // chain the other filters as nested queries
+      docs =
+          docs.concatMap(
+              d -> {
+                BuiltCondition keyCondition = BuiltCondition.of("key", Predicate.EQ, d.id());
+
+                AbstractBound<?> nestedQuery =
+                    db.builder()
+                        .select()
+                        .column("key")
+                        .column("leaf")
+                        .from(keyspace, collection)
+                        .where(keyCondition)
+                        .where(buildConditions(nestedCondition, db.treatBooleansAsNumeric()))
+                        .allowFiltering()
+                        .build()
+                        .bind();
+
+                // If the nested query finds any docs, return the input doc to preserve
+                // the paging order of the main query
+                return db.executeSelect(nestedQuery, 1, null).limit(1).map(nested -> d);
+              });
     }
 
-    currentCandidateKeys.addAll(candidatesThisPage);
-    return currentCandidateKeys;
+    return docs;
   }
 
   private JsonNode searchWithOnlyInMemoryFilters(
@@ -1018,131 +935,38 @@ public class DocumentService {
       List<String> fields,
       Paginator paginator)
       throws UnauthorizedException {
-    List<Row> leftoverRows = Collections.emptyList();
     ObjectNode docsResult = mapper.createObjectNode();
-    LinkedHashSet<String> existsByDoc = new LinkedHashSet<>();
 
-    do {
-      List<Row> page =
-          searchRows(
-              keyspace,
-              collection,
-              db,
-              Collections.emptyList(),
-              new ArrayList<>(),
-              Collections.emptyList(),
-              Collections.emptyList(),
-              false,
-              null,
-              paginator);
-      ArrayList<Row> rowsResult = new ArrayList<>();
-      rowsResult.addAll(leftoverRows);
-      rowsResult.addAll(page);
-      boolean endOfResult = !paginator.hasDbPageState();
-      leftoverRows =
-          updateExistenceForMap(
-              existsByDoc, rowsResult, inMemoryFilters, db.treatBooleansAsNumeric(), endOfResult);
-    } while (existsByDoc.size() <= paginator.docPageSize && paginator.hasDbPageState());
+    List<RawDocument> docs =
+        db.executeSelect(
+                keyspace,
+                collection,
+                ImmutableList.of(),
+                docsApiConfiguration.getSearchPageSize(),
+                paginator.getCurrentDbPageState())
+            .compose(filterInMemory(db, inMemoryFilters))
+            .limit(paginator.docPageSize)
+            .toList()
+            .blockingGet();
 
-    // Either we've reached the end of all rows in the collection, or we have enough rows
-    // in memory to build the final result.
-    Set<String> docNames = existsByDoc;
-    if (existsByDoc.size() > paginator.docPageSize) {
-      docNames = new HashSet<>();
-      Iterator<String> iter = existsByDoc.iterator();
-      String lastSeenId = null;
-      for (int i = 0; i < paginator.docPageSize; i++) {
-        lastSeenId = iter.next();
-        docNames.add(lastSeenId);
-      }
-      paginator.setDocumentPageState(lastSeenId);
-    } else {
-      paginator.clearDocumentPageState();
-    }
+    paginator.setDocumentPageState(docs);
 
-    List<BuiltCondition> predicate =
-        ImmutableList.of(BuiltCondition.of("key", Predicate.IN, new ArrayList<>(docNames)));
-
-    List<Row> rows = db.executeSelect(keyspace, collection, predicate).rows();
-    Map<String, List<Row>> rowsByDoc = new HashMap<>();
-    for (Row row : rows) {
-      String key = row.getString("key");
-      List<Row> rowsAtKey = rowsByDoc.getOrDefault(key, new ArrayList<>());
-      if (fields.isEmpty() || fields.stream().anyMatch(field -> fieldMatchesRowPath(row, field))) {
-        rowsAtKey.add(row);
-      }
-      rowsByDoc.put(key, rowsAtKey);
-    }
-
-    for (Map.Entry<String, List<Row>> entry : rowsByDoc.entrySet()) {
-      docsResult.set(
-          entry.getKey(),
-          jsonConverterService.convertToJsonDoc(
-              entry.getValue(), false, db.treatBooleansAsNumeric()));
-    }
+    addToJsonMap(db, docsResult, docs, fields);
 
     return docsResult;
   }
 
-  /**
-   * Searches a document collection for particular results. If `fields` is non-empty, queries
-   * Cassandra for any data that matches `path` and then does matching of the selection set and
-   * filtering in memory.
-   *
-   * <p>A major restriction: if `fields` is non-empty or `filters` includes a filter that has
-   * "limited support" ($nin, $in, $ne), then the result set MUST fit in a single page. A requester
-   * could alter `page-size` up to a limit of 1000 to attempt to achieve this.
-   *
-   * @param keyspace the keyspace (document namespace) where the table lives
-   * @param collection the table (document collection)
-   * @param db the DB utility
-   * @param filters A list of FilterConditions
-   * @param fields the fields to return
-   * @param path the path in the document that is being searched on
-   * @param recurse legacy boolean, only used for v1 of the API
-   * @param documentKey filter down to only one document's results
-   * @param paginator A Paginator object to facilitate paging
-   * @return
-   * @throws ExecutionException
-   * @throws InterruptedException
-   */
-  @VisibleForTesting
-  List<Row> searchRows(
-      String keyspace,
-      String collection,
-      DocumentDB db,
-      List<BuiltCondition> additionalWhereConditions,
-      List<FilterCondition> filters,
-      List<String> fields,
-      List<String> path,
-      Boolean recurse,
-      String documentKey,
-      Paginator paginator)
-      throws UnauthorizedException {
-    StringBuilder pathStr = new StringBuilder();
-    List<BuiltCondition> predicates = new ArrayList<>();
-
-    if (!filters.isEmpty() && fields.isEmpty()) {
-      FilterCondition first = filters.get(0);
-      predicates.add(BuiltCondition.of("leaf", Predicate.EQ, first.getField()));
-    }
-
-    boolean manyPathsFound = false;
-
+  private void collectNestedElementConditions(List<BuiltCondition> predicates, List<String> path) {
     int i;
     for (i = 0; i < path.size(); i++) {
       String[] pathSegmentSplit = path.get(i).split(",");
       if (pathSegmentSplit.length == 1) {
         String pathSegment = pathSegmentSplit[0];
         if (pathSegment.equals(DocumentDB.GLOB_VALUE)) {
-          manyPathsFound = true;
           predicates.add(BuiltCondition.of("p" + i, Predicate.GT, ""));
         } else {
           String convertedPath = convertArrayPath(pathSegment);
           predicates.add(BuiltCondition.of("p" + i, Predicate.EQ, convertedPath));
-          if (!manyPathsFound) {
-            pathStr.append("/").append(pathSegment);
-          }
         }
       } else {
         List<String> segmentsList = Arrays.asList(pathSegmentSplit);
@@ -1150,88 +974,46 @@ public class DocumentService {
         segmentsList =
             segmentsList.stream().map(this::convertArrayPath).collect(Collectors.toList());
 
-        manyPathsFound = true;
         predicates.add(BuiltCondition.of("p" + i, Predicate.IN, segmentsList));
       }
     }
+  }
 
-    List<FilterCondition> inCassandraFilters = new ArrayList<>();
-    List<FilterCondition> inMemoryFilters = filters;
-
-    if (fields.isEmpty()) {
-      inCassandraFilters =
-          filters.stream()
-              .filter(f -> !FilterOp.LIMITED_SUPPORT_FILTERS.contains(f.getFilterOp()))
-              .collect(Collectors.toList());
-      inMemoryFilters =
-          filters.stream()
-              .filter(f -> FilterOp.LIMITED_SUPPORT_FILTERS.contains(f.getFilterOp()))
-              .collect(Collectors.toList());
-    }
-
-    if ((recurse == null || !recurse)
-        && path.size() < db.MAX_DEPTH
-        && !inCassandraFilters.isEmpty()) {
-      predicates.add(BuiltCondition.of("p" + i++, Predicate.EQ, filters.get(0).getField()));
-    } else if (!path.isEmpty()) {
-      predicates.add(BuiltCondition.of("p" + i++, Predicate.GT, ""));
-    }
+  private List<BuiltCondition> buildConditions(
+      FilterCondition condition, boolean booleanAsNumeric) {
+    List<BuiltCondition> predicates = new ArrayList<>();
+    collectNestedElementConditions(predicates, condition.getPath());
+    collectFieldConditions(predicates, condition);
 
     // The rest of the paths must match empty-string
-    while (i < db.MAX_DEPTH && !path.isEmpty()) {
-      predicates.add(BuiltCondition.of("p" + i++, Predicate.EQ, ""));
+    for (int i = condition.getPath().size() + 1; i < MAX_DEPTH; i++) {
+      predicates.add(BuiltCondition.of("p" + i, Predicate.EQ, ""));
     }
 
-    for (FilterCondition filter : inCassandraFilters) {
-      // All fully supported filters are SingleFilterConditions, as of now
-      SingleFilterCondition singleFilter = (SingleFilterCondition) filter;
-      FilterOp queryOp = singleFilter.getFilterOp();
-      String queryValueField = singleFilter.getValueColumnName();
-      Object queryValue = singleFilter.getValue(db.treatBooleansAsNumeric());
-      if (queryOp != FilterOp.EXISTS) {
-        predicates.add(BuiltCondition.of(queryValueField, queryOp.predicate, queryValue));
-      }
+    collectValueConditions(predicates, condition, booleanAsNumeric);
+    return predicates;
+  }
+
+  private void collectFieldConditions(List<BuiltCondition> predicates, FilterCondition condition) {
+    predicates.add(
+        BuiltCondition.of("p" + condition.getPath().size(), Predicate.EQ, condition.getField()));
+  }
+
+  private void collectValueConditions(
+      List<BuiltCondition> predicates, FilterCondition condition, boolean booleanAsNumeric) {
+    if (condition.getFilterOp() == FilterOp.EXISTS) {
+      // conditions on the clustering key columns are sufficient for `EXISTS` as the storage leyer
+      return;
     }
 
-    ResultSet r;
-
-    predicates.addAll(additionalWhereConditions);
-    if (!predicates.isEmpty()) {
-      r =
-          db.executeSelect(
-              keyspace,
-              collection,
-              predicates,
-              true,
-              paginator.dbPageSize,
-              paginator.getCurrentDbPageState());
-    } else {
-      r =
-          db.executeSelectAll(
-              keyspace, collection, paginator.dbPageSize, paginator.getCurrentDbPageState());
-    }
-
-    List<Row> rows = r.currentPageRows();
-
-    paginator.useResultSet(r);
-
-    if (documentKey != null) {
-      rows =
-          rows.stream()
-              .filter(row -> row.getString("key").equals(documentKey))
-              .collect(Collectors.toList());
-    }
-
-    if (!inMemoryFilters.isEmpty() && paginator.hasDbPageState()) {
-      throw new ErrorCodeRuntimeException(ErrorCode.DOCS_API_SEARCH_RESULTS_NOT_FITTING);
-    }
-
-    rows = filterToSelectionSet(rows, fields, path);
-    rows =
-        applyInMemoryFilters(
-            rows, inMemoryFilters, Math.max(fields.size(), 1), db.treatBooleansAsNumeric());
-
-    return rows;
+    // Only SingleFilterCondition is currently supported at persistence level
+    SingleFilterCondition singleFilter = (SingleFilterCondition) condition;
+    FilterOp queryOp = singleFilter.getFilterOp();
+    String queryValueField = singleFilter.getValueColumnName();
+    Object queryValue = singleFilter.getValue(booleanAsNumeric);
+    BuiltCondition filterCondition =
+        BuiltCondition.of(queryValueField, queryOp.predicate, queryValue);
+    predicates.add(filterCondition);
   }
 
   private String getParentPathFromRow(Row row) {
@@ -1322,67 +1104,47 @@ public class DocumentService {
     return normalizedList;
   }
 
-  /**
-   * Applies all of the @param inMemoryFilters, conjunctively (using AND).
-   *
-   * @param rows the result set from cassandra
-   * @param inMemoryFilters the filters to apply to `rows`
-   * @param fieldsPerDoc The number of rows that make up a single document result
-   * @return rows for each doc that match all filters
-   */
-  private List<Row> applyInMemoryFilters(
-      List<Row> rows,
+  private boolean matchesFilters(
       List<FilterCondition> inMemoryFilters,
-      int fieldsPerDoc,
-      boolean numericBooleans) {
-    if (inMemoryFilters.isEmpty()) {
-      return rows;
-    }
-    Set<String> filterFieldPaths =
-        inMemoryFilters.stream().map(FilterCondition::getFullFieldPath).collect(Collectors.toSet());
-    return Lists.partition(rows, fieldsPerDoc).stream()
-        .filter(
-            docChunk -> {
-              List<Row> fieldRows =
-                  docChunk.stream()
-                      .filter(
-                          r -> {
-                            if (r == null || r.getString("leaf") == null) {
-                              return false;
-                            }
-                            List<String> parentPath =
-                                PATH_SPLITTER.splitToList(getParentPathFromRow(r));
-                            String rowPath = "";
-                            if (parentPath.size() == 2) {
-                              rowPath = parentPath.get(1);
-                            }
-                            String fullRowPath = rowPath + r.getString("leaf");
-                            List<FilterCondition> matchingFilters =
-                                inMemoryFilters.stream()
-                                    .filter(f -> pathsMatch(fullRowPath, f.getFullFieldPath()))
-                                    .collect(Collectors.toList());
-                            if (matchingFilters.isEmpty()) {
-                              return false;
-                            }
-                            return allFiltersMatch(r, matchingFilters, numericBooleans);
-                          })
-                      .collect(Collectors.toList());
-              // This ensures that wildcard paths are properly counted with non-wildcard paths,
-              // by making sure that for every filter above, at least one matches a valid row.
-              return filterFieldPaths.stream()
-                  .allMatch(
-                      fieldPath ->
-                          fieldRows.stream()
-                              .anyMatch(
-                                  row -> {
-                                    List<String> segments =
-                                        PATH_SPLITTER.splitToList(getParentPathFromRow(row));
-                                    String path = segments.get(segments.size() - 1);
-                                    return pathsMatch(path + row.getString("leaf"), fieldPath);
-                                  }));
-            })
-        .flatMap(x -> x.stream())
-        .collect(Collectors.toList());
+      boolean numericBooleans,
+      Set<String> filterFieldPaths,
+      List<Row> docChunk) {
+    List<Row> fieldRows =
+        docChunk.stream()
+            .filter(
+                r -> {
+                  if (r == null || r.getString("leaf") == null) {
+                    return false;
+                  }
+                  List<String> parentPath = PATH_SPLITTER.splitToList(getParentPathFromRow(r));
+                  String rowPath = "";
+                  if (parentPath.size() == 2) {
+                    rowPath = parentPath.get(1);
+                  }
+                  String fullRowPath = rowPath + r.getString("leaf");
+                  List<FilterCondition> matchingFilters =
+                      inMemoryFilters.stream()
+                          .filter(f -> pathsMatch(fullRowPath, f.getFullFieldPath()))
+                          .collect(Collectors.toList());
+                  if (matchingFilters.isEmpty()) {
+                    return false;
+                  }
+                  return allFiltersMatch(r, matchingFilters, numericBooleans);
+                })
+            .collect(Collectors.toList());
+    // This ensures that wildcard paths are properly counted with non-wildcard paths,
+    // by making sure that for every filter above, at least one matches a valid row.
+    return filterFieldPaths.stream()
+        .allMatch(
+            fieldPath ->
+                fieldRows.stream()
+                    .anyMatch(
+                        row -> {
+                          List<String> segments =
+                              PATH_SPLITTER.splitToList(getParentPathFromRow(row));
+                          String path = segments.get(segments.size() - 1);
+                          return pathsMatch(path + row.getString("leaf"), fieldPath);
+                        }));
   }
 
   private Boolean getBooleanFromRow(Row row, String colName, boolean numericBooleans) {

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/FlowableConnectOnRequest.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/FlowableConnectOnRequest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.web.docsapi.service;
+
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.FlowableTransformer;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.flowables.ConnectableFlowable;
+import io.reactivex.rxjava3.functions.Consumer;
+import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/**
+ * Subscribes to the given {@link ConnectableFlowable} but connects only when downstream subscribers
+ * {@link Subscription#request(long) request} elements.
+ *
+ * <p>Note: upstream {@link Flowable} is never cancelled.
+ *
+ * @see #with()
+ */
+public class FlowableConnectOnRequest<T> extends Flowable<T> {
+
+  private final ConnectableFlowable<T> source;
+
+  private FlowableConnectOnRequest(ConnectableFlowable<T> source) {
+    this.source = source;
+  }
+
+  /**
+   * Creates a {@link Flowable#publish() publisher} from the given {@link Flowable} and wraps it in
+   * a {@link FlowableConnectOnRequest} instance.
+   */
+  public static <T> FlowableTransformer<T, T> with() {
+    return upstream -> new FlowableConnectOnRequest<>(upstream.publish());
+  }
+
+  @Override
+  protected void subscribeActual(@NonNull Subscriber<? super T> subscriber) {
+    source.subscribe(new OnRequestSubscription(subscriber));
+  }
+
+  private class OnRequestSubscription
+      implements Subscription, Subscriber<T>, @NonNull Consumer<Disposable> {
+
+    private final Subscriber<? super T> downstream;
+    private Subscription upstream;
+
+    private OnRequestSubscription(Subscriber<? super T> downstream) {
+      this.downstream = downstream;
+    }
+
+    @Override
+    public void request(long n) {
+      // We connect only when a requests comes. Also, ConnectableFuture impl. is expected to
+      // handle concurrent and repeated connect calls.
+      // `this` receives the connection's Disposable - see accept(...). We use an explicit
+      // Consumer<Disposable> here to avoid creating extra Consumer objects on every call.
+      source.connect(this);
+
+      upstream.request(n);
+    }
+
+    @Override
+    public void cancel() {
+      upstream.cancel();
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+      if (SubscriptionHelper.validate(upstream, s)) {
+        upstream = s;
+        downstream.onSubscribe(this);
+      }
+    }
+
+    @Override
+    public void onNext(T value) {
+      downstream.onNext(value);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      downstream.onError(t);
+    }
+
+    @Override
+    public void onComplete() {
+      downstream.onComplete();
+    }
+
+    @Override
+    public void accept(Disposable disposable) throws Throwable {
+      // nop - we do not cancel Flowable connections (cf. request(int))
+    }
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.web.docsapi.service;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+import hu.akarnokd.rxjava2.operators.ExpandStrategy;
+import hu.akarnokd.rxjava2.operators.FlowableTransformers;
+import io.reactivex.BackpressureStrategy;
+import io.reactivex.Flowable;
+import io.reactivex.FlowableOnSubscribe;
+import io.reactivex.Single;
+import io.stargate.db.ImmutableParameters;
+import io.stargate.db.datastore.DataStore;
+import io.stargate.db.datastore.ResultSet;
+import io.stargate.db.datastore.Row;
+import io.stargate.db.query.builder.AbstractBound;
+import io.stargate.db.query.builder.BuiltSelect;
+import io.stargate.db.schema.Column;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+/** Executes pre-built document queries, groups document rows and manages document pagination. */
+public class QueryExecutor {
+  private final Accumulator TERM = new Accumulator();
+
+  private final DataStore dataStore;
+
+  public QueryExecutor(DataStore dataStore) {
+    this.dataStore = dataStore;
+  }
+
+  public Flowable<RawDocument> queryDocs(
+      AbstractBound<?> query, int pageSize, ByteBuffer pagingState) {
+    return queryDocs(1, query, pageSize, pagingState);
+  }
+
+  public Flowable<RawDocument> queryDocs(
+      int identityDepth, AbstractBound<?> query, int pageSize, ByteBuffer pagingState) {
+    BuiltSelect select = (BuiltSelect) query.source().query();
+    if (identityDepth < 1 || identityDepth > select.table().primaryKeyColumns().size()) {
+      throw new IllegalArgumentException("Invalid document identity depth: " + identityDepth);
+    }
+
+    List<Column> idColumns = select.table().primaryKeyColumns().subList(0, identityDepth);
+
+    return execute(query, pageSize, pagingState)
+        .concatMap(rs -> Flowable.fromIterable(seeds(rs, idColumns)), 1)
+        .concatWith(Single.just(TERM))
+        .scan(Accumulator::combine)
+        .filter(Accumulator::isComplete)
+        .map(Accumulator::toDoc);
+  }
+
+  public Flowable<ResultSet> execute(AbstractBound<?> query, int pageSize, ByteBuffer pagingState) {
+    return fetchPage(query, pageSize, pagingState)
+        .compose( // Expand BREADTH_FIRST to reduce the number of "proactive" page requests
+            FlowableTransformers.expand(
+                rs -> fetchNext(rs, pageSize, query), ExpandStrategy.BREADTH_FIRST, 1));
+  }
+
+  private Flowable<ResultSet> fetchPage(
+      AbstractBound<?> query, int pageSize, ByteBuffer pagingState) {
+    CompletableFuture<ResultSet> futureResult = new CompletableFuture<>();
+    return Flowable.create(
+            (FlowableOnSubscribe<ResultSet>)
+                emitter -> // separate subscription from execution - see doOnRequest
+                futureResult.whenComplete(
+                        (rows, t) -> {
+                          if (t != null) {
+                            emitter.onError(t);
+                          } else {
+                            emitter.onNext(rows);
+                            emitter.onComplete();
+                          }
+                        }),
+            BackpressureStrategy.BUFFER)
+        .doOnRequest( // execute only when requested
+            n -> // Note: `n` should be 1 and used only once - see .limit(1) below
+            dataStore
+                    .execute(
+                        query,
+                        p -> {
+                          ImmutableParameters.Builder builder = p.toBuilder();
+                          builder.pageSize(pageSize);
+                          if (pagingState != null) {
+                            builder.pagingState(pagingState);
+                          }
+                          return builder.build();
+                        })
+                    .whenComplete(
+                        (rows, t) -> {
+                          if (t != null) {
+                            futureResult.completeExceptionally(t);
+                          } else {
+                            futureResult.complete(rows);
+                          }
+                        }))
+        .limit(1);
+  }
+
+  private Flowable<ResultSet> fetchNext(ResultSet rs, int pageSize, AbstractBound<?> query) {
+    ByteBuffer nextPagingState = rs.getPagingState();
+    if (nextPagingState == null) {
+      return Flowable.empty();
+    } else {
+      return fetchPage(query, pageSize, nextPagingState);
+    }
+  }
+
+  private Iterable<Accumulator> seeds(ResultSet rs, List<Column> keyColumns) {
+    List<Row> rows = rs.currentPageRows();
+    List<Accumulator> seeds = new ArrayList<>(rows.size());
+    for (Row row : rows) {
+      String id = row.getString("key");
+      Builder<String> docKey = ImmutableList.builder();
+      for (Column c : keyColumns) {
+        docKey.add(Objects.requireNonNull(row.getString(c.name())));
+      }
+      seeds.add(new Accumulator(id, docKey.build(), rs, row));
+    }
+    return seeds;
+  }
+
+  public class Accumulator {
+
+    private final String id;
+    private final List<String> docKey;
+    private final List<Row> rows;
+    private final boolean complete;
+    private final Accumulator next;
+    private ResultSet lastResultSet;
+
+    private Accumulator() {
+      id = null;
+      docKey = null;
+      rows = null;
+      next = null;
+      complete = false;
+    }
+
+    private Accumulator(String id, List<String> docKey, ResultSet resultSet, Row seedRow) {
+      this.id = id;
+      this.docKey = docKey;
+      this.rows = new ArrayList<>();
+      this.next = null;
+      this.complete = false;
+      this.lastResultSet = resultSet;
+
+      rows.add(seedRow);
+    }
+
+    private Accumulator(
+        String id, List<String> docKey, ResultSet resultSet, List<Row> rows, Accumulator next) {
+      this.id = id;
+      this.docKey = docKey;
+      this.rows = rows;
+      this.next = next;
+      this.complete = true;
+      this.lastResultSet = resultSet;
+    }
+
+    boolean isComplete() {
+      return complete;
+    }
+
+    public RawDocument toDoc() {
+      if (!complete) {
+        throw new IllegalStateException("Incomplete document.");
+      }
+
+      boolean hasNext = next != null || lastResultSet.getPagingState() != null;
+      return new RawDocument(id, docKey, lastResultSet, hasNext, rows);
+    }
+
+    private Accumulator end() {
+      if (next != null) {
+        if (!complete) {
+          throw new IllegalStateException("Ending an incomplete document");
+        }
+
+        return next.end();
+      }
+
+      if (complete) {
+        throw new IllegalStateException("Already complete");
+      }
+
+      return new Accumulator(id, docKey, lastResultSet, rows, null);
+    }
+
+    private void append(Accumulator other) {
+      rows.addAll(other.rows);
+      lastResultSet = other.lastResultSet;
+    }
+
+    private Accumulator combine(Accumulator buffer) {
+      if (buffer == TERM) {
+        return end();
+      }
+
+      if (complete) {
+        if (next == null) {
+          throw new IllegalStateException(
+              "Unexpected continuation after a terminal document element.");
+        }
+
+        return next.combine(buffer);
+      }
+
+      if (docKey.equals(buffer.docKey)) {
+        append(buffer);
+        return this; // still not complete
+      } else {
+        return new Accumulator(id, docKey, lastResultSet, rows, buffer);
+      }
+    }
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
@@ -142,7 +142,7 @@ public class QueryExecutor {
     return seeds;
   }
 
-  public class Accumulator {
+  private class Accumulator {
 
     private final String id;
     private final List<String> docKey;

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
@@ -17,12 +17,12 @@ package io.stargate.web.docsapi.service;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
-import hu.akarnokd.rxjava2.operators.ExpandStrategy;
-import hu.akarnokd.rxjava2.operators.FlowableTransformers;
-import io.reactivex.BackpressureStrategy;
-import io.reactivex.Flowable;
-import io.reactivex.FlowableOnSubscribe;
-import io.reactivex.Single;
+import hu.akarnokd.rxjava3.operators.ExpandStrategy;
+import hu.akarnokd.rxjava3.operators.FlowableTransformers;
+import io.reactivex.rxjava3.core.BackpressureStrategy;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.FlowableOnSubscribe;
+import io.reactivex.rxjava3.core.Single;
 import io.stargate.db.ImmutableParameters;
 import io.stargate.db.datastore.DataStore;
 import io.stargate.db.datastore.ResultSet;
@@ -116,7 +116,7 @@ public class QueryExecutor {
                             futureResult.complete(rows);
                           }
                         }))
-        .limit(1);
+        .take(1);
   }
 
   private Flowable<ResultSet> fetchNext(ResultSet rs, int pageSize, AbstractBound<?> query) {

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
@@ -97,6 +97,10 @@ public class QueryExecutor {
                     .execute(
                         query,
                         p -> {
+                          if (pageSize <= 0) {
+                            return p; // if page size is not set pagingState is ignored by C*
+                          }
+
                           ImmutableParameters.Builder builder = p.toBuilder();
                           builder.pageSize(pageSize);
                           if (pagingState != null) {

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
@@ -52,13 +52,13 @@ public class QueryExecutor {
   }
 
   public Flowable<RawDocument> queryDocs(
-      int identityDepth, AbstractBound<?> query, int pageSize, ByteBuffer pagingState) {
+      int keyDepth, AbstractBound<?> query, int pageSize, ByteBuffer pagingState) {
     BuiltSelect select = (BuiltSelect) query.source().query();
-    if (identityDepth < 1 || identityDepth > select.table().primaryKeyColumns().size()) {
-      throw new IllegalArgumentException("Invalid document identity depth: " + identityDepth);
+    if (keyDepth < 1 || keyDepth > select.table().primaryKeyColumns().size()) {
+      throw new IllegalArgumentException("Invalid document identity depth: " + keyDepth);
     }
 
-    List<Column> idColumns = select.table().primaryKeyColumns().subList(0, identityDepth);
+    List<Column> idColumns = select.table().primaryKeyColumns().subList(0, keyDepth);
 
     return execute(query, pageSize, pagingState)
         .flatMap(rs -> Flowable.fromIterable(seeds(rs, idColumns)), 1) // concurrency factor 1

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
@@ -61,7 +61,7 @@ public class QueryExecutor {
     List<Column> idColumns = select.table().primaryKeyColumns().subList(0, identityDepth);
 
     return execute(query, pageSize, pagingState)
-        .concatMap(rs -> Flowable.fromIterable(seeds(rs, idColumns)), 1)
+        .flatMap(rs -> Flowable.fromIterable(seeds(rs, idColumns)), 1) // concurrency factor 1
         .concatWith(Single.just(TERM))
         .scan(Accumulator::combine)
         .filter(Accumulator::isComplete)

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/RawDocument.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/RawDocument.java
@@ -15,8 +15,8 @@
  */
 package io.stargate.web.docsapi.service;
 
-import io.reactivex.Flowable;
-import io.reactivex.Single;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
 import io.stargate.db.PagingPosition;
 import io.stargate.db.PagingPosition.ResumeMode;
 import io.stargate.db.datastore.ResultSet;
@@ -55,7 +55,7 @@ public class RawDocument {
   }
 
   public Single<RawDocument> populateFrom(Flowable<RawDocument> docs) {
-    return docs.limit(1)
+    return docs.take(1)
         .singleElement()
         .map(this::populateFrom)
         .switchIfEmpty(Single.fromCallable(() -> replaceRows(Collections.emptyList())));

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/RawDocument.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/RawDocument.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.web.docsapi.service;
+
+import io.reactivex.Flowable;
+import io.reactivex.Single;
+import io.stargate.db.PagingPosition;
+import io.stargate.db.PagingPosition.ResumeMode;
+import io.stargate.db.datastore.ResultSet;
+import io.stargate.db.datastore.Row;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+public class RawDocument {
+
+  private final String id;
+  private final List<String> docKey;
+  private final ResultSet resultSet;
+  private final boolean hasNext;
+  private final List<Row> rows;
+
+  public RawDocument(
+      String id, List<String> docKey, ResultSet resultSet, boolean hasNext, List<Row> rows) {
+    this.id = id;
+    this.docKey = docKey;
+    this.resultSet = resultSet;
+    this.hasNext = hasNext;
+    this.rows = rows;
+  }
+
+  public String id() {
+    return id;
+  }
+
+  public List<String> key() {
+    return docKey;
+  }
+
+  public List<Row> rows() {
+    return rows;
+  }
+
+  public Single<RawDocument> populateFrom(Flowable<RawDocument> docs) {
+    return docs.limit(1).map(this::populateFrom).singleElement().toSingle();
+  }
+
+  public RawDocument populateFrom(RawDocument doc) {
+    if (!id.equals(doc.id)) {
+      throw new IllegalStateException(
+          String.format("Document ID mismatch. Expecting %s, got %s", id, doc.id));
+    }
+
+    // Use query state of current doc, but rows from the other doc
+    return new RawDocument(id, docKey, resultSet, hasNext, doc.rows);
+  }
+
+  public boolean hasPagingState() {
+    return hasNext && !rows.isEmpty();
+  }
+
+  public ByteBuffer makePagingState() {
+    if (!hasNext) {
+      return null;
+    }
+
+    if (rows.isEmpty()) {
+      throw new IllegalStateException("Cannot resume paging from an empty document");
+    }
+
+    ResumeMode resumeMode = ResumeMode.NEXT_PARTITION;
+    if (docKey.size() > 1) {
+      resumeMode = ResumeMode.NEXT_ROW;
+    }
+
+    Row lastRow = rows.get(rows.size() - 1);
+
+    return resultSet.makePagingState(
+        PagingPosition.ofCurrentRow(lastRow).resumeFrom(resumeMode).build());
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/TimeSource.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/TimeSource.java
@@ -1,0 +1,9 @@
+package io.stargate.web.docsapi.service;
+
+public interface TimeSource {
+
+  TimeSource SYSTEM = () -> System.currentTimeMillis() * 1000;
+
+  /** Microseconds since {@link java.lang.System#currentTimeMillis() epoch}. */
+  long currentTimeMicros();
+}

--- a/restapi/src/test/java/io/stargate/db/datastore/AbstractDataStoreTest.java
+++ b/restapi/src/test/java/io/stargate/db/datastore/AbstractDataStoreTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.db.datastore;
+
+import io.stargate.db.datastore.ValidatingDataStore.QueryExpectation;
+import io.stargate.db.schema.Schema;
+import io.stargate.db.schema.Table;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+public abstract class AbstractDataStoreTest {
+
+  private ValidatingDataStore dataStore;
+
+  protected abstract Schema schema();
+
+  protected DataStore datastore() {
+    return dataStore;
+  }
+
+  @BeforeEach
+  public void createDataStore() {
+    dataStore = new ValidatingDataStore(schema());
+    dataStore.reset();
+  }
+
+  @AfterEach
+  public void checkExpectedExecutions() {
+    dataStore.validate();
+  }
+
+  protected void ignorePreparedExecutions() {
+    dataStore.ignorePrepared();
+  }
+
+  protected QueryExpectation withQuery(Table table, String cql, Object... params) {
+    return dataStore.withQuery(table, cql, params);
+  }
+
+  protected QueryExpectation withAnySelectFrom(Table table) {
+    return dataStore.withAnySelectFrom(table);
+  }
+
+  protected QueryExpectation withAnyUpdateOf(Table table) {
+    return dataStore.withAnyUpdateOf(table);
+  }
+
+  protected QueryExpectation withAnyInsertInfo(Table table) {
+    return dataStore.withAnyInsertInfo(table);
+  }
+}

--- a/restapi/src/test/java/io/stargate/db/datastore/ListBackedResultSet.java
+++ b/restapi/src/test/java/io/stargate/db/datastore/ListBackedResultSet.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.db.datastore;
+
+import io.stargate.db.PagingPosition;
+import io.stargate.db.schema.Column;
+import io.stargate.db.schema.Table;
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import javax.validation.constraints.NotNull;
+
+/**
+ * A simple result set implementation that simply stores data in a List. Produces {@link
+ * MapBackedRow} rows when iterating the results.
+ */
+public class ListBackedResultSet implements ResultSet {
+
+  private final List<Column> columns;
+  private final List<Row> currentPage;
+  private final ValidatingPaginator paginator;
+
+  public ListBackedResultSet(List<Column> columns, List<Row> data, ValidatingPaginator paginator) {
+    this.columns = columns;
+    this.currentPage = data;
+    this.paginator = paginator;
+  }
+
+  public static ResultSet of(
+      Table table, List<Map<String, Object>> data, ValidatingPaginator paginator) {
+    data = paginator.filter(data);
+    Set<String> columnNames =
+        data.stream().flatMap(m -> m.keySet().stream()).collect(Collectors.toSet());
+    List<Column> columns = columnNames.stream().map(table::column).collect(Collectors.toList());
+
+    if (columnNames.isEmpty()) { // empty `data`
+      columns = table.columns(); // use all columns as a fallback for tests
+    }
+
+    List<Row> rows = data.stream().map(m -> MapBackedRow.of(table, m)).collect(Collectors.toList());
+    return new ListBackedResultSet(columns, rows, paginator);
+  }
+
+  @Override
+  public List<Column> columns() {
+    return columns;
+  }
+
+  @Override
+  public List<Row> currentPageRows() {
+    return currentPage;
+  }
+
+  @Override
+  public boolean hasNoMoreFetchedRows() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ResultSet withRowInspector(Predicate<Row> authzFilter) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  @NotNull
+  public Iterator<Row> iterator() {
+    throw new UnsupportedOperationException("Expecting page-by-page fetching");
+  }
+
+  @Override
+  public Row one() {
+    throw new UnsupportedOperationException("Expecting page-by-page fetching");
+  }
+
+  @Override
+  public List<Row> rows() {
+    throw new UnsupportedOperationException("Expecting page-by-page fetching");
+  }
+
+  @Override
+  public ByteBuffer getPagingState() {
+    return paginator.pagingState();
+  }
+
+  @Override
+  public ByteBuffer makePagingState(PagingPosition position) {
+    return paginator.pagingState(position, currentPage);
+  }
+}

--- a/restapi/src/test/java/io/stargate/db/datastore/MapBackedRow.java
+++ b/restapi/src/test/java/io/stargate/db/datastore/MapBackedRow.java
@@ -74,6 +74,22 @@ public class MapBackedRow implements Row {
     return (double) dataMap.get(name);
   }
 
+  @Override
+  public long getLong(@NonNull String name) {
+    return ((Number) dataMap.get(name)).longValue();
+  }
+
+  @Override
+  public boolean getBoolean(@NonNull String name) {
+    assertThat(table.column(name)).isNotNull();
+    return (boolean) dataMap.get(name);
+  }
+
+  @Override
+  public boolean isNull(@NonNull String name) {
+    return !dataMap.containsKey(name);
+  }
+
   @Nullable
   @Override
   public ByteBuffer getBytesUnsafe(@NonNull String name) {

--- a/restapi/src/test/java/io/stargate/db/datastore/MapBackedRow.java
+++ b/restapi/src/test/java/io/stargate/db/datastore/MapBackedRow.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.db.datastore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.ProtocolVersion;
+import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.stargate.db.schema.Column;
+import io.stargate.db.schema.Table;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * A simple DseRow implementation that simply stores data in a {@link Map}. Created via {@link
+ * ListBackedResultSet}.
+ */
+public class MapBackedRow implements Row {
+  private final Table table;
+  private final Map<String, Object> dataMap;
+
+  public static Row of(Table table, Map<String, Object> dataMap) {
+    return new MapBackedRow(table, dataMap);
+  }
+
+  private MapBackedRow(Table table, Map<String, Object> data) {
+    this.table = table;
+    this.dataMap = data;
+  }
+
+  @Override
+  public List<Column> columns() {
+    return table.columns().stream()
+        .filter(c -> dataMap.containsKey(c.name()))
+        .collect(Collectors.toList());
+  }
+
+  @Nullable
+  @Override
+  public Object getObject(@NonNull String name) {
+    assertThat(table.column(name)).isNotNull();
+    return dataMap.get(name);
+  }
+
+  @Nullable
+  @Override
+  public String getString(@NonNull String name) {
+    assertThat(table.column(name)).isNotNull();
+    return (String) dataMap.get(name);
+  }
+
+  @Override
+  public double getDouble(@NonNull String name) {
+    assertThat(table.column(name)).isNotNull();
+    return (double) dataMap.get(name);
+  }
+
+  @Nullable
+  @Override
+  public ByteBuffer getBytesUnsafe(@NonNull String name) {
+    // Should only be used for building paging name, not for actual values.
+    // Assume that relevant values are Strings.
+    String value = dataMap.get(name).toString();
+    return ByteBuffer.wrap(value.getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Override
+  public int firstIndexOf(@NonNull String name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @NonNull
+  @Override
+  public DataType getType(@NonNull String name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nullable
+  @Override
+  public ByteBuffer getBytesUnsafe(int i) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int size() {
+    return dataMap.size();
+  }
+
+  @NonNull
+  @Override
+  public DataType getType(int i) {
+    throw new UnsupportedOperationException();
+  }
+
+  @NonNull
+  @Override
+  public CodecRegistry codecRegistry() {
+    throw new UnsupportedOperationException();
+  }
+
+  @NonNull
+  @Override
+  public ProtocolVersion protocolVersion() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/restapi/src/test/java/io/stargate/db/datastore/ValidatingDataStore.java
+++ b/restapi/src/test/java/io/stargate/db/datastore/ValidatingDataStore.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.db.datastore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.stargate.db.BatchType;
+import io.stargate.db.Parameters;
+import io.stargate.db.query.BindMarker;
+import io.stargate.db.query.BoundQuery;
+import io.stargate.db.query.Query;
+import io.stargate.db.query.QueryType;
+import io.stargate.db.query.TypedValue;
+import io.stargate.db.query.TypedValue.Codec;
+import io.stargate.db.schema.Schema;
+import io.stargate.db.schema.Table;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.UnaryOperator;
+import java.util.regex.Pattern;
+import org.apache.cassandra.stargate.utils.MD5Digest;
+import org.assertj.core.api.AbstractIntegerAssert;
+import org.assertj.core.api.Assertions;
+
+public class ValidatingDataStore implements DataStore {
+  private final Schema schema;
+  private final List<QueryExpectation> expectedQueries = new ArrayList<>();
+  private final List<Prepared<?>> prepared = new ArrayList<>();
+  private final List<ExpectedExecution> expectedExecutions = new ArrayList<>();
+
+  public ValidatingDataStore(Schema schema) {
+    this.schema = schema;
+  }
+
+  public void reset() {
+    prepared.clear();
+    expectedExecutions.clear();
+    expectedQueries.clear();
+  }
+
+  public void ignorePrepared() {
+    prepared.clear();
+  }
+
+  public void validate() {
+    prepared.forEach(Prepared::validate);
+    expectedExecutions.forEach(ExpectedExecution::validate);
+  }
+
+  @Override
+  public Codec valueCodec() {
+    return Codec.testCodec();
+  }
+
+  @Override
+  public boolean supportsSecondaryIndex() {
+    return true;
+  }
+
+  @Override
+  public boolean supportsSAI() {
+    return false;
+  }
+
+  @Override
+  public boolean supportsLoggedBatches() {
+    return false;
+  }
+
+  @Override
+  public <B extends BoundQuery> CompletableFuture<Query<B>> prepare(Query<B> query) {
+    String queryString = query.queryStringForPreparation();
+    expectedQueries.stream()
+        .filter(qe -> qe.matches(queryString))
+        .findAny()
+        .orElseGet(() -> Assertions.fail("Unexpected query: " + queryString));
+
+    Prepared<B> p = new Prepared<>(query);
+    prepared.add(p);
+    return CompletableFuture.completedFuture(p);
+  }
+
+  @Override
+  public CompletableFuture<ResultSet> execute(
+      BoundQuery query, UnaryOperator<Parameters> parametersModifier) {
+    ExpectedExecution execution;
+    if (query instanceof ExpectedExecution) {
+      execution = (ExpectedExecution) query;
+    } else {
+      Prepared<?> prepared = (Prepared<?>) prepare(query.source().query()).join();
+      execution = (ExpectedExecution) prepared.bindValues(query.values());
+    }
+
+    Parameters parameters = parametersModifier.apply(Parameters.defaults());
+    return execution.execute(parameters);
+  }
+
+  @Override
+  public CompletableFuture<ResultSet> batch(
+      Collection<BoundQuery> queries,
+      BatchType batchType,
+      UnaryOperator<Parameters> parametersModifier) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Schema schema() {
+    return schema;
+  }
+
+  @Override
+  public boolean isInSchemaAgreement() {
+    return true;
+  }
+
+  @Override
+  public void waitForSchemaAgreement() {}
+
+  private QueryExpectation add(QueryExpectation expectation) {
+    expectedQueries.add(expectation);
+    return expectation;
+  }
+
+  public QueryExpectation withQuery(Table table, String cql, Object... params) {
+    cql = String.format(cql, table.keyspace() + "." + table.name());
+    return add(new QueryExpectation(table, Pattern.quote(cql), params));
+  }
+
+  protected QueryExpectation withAnySelectFrom(Table table) {
+    String regex = "SELECT.*FROM.*" + table.keyspace() + "\\." + table.name() + ".*";
+    return add(new QueryExpectation(table, regex, new Object[0]));
+  }
+
+  protected QueryExpectation withAnyUpdateOf(Table table) {
+    String regex = "UPDATE.*" + table.keyspace() + "\\." + table.name() + ".*";
+    return add(new QueryExpectation(table, regex));
+  }
+
+  protected QueryExpectation withAnyInsertInfo(Table table) {
+    String regex = "INSERT INTO.*" + table.keyspace() + "\\." + table.name() + ".*";
+    return add(new QueryExpectation(table, regex));
+  }
+
+  protected QueryExpectation withAnyDeleteFrom(Table table) {
+    String regex = "DELETE.*FROM.*" + table.keyspace() + "\\." + table.name() + ".*";
+    return add(new QueryExpectation(table, regex));
+  }
+
+  private class Prepared<B extends BoundQuery> implements Query<B> {
+    private final String actualCql;
+    private final Query<B> query;
+    private boolean bound;
+
+    private Prepared(Query<B> query) {
+      this.actualCql = query.queryStringForPreparation();
+      this.query = query;
+    }
+
+    @Override
+    public Codec valueCodec() {
+      return Codec.testCodec();
+    }
+
+    @Override
+    public List<BindMarker> bindMarkers() {
+      return query.bindMarkers();
+    }
+
+    @Override
+    public Optional<MD5Digest> preparedId() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Query<B> withPreparedId(MD5Digest preparedId) {
+      return this;
+    }
+
+    @Override
+    public String queryStringForPreparation() {
+      return actualCql;
+    }
+
+    @Override
+    public B bindValues(List<TypedValue> values) {
+      QueryExpectation expectation =
+          expectedQueries.stream()
+              .filter(qe -> qe.matches(actualCql, values))
+              .findFirst()
+              .orElseGet(
+                  () ->
+                      Assertions.fail(
+                          "Unexpected query: " + actualCql + " with params: " + values));
+
+      ExpectedExecution exec = new ExpectedExecution(this, expectation);
+      expectedExecutions.add(exec);
+      bound = true;
+      //noinspection unchecked
+      return (B) exec;
+    }
+
+    public void validate() {
+      if (!bound) {
+        Assertions.fail("The following query was prepared but never bound: " + actualCql);
+      }
+    }
+  }
+
+  public abstract static class QueryAssert {
+    private final AtomicInteger executeCount = new AtomicInteger();
+
+    public AbstractIntegerAssert<?> assertExecuteCount() {
+      return Assertions.assertThat(executeCount.get());
+    }
+
+    void executed() {
+      executeCount.incrementAndGet();
+    }
+  }
+
+  public static class QueryExpectation extends QueryAssert {
+
+    private final Table table;
+    private final Pattern cqlPattern;
+    private final Object[] params;
+    private int pageSize = Integer.MAX_VALUE;
+    private List<Map<String, Object>> rows;
+
+    private QueryExpectation(Table table, String cqlRegEx, Object[] params) {
+      this.cqlPattern = Pattern.compile(cqlRegEx);
+      this.table = table;
+      this.params = params;
+    }
+
+    private QueryExpectation(Table table, String cqlRegEx) {
+      this.cqlPattern = Pattern.compile(cqlRegEx);
+      this.table = table;
+      this.params = null;
+    }
+
+    public QueryExpectation withPageSize(int pageSize) {
+      this.pageSize = pageSize;
+      return this;
+    }
+
+    public QueryAssert returningNothing() {
+      return returning(Collections.emptyList());
+    }
+
+    public QueryAssert returning(List<Map<String, Object>> rows) {
+      this.rows = rows;
+      return this;
+    }
+
+    private boolean matches(String cql) {
+      return cqlPattern.matcher(cql).matches();
+    }
+
+    private static Object[] values(List<TypedValue> values) {
+      return values.stream().map(TypedValue::javaValue).toArray();
+    }
+
+    private boolean matches(String cql, List<TypedValue> values) {
+      return matches(cql) && (params == null || Arrays.equals(params, values(values)));
+    }
+  }
+
+  private class ExpectedExecution implements BoundQuery {
+
+    private final Prepared<?> query;
+    private final QueryExpectation expectation;
+    private boolean executed;
+
+    public ExpectedExecution(Prepared<?> query, QueryExpectation expectation) {
+      this.query = query;
+      this.expectation = expectation;
+    }
+
+    private void validate() {
+      if (!executed) {
+        Assertions.fail(
+            "The following query was prepared but not executed: "
+                + query.actualCql
+                + ", params: "
+                + Arrays.toString(expectation.params));
+      }
+    }
+
+    private CompletableFuture<ResultSet> execute(Parameters parameters) {
+      executed = true;
+
+      Optional<ByteBuffer> pagingState = parameters.pagingState();
+      if (expectation.pageSize < Integer.MAX_VALUE) {
+        assertThat(parameters.pageSize()).hasValue(expectation.pageSize);
+      }
+
+      ValidatingPaginator paginator = ValidatingPaginator.of(expectation.pageSize, pagingState);
+
+      expectation.executed();
+      return CompletableFuture.completedFuture(
+          ListBackedResultSet.of(expectation.table, expectation.rows, paginator));
+      //      return CompletableFuture.supplyAsync(
+      //          () -> ListBackedResultSet.of(expectation.table, expectation.rows, paginator));
+    }
+
+    @Override
+    public QueryType type() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Source<?> source() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<TypedValue> values() {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/restapi/src/test/java/io/stargate/db/datastore/ValidatingDataStore.java
+++ b/restapi/src/test/java/io/stargate/db/datastore/ValidatingDataStore.java
@@ -121,7 +121,13 @@ public class ValidatingDataStore implements DataStore {
       Collection<BoundQuery> queries,
       BatchType batchType,
       UnaryOperator<Parameters> parametersModifier) {
-    throw new UnsupportedOperationException();
+    CompletableFuture<ResultSet> last = null;
+    for (BoundQuery query : queries) {
+      last = execute(query);
+    }
+
+    assertThat(last).isNotNull();
+    return last;
   }
 
   @Override

--- a/restapi/src/test/java/io/stargate/db/datastore/ValidatingPaginator.java
+++ b/restapi/src/test/java/io/stargate/db/datastore/ValidatingPaginator.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.db.datastore;
+
+import static io.stargate.db.PagingPosition.ResumeMode.NEXT_PARTITION;
+import static io.stargate.db.PagingPosition.ResumeMode.NEXT_ROW;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.stargate.db.PagingPosition;
+import io.stargate.db.schema.Column;
+import io.stargate.db.schema.Column.Kind;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+
+public class ValidatingPaginator {
+
+  public static final int MAGIC = 1020304050;
+  private final int pageSize;
+  private final int offset;
+  private int nextOffset = -1;
+
+  private ValidatingPaginator(int pageSize, int offset) {
+    this.pageSize = pageSize;
+    this.offset = offset;
+  }
+
+  public static ValidatingPaginator of(int pageSize) {
+    return new ValidatingPaginator(pageSize, -1);
+  }
+
+  public static ValidatingPaginator of(int pageSize, Optional<ByteBuffer> pagingState) {
+    int offset =
+        pagingState
+            .map(
+                buf -> {
+                  int magic = buf.getInt();
+                  assertThat(magic).isEqualTo(MAGIC);
+                  return buf.getInt();
+                })
+            .orElse(0);
+
+    return new ValidatingPaginator(pageSize, offset);
+  }
+
+  public <T> List<T> filter(List<T> data) {
+    int from = Math.max(offset, 0);
+    int to = Math.min(from + pageSize, data.size());
+    List<T> filtered = data.subList(from, to);
+
+    if (data.size() > to) {
+      nextOffset = to;
+    }
+
+    return filtered;
+  }
+
+  public ByteBuffer pagingState() {
+    if (nextOffset < 0) {
+      return null;
+    }
+
+    return pagingState(nextOffset);
+  }
+
+  private static ByteBuffer pagingState(int offset) {
+    ByteBuffer buffer = ByteBuffer.allocate(8);
+    buffer.putInt(MAGIC);
+    buffer.putInt(offset);
+    buffer.rewind();
+    return buffer;
+  }
+
+  public ByteBuffer pagingState(PagingPosition position, List<Row> rows) {
+    assertThat(position.resumeFrom()).matches(m -> m == NEXT_PARTITION || m == NEXT_ROW);
+    Map<Column, ByteBuffer> values = position.currentRow();
+    int resumeIdx = -1;
+    int nextIdx = 1;
+    for (Row row : rows) {
+      boolean found = true;
+      for (Entry<Column, ByteBuffer> e : values.entrySet()) {
+        Column column = e.getKey();
+        Kind kind = column.kind();
+        assertThat(kind).isNotNull();
+
+        if (!kind.isPrimaryKeyKind()) {
+          continue;
+        }
+
+        if (position.resumeFrom() == NEXT_PARTITION && !(kind == Kind.PartitionKey)) {
+          continue; // ignore clustering columns for ResumeMode.NEXT_PARTITION
+        }
+
+        ByteBuffer value = row.getBytesUnsafe(column.name());
+        assertThat(value).isNotNull();
+
+        if (!value.equals(e.getValue())) {
+          found = false;
+          break;
+        }
+      }
+
+      if (found) {
+        resumeIdx = nextIdx;
+      }
+
+      nextIdx++;
+    }
+
+    if (resumeIdx < 0) {
+      throw new IllegalStateException("Requested PagingPosition not found");
+    }
+
+    return pagingState(offset + resumeIdx);
+  }
+}

--- a/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
@@ -37,8 +37,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class DocumentResourceV2Test {
   private final AuthenticatedDB authenticatedDBMock = mock(AuthenticatedDB.class);
   @InjectMocks private DocumentResourceV2 documentResourceV2;
@@ -624,12 +627,6 @@ public class DocumentResourceV2Test {
     List<FilterCondition> conditions = new ArrayList<>();
     conditions.add(
         new SingleFilterCondition(ImmutableList.of("a", "b", "c", "field1"), "$eq", "value"));
-
-    Mockito.when(documentServiceMock.convertToFilterOps(anyList(), anyObject()))
-        .thenReturn(conditions);
-
-    Mockito.when(documentServiceMock.convertToSelectionList(anyObject()))
-        .thenReturn(ImmutableList.of("field1"));
 
     Response r =
         documentResourceV2.searchDoc(

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -1,1888 +1,759 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.stargate.web.docsapi.service;
 
+import static io.stargate.db.schema.Column.Kind.Clustering;
+import static io.stargate.db.schema.Column.Kind.PartitionKey;
+import static io.stargate.db.schema.Column.Kind.Regular;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyListOf;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.anyList;
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import com.datastax.oss.driver.api.core.ProtocolVersion;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap.Builder;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ImmutableList;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonNull;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
+import io.stargate.auth.AuthenticationService;
+import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
+import io.stargate.auth.Scope;
+import io.stargate.auth.SourceAPI;
 import io.stargate.auth.UnauthorizedException;
-import io.stargate.db.datastore.ArrayListBackedRow;
-import io.stargate.db.datastore.DataStore;
-import io.stargate.db.datastore.ResultSet;
-import io.stargate.db.datastore.Row;
-import io.stargate.db.query.builder.BuiltCondition;
+import io.stargate.db.datastore.AbstractDataStoreTest;
+import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.schema.Column;
 import io.stargate.db.schema.Column.Type;
+import io.stargate.db.schema.ImmutableColumn;
+import io.stargate.db.schema.ImmutableKeyspace;
+import io.stargate.db.schema.ImmutableSchema;
+import io.stargate.db.schema.ImmutableTable;
+import io.stargate.db.schema.Keyspace;
+import io.stargate.db.schema.Schema;
+import io.stargate.db.schema.Table;
 import io.stargate.web.docsapi.dao.DocumentDB;
-import io.stargate.web.docsapi.dao.Paginator;
-import io.stargate.web.docsapi.exception.ErrorCode;
-import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
-import io.stargate.web.docsapi.service.filter.FilterCondition;
-import io.stargate.web.docsapi.service.filter.ListFilterCondition;
-import io.stargate.web.docsapi.service.filter.SingleFilterCondition;
+import io.stargate.web.docsapi.models.DocumentResponseWrapper;
+import io.stargate.web.docsapi.resources.DocumentResourceV2;
 import io.stargate.web.resources.Db;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.PathSegment;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.jsfr.json.JsonSurfer;
-import org.jsfr.json.JsonSurferGson;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriInfo;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.*;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class DocumentServiceTest {
-  private final DataStore dataStore = Mockito.mock(DataStore.class);
-  @InjectMocks DocumentService service;
-  @Mock JsonConverter jsonConverter;
-  @Mock DocsSchemaChecker schemaChecker;
-  @Spy ObjectMapper serviceMapper;
-  @Spy DocsApiConfiguration docsConfig;
+public class DocumentServiceTest extends AbstractDataStoreTest {
 
-  private Method convertToBracketedPath;
-  private Method leftPadTo6;
-  private Method convertArrayPath;
-  private Method isEmptyObject;
-  private Method isEmptyArray;
-  private Method shredPayload;
-  private Method validateOpAndValue;
-  private Method addRowsToMap;
-  private Method updateExistenceForMap;
-  private Method getParentPathFromRow;
-  private Method filterToSelectionSet;
-  private Method applyInMemoryFilters;
-  private Method pathsMatch;
-  private Method checkEqualsOp;
-  private Method checkInOp;
-  private Method checkGtOp;
-  private Method checkLtOp;
-  private Method searchRows;
+  private static final Object SEPARATOR = new Object();
 
+  protected static final Table table =
+      ImmutableTable.builder()
+          .keyspace("test_docs")
+          .name("collection1")
+          .addColumns(
+              ImmutableColumn.builder().name("key").type(Type.Text).kind(PartitionKey).build())
+          .addColumns(clusteringColumns())
+          .addColumns(ImmutableColumn.builder().name("leaf").type(Type.Text).kind(Regular).build())
+          .addColumns(
+              ImmutableColumn.builder().name("text_value").type(Type.Text).kind(Regular).build())
+          .addColumns(
+              ImmutableColumn.builder().name("dbl_value").type(Type.Double).kind(Regular).build())
+          .addColumns(
+              ImmutableColumn.builder().name("bool_value").type(Type.Boolean).kind(Regular).build())
+          .build();
+
+  private static final Keyspace keyspace =
+      ImmutableKeyspace.builder().name("test_docs").addTables(table).build();
+
+  private static final Schema schema = ImmutableSchema.builder().addKeyspaces(keyspace).build();
   private static final ObjectMapper mapper = new ObjectMapper();
-  private static final Map<String, String> EMPTY_HEADERS = Collections.emptyMap();
+
+  private final AtomicLong now = new AtomicLong();
+  private final TimeSource timeSource = now::get;
+  private final DocsApiConfiguration config = new DocsApiConfiguration() {};
+  private final DocsSchemaChecker schemaChecker = new DocsSchemaChecker();
+  private final JsonConverter converter = new JsonConverter(mapper, config);
+  private final String authToken = "test-auth-token";
+  private final AuthenticationSubject subject = AuthenticationSubject.of(authToken, "user1", false);
+  @Mock private AuthenticationService authenticationService;
+  @Mock private AuthorizationService authorizationService;
+  @Mock private DataStoreFactory dataStoreFactory;
+  @Mock private UriInfo uriInfo;
+
+  @Mock(answer = RETURNS_DEEP_STUBS)
+  private HttpHeaders headers;
+
+  @Mock(answer = RETURNS_DEEP_STUBS)
+  private HttpServletRequest request;
+
+  private Db db;
+  private DocumentService service;
+  private DocumentResourceV2 resource;
+
+  private static Column[] clusteringColumns() {
+    Column[] columns = new Column[DocumentDB.MAX_DEPTH];
+    for (int i = 0; i < columns.length; i++) {
+      columns[i] = ImmutableColumn.builder().name("p" + i).type(Type.Text).kind(Clustering).build();
+    }
+    return columns;
+  }
+
+  @Override
+  protected Schema schema() {
+    return schema;
+  }
 
   @BeforeEach
-  public void setup() throws NoSuchMethodException {
-    convertToBracketedPath =
-        DocumentService.class.getDeclaredMethod("convertToBracketedPath", String.class);
-    convertToBracketedPath.setAccessible(true);
-    leftPadTo6 = DocumentService.class.getDeclaredMethod("leftPadTo6", String.class);
-    leftPadTo6.setAccessible(true);
-    convertArrayPath = DocumentService.class.getDeclaredMethod("convertArrayPath", String.class);
-    convertArrayPath.setAccessible(true);
-    isEmptyObject = DocumentService.class.getDeclaredMethod("isEmptyObject", Object.class);
-    isEmptyObject.setAccessible(true);
-    isEmptyArray = DocumentService.class.getDeclaredMethod("isEmptyArray", Object.class);
-    isEmptyArray.setAccessible(true);
-    shredPayload =
-        DocumentService.class.getDeclaredMethod(
-            "shredPayload",
-            JsonSurfer.class,
-            DocumentDB.class,
-            List.class,
-            String.class,
-            String.class,
-            boolean.class,
-            boolean.class);
-    shredPayload.setAccessible(true);
-    validateOpAndValue =
-        DocumentService.class.getDeclaredMethod(
-            "validateOpAndValue", String.class, JsonNode.class, String.class);
-    validateOpAndValue.setAccessible(true);
-    addRowsToMap = DocumentService.class.getDeclaredMethod("addRowsToMap", Map.class, List.class);
-    addRowsToMap.setAccessible(true);
-    updateExistenceForMap =
-        DocumentService.class.getDeclaredMethod(
-            "updateExistenceForMap",
-            Set.class,
-            List.class,
-            List.class,
-            boolean.class,
-            boolean.class);
-    updateExistenceForMap.setAccessible(true);
-    getParentPathFromRow =
-        DocumentService.class.getDeclaredMethod("getParentPathFromRow", Row.class);
-    getParentPathFromRow.setAccessible(true);
-    filterToSelectionSet =
-        DocumentService.class.getDeclaredMethod(
-            "filterToSelectionSet", List.class, List.class, List.class);
-    filterToSelectionSet.setAccessible(true);
-    applyInMemoryFilters =
-        DocumentService.class.getDeclaredMethod(
-            "applyInMemoryFilters", List.class, List.class, int.class, boolean.class);
-    applyInMemoryFilters.setAccessible(true);
-    pathsMatch = DocumentService.class.getDeclaredMethod("pathsMatch", String.class, String.class);
-    pathsMatch.setAccessible(true);
-    checkEqualsOp =
-        DocumentService.class.getDeclaredMethod(
-            "checkEqualsOp",
-            SingleFilterCondition.class,
-            String.class,
-            Boolean.class,
-            Double.class);
-    checkEqualsOp.setAccessible(true);
-    checkInOp =
-        DocumentService.class.getDeclaredMethod(
-            "checkInOp", ListFilterCondition.class, String.class, Boolean.class, Double.class);
-    checkInOp.setAccessible(true);
-    checkGtOp =
-        DocumentService.class.getDeclaredMethod(
-            "checkGtOp", SingleFilterCondition.class, String.class, Boolean.class, Double.class);
-    checkGtOp.setAccessible(true);
+  void setup() throws UnauthorizedException {
+    when(dataStoreFactory.createInternal(any())).thenReturn(datastore());
+    when(dataStoreFactory.create(any(), any())).thenReturn(datastore());
 
-    checkLtOp =
-        DocumentService.class.getDeclaredMethod(
-            "checkLtOp", SingleFilterCondition.class, String.class, Boolean.class, Double.class);
-    checkLtOp.setAccessible(true);
-    searchRows =
-        DocumentService.class.getDeclaredMethod(
-            "searchRows",
-            String.class,
-            String.class,
-            DocumentDB.class,
-            List.class,
-            List.class,
-            List.class,
-            List.class,
-            Boolean.class,
-            String.class,
-            Paginator.class);
-    searchRows.setAccessible(true);
+    db = new Db(authenticationService, authorizationService, dataStoreFactory);
+
+    when(authenticationService.validateToken(eq(authToken), anyMap())).thenReturn(subject);
+    service = new DocumentService(timeSource, mapper, converter, config, schemaChecker);
+    resource = new DocumentResourceV2(db, mapper, service, config, schemaChecker);
   }
 
-  @Test
-  public void convertToBracketedPath() throws IllegalAccessException, InvocationTargetException {
-    String input = "$.a.b";
-    String res = (String) convertToBracketedPath.invoke(service, input);
-    assertThat(res).isEqualTo("$['a']['b']");
-
-    input = "a.b";
-    res = (String) convertToBracketedPath.invoke(service, input);
-    assertThat(res).isEqualTo("['a']['b']");
-
-    input = "$.$.c";
-    res = (String) convertToBracketedPath.invoke(service, input);
-    assertThat(res).isEqualTo("$['$']['c']");
-
-    input = "$.a.b[0].c";
-    res = (String) convertToBracketedPath.invoke(service, input);
-    assertThat(res).isEqualTo("$['a']['b'][0]['c']");
-
-    input = "$.a.I need some space.c";
-    res = (String) convertToBracketedPath.invoke(service, input);
-    assertThat(res).isEqualTo("$['a']['I need some space']['c']");
-
-    input = "$.a.0[0].c";
-    res = (String) convertToBracketedPath.invoke(service, input);
-    assertThat(res).isEqualTo("$['a']['0'][0]['c']");
-
-    input = "$.@.23.f";
-    res = (String) convertToBracketedPath.invoke(service, input);
-    assertThat(res).isEqualTo("$['@']['23']['f']");
-
-    // This should really never be sent to this function...but it does "work"
-    input = "$..a";
-    res = (String) convertToBracketedPath.invoke(service, input);
-    assertThat(res).isEqualTo("$['']['a']");
+  private Map<String, Object> leafRow(String id) {
+    return m("key", id, "leaf", "test-value");
   }
 
-  @Test
-  public void leftPadTo6() throws InvocationTargetException, IllegalAccessException {
-    String result = (String) leftPadTo6.invoke(service, "");
-    assertThat(result).isEqualTo("000000");
-
-    result = (String) leftPadTo6.invoke(service, "00");
-    assertThat(result).isEqualTo("000000");
-
-    result = (String) leftPadTo6.invoke(service, "1");
-    assertThat(result).isEqualTo("000001");
-
-    result = (String) leftPadTo6.invoke(service, "abc");
-    assertThat(result).isEqualTo("000abc");
-
-    result = (String) leftPadTo6.invoke(service, "AbCd");
-    assertThat(result).isEqualTo("00AbCd");
+  private Map<String, Object> row(String id, Double value, String... path) {
+    Builder<String, Object> map = row(id, path);
+    map.put("dbl_value", value);
+    return map.build();
   }
 
-  @Test
-  public void convertArrayPath() throws InvocationTargetException, IllegalAccessException {
-    String result = (String) convertArrayPath.invoke(service, "");
-    assertThat(result).isEqualTo("");
-
-    result = (String) convertArrayPath.invoke(service, "a");
-    assertThat(result).isEqualTo("a");
-
-    result = (String) convertArrayPath.invoke(service, "[0]");
-    assertThat(result).isEqualTo("[000000]");
-
-    result = (String) convertArrayPath.invoke(service, "[0101]");
-    assertThat(result).isEqualTo("[000101]");
-
-    result = (String) convertArrayPath.invoke(service, "[999999]");
-    assertThat(result).isEqualTo("[999999]");
+  private Map<String, Object> row(String id, Boolean value, String... path) {
+    Builder<String, Object> map = row(id, path);
+    map.put("bool_value", value);
+    return map.build();
   }
 
-  @Test
-  public void convertArrayPath_invalidInput() {
-    Throwable thrown = catchThrowable(() -> convertArrayPath.invoke(service, "[]"));
-    assertThat(thrown.getCause())
-        .isInstanceOf(NumberFormatException.class)
-        .hasMessage("For input string: \"\"");
-
-    thrown = catchThrowable(() -> convertArrayPath.invoke(service, "[a]"));
-    assertThat(thrown.getCause())
-        .isInstanceOf(NumberFormatException.class)
-        .hasMessage("For input string: \"a\"");
-
-    thrown = catchThrowable(() -> convertArrayPath.invoke(service, "[1000000]"));
-    assertThat(thrown.getCause())
-        .isInstanceOf(ErrorCodeRuntimeException.class)
-        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_GENERAL_ARRAY_LENGTH_EXCEEDED)
-        .hasMessage("Max array length of 1000000 exceeded.");
+  private Map<String, Object> row(String id, String value, String... path) {
+    Builder<String, Object> map = row(id, path);
+    map.put("text_value", value);
+    return map.build();
   }
 
-  @Test
-  public void isEmptyObject() throws InvocationTargetException, IllegalAccessException {
-    assertThat(isEmptyObject.invoke(service, "a")).isEqualTo(false);
-    assertThat(isEmptyObject.invoke(service, (Object) null)).isEqualTo(false);
-    assertThat(isEmptyObject.invoke(service, JsonNull.INSTANCE)).isEqualTo(false);
-    assertThat(isEmptyObject.invoke(service, new JsonArray())).isEqualTo(false);
-    JsonArray nonEmptyArray = new JsonArray();
-    nonEmptyArray.add("something");
-    assertThat(isEmptyObject.invoke(service, nonEmptyArray)).isEqualTo(false);
-    JsonObject nonEmptyObj = new JsonObject();
-    nonEmptyObj.add("key", new JsonPrimitive("something"));
-    assertThat(isEmptyObject.invoke(service, nonEmptyObj)).isEqualTo(false);
-    assertThat(isEmptyObject.invoke(service, new JsonObject())).isEqualTo(true);
-  }
-
-  @Test
-  public void isEmptyArray() throws InvocationTargetException, IllegalAccessException {
-    assertThat(isEmptyArray.invoke(service, "a")).isEqualTo(false);
-    assertThat(isEmptyArray.invoke(service, (Object) null)).isEqualTo(false);
-    assertThat(isEmptyArray.invoke(service, JsonNull.INSTANCE)).isEqualTo(false);
-    JsonObject nonEmptyObj = new JsonObject();
-    nonEmptyObj.add("key", new JsonPrimitive("something"));
-    assertThat(isEmptyArray.invoke(service, nonEmptyObj)).isEqualTo(false);
-    assertThat(isEmptyArray.invoke(service, new JsonObject())).isEqualTo(false);
-    JsonArray nonEmptyArray = new JsonArray();
-    nonEmptyArray.add("something");
-    assertThat(isEmptyArray.invoke(service, nonEmptyArray)).isEqualTo(false);
-    assertThat(isEmptyArray.invoke(service, new JsonArray())).isEqualTo(true);
-  }
-
-  @Test
-  public void shredPayload_booleanLeaf() throws InvocationTargetException, IllegalAccessException {
-    DocumentDB dbMock = mock(DocumentDB.class);
-    when(dbMock.newBindMap(any())).thenCallRealMethod();
-
-    List<String> path = new ArrayList<>();
-    String key = "eric";
-    String payload = "{\"cool\": {\"document\": true}}";
-    ImmutablePair<?, ?> shredResult =
-        (ImmutablePair<?, ?>)
-            shredPayload.invoke(
-                service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, false, true);
-    List<?> bindVariables = (List<?>) shredResult.left;
-    List<?> topLevelKeys = (List<?>) shredResult.right;
-    assertThat(bindVariables.size()).isEqualTo(1);
-    Object[] vars = (Object[]) bindVariables.get(0);
-    assertThat(vars.length).isEqualTo(69);
-    Object[] expected = {
-      "eric",
-      "cool",
-      "document",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "document",
-      null,
-      null,
-      true,
-    };
-    for (int i = 0; i < vars.length; i++) {
-      assertThat(vars[i]).isEqualTo(expected[i]);
-    }
-
-    assertThat(topLevelKeys.size()).isEqualTo(1);
-    assertThat(topLevelKeys.get(0)).isEqualTo("cool");
-  }
-
-  @Test
-  public void shredPayload_numberLeaf() throws InvocationTargetException, IllegalAccessException {
-    DocumentDB dbMock = mock(DocumentDB.class);
-    when(dbMock.newBindMap(any())).thenCallRealMethod();
-
-    List<String> path = new ArrayList<>();
-    String key = "eric";
-    String payload = "{\"cool\": {\"document\": 3}}";
-    ImmutablePair<?, ?> shredResult =
-        (ImmutablePair<?, ?>)
-            shredPayload.invoke(
-                service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, false, true);
-    List<?> bindVariables = (List<?>) shredResult.left;
-    List<?> topLevelKeys = (List<?>) shredResult.right;
-    assertThat(bindVariables.size()).isEqualTo(1);
-    Object[] vars = (Object[]) bindVariables.get(0);
-    assertThat(vars.length).isEqualTo(69);
-    Object[] expected = {
-      "eric",
-      "cool",
-      "document",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "document",
-      null,
-      3.0,
-      null
-    };
-    for (int i = 0; i < vars.length; i++) {
-      assertThat(vars[i]).isEqualTo(expected[i]);
-    }
-
-    assertThat(topLevelKeys.size()).isEqualTo(1);
-    assertThat(topLevelKeys.get(0)).isEqualTo("cool");
-  }
-
-  @Test
-  public void shredPayload_stringLeaf() throws InvocationTargetException, IllegalAccessException {
-    DocumentDB dbMock = mock(DocumentDB.class);
-    when(dbMock.newBindMap(any())).thenCallRealMethod();
-
-    List<String> path = new ArrayList<>();
-    String key = "eric";
-    String payload = "{\"cool\": {\"document\": \"leaf\"}}";
-    ImmutablePair<?, ?> shredResult =
-        (ImmutablePair<?, ?>)
-            shredPayload.invoke(
-                service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, false, true);
-    List<?> bindVariables = (List<?>) shredResult.left;
-    List<?> topLevelKeys = (List<?>) shredResult.right;
-    assertThat(bindVariables.size()).isEqualTo(1);
-    Object[] vars = (Object[]) bindVariables.get(0);
-    assertThat(vars.length).isEqualTo(69);
-    Object[] expected = {
-      "eric",
-      "cool",
-      "document",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "document",
-      "leaf",
-      null,
-      null
-    };
-    for (int i = 0; i < vars.length; i++) {
-      assertThat(vars[i]).isEqualTo(expected[i]);
-    }
-
-    assertThat(topLevelKeys.size()).isEqualTo(1);
-    assertThat(topLevelKeys.get(0)).isEqualTo("cool");
-  }
-
-  @Test
-  public void shredPayload_emptyObjectLeaf()
-      throws InvocationTargetException, IllegalAccessException {
-    DocumentDB dbMock = mock(DocumentDB.class);
-    when(dbMock.newBindMap(any())).thenCallRealMethod();
-
-    List<String> path = new ArrayList<>();
-    String key = "eric";
-    String payload = "{\"cool\": {\"document\": {}}}";
-    ImmutablePair<?, ?> shredResult =
-        (ImmutablePair<?, ?>)
-            shredPayload.invoke(
-                service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, false, true);
-    List<?> bindVariables = (List<?>) shredResult.left;
-    List<?> topLevelKeys = (List<?>) shredResult.right;
-    assertThat(bindVariables.size()).isEqualTo(1);
-    Object[] vars = (Object[]) bindVariables.get(0);
-    assertThat(vars.length).isEqualTo(69);
-    Object[] expected = {
-      "eric",
-      "cool",
-      "document",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "document",
-      DocumentDB.EMPTY_OBJECT_MARKER,
-      null,
-      null,
-    };
-    for (int i = 0; i < vars.length; i++) {
-      assertThat(vars[i]).isEqualTo(expected[i]);
-    }
-
-    assertThat(topLevelKeys.size()).isEqualTo(1);
-    assertThat(topLevelKeys.get(0)).isEqualTo("cool");
-  }
-
-  @Test
-  public void shredPayload_emptyArrayLeaf()
-      throws InvocationTargetException, IllegalAccessException {
-    DocumentDB dbMock = mock(DocumentDB.class);
-    when(dbMock.newBindMap(any())).thenCallRealMethod();
-
-    List<String> path = new ArrayList<>();
-    String key = "eric";
-    String payload = "{\"cool\": {\"document\": []}}";
-    ImmutablePair<?, ?> shredResult =
-        (ImmutablePair<?, ?>)
-            shredPayload.invoke(
-                service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, false, true);
-    List<?> bindVariables = (List<?>) shredResult.left;
-    List<?> topLevelKeys = (List<?>) shredResult.right;
-    assertThat(bindVariables.size()).isEqualTo(1);
-    Object[] vars = (Object[]) bindVariables.get(0);
-    assertThat(vars.length).isEqualTo(69);
-    Object[] expected = {
-      "eric",
-      "cool",
-      "document",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "document",
-      DocumentDB.EMPTY_ARRAY_MARKER,
-      null,
-      null
-    };
-    for (int i = 0; i < vars.length; i++) {
-      assertThat(vars[i]).isEqualTo(expected[i]);
-    }
-
-    assertThat(topLevelKeys.size()).isEqualTo(1);
-    assertThat(topLevelKeys.get(0)).isEqualTo("cool");
-  }
-
-  @Test
-  public void shredPayload_nullLeaf() throws InvocationTargetException, IllegalAccessException {
-    DocumentDB dbMock = mock(DocumentDB.class);
-    when(dbMock.newBindMap(any())).thenCallRealMethod();
-
-    List<String> path = new ArrayList<>();
-    String key = "eric";
-    String payload = "{\"cool\": {\"document\": null}}";
-    ImmutablePair<?, ?> shredResult =
-        (ImmutablePair<?, ?>)
-            shredPayload.invoke(
-                service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, false, true);
-    List<?> bindVariables = (List<?>) shredResult.left;
-    List<?> topLevelKeys = (List<?>) shredResult.right;
-    assertThat(bindVariables.size()).isEqualTo(1);
-    Object[] vars = (Object[]) bindVariables.get(0);
-    assertThat(vars.length).isEqualTo(69);
-    Object[] expected = {
-      "eric",
-      "cool",
-      "document",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "document",
-      null,
-      null,
-      null
-    };
-    for (int i = 0; i < vars.length; i++) {
-      assertThat(vars[i]).isEqualTo(expected[i]);
-    }
-
-    assertThat(topLevelKeys.size()).isEqualTo(1);
-    assertThat(topLevelKeys.get(0)).isEqualTo("cool");
-  }
-
-  @Test
-  public void shredPayload_invalidKeys() {
-    DocumentDB dbMock = mock(DocumentDB.class);
-    when(dbMock.newBindMap(any())).thenCallRealMethod();
-
-    List<String> path = new ArrayList<>();
-    String key = "eric";
-    String payload = "{\"coo]\": {\"document\": null}}";
-    Throwable thrown =
-        catchThrowable(
-            () ->
-                shredPayload.invoke(
-                    service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, false, true));
-    assertThat(thrown.getCause())
-        .isInstanceOf(ErrorCodeRuntimeException.class)
-        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_GENERAL_INVALID_FIELD_NAME)
-        .hasMessageContaining("are not permitted in JSON field names, invalid field coo]");
-  }
-
-  @Test
-  public void shredPayload_patchingArrayInvalid() {
-    DocumentDB dbMock = mock(DocumentDB.class);
-    when(dbMock.newBindMap(any())).thenCallRealMethod();
-
-    List<String> path = new ArrayList<>();
-    String key = "eric";
-    String payload = "[1, 2, 3]";
-    Throwable thrown =
-        catchThrowable(
-            () ->
-                shredPayload.invoke(
-                    service, JsonSurferGson.INSTANCE, dbMock, path, key, payload, true, true));
-    assertThat(thrown.getCause())
-        .isInstanceOf(ErrorCodeRuntimeException.class)
-        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_PATCH_ARRAY_NOT_ACCEPTED)
-        .hasMessageContaining(ErrorCode.DOCS_API_PATCH_ARRAY_NOT_ACCEPTED.getDefaultMessage());
-  }
-
-  @Test
-  public void putAtPath() throws UnauthorizedException {
-    DocumentDB dbMock = mock(DocumentDB.class);
-    Db dbFactoryMock = mock(Db.class);
-    when(dbFactoryMock.getDocDataStoreForToken(anyString(), any())).thenReturn(dbMock);
-    when(dbMock.newBindMap(any())).thenCallRealMethod();
-
-    service.putAtPath(
-        "authToken",
-        "ks",
-        "collection",
-        "id",
-        "{\"some\": \"data\"}",
-        new ArrayList<>(),
-        false,
-        dbFactoryMock,
-        true,
-        EMPTY_HEADERS);
-
-    verify(dbMock, times(1))
-        .deleteThenInsertBatch(anyString(), anyString(), anyString(), any(), any(), anyLong());
-    verify(dbMock, times(0))
-        .deletePatchedPathsThenInsertBatch(
-            anyString(), anyString(), anyString(), any(), any(), any(), anyLong());
-  }
-
-  @Test
-  public void putAtPath_patching() throws UnauthorizedException {
-    DocumentDB dbMock = mock(DocumentDB.class);
-    Db dbFactoryMock = mock(Db.class);
-    when(dbFactoryMock.getDocDataStoreForToken(anyString(), any())).thenReturn(dbMock);
-    when(dbMock.newBindMap(any())).thenCallRealMethod();
-
-    service.putAtPath(
-        "authToken",
-        "ks",
-        "collection",
-        "id",
-        "{\"some\": \"data\"}",
-        new ArrayList<>(),
-        true,
-        dbFactoryMock,
-        true,
-        EMPTY_HEADERS);
-
-    verify(dbMock, times(0))
-        .deleteThenInsertBatch(anyString(), anyString(), anyString(), any(), any(), anyLong());
-    verify(dbMock, times(1))
-        .deletePatchedPathsThenInsertBatch(
-            anyString(), anyString(), anyString(), any(), any(), any(), anyLong());
-  }
-
-  @Test
-  public void putAtPath_noData() throws UnauthorizedException {
-    DocumentDB dbMock = mock(DocumentDB.class);
-    Db dbFactoryMock = mock(Db.class);
-    when(dbFactoryMock.getDocDataStoreForToken(anyString(), any())).thenReturn(dbMock);
-
-    Throwable thrown =
-        catchThrowable(
-            () ->
-                service.putAtPath(
-                    "authToken",
-                    "ks",
-                    "collection",
-                    "id",
-                    "\"a\"",
-                    new ArrayList<>(),
-                    true,
-                    dbFactoryMock,
-                    true,
-                    EMPTY_HEADERS));
-
-    assertThat(thrown)
-        .isInstanceOf(ErrorCodeRuntimeException.class)
-        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_PUT_PAYLOAD_INVALID)
-        .hasMessageContaining(
-            "Updating a key with just a JSON primitive, empty object, or empty array is not allowed.");
-  }
-
-  @Test
-  public void getJsonAtPath() throws UnauthorizedException {
-    DocumentDB dbMock = mock(DocumentDB.class);
-    ResultSet rsMock = mock(ResultSet.class);
-    when(dbMock.executeSelect(anyString(), anyString(), anyListOf(BuiltCondition.class)))
-        .thenReturn(rsMock);
-    when(rsMock.rows()).thenReturn(new ArrayList<>());
-
-    List<PathSegment> path = smallPath();
-    JsonNode result = service.getJsonAtPath(dbMock, "ks", "collection", "id", path);
-
-    assertThat(result).isNull();
-  }
-
-  @Test
-  public void getJsonAtPath_withRowsEmptyJson() throws UnauthorizedException {
-    DocumentDB dbMock = mock(DocumentDB.class);
-    ResultSet rsMock = mock(ResultSet.class);
-    when(dbMock.executeSelect(anyString(), anyString(), anyListOf(BuiltCondition.class)))
-        .thenReturn(rsMock);
-
-    List<Row> rows = makeInitialRowData(false);
-    when(rsMock.rows()).thenReturn(rows);
-
-    List<PathSegment> path = smallPath();
-
-    when(jsonConverter.convertToJsonDoc(anyList(), any(), anyBoolean(), anyBoolean()))
-        .thenReturn(mapper.createObjectNode());
-
-    JsonNode result = service.getJsonAtPath(dbMock, "ks", "collection", "id", path);
-
-    assertThat(result).isNull();
-  }
-
-  @Test
-  public void getJsonAtPath_withRows() throws JsonProcessingException, UnauthorizedException {
-    DocumentDB dbMock = mock(DocumentDB.class);
-    ResultSet rsMock = mock(ResultSet.class);
-    when(dbMock.executeSelect(anyString(), anyString(), anyListOf(BuiltCondition.class)))
-        .thenReturn(rsMock);
-
-    List<Row> rows = makeInitialRowData(false);
-    when(rsMock.rows()).thenReturn(rows);
-
-    List<PathSegment> path = smallPath();
-
-    ObjectNode jsonObj = mapper.createObjectNode();
-    jsonObj.set("abc", mapper.readTree("[1]"));
-
-    when(jsonConverter.convertToJsonDoc(anyListOf(Row.class), any(), anyBoolean(), anyBoolean()))
-        .thenReturn(jsonObj);
-
-    JsonNode result = service.getJsonAtPath(dbMock, "ks", "collection", "id", path);
-
-    assertThat(result).isEqualTo(IntNode.valueOf(1));
-  }
-
-  @Test
-  public void validateOpAndValue()
-      throws JsonProcessingException, InvocationTargetException, IllegalAccessException {
-    final JsonNode value = mapper.readTree("{\"a\": \"b\"}");
-    validateOpAndValue.invoke(service, "not_valid", value, "field");
-
-    Throwable thrown =
-        catchThrowable(() -> validateOpAndValue.invoke(service, "$ne", value, "field"));
-    assertThat(thrown.getCause())
-        .isInstanceOf(ErrorCodeRuntimeException.class)
-        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_SEARCH_FILTER_INVALID)
-        .hasMessageContaining("was expecting a value or `null`");
-
-    thrown = catchThrowable(() -> validateOpAndValue.invoke(service, "$exists", value, "field"));
-    assertThat(thrown.getCause())
-        .isInstanceOf(ErrorCodeRuntimeException.class)
-        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_SEARCH_FILTER_INVALID)
-        .hasMessageContaining("only supports the value `true`");
-
-    final JsonNode value2 = mapper.readTree("false");
-    thrown = catchThrowable(() -> validateOpAndValue.invoke(service, "$exists", value2, "field"));
-    assertThat(thrown.getCause())
-        .isInstanceOf(ErrorCodeRuntimeException.class)
-        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_SEARCH_FILTER_INVALID)
-        .hasMessageContaining("only supports the value `true`");
-
-    thrown = catchThrowable(() -> validateOpAndValue.invoke(service, "$gt", value, "field"));
-    assertThat(thrown.getCause())
-        .isInstanceOf(ErrorCodeRuntimeException.class)
-        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_SEARCH_FILTER_INVALID)
-        .hasMessageContaining("was expecting a non-null value");
-
-    thrown = catchThrowable(() -> validateOpAndValue.invoke(service, "$in", value, "field"));
-    assertThat(thrown.getCause())
-        .isInstanceOf(ErrorCodeRuntimeException.class)
-        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_SEARCH_FILTER_INVALID)
-        .hasMessageContaining("was expecting an array");
-  }
-
-  @Test
-  public void convertToSelectionList() throws JsonProcessingException {
-    JsonNode input = mapper.readTree("[\"A\", \"B\"]");
-    List<String> res = service.convertToSelectionList(input);
-    List<String> expected = new ArrayList<>();
-    expected.add("A");
-    expected.add("B");
-    assertThat(res).isEqualTo(expected);
-  }
-
-  @Test
-  public void convertToSelectionList_invalidInput() throws JsonProcessingException {
-    final JsonNode input = mapper.readTree("{}");
-    Throwable thrown = catchThrowable(() -> service.convertToSelectionList(input));
-    assertThat(thrown)
-        .isInstanceOf(ErrorCodeRuntimeException.class)
-        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_GENERAL_FIELDS_INVALID)
-        .hasMessage("`fields` must be a JSON array, found {}");
-
-    final JsonNode input2 = mapper.readTree("[\"A\", 0]");
-    thrown = catchThrowable(() -> service.convertToSelectionList(input2));
-    assertThat(thrown)
-        .isInstanceOf(ErrorCodeRuntimeException.class)
-        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_GENERAL_FIELDS_INVALID)
-        .hasMessage("Each field must be a string, found 0");
-  }
-
-  @Test
-  public void convertToFilterOps() throws JsonProcessingException {
-    JsonNode input =
-        mapper.readTree(
-            "{\"a.b.c\": {\"$eq\": 1, \"$lt\": true, \"$lte\": \"1\", \"$ne\": null, \"$in\": [1, \"a\", true]}}");
-    List<FilterCondition> result = service.convertToFilterOps(new ArrayList<>(), input);
-    List<FilterCondition> expected = new ArrayList<>();
-    expected.add(
-        new SingleFilterCondition(ImmutableList.of("a", "b", "c"), "$eq", Double.valueOf(1)));
-    expected.add(new SingleFilterCondition(ImmutableList.of("a", "b", "c"), "$lt", true));
-    expected.add(new SingleFilterCondition(ImmutableList.of("a", "b", "c"), "$lte", "1"));
-    expected.add(new SingleFilterCondition(ImmutableList.of("a", "b", "c"), "$ne", (String) null));
-    expected.add(
-        new ListFilterCondition(
-            ImmutableList.of("a", "b", "c"), "$in", ImmutableList.of(1, "a", true)));
-    assertThat(result.toString()).isEqualTo(expected.toString());
-  }
-
-  @Test
-  public void convertToFilterOps_invalidInput() throws JsonProcessingException {
-    final JsonNode input = mapper.readTree("[]");
-    Throwable thrown = catchThrowable(() -> service.convertToFilterOps(new ArrayList<>(), input));
-    assertThat(thrown)
-        .isInstanceOf(ErrorCodeRuntimeException.class)
-        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_SEARCH_OBJECT_REQUIRED)
-        .hasMessage(ErrorCode.DOCS_API_SEARCH_OBJECT_REQUIRED.getDefaultMessage());
-
-    final JsonNode input2 = mapper.readTree("{\"\": {}}");
-    thrown = catchThrowable(() -> service.convertToFilterOps(new ArrayList<>(), input2));
-    assertThat(thrown)
-        .isInstanceOf(ErrorCodeRuntimeException.class)
-        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_GENERAL_FIELDS_INVALID)
-        .hasMessage(ErrorCode.DOCS_API_GENERAL_FIELDS_INVALID.getDefaultMessage());
-
-    final JsonNode input3 = mapper.readTree("{\"a\": []}}");
-    thrown = catchThrowable(() -> service.convertToFilterOps(new ArrayList<>(), input3));
-    assertThat(thrown)
-        .isInstanceOf(ErrorCodeRuntimeException.class)
-        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_SEARCH_OBJECT_REQUIRED)
-        .hasMessage("Search entry for field a was expecting a JSON object as input.");
-  }
-
-  @Test
-  public void deleteAtPath() throws UnauthorizedException {
-    AuthorizationService authorizationService = mock(AuthorizationService.class);
-    DocumentDB dbMock = mock(DocumentDB.class);
-
-    service.deleteAtPath(dbMock, "keyspace", "collection", "id", smallPath());
-    verify(dbMock, times(1))
-        .delete(anyString(), anyString(), anyString(), anyListOf(String.class), anyLong());
-  }
-
-  // searchDocuments unit tests excluded here, it is in deprecated v1
-
-  @Test
-  public void searchDocumentsV2_emptyResult() throws Exception {
-    DocumentDB dbMock = Mockito.mock(DocumentDB.class);
-    DocumentService serviceMock = Mockito.mock(DocumentService.class);
-    Mockito.when(serviceMock.searchDocumentsV2(any(), any(), any(), any(), any(), any(), any()))
-        .thenCallRealMethod();
-    Mockito.when(
-            serviceMock.searchRows(
-                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-        .thenReturn(new ArrayList<>());
-    int pageSizeParam = 0;
-    Paginator paginator =
-        new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
-
-    List<FilterCondition> filters =
-        ImmutableList.of(
-            new SingleFilterCondition(ImmutableList.of("a", "b", "c"), "$eq", "value"));
-    JsonNode result =
-        serviceMock.searchDocumentsV2(
-            dbMock, "keyspace", "collection", filters, new ArrayList<>(), null, paginator);
-    assertThat(result).isNull();
-  }
-
-  @Test
-  public void searchDocumentsV2_existingResult() throws Exception {
-    DocumentDB dbMock = Mockito.mock(DocumentDB.class);
-
-    ResultSet rsMock = mock(ResultSet.class);
-    List<Row> rows = makeInitialRowData(false);
-    when(dbMock.executeSelect(anyString(), anyString(), any(), anyBoolean(), anyInt(), any()))
-        .thenReturn(rsMock);
-    when(rsMock.currentPageRows()).thenReturn(rows);
-    int pageSizeParam = 0;
-    Paginator paginator =
-        new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
-
-    List<FilterCondition> filters =
-        ImmutableList.of(
-            new SingleFilterCondition(ImmutableList.of("a", "b", "c"), "$eq", "value"));
-    JsonNode result =
-        service.searchDocumentsV2(
-            dbMock, "keyspace", "collection", filters, new ArrayList<>(), null, paginator);
-    assertThat(paginator.getCurrentDbPageState()).isNull();
-    assertThat(result.at("/1").isMissingNode()).isFalse();
-  }
-
-  @Test
-  public void searchDocumentsV2_existingResultWithFields() throws Exception {
-    DocumentDB dbMock = Mockito.mock(DocumentDB.class);
-
-    ResultSet rsMock = mock(ResultSet.class);
-    List<Row> rows = makeInitialRowData(false);
-    when(dbMock.executeSelect(anyString(), anyString(), any(), anyBoolean(), anyInt(), any()))
-        .thenReturn(rsMock);
-    when(rsMock.currentPageRows()).thenReturn(rows);
-
-    List<FilterCondition> filters =
-        ImmutableList.of(
-            new SingleFilterCondition(ImmutableList.of("a", "b", "c"), "$exists", true));
-    int pageSizeParam = 0;
-    Paginator paginator =
-        new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
-    JsonNode result =
-        service.searchDocumentsV2(
-            dbMock, "keyspace", "collection", filters, ImmutableList.of("field"), null, paginator);
-    assertThat(paginator.getCurrentDbPageState()).isNull();
-    assertThat(result).isNull();
-  }
-
-  @Test
-  public void addRowsToMap() throws InvocationTargetException, IllegalAccessException {
-    Map<String, List<Row>> rowsByDoc = new HashMap<>();
-    List<Row> rows = makeInitialRowData(false);
-    addRowsToMap.invoke(service, rowsByDoc, rows);
-    assertThat(rowsByDoc.get("1")).isEqualTo(rows);
-  }
-
-  @Test
-  public void updateExistenceForMap() throws InvocationTargetException, IllegalAccessException {
-    Set<String> existenceByDoc = new HashSet<>();
-    List<Row> rows = makeInitialRowData(false);
-    updateExistenceForMap.invoke(service, existenceByDoc, rows, new ArrayList<>(), false, true);
-    assertThat(existenceByDoc.contains("1")).isTrue();
-  }
-
-  @Test
-  public void getFullDocuments_lessThanLimit() throws Exception {
-    DocumentDB dbMock = mock(DocumentDB.class);
-
-    ResultSet rsMock = mock(ResultSet.class);
-    List<Row> rows = makeInitialRowData(false);
-    when(dbMock.executeSelectAll(anyString(), anyString(), anyInt(), any())).thenReturn(rsMock);
-    when(rsMock.currentPageRows()).thenReturn(rows);
-    Mockito.when(jsonConverter.convertToJsonDoc(anyList(), anyBoolean(), anyBoolean()))
-        .thenReturn(mapper.readTree("{\"a\": 1}"));
-    int pageSizeParam = 0;
-    Paginator paginator =
-        new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
-
-    JsonNode result =
-        service.getFullDocuments(dbMock, "keyspace", "collection", new ArrayList<>(), paginator);
-    assertThat(paginator.getCurrentDbPageState()).isNull();
-    assertThat(result).isEqualTo(mapper.readTree("{\"1\": {\"a\": 1}}"));
-  }
-
-  @Test
-  public void getFullDocuments_greaterThanLimit() throws Exception {
-    DocumentDB dbMock = mock(DocumentDB.class);
-
-    ResultSet rsMock = mock(ResultSet.class);
-    List<Row> rows = makeInitialRowData(false);
-    when(dbMock.executeSelectAll(anyString(), anyString(), anyInt(), any())).thenReturn(rsMock);
-    when(rsMock.currentPageRows()).thenReturn(rows);
-    List<Row> twoDocsRows = makeInitialRowData(false);
-    twoDocsRows.addAll(makeRowDataForSecondDoc(false));
-    Mockito.when(jsonConverter.convertToJsonDoc(anyList(), anyBoolean(), anyBoolean()))
-        .thenReturn(mapper.readTree("{\"a\": 1}"));
-    int pageSizeParam = 0;
-    Paginator paginator =
-        new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
-
-    JsonNode result =
-        service.getFullDocuments(dbMock, "keyspace", "collection", new ArrayList<>(), paginator);
-    assertThat(paginator.getCurrentDbPageState()).isNull();
-    assertThat(result).isEqualTo(mapper.readTree("{\"1\": {\"a\": 1}}"));
-  }
-
-  @Test
-  public void searchRows()
-      throws InvocationTargetException, IllegalAccessException, UnauthorizedException {
-    DocumentDB dbMock = mock(DocumentDB.class);
-
-    ResultSet rsMock = mock(ResultSet.class);
-    List<Row> rows = makeInitialRowData(false);
-    when(dbMock.executeSelectAll(anyString(), anyString(), anyInt(), any())).thenReturn(rsMock);
-    when(dbMock.executeSelect(anyString(), anyString(), any(), anyBoolean(), anyInt(), any()))
-        .thenReturn(rsMock);
-    when(rsMock.currentPageRows()).thenReturn(rows);
-
-    List<FilterCondition> filters =
-        ImmutableList.of(new SingleFilterCondition(ImmutableList.of("a,b", "*", "c"), "$eq", true));
-
-    int pageSizeParam = 0;
-    Paginator paginator =
-        new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
-
-    List<Row> result =
-        (List<Row>)
-            searchRows.invoke(
-                service,
-                "keyspace",
-                "collection",
-                dbMock,
-                new ArrayList<>(),
-                filters,
-                new ArrayList<>(),
-                ImmutableList.of("a,b", "*", "c"),
-                false,
-                null,
-                paginator);
-
-    assertThat(paginator.getCurrentDbPageState()).isNull();
-    assertThat(result).isEqualTo(rows);
-
-    paginator = new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
-    result =
-        (List<Row>)
-            searchRows.invoke(
-                service,
-                "keyspace",
-                "collection",
-                dbMock,
-                new ArrayList<>(),
-                new ArrayList<>(),
-                new ArrayList<>(),
-                new ArrayList<>(),
-                false,
-                null,
-                paginator);
-
-    assertThat(paginator.getCurrentDbPageState()).isNull();
-    assertThat(result).isEqualTo(rows);
-  }
-
-  @Test
-  public void searchRows_invalid() throws UnauthorizedException {
-    DocumentDB dbMock = mock(DocumentDB.class);
-    ResultSet rsMock = mock(ResultSet.class);
-    when(dbMock.executeSelect(anyString(), anyString(), any(), anyBoolean(), anyInt(), any()))
-        .thenReturn(rsMock);
-    when(rsMock.getPagingState()).thenReturn(ByteBuffer.wrap(new byte[0]));
-
-    int pageSizeParam = 0;
-    Paginator paginator =
-        new Paginator(dataStore, null, pageSizeParam, DocumentDB.SEARCH_PAGE_SIZE);
-
-    List<FilterCondition> filters =
-        ImmutableList.of(new SingleFilterCondition(ImmutableList.of("a,b", "*", "c"), "$ne", true));
-
-    Throwable thrown =
-        catchThrowable(
-            () ->
-                searchRows.invoke(
-                    service,
-                    "keyspace",
-                    "collection",
-                    dbMock,
-                    new ArrayList<>(),
-                    filters,
-                    new ArrayList<>(),
-                    ImmutableList.of("a,b", "*", "c"),
-                    null,
-                    null,
-                    paginator));
-
-    assertThat(thrown.getCause())
-        .isInstanceOf(ErrorCodeRuntimeException.class)
-        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_SEARCH_RESULTS_NOT_FITTING)
-        .hasMessage(ErrorCode.DOCS_API_SEARCH_RESULTS_NOT_FITTING.getDefaultMessage());
-  }
-
-  @Test
-  public void getParentPathFromRow() throws InvocationTargetException, IllegalAccessException {
-    Row row = makeInitialRowData(false).get(1);
-    String result = (String) getParentPathFromRow.invoke(service, row);
-    assertThat(result).isEqualTo("1/a.b.");
-  }
-
-  @Test
-  public void filterToSelectionSet() throws InvocationTargetException, IllegalAccessException {
-    List<Row> rows = makeInitialRowData(false);
-    rows = rows.subList(1, rows.size());
-
-    List<?> result =
-        (List<?>)
-            filterToSelectionSet.invoke(
-                service, rows, new ArrayList<>(), ImmutableList.of("a", "b"));
-    assertThat(result).isEqualTo(rows);
-
-    List<String> selectionSet = ImmutableList.of("c", "n1", "n2", "n3");
-    result =
-        (List<?>)
-            filterToSelectionSet.invoke(service, rows, selectionSet, ImmutableList.of("a", "b"));
-    List<Row> expected = new ArrayList<>();
-    expected.add(rows.get(0));
-    for (int i = 0; i < 7; i++) {
-      expected.add(null);
-    }
-    assertThat(result).isEqualTo(expected);
-  }
-
-  @Test
-  public void applyInMemoryFilters() throws InvocationTargetException, IllegalAccessException {
-    List<Row> rows = makeInitialRowData(false);
-    rows = rows.subList(1, rows.size());
-    List<FilterCondition> filters =
-        ImmutableList.of(new SingleFilterCondition(ImmutableList.of("a", "b", "c"), "$eq", true));
-    List<?> result =
-        (List<?>) applyInMemoryFilters.invoke(service, rows, new ArrayList<>(), 1, false);
-    assertThat(result).isEqualTo(rows);
-
-    result = (List<?>) applyInMemoryFilters.invoke(service, rows, filters, 1, false);
-    assertThat(result.size()).isEqualTo(1);
-    assertThat(result.get(0)).isEqualTo(rows.get(0));
-
-    filters =
-        ImmutableList.of(
-            new SingleFilterCondition(ImmutableList.of("a", "b", "c"), "$exists", true));
-    result = (List<?>) applyInMemoryFilters.invoke(service, rows, filters, 1, false);
-    assertThat(result.size()).isEqualTo(1);
-    assertThat(result.get(0)).isEqualTo(rows.get(0));
-
-    filters =
-        ImmutableList.of(
-            new SingleFilterCondition(ImmutableList.of("a", "b", "x"), "$exists", true));
-    result = (List<?>) applyInMemoryFilters.invoke(service, rows, filters, 1, false);
-    assertThat(result.size()).isEqualTo(0);
-
-    filters =
-        ImmutableList.of(new SingleFilterCondition(ImmutableList.of("a", "b", "c"), "$gt", true));
-    result = (List<?>) applyInMemoryFilters.invoke(service, rows, filters, 1, false);
-    assertThat(result.size()).isEqualTo(0);
-
-    filters =
-        ImmutableList.of(new SingleFilterCondition(ImmutableList.of("a", "b", "c"), "$gte", 2.0));
-    result = (List<?>) applyInMemoryFilters.invoke(service, rows, filters, 1, false);
-    assertThat(result.size()).isEqualTo(0);
-
-    filters =
-        ImmutableList.of(new SingleFilterCondition(ImmutableList.of("a", "b", "c"), "$lt", true));
-    result = (List<?>) applyInMemoryFilters.invoke(service, rows, filters, 1, false);
-    assertThat(result.size()).isEqualTo(0);
-
-    filters =
-        ImmutableList.of(new SingleFilterCondition(ImmutableList.of("a", "b", "c"), "$lte", false));
-    result = (List<?>) applyInMemoryFilters.invoke(service, rows, filters, 1, false);
-    assertThat(result.size()).isEqualTo(0);
-
-    filters =
-        ImmutableList.of(new SingleFilterCondition(ImmutableList.of("a", "b", "c"), "$ne", true));
-    result = (List<?>) applyInMemoryFilters.invoke(service, rows, filters, 1, false);
-    assertThat(result.size()).isEqualTo(0);
-
-    filters =
-        ImmutableList.of(
-            new ListFilterCondition(
-                ImmutableList.of("a", "b", "c"), "$in", ImmutableList.of(false)));
-    result = (List<?>) applyInMemoryFilters.invoke(service, rows, filters, 1, false);
-    assertThat(result.size()).isEqualTo(0);
-
-    filters =
-        ImmutableList.of(
-            new ListFilterCondition(
-                ImmutableList.of("a", "b", "c"), "$nin", ImmutableList.of(true)));
-    result = (List<?>) applyInMemoryFilters.invoke(service, rows, filters, 1, false);
-    assertThat(result.size()).isEqualTo(0);
-  }
-
-  @Test
-  public void pathsMatch() throws InvocationTargetException, IllegalAccessException {
-    boolean res = (boolean) pathsMatch.invoke(service, "", "");
-    assertThat(res).isTrue();
-
-    res = (boolean) pathsMatch.invoke(service, "a", "a");
-    assertThat(res).isTrue();
-
-    res = (boolean) pathsMatch.invoke(service, "a", "b");
-    assertThat(res).isFalse();
-
-    res = (boolean) pathsMatch.invoke(service, "a.b", "a.b");
-    assertThat(res).isTrue();
-
-    res = (boolean) pathsMatch.invoke(service, "a.b", "a.c");
-    assertThat(res).isFalse();
-
-    res = (boolean) pathsMatch.invoke(service, "a.*.c", "a.b.c");
-    assertThat(res).isTrue();
-
-    res = (boolean) pathsMatch.invoke(service, "a.*.d", "a.b.c");
-    assertThat(res).isFalse();
-  }
-
-  @Test
-  public void checkEqualsOp() throws InvocationTargetException, IllegalAccessException {
-    SingleFilterCondition cond = new SingleFilterCondition(ImmutableList.of("a"), "$eq", true);
-    Boolean res = (Boolean) checkEqualsOp.invoke(service, cond, null, true, null);
-    assertThat(res).isTrue();
-
-    cond = new SingleFilterCondition(ImmutableList.of("a"), "$eq", "a");
-    res = (Boolean) checkEqualsOp.invoke(service, cond, "a", null, null);
-    assertThat(res).isTrue();
-
-    cond = new SingleFilterCondition(ImmutableList.of("a"), "$eq", 3.14);
-    res = (Boolean) checkEqualsOp.invoke(service, cond, null, null, 3.14);
-    assertThat(res).isTrue();
-
-    cond = new SingleFilterCondition(ImmutableList.of("a"), "$eq", false);
-    res = (Boolean) checkEqualsOp.invoke(service, cond, null, true, null);
-    assertThat(res).isFalse();
-
-    cond = new SingleFilterCondition(ImmutableList.of("a"), "$eq", 3.0);
-    res = (Boolean) checkEqualsOp.invoke(service, cond, null, null, 3.1);
-    assertThat(res).isFalse();
-
-    cond = new SingleFilterCondition(ImmutableList.of("a"), "$eq", "A");
-    res = (Boolean) checkEqualsOp.invoke(service, cond, "a", null, null);
-    assertThat(res).isFalse();
-
-    cond = new SingleFilterCondition(ImmutableList.of("a"), "$eq", "A");
-    res = (Boolean) checkEqualsOp.invoke(service, cond, null, true, null);
-    assertThat(res).isFalse();
-  }
-
-  @Test
-  public void checkInOp() throws InvocationTargetException, IllegalAccessException {
-    ListFilterCondition cond =
-        new ListFilterCondition(ImmutableList.of("a"), "$in", ImmutableList.of("a", "b", "c"));
-    Boolean res = (Boolean) checkInOp.invoke(service, cond, "a", null, null);
-    assertThat(res).isTrue();
-
-    cond = new ListFilterCondition(ImmutableList.of("a"), "$in", ImmutableList.of(true));
-    res = (Boolean) checkInOp.invoke(service, cond, null, true, null);
-    assertThat(res).isTrue();
-
-    cond = new ListFilterCondition(ImmutableList.of("a"), "$in", ImmutableList.of(4.5));
-    res = (Boolean) checkInOp.invoke(service, cond, null, null, 4.5);
-    assertThat(res).isTrue();
-
-    cond = new ListFilterCondition(ImmutableList.of("a"), "$in", ImmutableList.of("a", "b"));
-    res = (Boolean) checkInOp.invoke(service, cond, "c", null, null);
-    assertThat(res).isFalse();
-
-    cond = new ListFilterCondition(ImmutableList.of("a"), "$in", ImmutableList.of(true));
-    res = (Boolean) checkInOp.invoke(service, cond, null, false, null);
-    assertThat(res).isFalse();
-
-    cond = new ListFilterCondition(ImmutableList.of("a"), "$in", ImmutableList.of(4.5));
-    res = (Boolean) checkInOp.invoke(service, cond, null, null, 4.4);
-    assertThat(res).isFalse();
-
-    cond = new ListFilterCondition(ImmutableList.of("a"), "$in", ImmutableList.of(4.5));
-    res = (Boolean) checkInOp.invoke(service, cond, null, null, null);
-    assertThat(res).isFalse();
-
-    cond = new ListFilterCondition(ImmutableList.of("a"), "$in", ImmutableList.of(4.5));
-    res = (Boolean) checkInOp.invoke(service, cond, null, true, null);
-    assertThat(res).isFalse();
-
-    cond = new ListFilterCondition(ImmutableList.of("a"), "$in", new ArrayList<>());
-    res = (Boolean) checkInOp.invoke(service, cond, null, true, null);
-    assertThat(res).isFalse();
-  }
-
-  @Test
-  public void checkGtOp() throws InvocationTargetException, IllegalAccessException {
-    SingleFilterCondition cond = new SingleFilterCondition(ImmutableList.of("a"), "$gt", false);
-    Boolean res = (Boolean) checkGtOp.invoke(service, cond, null, true, null);
-    assertThat(res).isTrue();
-
-    cond = new SingleFilterCondition(ImmutableList.of("a"), "$gt", "a");
-    res = (Boolean) checkGtOp.invoke(service, cond, "b", null, null);
-    assertThat(res).isTrue();
-
-    cond = new SingleFilterCondition(ImmutableList.of("a"), "$gt", 3.14);
-    res = (Boolean) checkGtOp.invoke(service, cond, null, null, 3.141);
-    assertThat(res).isTrue();
-
-    cond = new SingleFilterCondition(ImmutableList.of("a"), "$gt", true);
-    res = (Boolean) checkGtOp.invoke(service, cond, null, true, null);
-    assertThat(res).isFalse();
-
-    cond = new SingleFilterCondition(ImmutableList.of("a"), "$gt", 3.2);
-    res = (Boolean) checkGtOp.invoke(service, cond, null, null, 3.1);
-    assertThat(res).isFalse();
-
-    cond = new SingleFilterCondition(ImmutableList.of("a"), "$gt", "b");
-    res = (Boolean) checkGtOp.invoke(service, cond, "a", null, null);
-    assertThat(res).isFalse();
-
-    cond = new SingleFilterCondition(ImmutableList.of("a"), "$eq", "A");
-    res = (Boolean) checkGtOp.invoke(service, cond, null, true, null);
-    assertThat(res).isNull();
-  }
-
-  @Test
-  public void checkLtOp() throws InvocationTargetException, IllegalAccessException {
-    SingleFilterCondition cond = new SingleFilterCondition(ImmutableList.of("a"), "$lt", true);
-    Boolean res = (Boolean) checkLtOp.invoke(service, cond, null, false, null);
-    assertThat(res).isTrue();
-
-    cond = new SingleFilterCondition(ImmutableList.of("a"), "$lt", "b");
-    res = (Boolean) checkLtOp.invoke(service, cond, "a", null, null);
-    assertThat(res).isTrue();
-
-    cond = new SingleFilterCondition(ImmutableList.of("a"), "$lt", 3.14);
-    res = (Boolean) checkLtOp.invoke(service, cond, null, null, 3.13);
-    assertThat(res).isTrue();
-
-    cond = new SingleFilterCondition(ImmutableList.of("a"), "$lt", true);
-    res = (Boolean) checkLtOp.invoke(service, cond, null, true, null);
-    assertThat(res).isFalse();
-
-    cond = new SingleFilterCondition(ImmutableList.of("a"), "$lt", 3.2);
-    res = (Boolean) checkLtOp.invoke(service, cond, null, null, 3.3);
-    assertThat(res).isFalse();
-
-    cond = new SingleFilterCondition(ImmutableList.of("a"), "$lt", "b");
-    res = (Boolean) checkLtOp.invoke(service, cond, "c", null, null);
-    assertThat(res).isFalse();
-
-    cond = new SingleFilterCondition(ImmutableList.of("a"), "$lt", "A");
-    res = (Boolean) checkLtOp.invoke(service, cond, null, true, null);
-    assertThat(res).isNull();
-  }
-
-  public static List<Row> makeInitialRowData(boolean numericBooleans) {
-    List<Row> rows = new ArrayList<>();
-    Map<String, Object> data0 = new HashMap<>();
-    Map<String, Object> data1 = new HashMap<>();
-    Map<String, Object> data2 = new HashMap<>();
-    Map<String, Object> data3 = new HashMap<>();
-    data0.put("key", "1");
-    data1.put("key", "1");
-    data2.put("key", "1");
-    data3.put("key", "1");
-
-    data0.put("writetime(leaf)", 0L);
-    data1.put("writetime(leaf)", 0L);
-    data2.put("writetime(leaf)", 0L);
-    data3.put("writetime(leaf)", 0L);
-
-    data0.put("p0", "");
-    data0.put("p1", "");
-    data0.put("p2", "");
-    data0.put("p3", "");
-    data0.put("leaf", DocumentDB.ROOT_DOC_MARKER);
-
-    data1.put("p0", "a");
-    data1.put("p1", "b");
-    data1.put("p2", "c");
-    data1.put("bool_value", true);
-    data1.put("p3", "");
-    data1.put("leaf", "c");
-
-    data2.put("p0", "d");
-    data2.put("p1", "e");
-    data2.put("p2", "[0]");
-    data2.put("dbl_value", 3.0);
-    data2.put("p3", "");
-    data2.put("leaf", "[0]");
-
-    data3.put("p0", "f");
-    data3.put("text_value", "abc");
-    data3.put("p1", "");
-    data3.put("p2", "");
-    data3.put("p3", "");
-    data3.put("leaf", "f");
-
-    rows.add(makeRow(data0, numericBooleans));
-    rows.add(makeRow(data1, numericBooleans));
-    rows.add(makeRow(data2, numericBooleans));
-    rows.add(makeRow(data3, numericBooleans));
-
-    return rows;
-  }
-
-  public static List<Row> makeSecondRowData(boolean numericBooleans) {
-    List<Row> rows = new ArrayList<>();
-    Map<String, Object> data1 = new HashMap<>();
-    data1.put("key", "1");
-    data1.put("writetime(leaf)", 1L);
-    data1.put("p0", "a");
-    data1.put("p1", "b");
-    data1.put("p2", "c");
-    data1.put("p3", "d");
-    data1.put("text_value", "replaced");
-    data1.put("leaf", "d");
-    data1.put("p4", "");
-    rows.add(makeRow(data1, numericBooleans));
-
-    Map<String, Object> data2 = new HashMap<>();
-    data2.put("key", "1");
-    data2.put("writetime(leaf)", 1L);
-    data2.put("p0", "d");
-    data2.put("p1", "e");
-    data2.put("p2", "f");
-    data2.put("p3", "g");
-    data2.put("text_value", "replaced");
-    data2.put("leaf", "g");
-    data2.put("p4", "");
-    rows.add(makeRow(data2, numericBooleans));
-    return rows;
-  }
-
-  public static List<Row> makeThirdRowData(boolean numericBooleans) {
-    List<Row> rows = new ArrayList<>();
-    Map<String, Object> data1 = new HashMap<>();
-
-    data1.put("key", "1");
-    data1.put("writetime(leaf)", 2L);
-    data1.put("p0", "[0]");
-    data1.put("text_value", "replaced");
-    data1.put("p1", "");
-    data1.put("p2", "");
-    data1.put("p3", "");
-    data1.put("leaf", "[0]");
-    ;
-
-    rows.add(makeRow(data1, numericBooleans));
-    return rows;
-  }
-
-  public static List<Row> makeMultipleReplacements() {
-    List<Row> rows = new ArrayList<>();
-    Map<String, Object> data1 = new HashMap<>();
-
-    data1.put("key", "1");
-    data1.put("writetime(leaf)", 0L);
-    data1.put("p0", "a");
-    data1.put("p1", "[0]");
-    data1.put("p2", "b");
-    data1.put("p3", "c");
-    data1.put("text_value", "initial");
-    data1.put("p4", "");
-    data1.put("leaf", "c");
-
-    Map<String, Object> data2 = new HashMap<>();
-
-    data2.put("key", "1");
-    data2.put("writetime(leaf)", 1L);
-    data2.put("p0", "a");
-    data2.put("p1", "[0]");
-    data2.put("p2", "");
-    data2.put("p3", "");
-    data2.put("text_value", "initial");
-    data2.put("leaf", "a");
-
-    Map<String, Object> data3 = new HashMap<>();
-
-    data3.put("key", "1");
-    data3.put("writetime(leaf)", 2L);
-    data3.put("p0", "a");
-    data3.put("p1", "[0]");
-    data3.put("p2", "[0]");
-    data3.put("dbl_value", 1.23);
-    data3.put("p3", "");
-    data3.put("leaf", "a");
-
-    Map<String, Object> data4 = new HashMap<>();
-
-    data4.put("key", "1");
-    data4.put("writetime(leaf)", 3L);
-    data4.put("p0", "a");
-    data4.put("p1", "[0]");
-    data4.put("p2", "c");
-    data4.put("text_value", DocumentDB.EMPTY_ARRAY_MARKER);
-    data4.put("p3", "");
-    data4.put("leaf", "c");
-
-    Map<String, Object> data5 = new HashMap<>();
-
-    data5.put("key", "1");
-    data5.put("writetime(leaf)", 4L);
-    data5.put("p0", "a");
-    data5.put("p1", "b");
-    data5.put("p2", "c");
-    data5.put("text_value", DocumentDB.EMPTY_OBJECT_MARKER);
-    data5.put("p3", "");
-    data5.put("leaf", "c");
-
-    rows.add(makeRow(data1, false));
-    rows.add(makeRow(data2, false));
-    rows.add(makeRow(data3, false));
-    rows.add(makeRow(data4, false));
-    rows.add(makeRow(data5, false));
-    return rows;
-  }
-
-  public List<Row> makeRowDataForSecondDoc(boolean numericBooleans) {
-    List<Row> rows = new ArrayList<>();
-    Map<String, Object> data1 = new HashMap<>();
-
-    data1.put("key", "2");
-    data1.put("writetime(leaf)", 2L);
-    data1.put("p0", "[0]");
-    data1.put("text_value", "replaced");
-    data1.put("p1", "");
-    data1.put("p2", "");
-    data1.put("p3", "");
-    data1.put("leaf", "[0]");
-
-    rows.add(makeRow(data1, numericBooleans));
-    return rows;
-  }
-
-  private List<PathSegment> smallPath() {
-    List<PathSegment> path = new ArrayList<>();
-    path.add(
-        new PathSegment() {
-          @Override
-          public String getPath() {
-            return "abc";
-          }
-
-          @Override
-          public MultivaluedMap<String, String> getMatrixParameters() {
-            return null;
-          }
-        });
-    path.add(
-        new PathSegment() {
-          @Override
-          public String getPath() {
-            return "[0]";
-          }
-
-          @Override
-          public MultivaluedMap<String, String> getMatrixParameters() {
-            return null;
-          }
-        });
-    return path;
-  }
-
-  private static Row makeRow(Map<String, Object> data, boolean numericBooleans) {
-    List<Column> columns = new ArrayList<>(DocumentDB.allColumns());
-    columns.add(Column.create("writetime(leaf)", Type.Bigint));
-    List<ByteBuffer> values = new ArrayList<>(columns.size());
-    ProtocolVersion version = ProtocolVersion.DEFAULT;
-    if (numericBooleans) {
-      columns.replaceAll(
-          col -> {
-            if (col.name().equals("bool_value")) {
-              return Column.create("bool_value", Type.Tinyint);
-            }
-            return col;
-          });
-    }
-
-    for (Column column : columns) {
-      Object v = data.get(column.name());
-      if (column.name().equals("bool_value") && numericBooleans && v != null) {
-        v = ((Boolean) v) ? (byte) 1 : (byte) 0;
+  private Builder<String, Object> row(String id, String... path) {
+    Builder<String, Object> map = ImmutableMap.builder();
+    map.put("key", id);
+    map.put("writetime(leaf)", 123);
+    String leaf = null;
+    for (int i = 0; i < DocumentDB.MAX_DEPTH; i++) {
+      String p;
+      if (i < path.length) {
+        p = path[i];
+        leaf = p;
+      } else {
+        p = "";
       }
-      values.add(v == null ? null : column.type().codec().encode(v, version));
+
+      map.put("p" + i, p);
     }
-    return new ArrayListBackedRow(columns, values, version);
+
+    assertThat(leaf).isNotNull();
+    map.put("leaf", leaf);
+    return map;
+  }
+
+  private <T> DocumentResponseWrapper<T> unwrap(Response r) throws JsonProcessingException {
+    assertThat(r.getStatus())
+        .withFailMessage("Unexpected error code: " + r.getStatus() + ", message: " + r.getEntity())
+        .isEqualTo(Status.OK.getStatusCode());
+
+    String entity = (String) r.getEntity();
+    @SuppressWarnings("unchecked")
+    DocumentResponseWrapper<T> resp = mapper.readValue(entity, DocumentResponseWrapper.class);
+
+    assertThat(resp).isNotNull();
+    return resp;
+  }
+
+  private <T> DocumentResponseWrapper<T> getDocPath(
+      String id, String where, String fields, List<PathSegment> path)
+      throws JsonProcessingException {
+    return unwrap(
+        resource.getDocPath(
+            headers,
+            uriInfo,
+            authToken,
+            keyspace.name(),
+            table.name(),
+            id,
+            path,
+            where,
+            fields,
+            0,
+            null,
+            false,
+            request));
+  }
+
+  private <T> DocumentResponseWrapper<T> searchDoc(String where, String fields)
+      throws JsonProcessingException {
+    return unwrap(
+        resource.searchDoc(
+            headers,
+            uriInfo,
+            authToken,
+            keyspace.name(),
+            table.name(),
+            where,
+            fields,
+            20,
+            null,
+            false,
+            request));
+  }
+
+  private <T> String getDocPathRaw(String id, String where, String fields, List<PathSegment> path) {
+    Response r =
+        resource.getDocPath(
+            headers,
+            uriInfo,
+            authToken,
+            keyspace.name(),
+            table.name(),
+            id,
+            path,
+            where,
+            fields,
+            0,
+            null,
+            true, // raw
+            request);
+
+    assertThat(r.getStatus())
+        .withFailMessage("Unexpected error code: " + r.getStatus() + ", message: " + r.getEntity())
+        .isEqualTo(Status.OK.getStatusCode());
+
+    return (String) r.getEntity();
+  }
+
+  private PathSegment p(String segment) {
+    return new PathSegment() {
+      @Override
+      public String getPath() {
+        return segment;
+      }
+
+      @Override
+      public MultivaluedMap<String, String> getMatrixParameters() {
+        throw new UnsupportedOperationException();
+      }
+    };
+  }
+
+  private Map<String, Object> m(Object... keyValues) {
+    assertThat(keyValues.length).isEven();
+    Builder<String, Object> map = ImmutableMap.builder();
+    for (int i = 0; i < keyValues.length; i++) {
+      Object key = keyValues[i++];
+      Object value = keyValues[i];
+      map.put(key.toString(), value);
+    }
+    return map.build();
+  }
+
+  private String selectAll(String where) {
+    return "SELECT key, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p30, p31, p32, p33, p34, p35, p36, p37, p38, p39, p40, p41, p42, p43, p44, p45, p46, p47, p48, p49, p50, p51, p52, p53, p54, p55, p56, p57, p58, p59, p60, p61, p62, p63, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM test_docs.collection1"
+        + (where.isEmpty() ? "" : " " + where);
+  }
+
+  @Test
+  void testGetDocById() throws JsonProcessingException {
+    final String id = "id1";
+    withQuery(table, selectAll("WHERE key = ?"), id)
+        .returning(ImmutableList.of(row(id, 1.0, "a"), row(id, 2.0, "b")));
+    DocumentResponseWrapper<Map<String, ?>> r =
+        unwrap(
+            resource.getDoc(
+                headers,
+                uriInfo,
+                authToken,
+                keyspace.name(),
+                table.name(),
+                id,
+                null,
+                null,
+                0,
+                null,
+                false,
+                request));
+    assertThat(r.getDocumentId()).isEqualTo(id);
+    assertThat(r.getPageState()).isNull();
+    assertThat(r.getData()).isEqualTo(m("a", 1, "b", 2));
+  }
+
+  @Test
+  void testGetDocPath() throws JsonProcessingException {
+    final String id = "id0";
+    withQuery(table, selectAll("WHERE key = ? AND p0 = ? AND p1 = ?"), id, "a", "c")
+        .returning(ImmutableList.of(row(id, 1.0, "a", "c", "x"), row(id, 2.0, "a", "c", "y")));
+
+    DocumentResponseWrapper<Map<String, ?>> r =
+        getDocPath(id, null, null, ImmutableList.of(p("a"), p("c")));
+    assertThat(r.getDocumentId()).isEqualTo(id);
+    assertThat(r.getPageState()).isNull();
+    assertThat(r.getData()).isEqualTo(m("x", 1, "y", 2));
+  }
+
+  @Test
+  void testGetDocPathRaw() throws JsonProcessingException {
+    final String id = "id0";
+    withQuery(table, selectAll("WHERE key = ? AND p0 = ? AND p1 = ?"), id, "a", "c")
+        .returning(ImmutableList.of(row(id, 1.0, "a", "c", "x"), row(id, 2.0, "a", "c", "y")));
+
+    String result = getDocPathRaw(id, null, null, ImmutableList.of(p("a"), p("c")));
+    assertThat(result).isEqualTo("{\"x\":1,\"y\":2}");
+  }
+
+  @Test
+  void testGetDocPathWhere() throws JsonProcessingException {
+    final String id = "id1";
+    ImmutableList<Map<String, Object>> rows =
+        ImmutableList.of(
+            row(id, 3.0, "a", "d", "c"), row(id, 10.0, "a", "e", "c"), row(id, 1.0, "a", "f", "c"));
+    withQuery(
+            table,
+            selectAll(
+                "WHERE key = ? AND leaf = ? AND p0 = ? AND p1 > ? AND p2 = ? AND dbl_value > ? ALLOW FILTERING"),
+            id,
+            "c",
+            "a",
+            "",
+            "c",
+            1.0d)
+        .returning(rows);
+    withQuery(
+            table,
+            selectAll(
+                "WHERE key = ? AND leaf = ? AND p0 = ? AND p1 > ? AND p2 = ? AND dbl_value < ? ALLOW FILTERING"),
+            id,
+            "c",
+            "a",
+            "",
+            "c",
+            1000.0d)
+        .returning(rows);
+
+    DocumentResponseWrapper<List<Map<String, ?>>> r =
+        getDocPath(id, "{\"a.*.c\":{\"$gt\":1,\"$ne\":10}}", null, ImmutableList.of());
+    assertThat(r.getDocumentId()).isEqualTo(id);
+    assertThat(r.getPageState()).isNull();
+    assertThat(r.getData())
+        .isEqualTo(ImmutableList.of(m("a", m("d", m("c", 3))), m("a", m("f", m("c", 1)))));
+
+    r = getDocPath(id, "{\"a.*.c\":{\"$lt\":1000}}", null, ImmutableList.of());
+    assertThat(r.getDocumentId()).isEqualTo(id);
+    assertThat(r.getPageState()).isNull();
+    assertThat(r.getData())
+        .isEqualTo(
+            ImmutableList.of(
+                m("a", m("d", m("c", 3))), m("a", m("e", m("c", 10))), m("a", m("f", m("c", 1)))));
+  }
+
+  @Test
+  void testGetDocPathFields() throws JsonProcessingException {
+    final String id = "id1";
+    withQuery(table, selectAll("WHERE key = ? AND p0 = ? AND p1 > ? ALLOW FILTERING"), id, "a", "")
+        .returning(
+            ImmutableList.of(
+                row(id, 3.0, "a", "d", "c"),
+                row(id, true, "a", "d", "z"),
+                row(id, "yy", new String[] {"a", "d", "y"}),
+                row(id, 10.0, "a", "e", "c"),
+                row(id, 20.0, "a", "e", "z"),
+                row(id, 100.0, "a", "f", "c")));
+
+    DocumentResponseWrapper<List<Map<String, ?>>> r =
+        getDocPath(id, "{\"a.*.c\":{\"$gte\":1,\"$ne\":10}}", "[\"c\", \"z\"]", ImmutableList.of());
+    assertThat(r.getDocumentId()).isEqualTo(id);
+    assertThat(r.getPageState()).isNull();
+    assertThat(r.getData())
+        .isEqualTo(
+            ImmutableList.of(m("a", m("d", m("c", 3, "z", true))), m("a", m("f", m("c", 100)))));
+
+    r =
+        getDocPath(
+            id, "{\"a.*.c\":{\"$lt\":1000,\"$ne\":10}}", "[\"c\", \"z\"]", ImmutableList.of());
+    assertThat(r.getDocumentId()).isEqualTo(id);
+    assertThat(r.getPageState()).isNull();
+    assertThat(r.getData())
+        .isEqualTo(
+            ImmutableList.of(m("a", m("d", m("c", 3, "z", true))), m("a", m("f", m("c", 100)))));
+
+    r = getDocPath(id, "{\"a.*.c\":{\"$in\":[3]}}", "[\"c\", \"z\"]", ImmutableList.of());
+    assertThat(r.getData()).isEqualTo(ImmutableList.of(m("a", m("d", m("c", 3, "z", true)))));
+
+    r = getDocPath(id, "{\"a.*.c\":{\"$lte\":3}}", "[\"c\", \"z\"]", ImmutableList.of());
+    assertThat(r.getData()).isEqualTo(ImmutableList.of(m("a", m("d", m("c", 3, "z", true)))));
+
+    r = getDocPath(id, "{\"a.*.c\":{\"$nin\":[10, 100]}}", "[\"c\", \"z\"]", ImmutableList.of());
+    assertThat(r.getData()).isEqualTo(ImmutableList.of(m("a", m("d", m("c", 3, "z", true)))));
+
+    r = getDocPath(id, "{\"a.*.z\":{\"$in\":[true]}}", "[\"c\", \"z\"]", ImmutableList.of());
+    assertThat(r.getData()).isEqualTo(ImmutableList.of(m("a", m("d", m("c", 3, "z", true)))));
+
+    r = getDocPath(id, "{\"a.*.y\":{\"$in\":[\"yy\"]}}", "[\"c\", \"y\"]", ImmutableList.of());
+    assertThat(r.getData()).isEqualTo(ImmutableList.of(m("a", m("d", m("c", 3, "y", "yy")))));
+
+    assertThat(
+            getDocPathRaw(
+                id, "{\"a.*.c\":{\"$gt\":1,\"$ne\":10}}", "[\"c\", \"z\"]", ImmutableList.of()))
+        .isEqualTo("[{\"a\":{\"d\":{\"c\":3,\"z\":true}}},{\"a\":{\"f\":{\"c\":100}}}]");
+  }
+
+  private Object[] fillParams(Object val, int count, double lastValue, Object... params) {
+    Object[] result = new Object[params.length + count + 1];
+    Arrays.fill(result, val);
+    System.arraycopy(params, 0, result, 0, params.length);
+    result[result.length - 1] = lastValue;
+    return result;
+  }
+
+  private Object[] fillParams(int totalCount, Object... params) {
+    Object[] result = new Object[totalCount];
+    Arrays.fill(result, ""); // default value for pNN columns
+    int idx = 0;
+    for (Object param : params) {
+      if (param == SEPARATOR) {
+        idx = totalCount - params.length + idx + 1;
+        continue;
+      }
+
+      result[idx++] = param;
+    }
+
+    return result;
+  }
+
+  @Test
+  void testSearchDocEmpty() throws JsonProcessingException {
+    withQuery(
+            table,
+            "SELECT key, leaf FROM test_docs.collection1 WHERE p0 = ? AND p1 > ? AND p2 = ? AND p3 = ? AND p4 = ? AND p5 = ? AND p6 = ? AND p7 = ? AND p8 = ? AND p9 = ? AND p10 = ? AND p11 = ? AND p12 = ? AND p13 = ? AND p14 = ? AND p15 = ? AND p16 = ? AND p17 = ? AND p18 = ? AND p19 = ? AND p20 = ? AND p21 = ? AND p22 = ? AND p23 = ? AND p24 = ? AND p25 = ? AND p26 = ? AND p27 = ? AND p28 = ? AND p29 = ? AND p30 = ? AND p31 = ? AND p32 = ? AND p33 = ? AND p34 = ? AND p35 = ? AND p36 = ? AND p37 = ? AND p38 = ? AND p39 = ? AND p40 = ? AND p41 = ? AND p42 = ? AND p43 = ? AND p44 = ? AND p45 = ? AND p46 = ? AND p47 = ? AND p48 = ? AND p49 = ? AND p50 = ? AND p51 = ? AND p52 = ? AND p53 = ? AND p54 = ? AND p55 = ? AND p56 = ? AND p57 = ? AND p58 = ? AND p59 = ? AND p60 = ? AND p61 = ? AND p62 = ? AND p63 = ? AND dbl_value > ? ALLOW FILTERING",
+            fillParams("", 61, 1.0d, "a", "", "c"))
+        .returningNothing();
+    DocumentResponseWrapper<Map<String, ?>> r = searchDoc("{\"a.*.c\":{\"$gt\":1}}", null);
+    assertThat(r.getPageState()).isNull();
+    assertThat(r.getData()).isEqualTo(m());
+  }
+
+  @Test
+  void testSearchDoc() throws JsonProcessingException {
+    final String id1 = "id1";
+    final String id2 = "id2";
+
+    withQuery(
+            table,
+            "SELECT key, leaf FROM test_docs.collection1 WHERE p0 = ? AND p1 = ? AND p2 = ? AND p3 = ? AND p4 = ? AND p5 = ? AND p6 = ? AND p7 = ? AND p8 = ? AND p9 = ? AND p10 = ? AND p11 = ? AND p12 = ? AND p13 = ? AND p14 = ? AND p15 = ? AND p16 = ? AND p17 = ? AND p18 = ? AND p19 = ? AND p20 = ? AND p21 = ? AND p22 = ? AND p23 = ? AND p24 = ? AND p25 = ? AND p26 = ? AND p27 = ? AND p28 = ? AND p29 = ? AND p30 = ? AND p31 = ? AND p32 = ? AND p33 = ? AND p34 = ? AND p35 = ? AND p36 = ? AND p37 = ? AND p38 = ? AND p39 = ? AND p40 = ? AND p41 = ? AND p42 = ? AND p43 = ? AND p44 = ? AND p45 = ? AND p46 = ? AND p47 = ? AND p48 = ? AND p49 = ? AND p50 = ? AND p51 = ? AND p52 = ? AND p53 = ? AND p54 = ? AND p55 = ? AND p56 = ? AND p57 = ? AND p58 = ? AND p59 = ? AND p60 = ? AND p61 = ? AND p62 = ? AND p63 = ? AND dbl_value > ? ALLOW FILTERING",
+            fillParams("", 62, 1.0d, "a", "c"))
+        .returning(ImmutableList.of(leafRow(id1), leafRow(id2)));
+
+    withQuery(
+            table,
+            "SELECT key, leaf FROM test_docs.collection1 WHERE key = ? AND p0 = ? AND p1 = ? AND p2 = ? AND p3 = ? AND p4 = ? AND p5 = ? AND p6 = ? AND p7 = ? AND p8 = ? AND p9 = ? AND p10 = ? AND p11 = ? AND p12 = ? AND p13 = ? AND p14 = ? AND p15 = ? AND p16 = ? AND p17 = ? AND p18 = ? AND p19 = ? AND p20 = ? AND p21 = ? AND p22 = ? AND p23 = ? AND p24 = ? AND p25 = ? AND p26 = ? AND p27 = ? AND p28 = ? AND p29 = ? AND p30 = ? AND p31 = ? AND p32 = ? AND p33 = ? AND p34 = ? AND p35 = ? AND p36 = ? AND p37 = ? AND p38 = ? AND p39 = ? AND p40 = ? AND p41 = ? AND p42 = ? AND p43 = ? AND p44 = ? AND p45 = ? AND p46 = ? AND p47 = ? AND p48 = ? AND p49 = ? AND p50 = ? AND p51 = ? AND p52 = ? AND p53 = ? AND p54 = ? AND p55 = ? AND p56 = ? AND p57 = ? AND p58 = ? AND p59 = ? AND p60 = ? AND p61 = ? AND p62 = ? AND p63 = ? AND dbl_value = ? ALLOW FILTERING",
+            fillParams("", 61, 2.0d, id1, "d", "e", "f"))
+        .returning(ImmutableList.of(leafRow(id1)));
+    withQuery(
+            table,
+            "SELECT key, leaf FROM test_docs.collection1 WHERE key = ? AND p0 = ? AND p1 = ? AND p2 = ? AND p3 = ? AND p4 = ? AND p5 = ? AND p6 = ? AND p7 = ? AND p8 = ? AND p9 = ? AND p10 = ? AND p11 = ? AND p12 = ? AND p13 = ? AND p14 = ? AND p15 = ? AND p16 = ? AND p17 = ? AND p18 = ? AND p19 = ? AND p20 = ? AND p21 = ? AND p22 = ? AND p23 = ? AND p24 = ? AND p25 = ? AND p26 = ? AND p27 = ? AND p28 = ? AND p29 = ? AND p30 = ? AND p31 = ? AND p32 = ? AND p33 = ? AND p34 = ? AND p35 = ? AND p36 = ? AND p37 = ? AND p38 = ? AND p39 = ? AND p40 = ? AND p41 = ? AND p42 = ? AND p43 = ? AND p44 = ? AND p45 = ? AND p46 = ? AND p47 = ? AND p48 = ? AND p49 = ? AND p50 = ? AND p51 = ? AND p52 = ? AND p53 = ? AND p54 = ? AND p55 = ? AND p56 = ? AND p57 = ? AND p58 = ? AND p59 = ? AND p60 = ? AND p61 = ? AND p62 = ? AND p63 = ? AND dbl_value = ? ALLOW FILTERING",
+            fillParams("", 61, 2.0d, id2, "d", "e", "f"))
+        .returning(ImmutableList.of(leafRow(id2)));
+
+    withQuery(table, selectAll("WHERE key = ?"), id1)
+        .returning(ImmutableList.of(row(id1, 3.0, "a", "b"), row(id1, 4.0, "a", "c")));
+
+    withQuery(table, selectAll("WHERE key = ?"), id2)
+        .returning(
+            ImmutableList.of(
+                row(id2, 5.0, "a", "b"), row(id2, 10.0, "a", "c"), row(id2, 5.0, "a", "d")));
+
+    DocumentResponseWrapper<Map<String, ?>> r =
+        searchDoc("{\"a.c\":{\"$gt\":1,\"$ne\":10},\"d.e.f\":{\"$eq\":2}}", null);
+    assertThat(r.getPageState()).isNull();
+    assertThat(r.getData()).isEqualTo(m(id1, m("a", m("b", 3, "c", 4))));
+
+    r = searchDoc("{\"a.c\":{\"$gt\":1},\"d.e.f\":{\"$eq\":2}}", null);
+    assertThat(r.getPageState()).isNull();
+    assertThat(r.getData())
+        .isEqualTo(m(id1, m("a", m("b", 3, "c", 4)), id2, m("a", m("b", 5, "c", 10, "d", 5))));
+
+    r = searchDoc("{\"a.c\":{\"$gt\":1},\"d.e.f\":{\"$eq\":2}}", "[\"a.b\"]");
+    assertThat(r.getPageState()).isNull();
+    assertThat(r.getData()).isEqualTo(m(id1, m("a", m("b", 3)), id2, m("a", m("b", 5))));
+  }
+
+  @Test
+  void testSearchDocInMemory() throws JsonProcessingException {
+    final String id1 = "id1";
+    final String id2 = "id2";
+    final String id3 = "id3";
+
+    // full scan
+    withQuery(table, selectAll(""))
+        .returning(
+            ImmutableList.of(
+                row(id1, 3.0, "a", "b"),
+                row(id1, 3.0, "a", "c"),
+                row(id1, 3.0, "a", "d"),
+                row(id2, 4.0, "a", "e"),
+                row(id2, 4.0, "a", "c"),
+                row(id3, 10.0, "a", "c"),
+                row(id3, 20.0, "a", "b")));
+
+    DocumentResponseWrapper<Map<String, ?>> r = searchDoc("{\"a.c\":{\"$ne\":10}}", null);
+    assertThat(r.getPageState()).isNull();
+    assertThat(r.getData())
+        .isEqualTo(m(id1, m("a", m("b", 3, "c", 3, "d", 3)), id2, m("a", m("e", 4, "c", 4))));
+
+    r = searchDoc("{\"a.c\":{\"$ne\":10}}", "[\"a.b\"]");
+    assertThat(r.getPageState()).isNull();
+    assertThat(r.getData()).isEqualTo(m(id1, m("a", m("b", 3)), id2, m()));
+  }
+
+  @Test
+  void testSearchDocFullScan() throws JsonProcessingException {
+    final String id1 = "id1";
+    final String id2 = "id2";
+    final String id3 = "id3";
+
+    // full scan
+    withQuery(table, selectAll(""))
+        .returning(
+            ImmutableList.of(
+                row(id1, 3.0, "a", "b"),
+                row(id1, 3.0, "a", "c"),
+                row(id1, 3.0, "a", "d"),
+                row(id2, 4.0, "a", "e"),
+                row(id2, 4.0, "a", "c"),
+                row(id3, 10.0, "a", "c"),
+                row(id3, 20.0, "a", "b")));
+
+    DocumentResponseWrapper<Map<String, ?>> r = searchDoc(null, null);
+    assertThat(r.getPageState()).isNull();
+    assertThat(r.getData())
+        .isEqualTo(
+            m(
+                id1,
+                m("a", m("b", 3, "c", 3, "d", 3)),
+                id2,
+                m("a", m("e", 4, "c", 4)),
+                id3,
+                m("a", m("b", 20, "c", 10))));
+
+    r = searchDoc(null, "[\"a.b\"]");
+    assertThat(r.getPageState()).isNull();
+    assertThat(r.getData()).isEqualTo(m(id1, m("a", m("b", 3)), id2, m(), id3, m("a", m("b", 20))));
+  }
+
+  @Test
+  void testPutAtPathRoot() throws UnauthorizedException {
+    withQuery(table, "DELETE FROM %s USING TIMESTAMP ? WHERE key = ?", 99L, "id1")
+        .returningNothing();
+
+    String insert =
+        "INSERT INTO %s (key, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p30, p31, p32, p33, p34, p35, p36, p37, p38, p39, p40, p41, p42, p43, p44, p45, p46, p47, p48, p49, p50, p51, p52, p53, p54, p55, p56, p57, p58, p59, p60, p61, p62, p63, leaf, text_value, dbl_value, bool_value) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) USING TIMESTAMP ?";
+    withQuery(table, insert, fillParams(70, "id1", "a", SEPARATOR, "a", null, 123.0d, null, 100L))
+        .returningNothing();
+    withQuery(table, insert, fillParams(70, "id1", "b", SEPARATOR, "b", null, null, true, 100L))
+        .returningNothing();
+    withQuery(table, insert, fillParams(70, "id1", "c", SEPARATOR, "c", "text", null, null, 100L))
+        .returningNothing();
+    withQuery(
+            table,
+            insert,
+            fillParams(
+                70, "id1", "d", SEPARATOR, "d", DocumentDB.EMPTY_OBJECT_MARKER, null, null, 100L))
+        .returningNothing();
+    withQuery(
+            table,
+            insert,
+            fillParams(
+                70, "id1", "e", SEPARATOR, "e", DocumentDB.EMPTY_ARRAY_MARKER, null, null, 100L))
+        .returningNothing();
+    withQuery(table, insert, fillParams(70, "id1", "f", SEPARATOR, "f", null, null, null, 100L))
+        .returningNothing();
+    withQuery(
+            table,
+            insert,
+            fillParams(70, "id1", "g", "[000000]", "h", SEPARATOR, "h", null, 1.0d, null, 100L))
+        .returningNothing();
+
+    now.set(100);
+    service.putAtPath(
+        authToken,
+        keyspace.name(),
+        table.name(),
+        "id1",
+        "{\"a\":123, \"b\":true, \"c\":\"text\", \"d\":{}, \"e\":[], \"f\":null, \"g\":[{\"h\":1}]}",
+        ImmutableList.of(),
+        false,
+        db,
+        true,
+        Collections.emptyMap());
+  }
+
+  @Test
+  void testPutAtPathNested() throws UnauthorizedException {
+    withQuery(
+            table,
+            "DELETE FROM test_docs.collection1 USING TIMESTAMP ? WHERE key = ? AND p0 = ? AND p1 = ? AND p2 = ?",
+            199L,
+            "id2",
+            "x",
+            "y",
+            "[000000]")
+        .returningNothing();
+
+    String insert =
+        "INSERT INTO %s (key, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p30, p31, p32, p33, p34, p35, p36, p37, p38, p39, p40, p41, p42, p43, p44, p45, p46, p47, p48, p49, p50, p51, p52, p53, p54, p55, p56, p57, p58, p59, p60, p61, p62, p63, leaf, text_value, dbl_value, bool_value) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) USING TIMESTAMP ?";
+    withQuery(
+            table,
+            insert,
+            fillParams(
+                70, "id2", "x", "y", "[000000]", "a", SEPARATOR, "a", null, 123.0d, null, 200L))
+        .returningNothing();
+
+    now.set(200);
+    service.putAtPath(
+        authToken,
+        keyspace.name(),
+        table.name(),
+        "id2",
+        "{\"a\":123}",
+        ImmutableList.of(p("x"), p("y"), p("[000000]")),
+        false,
+        db,
+        true,
+        Collections.emptyMap());
+  }
+
+  @Test
+  void testPutAtPathPatch() throws UnauthorizedException {
+    String insert =
+        "INSERT INTO %s (key, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p30, p31, p32, p33, p34, p35, p36, p37, p38, p39, p40, p41, p42, p43, p44, p45, p46, p47, p48, p49, p50, p51, p52, p53, p54, p55, p56, p57, p58, p59, p60, p61, p62, p63, leaf, text_value, dbl_value, bool_value) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) USING TIMESTAMP ?";
+    withQuery(table, insert, fillParams(70, "id3", "a", SEPARATOR, "a", null, 123.0d, null, 200L))
+        .returningNothing();
+
+    withQuery(
+            table,
+            "DELETE FROM %s USING TIMESTAMP ? WHERE key = ? AND p0 >= ? AND p0 <= ?",
+            199L,
+            "id3",
+            "[000000]",
+            "[999999]")
+        .returningNothing();
+    withQuery(
+            table,
+            "DELETE FROM %s USING TIMESTAMP ? WHERE key = ? AND p0 IN ?",
+            199L,
+            "id3",
+            ImmutableList.of("a"))
+        .returningNothing();
+
+    now.set(200);
+    service.putAtPath(
+        authToken,
+        keyspace.name(),
+        table.name(),
+        "id3",
+        "{\"a\":123}",
+        ImmutableList.of(),
+        true,
+        db,
+        true,
+        Collections.emptyMap());
+  }
+
+  @Test
+  void testPutAtPathUnauthorized() throws UnauthorizedException {
+    ThrowingCallable action =
+        () ->
+            service.putAtPath(
+                authToken,
+                keyspace.name(),
+                table.name(),
+                "id3",
+                "{\"a\":123}",
+                ImmutableList.of(),
+                true,
+                db,
+                true,
+                Collections.emptyMap());
+
+    Mockito.doThrow(new UnauthorizedException("test1"))
+        .when(authorizationService)
+        .authorizeDataWrite(
+            any(), eq(keyspace.name()), eq(table.name()), eq(Scope.DELETE), eq(SourceAPI.REST));
+
+    assertThatThrownBy(action).hasMessage("test1");
+
+    Mockito.doNothing()
+        .when(authorizationService)
+        .authorizeDataWrite(
+            any(), eq(keyspace.name()), eq(table.name()), eq(Scope.DELETE), eq(SourceAPI.REST));
+    Mockito.doThrow(new UnauthorizedException("test2"))
+        .when(authorizationService)
+        .authorizeDataWrite(
+            any(), eq(keyspace.name()), eq(table.name()), eq(Scope.MODIFY), eq(SourceAPI.REST));
+
+    assertThatThrownBy(action).hasMessage("test2");
+  }
+
+  @Test
+  void testGetDocPathUnauthorized() throws UnauthorizedException {
+    Mockito.doThrow(new UnauthorizedException("test3"))
+        .when(authorizationService)
+        .authorizeDataRead(any(), eq(keyspace.name()), eq(table.name()), eq(SourceAPI.REST));
+
+    assertThatThrownBy(
+            () -> getDocPath("id1", "{\"a.*.y\":{\"$in\":[\"yy\"]}}", null, ImmutableList.of()))
+        .hasMessageContaining("test3");
+  }
+
+  @Test
+  void testSearchDocUnauthorized() throws UnauthorizedException {
+    Mockito.doThrow(new UnauthorizedException("test4"))
+        .when(authorizationService)
+        .authorizeDataRead(any(), eq(keyspace.name()), eq(table.name()), eq(SourceAPI.REST));
+
+    assertThatThrownBy(() -> searchDoc("{\"a.*.y\":{\"$in\":[\"yy\"]}}", null))
+        .hasMessageContaining("test4");
   }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/FlowableConnectOnRequestTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/FlowableConnectOnRequestTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.web.docsapi.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
+import org.junit.jupiter.api.Test;
+
+class FlowableConnectOnRequestTest {
+
+  @Test
+  void testNoDataWithoutRequest() {
+    TestSubscriber<String> test =
+        Flowable.just("a").compose(FlowableConnectOnRequest.with()).test(0);
+    test.assertNotComplete();
+    assertThat(test.values()).isEmpty();
+  }
+
+  @Test
+  void testOnNext() {
+    Flowable.just("a").compose(FlowableConnectOnRequest.with()).test(1).assertValue("a");
+  }
+
+  @Test
+  void testMultipleRequests() {
+    TestSubscriber<String> test =
+        Flowable.just("a", "b", "c").compose(FlowableConnectOnRequest.with()).test(0);
+    test.request(1);
+    test.assertValues("a");
+    test.request(2);
+    test.assertValues("a", "b", "c");
+  }
+
+  @Test
+  void testOnComplete() {
+    Flowable.just("a").compose(FlowableConnectOnRequest.with()).test(1).assertComplete();
+  }
+
+  @Test
+  void testOnError() {
+    Flowable.error(new IllegalStateException("test-exception"))
+        .compose(FlowableConnectOnRequest.with())
+        .test(1)
+        .assertError(t -> t.getMessage().equals("test-exception"));
+  }
+
+  @Test
+  void testCancel() {
+    TestSubscriber<String> testSubscriber =
+        Flowable.just("a").compose(FlowableConnectOnRequest.with()).test(0);
+    testSubscriber.cancel();
+    testSubscriber.request(1); // not effective due to cancel() above
+    testSubscriber.assertNotComplete();
+    assertThat(testSubscriber.values()).isEmpty();
+  }
+}

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/QueryExecutorTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/QueryExecutorTest.java
@@ -1,0 +1,426 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.web.docsapi.service;
+
+import static io.stargate.db.schema.Column.Kind.Clustering;
+import static io.stargate.db.schema.Column.Kind.PartitionKey;
+import static io.stargate.db.schema.Column.Kind.Regular;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList.Builder;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import io.reactivex.Flowable;
+import io.stargate.db.datastore.AbstractDataStoreTest;
+import io.stargate.db.datastore.ResultSet;
+import io.stargate.db.datastore.ValidatingDataStore.QueryAssert;
+import io.stargate.db.query.Predicate;
+import io.stargate.db.query.builder.AbstractBound;
+import io.stargate.db.query.builder.BuiltQuery;
+import io.stargate.db.schema.Column.Type;
+import io.stargate.db.schema.ImmutableColumn;
+import io.stargate.db.schema.ImmutableKeyspace;
+import io.stargate.db.schema.ImmutableSchema;
+import io.stargate.db.schema.ImmutableTable;
+import io.stargate.db.schema.Keyspace;
+import io.stargate.db.schema.Schema;
+import io.stargate.db.schema.Table;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+class QueryExecutorTest extends AbstractDataStoreTest {
+
+  protected static final Table table =
+      ImmutableTable.builder()
+          .keyspace("test_docs")
+          .name("collection1")
+          .addColumns(
+              ImmutableColumn.builder().name("key").type(Type.Text).kind(PartitionKey).build())
+          .addColumns(ImmutableColumn.builder().name("p0").type(Type.Text).kind(Clustering).build())
+          .addColumns(ImmutableColumn.builder().name("p1").type(Type.Text).kind(Clustering).build())
+          .addColumns(ImmutableColumn.builder().name("p2").type(Type.Text).kind(Clustering).build())
+          .addColumns(ImmutableColumn.builder().name("p3").type(Type.Text).kind(Clustering).build())
+          .addColumns(
+              ImmutableColumn.builder().name("test_value").type(Type.Double).kind(Regular).build())
+          .build();
+
+  private static final Keyspace keyspace =
+      ImmutableKeyspace.builder().name("test_docs").addTables(table).build();
+
+  private static final Schema schema = ImmutableSchema.builder().addKeyspaces(keyspace).build();
+
+  private QueryExecutor executor;
+  private AbstractBound<?> allDocsQuery;
+  private BuiltQuery<?> allRowsForDocQuery;
+
+  @Override
+  protected Schema schema() {
+    return schema;
+  }
+
+  @BeforeEach
+  public void setup() {
+    executor = new QueryExecutor(datastore());
+    allDocsQuery = datastore().queryBuilder().select().star().from(table).build().bind();
+    allRowsForDocQuery =
+        datastore().queryBuilder().select().star().from(table).where("key", Predicate.EQ).build();
+  }
+
+  private Map<String, Object> row(String id, String p0, Double value) {
+    return ImmutableMap.of("key", id, "p0", p0, "test_value", value);
+  }
+
+  private Map<String, Object> row(String id, String p0, String p1, Double value) {
+    return ImmutableMap.of("key", id, "p0", p0, "p1", p1, "test_value", value);
+  }
+
+  private <T> List<T> get(Flowable<T> flowable) {
+    return StreamSupport.stream(flowable.blockingIterable().spliterator(), false)
+        .collect(Collectors.toList());
+  }
+
+  private <T> List<T> get(Flowable<T> flowable, int limit) {
+    return StreamSupport.stream(flowable.limit(limit).blockingIterable().spliterator(), false)
+        .collect(Collectors.toList());
+  }
+
+  @Test
+  void testFullScan() {
+    withQuery(table, "SELECT * FROM %s")
+        .returning(ImmutableList.of(row("1", "x", 1.0d), row("1", "y", 2.0d), row("2", "x", 3.0d)));
+
+    List<RawDocument> r1 = get(executor.queryDocs(allDocsQuery, 100, null));
+    assertThat(r1).extracting(RawDocument::id).containsExactly("1", "2");
+  }
+
+  private void withFiveTestDocs(int pageSize) {
+    withQuery(table, "SELECT * FROM %s")
+        .withPageSize(pageSize)
+        .returning(
+            ImmutableList.of(
+                row("1", "x", 1.0d),
+                row("1", "y", 2.0d),
+                row("2", "x", 3.0d),
+                row("3", "x", 1.0d),
+                row("4", "y", 2.0d),
+                row("4", "x", 3.0d),
+                row("5", "x", 3.0d),
+                row("5", "x", 3.0d)));
+  }
+
+  private void withFiveTestDocIds(int pageSize) {
+    withQuery(table, "SELECT * FROM %s")
+        .withPageSize(pageSize)
+        .returning(
+            ImmutableList.of(
+                row("1", "x", 1.0d),
+                row("2", "x", 3.0d),
+                row("3", "x", 1.0d),
+                row("4", "y", 2.0d),
+                row("5", "x", 3.0d)));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"1", "3", "5", "100"})
+  void testFullScanPaged(int pageSize) {
+    withFiveTestDocs(pageSize);
+
+    List<RawDocument> r1 = get(executor.queryDocs(allDocsQuery, pageSize, null));
+    assertThat(r1).extracting(RawDocument::id).containsExactly("1", "2", "3", "4", "5");
+
+    assertThat(r1.get(0).hasPagingState()).isTrue();
+    ByteBuffer ps1 = r1.get(0).makePagingState();
+    List<RawDocument> r2 = get(executor.queryDocs(allDocsQuery, pageSize, ps1));
+    assertThat(r2).extracting(RawDocument::id).containsExactly("2", "3", "4", "5");
+
+    assertThat(r1.get(1).hasPagingState()).isTrue();
+    ByteBuffer ps2 = r1.get(1).makePagingState();
+    List<RawDocument> r3 = get(executor.queryDocs(allDocsQuery, pageSize, ps2));
+    assertThat(r3).extracting(RawDocument::id).containsExactly("3", "4", "5");
+
+    assertThat(r1.get(3).hasPagingState()).isTrue();
+    ByteBuffer ps4 = r1.get(3).makePagingState();
+    List<RawDocument> r4 = get(executor.queryDocs(allDocsQuery, pageSize, ps4));
+    assertThat(r4).extracting(RawDocument::id).containsExactly("5");
+  }
+
+  @ParameterizedTest
+  @CsvSource({"1", "100", "5000"})
+  void testFullScanDeep(int pageSize) {
+    int N = 100_000;
+    Builder<Map<String, Object>> rows = ImmutableList.builder();
+    for (int i = 0; i < N; i++) { // generate 10 pages of data
+      rows.add(row("" + i, "a", 11.0d)); // one row per document
+    }
+
+    withQuery(table, "SELECT * FROM %s").withPageSize(pageSize).returning(rows.build());
+
+    // Testing potential stack overflow in Rx pipelines
+    assertThat(get(executor.queryDocs(allDocsQuery, pageSize, null))).hasSize(N);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"4", "10", "20", "50", "100", "500", "1000", "5000"})
+  void testPartialFullScan(int pageSize) throws InterruptedException {
+    Builder<Map<String, Object>> rows = ImmutableList.builder();
+    for (int i = 0; i <= 10 * pageSize; i++) { // generate 10 pages of data
+      rows.add(row("" + i, "a", 11.0d)); // one row per document
+    }
+
+    QueryAssert queryAssert =
+        withQuery(table, "SELECT * FROM %s").withPageSize(pageSize).returning(rows.build());
+
+    Flowable<RawDocument> flowable = executor.queryDocs(allDocsQuery, pageSize, null);
+    AtomicReference<Subscription> subscription = new AtomicReference<>();
+    Semaphore sem = new Semaphore(0);
+    flowable.subscribe(
+        new Subscriber<RawDocument>() {
+          @Override
+          public void onSubscribe(Subscription s) {
+            subscription.set(s);
+          }
+
+          @Override
+          public void onNext(RawDocument rawDocument) {
+            sem.release();
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            fail("Rx error: " + t, t);
+          }
+
+          @Override
+          public void onComplete() {
+            // nop
+          }
+        });
+
+    assertThat(subscription.get()).isNotNull();
+
+    subscription.get().request(1);
+    assertThat(sem.tryAcquire(30, TimeUnit.SECONDS)).isTrue();
+    queryAssert.assertExecuteCount().isEqualTo(2);
+
+    subscription.get().request(pageSize - 3); // total requested == pageSize - 2
+    assertThat(sem.tryAcquire(pageSize - 3, 30, TimeUnit.SECONDS)).isTrue();
+    queryAssert.assertExecuteCount().isEqualTo(2); // still on page 2
+
+    subscription.get().request(1);
+    // Total requested here == pageSize - 1
+    // One more row is requested from upstream to detect doc boundaries, which ends page 2
+    // and causes page 3 to be executed
+    assertThat(sem.tryAcquire(30, TimeUnit.SECONDS)).isTrue();
+    queryAssert.assertExecuteCount().isEqualTo(3);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"1", "3", "5", "100"})
+  void testFullScanFinalPagingState(int pageSize) {
+    withFiveTestDocs(pageSize);
+
+    List<RawDocument> r1 = get(executor.queryDocs(allDocsQuery, pageSize, null));
+    assertThat(r1).extracting(RawDocument::id).containsExactly("1", "2", "3", "4", "5");
+    assertThat(r1.get(4).makePagingState()).isNull();
+    assertThat(r1.get(4).hasPagingState()).isFalse();
+  }
+
+  @ParameterizedTest
+  @CsvSource({"1", "3", "5", "100"})
+  void testPopulate(int pageSize) {
+    withFiveTestDocIds(pageSize);
+    withQuery(table, "SELECT * FROM %s WHERE key = ?", "2")
+        .withPageSize(pageSize)
+        .returning(ImmutableList.of(row("2", "x", 3.0d), row("2", "y", 1.0d)));
+    withQuery(table, "SELECT * FROM %s WHERE key = ?", "5")
+        .withPageSize(pageSize)
+        .returning(
+            ImmutableList.of(
+                row("5", "x", 3.0d),
+                row("5", "z", 2.0d),
+                row("5", "y", 1.0d),
+                row("6", "x", 1.0d))); // the last row should be ignored
+
+    List<RawDocument> r1 = get(executor.queryDocs(allDocsQuery, pageSize, null));
+    assertThat(r1).extracting(RawDocument::id).containsExactly("1", "2", "3", "4", "5");
+
+    RawDocument doc2a = r1.get(1);
+    assertThat(doc2a.rows()).hasSize(1);
+    assertThat(doc2a.id()).isEqualTo("2");
+
+    RawDocument doc2b =
+        doc2a
+            .populateFrom(executor.queryDocs(allRowsForDocQuery.bind("2"), pageSize, null))
+            .blockingGet();
+    assertThat(doc2b.id()).isEqualTo("2");
+    assertThat(doc2b.rows()).hasSize(2);
+    assertThat(doc2b.hasPagingState()).isTrue();
+    assertThat(doc2b.makePagingState()).isEqualTo(doc2a.makePagingState());
+
+    RawDocument doc5a = r1.get(4);
+    assertThat(doc5a.id()).isEqualTo("5");
+    assertThat(doc5a.rows()).hasSize(1);
+    assertThat(doc5a.makePagingState()).isNull();
+    assertThat(doc5a.hasPagingState()).isFalse();
+
+    RawDocument doc5b =
+        doc5a
+            .populateFrom(executor.queryDocs(allRowsForDocQuery.bind("5"), pageSize, null))
+            .blockingGet();
+    assertThat(doc5b.id()).isEqualTo("5");
+    assertThat(doc5b.rows()).hasSize(3);
+    assertThat(doc5b.makePagingState()).isNull();
+    assertThat(doc5b.hasPagingState()).isFalse();
+  }
+
+  @Test
+  void testResultSetPagination() {
+    withFiveTestDocs(3);
+
+    List<ResultSet> r1 =
+        get(
+            executor.execute(
+                datastore().queryBuilder().select().star().from(table).build().bind(), 3, null));
+
+    assertThat(r1.get(0).currentPageRows())
+        .extracting(r -> r.getString("key"))
+        .containsExactly("1", "1", "2");
+    assertThat(r1.get(0).getPagingState()).isNotNull();
+    assertThat(r1.get(1).currentPageRows())
+        .extracting(r -> r.getString("key"))
+        .containsExactly("3", "4", "4");
+    assertThat(r1.get(1).getPagingState()).isNotNull();
+    assertThat(r1.get(2).currentPageRows())
+        .extracting(r -> r.getString("key"))
+        .containsExactly("5", "5");
+    assertThat(r1.get(2).getPagingState()).isNull();
+    assertThat(r1).hasSize(3);
+  }
+
+  @Test
+  void testSubDocuments() {
+    withQuery(table, "SELECT * FROM %s WHERE key = ? AND p0 > ?", "a", "x")
+        .withPageSize(3)
+        .returning(
+            ImmutableList.of(
+                row("a", "x", "2", 1.0d),
+                row("a", "x", "2", 2.0d),
+                row("a", "x", "2", 3.0d),
+                row("a", "x", "2", 4.0d),
+                row("a", "y", "2", 5.0d),
+                row("a", "y", "3", 6.0d),
+                row("a", "y", "3", 7.0d)));
+
+    List<RawDocument> docs =
+        get(
+            executor.queryDocs(
+                3,
+                datastore()
+                    .queryBuilder()
+                    .select()
+                    .star()
+                    .from(table)
+                    .where("key", Predicate.EQ, "a")
+                    .where("p0", Predicate.GT, "x")
+                    .build()
+                    .bind(),
+                3,
+                null));
+
+    assertThat(docs.get(0).rows())
+        .extracting(r -> r.getDouble("test_value"))
+        .containsExactly(1.0d, 2.0d, 3.0d, 4.0d);
+    assertThat(docs.get(0).key()).containsExactly("a", "x", "2");
+
+    assertThat(docs.get(1).rows()).extracting(r -> r.getDouble("test_value")).containsExactly(5.0d);
+    assertThat(docs.get(1).key()).containsExactly("a", "y", "2");
+
+    assertThat(docs.get(2).rows())
+        .extracting(r -> r.getDouble("test_value"))
+        .containsExactly(6.0d, 7.0d);
+    assertThat(docs.get(2).key()).containsExactly("a", "y", "3");
+  }
+
+  @ParameterizedTest
+  @CsvSource({"1", "3", "5", "100"})
+  void testSubDocumentsPaged(int pageSize) {
+    withQuery(table, "SELECT * FROM %s WHERE key = ? AND p0 > ?", "a", "x")
+        .withPageSize(pageSize)
+        .returning(
+            ImmutableList.of(
+                row("a", "x", "2", 1.0d),
+                row("a", "x", "2", 2.0d),
+                row("a", "x", "2", 3.0d),
+                row("a", "x", "2", 4.0d),
+                row("a", "y", "2", 5.0d),
+                row("a", "y", "2", 6.0d),
+                row("a", "y", "3", 8.0d),
+                row("a", "y", "3", 9.0d),
+                row("a", "y", "4", 10.0d)));
+
+    AbstractBound<?> query =
+        datastore()
+            .queryBuilder()
+            .select()
+            .star()
+            .from(table)
+            .where("key", Predicate.EQ, "a")
+            .where("p0", Predicate.GT, "x")
+            .build()
+            .bind();
+
+    List<RawDocument> docs = get(executor.queryDocs(3, query, pageSize, null), 2);
+
+    assertThat(docs).hasSize(2);
+    assertThat(docs.get(0).key()).containsExactly("a", "x", "2");
+
+    assertThat(docs.get(1).key()).containsExactly("a", "y", "2");
+
+    assertThat(docs.get(1).hasPagingState()).isTrue();
+    ByteBuffer ps2 = docs.get(1).makePagingState();
+    assertThat(ps2).isNotNull();
+
+    docs = get(executor.queryDocs(3, query, pageSize, ps2));
+
+    assertThat(docs).hasSize(2);
+    assertThat(docs.get(0).key()).containsExactly("a", "y", "3");
+    assertThat(docs.get(0).rows())
+        .extracting(r -> r.getDouble("test_value"))
+        .containsExactly(8.0d, 9.0d);
+    assertThat(docs.get(1).key()).containsExactly("a", "y", "4");
+    assertThat(docs.get(1).rows())
+        .extracting(r -> r.getDouble("test_value"))
+        .containsExactly(10.0d);
+
+    assertThat(docs.get(0).hasPagingState()).isTrue();
+    assertThat(docs.get(0).makePagingState()).isNotNull();
+    assertThat(docs.get(1).hasPagingState()).isFalse();
+    assertThat(docs.get(1).makePagingState()).isNull();
+  }
+}

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/QueryExecutorTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/QueryExecutorTest.java
@@ -136,18 +136,19 @@ class QueryExecutorTest extends AbstractDataStoreTest {
 
     List<RawDocument> r1 = executor.queryDocs(allDocsQuery, pageSize, null).test().values();
     assertThat(r1).extracting(RawDocument::id).containsExactly("1", "2", "3", "4", "5");
-
     assertThat(r1.get(0).hasPagingState()).isTrue();
+    assertThat(r1.get(1).hasPagingState()).isTrue();
+    assertThat(r1.get(2).hasPagingState()).isTrue();
+    assertThat(r1.get(3).hasPagingState()).isTrue();
+
     ByteBuffer ps1 = r1.get(0).makePagingState();
     List<RawDocument> r2 = executor.queryDocs(allDocsQuery, pageSize, ps1).test().values();
     assertThat(r2).extracting(RawDocument::id).containsExactly("2", "3", "4", "5");
 
-    assertThat(r1.get(1).hasPagingState()).isTrue();
     ByteBuffer ps2 = r1.get(1).makePagingState();
     List<RawDocument> r3 = executor.queryDocs(allDocsQuery, pageSize, ps2).test().values();
     assertThat(r3).extracting(RawDocument::id).containsExactly("3", "4", "5");
 
-    assertThat(r1.get(3).hasPagingState()).isTrue();
     ByteBuffer ps4 = r1.get(3).makePagingState();
     List<RawDocument> r4 = executor.queryDocs(allDocsQuery, pageSize, ps4).test().values();
     assertThat(r4).extracting(RawDocument::id).containsExactly("5");

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/QueryExecutorTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/QueryExecutorTest.java
@@ -23,8 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList.Builder;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
-import io.reactivex.Flowable;
-import io.reactivex.subscribers.TestSubscriber;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.stargate.db.datastore.AbstractDataStoreTest;
 import io.stargate.db.datastore.ResultSet;
 import io.stargate.db.datastore.ValidatingDataStore.QueryAssert;
@@ -182,7 +182,6 @@ class QueryExecutorTest extends AbstractDataStoreTest {
 
     Flowable<RawDocument> flowable = executor.queryDocs(allDocsQuery, pageSize, null);
     TestSubscriber<RawDocument> test = flowable.test(1);
-    test.assertSubscribed();
 
     test.awaitCount(1);
     test.assertValueAt(0, d -> d.id().equals("0"));
@@ -360,7 +359,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
             .build()
             .bind();
 
-    List<RawDocument> docs = executor.queryDocs(3, query, pageSize, null).limit(2).test().values();
+    List<RawDocument> docs = executor.queryDocs(3, query, pageSize, null).take(2).test().values();
 
     assertThat(docs).hasSize(2);
     assertThat(docs.get(0).key()).containsExactly("a", "x", "2");

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/RawDocumentTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/RawDocumentTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.web.docsapi.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import io.reactivex.Flowable;
+import io.stargate.db.datastore.ResultSet;
+import io.stargate.db.datastore.Row;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RawDocumentTest {
+
+  private final String id = "testId";
+  private final List<String> key = ImmutableList.of("1", "2");
+
+  @Mock private ResultSet rs1;
+  @Mock private ResultSet rs2;
+  @Mock private Row row1;
+  @Mock private Row row2;
+  private List<Row> rows;
+
+  @BeforeEach
+  void setup() {
+    rows = ImmutableList.of(row1, row2);
+  }
+
+  @Nested
+  class Populate {
+    @Test
+    void testRowsReplacement() {
+      RawDocument doc0 = new RawDocument(id, key, rs1, true, ImmutableList.of());
+      RawDocument doc1 = new RawDocument(id, key, rs2, false, rows);
+
+      List<RawDocument> docs = doc0.populateFrom(Flowable.just(doc1)).test().values();
+      assertThat(docs).hasSize(1);
+      assertThat(docs).element(0).extracting(RawDocument::id).isEqualTo(id);
+      assertThat(docs).element(0).extracting(RawDocument::key).isEqualTo(key);
+      assertThat(docs).element(0).extracting(RawDocument::rows).isSameAs(rows);
+      assertThat(docs).element(0).extracting(RawDocument::hasPagingState).isEqualTo(true);
+    }
+
+    @Test
+    void testEmptyRows() {
+      RawDocument doc0 = new RawDocument(id, key, rs1, true, rows);
+      RawDocument doc1 = new RawDocument(id, key, rs2, false, ImmutableList.of());
+
+      List<RawDocument> docs = doc0.populateFrom(Flowable.just(doc1)).test().values();
+      assertThat(docs).hasSize(1);
+      assertThat(docs).element(0).extracting(RawDocument::id).isEqualTo(id);
+      assertThat(docs).element(0).extracting(RawDocument::key).isEqualTo(key);
+      assertThat(docs).element(0).extracting(RawDocument::rows).asList().isEmpty();
+      // no data rows -> no paging state
+      assertThat(docs).element(0).extracting(RawDocument::hasPagingState).isEqualTo(false);
+    }
+
+    @Test
+    void testEmptyFlowable() {
+      RawDocument doc0 = new RawDocument(id, key, rs1, true, rows);
+
+      List<RawDocument> docs = doc0.populateFrom(Flowable.empty()).test().values();
+      assertThat(docs).hasSize(1);
+      assertThat(docs).element(0).extracting(RawDocument::id).isEqualTo(id);
+      assertThat(docs).element(0).extracting(RawDocument::key).isEqualTo(key);
+      // Populating from an empty result sets yields the same doc ID but no data rows
+      assertThat(docs).element(0).extracting(RawDocument::rows).asList().isEmpty();
+      // no data rows -> no paging state
+      assertThat(docs).element(0).extracting(RawDocument::hasPagingState).isEqualTo(false);
+    }
+  }
+}

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/RawDocumentTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/RawDocumentTest.java
@@ -18,7 +18,7 @@ package io.stargate.web.docsapi.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
-import io.reactivex.Flowable;
+import io.reactivex.rxjava3.core.Flowable;
 import io.stargate.db.datastore.ResultSet;
 import io.stargate.db.datastore.Row;
 import java.util.List;

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -1983,20 +1983,6 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             "{\"description\":\"The parameter `page-size` is limited to 20.\",\"code\":400}");
   }
 
-  @Test
-  public void testPaginationDisallowedLimitedSupport() throws IOException {
-    JsonNode doc1 =
-        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("longSearch.json"));
-    RestUtils.put(authToken, collectionPath + "/1", doc1.toString(), 200);
-
-    String r =
-        RestUtils.get(
-            authToken, collectionPath + "/1?where={\"*.value\":{\"$nin\": [3]}}&page-size=5", 400);
-    assertThat(r)
-        .isEqualTo(
-            "{\"description\":\"The results as requested must fit in one page, try increasing the `page-size` parameter.\",\"code\":400}");
-  }
-
   // Below are "namespace" tests that should match the REST Api's keyspace tests
   @Test
   public void getNamespaces() throws IOException {


### PR DESCRIPTION
* `QueryEngine` handles pagination at the `DataStore` level and collates document rows
* `RawDocument` represents those collated row collections and includes custom paging state
* `DocumentService` is refactored to rely on `QueryEngine` for pagination and document assembly
* `Paginator` is mostly used to passing internal paging state to the top-level HTTP handlers now.
* Fixes to page size defaults are also included

This PR is meant to enable further enhancements for #828

TODO:
- [x] Re-add authZ checks
- [x] Re-add unit tests for `DocumentService`
- [x] Remove code duplication (see Codacy report)
- [x] Perf. test

This is still an intermediate step on a longer journey to supporting ORs in Docs API.