### PR TITLE
Added client info metric tag provider

### DIFF
--- a/core/src/main/java/io/stargate/core/metrics/api/HttpMetricsTagProvider.java
+++ b/core/src/main/java/io/stargate/core/metrics/api/HttpMetricsTagProvider.java
@@ -34,7 +34,7 @@ public interface HttpMetricsTagProvider {
   /**
    * Returns tags for a HTTP request, usually extracted from the given headers.
    *
-   * <p>Nota that the implementation must return constant amount of tags for any input.
+   * <p>Note that the implementation must return constant amount of tags for any input.
    *
    * @param headers HTTP Headers
    * @return Tags

--- a/cql/pom.xml
+++ b/cql/pom.xml
@@ -81,7 +81,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -92,6 +91,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -118,7 +122,7 @@
                             org.apache.cassandra.stargate.*,
                             org.javatuples,
                             com.codahale.metrics,
-                            o.micrometer.core.*,
+                            io.micrometer.core.*,
                             com.datastax.oss.driver.shaded.guava.*,
                         ]]></Import-Package>
             <Export-Package>!*</Export-Package>

--- a/cql/pom.xml
+++ b/cql/pom.xml
@@ -118,6 +118,7 @@
                             org.apache.cassandra.stargate.*,
                             org.javatuples,
                             com.codahale.metrics,
+                            o.micrometer.core.*,
                             com.datastax.oss.driver.shaded.guava.*,
                         ]]></Import-Package>
             <Export-Package>!*</Export-Package>

--- a/cql/pom.xml
+++ b/cql/pom.xml
@@ -98,6 +98,11 @@
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/cql/src/main/java/io/stargate/cql/CqlActivator.java
+++ b/cql/src/main/java/io/stargate/cql/CqlActivator.java
@@ -55,7 +55,13 @@ public class CqlActivator extends BaseActivator {
     if (cql != null) { // Already started
       return null;
     }
-    cql = new CqlImpl(makeConfig(), persistence.get(), metrics.get(), authentication.get());
+    cql =
+        new CqlImpl(
+            makeConfig(),
+            persistence.get(),
+            metrics.get(),
+            authentication.get(),
+            clientInfoTagProvider.get());
     cql.start();
 
     return null;

--- a/cql/src/main/java/io/stargate/cql/CqlActivator.java
+++ b/cql/src/main/java/io/stargate/cql/CqlActivator.java
@@ -21,19 +21,19 @@ import io.stargate.core.metrics.api.Metrics;
 import io.stargate.cql.impl.CqlImpl;
 import io.stargate.db.DbActivator;
 import io.stargate.db.Persistence;
+import io.stargate.db.metrics.api.ClientInfoMetricsTagProvider;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;
-
-import io.stargate.db.metrics.api.ClientInfoMetricsTagProvider;
 import org.apache.cassandra.config.Config;
 import org.jetbrains.annotations.Nullable;
 
 public class CqlActivator extends BaseActivator {
   private CqlImpl cql;
   private final ServicePointer<Metrics> metrics = ServicePointer.create(Metrics.class);
-  private final ServicePointer<ClientInfoMetricsTagProvider> clientInfoTagProvider = ServicePointer.create(ClientInfoMetricsTagProvider.class);
+  private final ServicePointer<ClientInfoMetricsTagProvider> clientInfoTagProvider =
+      ServicePointer.create(ClientInfoMetricsTagProvider.class);
   private final ServicePointer<AuthenticationService> authentication =
       ServicePointer.create(
           AuthenticationService.class,

--- a/cql/src/main/java/io/stargate/cql/CqlActivator.java
+++ b/cql/src/main/java/io/stargate/cql/CqlActivator.java
@@ -25,12 +25,15 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;
+
+import io.stargate.db.metrics.api.ClientInfoMetricsTagProvider;
 import org.apache.cassandra.config.Config;
 import org.jetbrains.annotations.Nullable;
 
 public class CqlActivator extends BaseActivator {
   private CqlImpl cql;
   private final ServicePointer<Metrics> metrics = ServicePointer.create(Metrics.class);
+  private final ServicePointer<ClientInfoMetricsTagProvider> clientInfoTagProvider = ServicePointer.create(ClientInfoMetricsTagProvider.class);
   private final ServicePointer<AuthenticationService> authentication =
       ServicePointer.create(
           AuthenticationService.class,
@@ -70,9 +73,9 @@ public class CqlActivator extends BaseActivator {
   @Override
   protected List<ServicePointer<?>> dependencies() {
     if (USE_AUTH_SERVICE) {
-      return Arrays.asList(metrics, persistence, authentication);
+      return Arrays.asList(metrics, clientInfoTagProvider, persistence, authentication);
     } else {
-      return Arrays.asList(metrics, persistence);
+      return Arrays.asList(metrics, clientInfoTagProvider, persistence);
     }
   }
 

--- a/cql/src/main/java/io/stargate/cql/impl/CqlImpl.java
+++ b/cql/src/main/java/io/stargate/cql/impl/CqlImpl.java
@@ -22,6 +22,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.stargate.auth.AuthenticationService;
 import io.stargate.core.metrics.api.Metrics;
 import io.stargate.db.Persistence;
+import io.stargate.db.metrics.api.ClientInfoMetricsTagProvider;
 import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.Collection;
@@ -43,17 +44,20 @@ public class CqlImpl {
   private final Persistence persistence;
   private final Metrics metrics;
   private final AuthenticationService authentication;
+  private final ClientInfoMetricsTagProvider clientInfoTagProvider;
 
   public CqlImpl(
       Config config,
       Persistence persistence,
       Metrics metrics,
-      AuthenticationService authentication) {
+      AuthenticationService authentication,
+      ClientInfoMetricsTagProvider clientInfoTagProvider) {
     TransportDescriptor.daemonInitialization(config);
 
     this.persistence = persistence;
     this.metrics = metrics;
     this.authentication = authentication;
+    this.clientInfoTagProvider = clientInfoTagProvider;
 
     if (useEpoll()) {
       workerGroup = new EpollEventLoopGroup();
@@ -91,7 +95,8 @@ public class CqlImpl {
       }
     }
 
-    ClientMetrics.instance.init(servers, metrics.getRegistry("cql"));
+    ClientMetrics.instance.init(
+        servers, metrics.getRegistry("cql"), metrics.getMeterRegistry(), clientInfoTagProvider);
     servers.forEach(Server::start);
     persistence.setRpcReady(true);
   }

--- a/cql/src/main/java/io/stargate/cql/impl/CqlImpl.java
+++ b/cql/src/main/java/io/stargate/cql/impl/CqlImpl.java
@@ -95,10 +95,10 @@ public class CqlImpl {
       }
     }
 
-    int metricUpdateRate =
-        Integer.parseInt(System.getProperty("stargate.cql.metrics.updateRate", "10000"));
+    double metricsUpdatePeriodSeconds =
+        Double.parseDouble(System.getProperty("stargate.cql.metrics.updatePeriodSeconds", "0.1"));
     ClientMetrics.instance.init(
-        servers, metrics.getMeterRegistry(), clientInfoTagProvider, metricUpdateRate);
+        servers, metrics.getMeterRegistry(), clientInfoTagProvider, metricsUpdatePeriodSeconds);
     servers.forEach(Server::start);
     persistence.setRpcReady(true);
   }

--- a/cql/src/main/java/io/stargate/cql/impl/CqlImpl.java
+++ b/cql/src/main/java/io/stargate/cql/impl/CqlImpl.java
@@ -95,8 +95,10 @@ public class CqlImpl {
       }
     }
 
+    int metricUpdateRate =
+        Integer.parseInt(System.getProperty("stargate.cql.metrics.updateRate", "10000"));
     ClientMetrics.instance.init(
-        servers, metrics.getRegistry("cql"), metrics.getMeterRegistry(), clientInfoTagProvider);
+        servers, metrics.getMeterRegistry(), clientInfoTagProvider, metricUpdateRate);
     servers.forEach(Server::start);
     persistence.setRpcReady(true);
   }
@@ -104,6 +106,7 @@ public class CqlImpl {
   public void stop() {
     persistence.setRpcReady(false);
     servers.forEach(Server::stop);
+    ClientMetrics.instance.shutdown();
   }
 
   public static boolean useEpoll() {

--- a/cql/src/main/java/org/apache/cassandra/stargate/metrics/ClientMetrics.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/metrics/ClientMetrics.java
@@ -21,12 +21,24 @@ package org.apache.cassandra.stargate.metrics;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
-import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MultiGauge;
+import io.micrometer.core.instrument.Tags;
 import io.netty.buffer.ByteBufAllocatorMetricProvider;
 import io.stargate.db.ClientInfo;
 import io.stargate.db.metrics.api.ClientInfoMetricsTagProvider;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import org.apache.cassandra.metrics.DefaultNameFactory;
 import org.apache.cassandra.stargate.transport.internal.CBUtil;
 import org.apache.cassandra.stargate.transport.internal.Server;
@@ -194,6 +206,7 @@ public final class ClientMetrics {
     // ensure overwrite is called to re-write existing values to new ones
     connectedNativeClients.register(rows, true);
   }
+
   private Map<String, Integer> countConnectedClientsByUser() {
     Map<String, Integer> counts = new HashMap<>();
 
@@ -233,7 +246,8 @@ public final class ClientMetrics {
     private final AtomicInteger connectedClients;
 
     public ConnectionMetricsImpl(ClientInfo clientInfo) {
-      Tags tags = Optional.ofNullable(clientInfo)
+      Tags tags =
+          Optional.ofNullable(clientInfo)
               .map(clientInfoTagProvider::getClientInfoTags)
               .orElse(Tags.empty());
 
@@ -242,7 +256,8 @@ public final class ClientMetrics {
       authSuccess = meterRegistry.counter(AUTH_SUCCESS_METRIC, tags);
       authFailure = meterRegistry.counter(AUTH_FAILURE_METRIC, tags);
       authError = meterRegistry.counter(AUTH_ERROR_METRIC, tags);
-      connectedClients = meterRegistry.gauge(CONNECTED_NATIVE_CLIENTS_METRIC, tags, new AtomicInteger(0));
+      connectedClients =
+          meterRegistry.gauge(CONNECTED_NATIVE_CLIENTS_METRIC, tags, new AtomicInteger(0));
     }
 
     @Override
@@ -279,7 +294,5 @@ public final class ClientMetrics {
     public void decreaseConnectedNativeClients() {
       connectedClients.decrementAndGet();
     }
-
   }
-
 }

--- a/cql/src/main/java/org/apache/cassandra/stargate/metrics/ConnectionMetrics.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/metrics/ConnectionMetrics.java
@@ -19,18 +19,17 @@ package org.apache.cassandra.stargate.metrics;
 
 public interface ConnectionMetrics {
 
-    void markRequestProcessed();
+  void markRequestProcessed();
 
-    void markRequestDiscarded();
+  void markRequestDiscarded();
 
-    void markAuthSuccess();
+  void markAuthSuccess();
 
-    void markAuthFailure();
+  void markAuthFailure();
 
-    void markAuthError();
+  void markAuthError();
 
-    void increaseConnectedNativeClients();
+  void increaseConnectedNativeClients();
 
-    void decreaseConnectedNativeClients();
-
+  void decreaseConnectedNativeClients();
 }

--- a/cql/src/main/java/org/apache/cassandra/stargate/metrics/ConnectionMetrics.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/metrics/ConnectionMetrics.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.cassandra.stargate.metrics;
+
+public interface ConnectionMetrics {
+
+    void markRequestProcessed();
+
+    void markRequestDiscarded();
+
+    void markAuthSuccess();
+
+    void markAuthFailure();
+
+    void markAuthError();
+
+    void increaseConnectedNativeClients();
+
+    void decreaseConnectedNativeClients();
+
+}

--- a/cql/src/main/java/org/apache/cassandra/stargate/metrics/ConnectionMetrics.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/metrics/ConnectionMetrics.java
@@ -17,19 +17,26 @@
 
 package org.apache.cassandra.stargate.metrics;
 
+import io.micrometer.core.instrument.Tags;
+
+/** Interface that each connection can use to report metric or determine it Tags. */
 public interface ConnectionMetrics {
 
+  /** @return Returns micrometer tags associated with the connection. */
+  Tags getTags();
+
+  /** Marks request processed (increases the count). */
   void markRequestProcessed();
 
+  /** Marks request discarded (increases the count). */
   void markRequestDiscarded();
 
+  /** Marks auth success (increases the count). */
   void markAuthSuccess();
 
+  /** Marks auth failure (increases the count). */
   void markAuthFailure();
 
+  /** Marks auth error (increases the count). */
   void markAuthError();
-
-  void increaseConnectedNativeClients();
-
-  void decreaseConnectedNativeClients();
 }

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Connection.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Connection.java
@@ -19,7 +19,6 @@ package org.apache.cassandra.stargate.transport.internal;
 
 import io.netty.channel.Channel;
 import io.netty.util.AttributeKey;
-import org.apache.cassandra.stargate.metrics.ClientMetrics;
 import org.apache.cassandra.stargate.metrics.ConnectionMetrics;
 import org.apache.cassandra.stargate.transport.ProtocolVersion;
 import org.apache.cassandra.stargate.transport.internal.frame.FrameBodyTransformer;
@@ -35,14 +34,18 @@ public class Connection {
   private volatile FrameBodyTransformer transformer;
   private boolean throwOnOverload;
 
-  public Connection(Channel channel, ProtocolVersion version, Tracker tracker, ConnectionMetrics connectionMetrics) {
+  public Connection(
+      Channel channel,
+      ProtocolVersion version,
+      Tracker tracker,
+      ConnectionMetrics connectionMetrics) {
     this.channel = channel;
     this.version = version;
     this.tracker = tracker;
     this.connectionMetrics = connectionMetrics;
 
     tracker.addConnection(channel, this);
-    //TODO decrease where
+    // TODO decrease where
     connectionMetrics.increaseConnectedNativeClients();
   }
 

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Connection.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Connection.java
@@ -19,6 +19,8 @@ package org.apache.cassandra.stargate.transport.internal;
 
 import io.netty.channel.Channel;
 import io.netty.util.AttributeKey;
+import org.apache.cassandra.stargate.metrics.ClientMetrics;
+import org.apache.cassandra.stargate.metrics.ConnectionMetrics;
 import org.apache.cassandra.stargate.transport.ProtocolVersion;
 import org.apache.cassandra.stargate.transport.internal.frame.FrameBodyTransformer;
 
@@ -28,16 +30,20 @@ public class Connection {
   private final Channel channel;
   private final ProtocolVersion version;
   private final Tracker tracker;
+  private final ConnectionMetrics connectionMetrics;
 
   private volatile FrameBodyTransformer transformer;
   private boolean throwOnOverload;
 
-  public Connection(Channel channel, ProtocolVersion version, Tracker tracker) {
+  public Connection(Channel channel, ProtocolVersion version, Tracker tracker, ConnectionMetrics connectionMetrics) {
     this.channel = channel;
     this.version = version;
     this.tracker = tracker;
+    this.connectionMetrics = connectionMetrics;
 
     tracker.addConnection(channel, this);
+    //TODO decrease where
+    connectionMetrics.increaseConnectedNativeClients();
   }
 
   public void setTransformer(FrameBodyTransformer transformer) {
@@ -58,6 +64,10 @@ public class Connection {
 
   public Tracker getTracker() {
     return tracker;
+  }
+
+  public ConnectionMetrics getConnectionMetrics() {
+    return connectionMetrics;
   }
 
   public ProtocolVersion getVersion() {

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Connection.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Connection.java
@@ -45,8 +45,6 @@ public class Connection {
     this.connectionMetrics = connectionMetrics;
 
     tracker.addConnection(channel, this);
-    // TODO decrease where
-    connectionMetrics.increaseConnectedNativeClients();
   }
 
   public void setTransformer(FrameBodyTransformer transformer) {

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Frame.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Frame.java
@@ -207,8 +207,8 @@ public class Frame {
 
       if (buffer.readableBytes() < frameLength) return null;
 
-      ClientMetrics.instance.getTotalBytesRead().inc(frameLength);
-      ClientMetrics.instance.getBytesReceivedPerFrame().update(frameLength);
+      ClientMetrics.instance.incrementTotalBytesRead(frameLength);
+      ClientMetrics.instance.recordBytesReceivedPerFrame(frameLength);
 
       // extract body
       ByteBuf body = buffer.slice(idx, bodyLength);
@@ -287,8 +287,8 @@ public class Frame {
       header.writeInt(frame.body.readableBytes());
 
       int messageSize = header.readableBytes() + frame.body.readableBytes();
-      ClientMetrics.instance.getTotalBytesWritten().inc(messageSize);
-      ClientMetrics.instance.getBytesTransmittedPerFrame().update(messageSize);
+      ClientMetrics.instance.incrementTotalBytesWritten(messageSize);
+      ClientMetrics.instance.recordBytesTransmittedPerFrame(messageSize);
 
       results.add(header);
       results.add(frame.body);

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Message.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Message.java
@@ -688,7 +688,7 @@ public abstract class Message {
         logger.trace("Received: {}, v={}", request, connection.getVersion());
         connection.requests.inc();
 
-        ClientMetrics.instance.markRequestProcessed();
+        ClientMetrics.instance.markRequestProcessed(connection.clientInfo());
 
         CompletableFuture<? extends Response> req = request.execute(queryStartNanoTime);
 

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Message.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Message.java
@@ -618,9 +618,10 @@ public abstract class Message {
       // check for overloaded state by trying to allocate framesize to inflight payload trackers
       if (endpointAndGlobalPayloadsInFlight.tryAllocate(frameSize)
           != ResourceLimits.Outcome.SUCCESS) {
-        if (request.connection.isThrowOnOverload()) {
+        Connection connection = request.connection;
+        if (connection.isThrowOnOverload()) {
           // discard the request and throw an exception
-          ClientMetrics.instance.markRequestDiscarded();
+          ClientMetrics.instance.markRequestDiscarded(((ServerConnection) connection).clientInfo());
           logger.trace(
               "Discarded request of size: {}. InflightChannelRequestPayload: {}, InflightEndpointRequestPayload: {}, InflightOverallRequestPayload: {}, Request: {}",
               frameSize,

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Message.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Message.java
@@ -621,7 +621,7 @@ public abstract class Message {
         Connection connection = request.connection;
         if (connection.isThrowOnOverload()) {
           // discard the request and throw an exception
-          ClientMetrics.instance.markRequestDiscarded(((ServerConnection) connection).clientInfo());
+          connection.getConnectionMetrics().markRequestDiscarded();
           logger.trace(
               "Discarded request of size: {}. InflightChannelRequestPayload: {}, InflightEndpointRequestPayload: {}, InflightOverallRequestPayload: {}, Request: {}",
               frameSize,
@@ -689,7 +689,7 @@ public abstract class Message {
         logger.trace("Received: {}, v={}", request, connection.getVersion());
         connection.requests.inc();
 
-        ClientMetrics.instance.markRequestProcessed(connection.clientInfo());
+        connection.getConnectionMetrics().markRequestProcessed();
 
         CompletableFuture<? extends Response> req = request.execute(queryStartNanoTime);
 

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/ServerConnection.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/ServerConnection.java
@@ -27,7 +27,6 @@ import io.stargate.db.Persistence;
 import java.net.InetSocketAddress;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.security.cert.X509Certificate;
-
 import org.apache.cassandra.stargate.metrics.ClientMetrics;
 import org.apache.cassandra.stargate.transport.ProtocolException;
 import org.apache.cassandra.stargate.transport.ProtocolVersion;
@@ -52,7 +51,11 @@ public class ServerConnection extends Connection {
       Connection.Tracker tracker,
       Persistence persistence,
       AuthenticationService authentication) {
-    super(channel, version, tracker, ClientMetrics.instance.connectionMetrics(getClientInfo(channel, proxyInfo)));
+    super(
+        channel,
+        version,
+        tracker,
+        ClientMetrics.instance.connectionMetrics(getClientInfo(channel, proxyInfo)));
     this.clientInfo = getClientInfo(channel, proxyInfo);
     this.persistenceConnection = persistence.newConnection(clientInfo);
 
@@ -65,10 +68,8 @@ public class ServerConnection extends Connection {
   @NotNull
   private static ClientInfo getClientInfo(Channel channel, ProxyInfo proxyInfo) {
     return new ClientInfo(
-            proxyInfo != null
-                    ? proxyInfo.sourceAddress
-                    : (InetSocketAddress) channel.remoteAddress(),
-            proxyInfo != null ? proxyInfo.publicAddress : null);
+        proxyInfo != null ? proxyInfo.sourceAddress : (InetSocketAddress) channel.remoteAddress(),
+        proxyInfo != null ? proxyInfo.publicAddress : null);
   }
 
   public ClientInfo clientInfo() {

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/ServerConnection.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/ServerConnection.java
@@ -51,12 +51,26 @@ public class ServerConnection extends Connection {
       Connection.Tracker tracker,
       Persistence persistence,
       AuthenticationService authentication) {
-    super(
+    this(
         channel,
+        proxyInfo,
         version,
         tracker,
-        ClientMetrics.instance.connectionMetrics(getClientInfo(channel, proxyInfo)));
-    this.clientInfo = getClientInfo(channel, proxyInfo);
+        persistence,
+        authentication,
+        getClientInfo(channel, proxyInfo));
+  }
+
+  private ServerConnection(
+      Channel channel,
+      ProxyInfo proxyInfo,
+      ProtocolVersion version,
+      Connection.Tracker tracker,
+      Persistence persistence,
+      AuthenticationService authentication,
+      ClientInfo clientInfo) {
+    super(channel, version, tracker, ClientMetrics.instance.connectionMetrics(clientInfo));
+    this.clientInfo = clientInfo;
     this.persistenceConnection = persistence.newConnection(clientInfo);
 
     if (proxyInfo != null) this.persistenceConnection.setCustomProperties(proxyInfo.toHeaders());

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/AuthResponse.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/AuthResponse.java
@@ -87,7 +87,7 @@ public class AuthResponse extends Message.Request {
                         .setAuthenticatedUser(authenticatedUser);
                   }
 
-                  ClientMetrics.instance.markAuthSuccess();
+                  ClientMetrics.instance.markAuthSuccess(((ServerConnection) connection).clientInfo());
                   // authentication is complete, send a ready message to the client
 
                   future.complete(new AuthSuccess(challenge));
@@ -95,10 +95,10 @@ public class AuthResponse extends Message.Request {
                   future.complete(new AuthChallenge(challenge));
                 }
               } catch (AuthenticationException ae) {
-                ClientMetrics.instance.markAuthFailure();
+                ClientMetrics.instance.markAuthFailure(((ServerConnection) connection).clientInfo());
                 future.complete(ErrorMessage.fromException(ae));
               } catch (Exception e) {
-                ClientMetrics.instance.markAuthError();
+                ClientMetrics.instance.markAuthError(((ServerConnection) connection).clientInfo());
                 future.completeExceptionally(e);
               }
             });

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/AuthResponse.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/AuthResponse.java
@@ -87,7 +87,8 @@ public class AuthResponse extends Message.Request {
                         .setAuthenticatedUser(authenticatedUser);
                   }
 
-                  ClientMetrics.instance.markAuthSuccess(((ServerConnection) connection).clientInfo());
+                  ClientMetrics.instance.markAuthSuccess(
+                      ((ServerConnection) connection).clientInfo());
                   // authentication is complete, send a ready message to the client
 
                   future.complete(new AuthSuccess(challenge));
@@ -95,7 +96,8 @@ public class AuthResponse extends Message.Request {
                   future.complete(new AuthChallenge(challenge));
                 }
               } catch (AuthenticationException ae) {
-                ClientMetrics.instance.markAuthFailure(((ServerConnection) connection).clientInfo());
+                ClientMetrics.instance.markAuthFailure(
+                    ((ServerConnection) connection).clientInfo());
                 future.complete(ErrorMessage.fromException(ae));
               } catch (Exception e) {
                 ClientMetrics.instance.markAuthError(((ServerConnection) connection).clientInfo());

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/AuthResponse.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/AuthResponse.java
@@ -95,7 +95,6 @@ public class AuthResponse extends Message.Request {
                 }
               } catch (AuthenticationException ae) {
                 connection.getConnectionMetrics().markAuthFailure();
-                ;
                 future.complete(ErrorMessage.fromException(ae));
               } catch (Exception e) {
                 connection.getConnectionMetrics().markAuthError();

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/AuthResponse.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/AuthResponse.java
@@ -23,7 +23,6 @@ import io.stargate.db.Authenticator;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import org.apache.cassandra.stargate.exceptions.AuthenticationException;
-import org.apache.cassandra.stargate.metrics.ClientMetrics;
 import org.apache.cassandra.stargate.transport.ProtocolException;
 import org.apache.cassandra.stargate.transport.ProtocolVersion;
 import org.apache.cassandra.stargate.transport.internal.CBUtil;
@@ -95,10 +94,11 @@ public class AuthResponse extends Message.Request {
                   future.complete(new AuthChallenge(challenge));
                 }
               } catch (AuthenticationException ae) {
-                  connection.getConnectionMetrics().markAuthFailure();;
+                connection.getConnectionMetrics().markAuthFailure();
+                ;
                 future.complete(ErrorMessage.fromException(ae));
               } catch (Exception e) {
-                  connection.getConnectionMetrics().markAuthError();
+                connection.getConnectionMetrics().markAuthError();
                 future.completeExceptionally(e);
               }
             });

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/AuthResponse.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/AuthResponse.java
@@ -87,20 +87,18 @@ public class AuthResponse extends Message.Request {
                         .setAuthenticatedUser(authenticatedUser);
                   }
 
-                  ClientMetrics.instance.markAuthSuccess(
-                      ((ServerConnection) connection).clientInfo());
-                  // authentication is complete, send a ready message to the client
+                  connection.getConnectionMetrics().markAuthSuccess();
 
+                  // authentication is complete, send a ready message to the client
                   future.complete(new AuthSuccess(challenge));
                 } else {
                   future.complete(new AuthChallenge(challenge));
                 }
               } catch (AuthenticationException ae) {
-                ClientMetrics.instance.markAuthFailure(
-                    ((ServerConnection) connection).clientInfo());
+                  connection.getConnectionMetrics().markAuthFailure();;
                 future.complete(ErrorMessage.fromException(ae));
               } catch (Exception e) {
-                ClientMetrics.instance.markAuthError(((ServerConnection) connection).clientInfo());
+                  connection.getConnectionMetrics().markAuthError();
                 future.completeExceptionally(e);
               }
             });

--- a/cql/src/test/java/org/apache/cassandra/stargate/metrics/ClientMetricsTest.java
+++ b/cql/src/test/java/org/apache/cassandra/stargate/metrics/ClientMetricsTest.java
@@ -68,7 +68,7 @@ class ClientMetricsTest {
     when(clientTagProvider.getClientInfoTags(clientInfo2)).thenReturn(Tags.of("client", "two"));
 
     List<Server> servers = Arrays.asList(server1, server2);
-    clientMetrics.init(servers, meterRegistry, clientTagProvider, 0);
+    clientMetrics.init(servers, meterRegistry, clientTagProvider, 0d);
   }
 
   @Nested
@@ -299,16 +299,12 @@ class ClientMetricsTest {
 
     @Test
     public void happyPath() {
-      ConnectionMetrics connectionMetrics1 = mock(ConnectionMetrics.class);
-      ConnectionMetrics connectionMetrics2 = mock(ConnectionMetrics.class);
-      Map<ConnectionMetrics, Integer> clientInfoConnectionMap = new HashMap<>();
-      clientInfoConnectionMap.put(connectionMetrics1, 10);
-      clientInfoConnectionMap.put(connectionMetrics2, 20);
+      Map<Tags, Integer> clientInfoTagsMap = new HashMap<>();
+      clientInfoTagsMap.put(Tags.of("cm", "one"), 10);
+      clientInfoTagsMap.put(Tags.of("cm", "two"), 20);
 
-      when(connectionMetrics1.getTags()).thenReturn(Tags.of("cm", "one"));
-      when(connectionMetrics2.getTags()).thenReturn(Tags.of("cm", "two"));
-      when(server1.countConnectedClientsByConnectionMetrics()).thenReturn(clientInfoConnectionMap);
-      when(server2.countConnectedClientsByConnectionMetrics()).thenReturn(clientInfoConnectionMap);
+      when(server1.countConnectedClientsByConnectionTags()).thenReturn(clientInfoTagsMap);
+      when(server2.countConnectedClientsByConnectionTags()).thenReturn(clientInfoTagsMap);
 
       clientMetrics.updateConnectedClients();
 
@@ -331,21 +327,16 @@ class ClientMetricsTest {
 
     @Test
     public void removedConnections() {
-      ConnectionMetrics connectionMetrics1 = mock(ConnectionMetrics.class);
-      ConnectionMetrics connectionMetrics2 = mock(ConnectionMetrics.class);
-      Map<ConnectionMetrics, Integer> clientInfoConnectionMap = new HashMap<>();
-      clientInfoConnectionMap.put(connectionMetrics1, 10);
-      clientInfoConnectionMap.put(connectionMetrics2, 20);
-
-      when(connectionMetrics1.getTags()).thenReturn(Tags.of("cm", "one"));
-      when(connectionMetrics2.getTags()).thenReturn(Tags.of("cm", "two"));
-      when(server1.countConnectedClientsByConnectionMetrics()).thenReturn(clientInfoConnectionMap);
-      when(server2.countConnectedClientsByConnectionMetrics()).thenReturn(clientInfoConnectionMap);
+      Map<Tags, Integer> clientInfoTagsMap = new HashMap<>();
+      clientInfoTagsMap.put(Tags.of("cm", "one"), 10);
+      clientInfoTagsMap.put(Tags.of("cm", "two"), 20);
+      when(server1.countConnectedClientsByConnectionTags()).thenReturn(clientInfoTagsMap);
+      when(server2.countConnectedClientsByConnectionTags()).thenReturn(clientInfoTagsMap);
 
       clientMetrics.updateConnectedClients();
 
-      when(server1.countConnectedClientsByConnectionMetrics()).thenReturn(clientInfoConnectionMap);
-      when(server2.countConnectedClientsByConnectionMetrics()).thenReturn(Collections.emptyMap());
+      when(server1.countConnectedClientsByConnectionTags()).thenReturn(clientInfoTagsMap);
+      when(server2.countConnectedClientsByConnectionTags()).thenReturn(Collections.emptyMap());
 
       clientMetrics.updateConnectedClients();
 
@@ -368,21 +359,16 @@ class ClientMetricsTest {
 
     @Test
     public void noConnections() {
-      ConnectionMetrics connectionMetrics1 = mock(ConnectionMetrics.class);
-      ConnectionMetrics connectionMetrics2 = mock(ConnectionMetrics.class);
-      Map<ConnectionMetrics, Integer> clientInfoConnectionMap = new HashMap<>();
-      clientInfoConnectionMap.put(connectionMetrics1, 10);
-      clientInfoConnectionMap.put(connectionMetrics2, 20);
-
-      when(connectionMetrics1.getTags()).thenReturn(Tags.of("cm", "one"));
-      when(connectionMetrics2.getTags()).thenReturn(Tags.of("cm", "two"));
-      when(server1.countConnectedClientsByConnectionMetrics()).thenReturn(clientInfoConnectionMap);
-      when(server2.countConnectedClientsByConnectionMetrics()).thenReturn(clientInfoConnectionMap);
+      Map<Tags, Integer> clientInfoTagsMap = new HashMap<>();
+      clientInfoTagsMap.put(Tags.of("cm", "one"), 10);
+      clientInfoTagsMap.put(Tags.of("cm", "two"), 20);
+      when(server1.countConnectedClientsByConnectionTags()).thenReturn(clientInfoTagsMap);
+      when(server2.countConnectedClientsByConnectionTags()).thenReturn(clientInfoTagsMap);
 
       clientMetrics.updateConnectedClients();
 
-      when(server1.countConnectedClientsByConnectionMetrics()).thenReturn(Collections.emptyMap());
-      when(server2.countConnectedClientsByConnectionMetrics()).thenReturn(Collections.emptyMap());
+      when(server1.countConnectedClientsByConnectionTags()).thenReturn(Collections.emptyMap());
+      when(server2.countConnectedClientsByConnectionTags()).thenReturn(Collections.emptyMap());
 
       clientMetrics.updateConnectedClients();
 

--- a/cql/src/test/java/org/apache/cassandra/stargate/metrics/ClientMetricsTest.java
+++ b/cql/src/test/java/org/apache/cassandra/stargate/metrics/ClientMetricsTest.java
@@ -71,9 +71,9 @@ class ClientMetricsTest {
 
     @Test
     public void happyPath() {
-      clientMetrics.markRequestProcessed(clientInfo1);
-      clientMetrics.markRequestProcessed(clientInfo1);
-      clientMetrics.markRequestProcessed(clientInfo2);
+      clientMetrics.connectionMetrics(clientInfo1).markRequestProcessed();
+      clientMetrics.connectionMetrics(clientInfo1).markRequestProcessed();
+      clientMetrics.connectionMetrics(clientInfo2).markRequestProcessed();
 
       Counter c1 =
           meterRegistry
@@ -98,9 +98,9 @@ class ClientMetricsTest {
 
     @Test
     public void happyPath() {
-      clientMetrics.markRequestDiscarded(clientInfo1);
-      clientMetrics.markRequestDiscarded(clientInfo1);
-      clientMetrics.markRequestDiscarded(clientInfo2);
+      clientMetrics.connectionMetrics(clientInfo1).markRequestDiscarded();
+      clientMetrics.connectionMetrics(clientInfo1).markRequestDiscarded();
+      clientMetrics.connectionMetrics(clientInfo2).markRequestDiscarded();
 
       Counter c1 =
           meterRegistry
@@ -125,9 +125,9 @@ class ClientMetricsTest {
 
     @Test
     public void happyPath() {
-      clientMetrics.markAuthSuccess(clientInfo1);
-      clientMetrics.markAuthSuccess(clientInfo1);
-      clientMetrics.markAuthSuccess(clientInfo2);
+      clientMetrics.connectionMetrics(clientInfo1).markAuthSuccess();
+      clientMetrics.connectionMetrics(clientInfo1).markAuthSuccess();
+      clientMetrics.connectionMetrics(clientInfo2).markAuthSuccess();
 
       Counter c1 =
           meterRegistry
@@ -152,9 +152,9 @@ class ClientMetricsTest {
 
     @Test
     public void happyPath() {
-      clientMetrics.markAuthFailure(clientInfo1);
-      clientMetrics.markAuthFailure(clientInfo1);
-      clientMetrics.markAuthFailure(clientInfo2);
+      clientMetrics.connectionMetrics(clientInfo1).markAuthFailure();
+      clientMetrics.connectionMetrics(clientInfo1).markAuthFailure();
+      clientMetrics.connectionMetrics(clientInfo2).markAuthFailure();
 
       Counter c1 =
           meterRegistry
@@ -179,9 +179,9 @@ class ClientMetricsTest {
 
     @Test
     public void happyPath() {
-      clientMetrics.markAuthError(clientInfo1);
-      clientMetrics.markAuthError(clientInfo1);
-      clientMetrics.markAuthError(clientInfo2);
+      clientMetrics.connectionMetrics(clientInfo1).markAuthError();
+      clientMetrics.connectionMetrics(clientInfo1).markAuthError();
+      clientMetrics.connectionMetrics(clientInfo2).markAuthError();
 
       Counter c1 =
           meterRegistry

--- a/cql/src/test/java/org/apache/cassandra/stargate/metrics/ClientMetricsTest.java
+++ b/cql/src/test/java/org/apache/cassandra/stargate/metrics/ClientMetricsTest.java
@@ -1,0 +1,399 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.cassandra.stargate.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.MetricRegistry;
+import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.stargate.db.ClientInfo;
+import io.stargate.db.metrics.api.ClientInfoMetricsTagProvider;
+import java.util.*;
+import org.apache.cassandra.stargate.transport.internal.Server;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ClientMetricsTest {
+
+  ClientMetrics clientMetrics = ClientMetrics.instance;
+
+  MeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+  // manual mocks, init before all
+  MetricRegistry metricRegistry; // TODO Remove when possible
+  ClientInfoMetricsTagProvider clientTagProvider;
+  Server server1;
+  Server server2;
+  ClientInfo clientInfo1;
+  ClientInfo clientInfo2;
+
+  @BeforeAll
+  public void initMocks() {
+    metricRegistry = mock(MetricRegistry.class);
+    clientTagProvider = mock(ClientInfoMetricsTagProvider.class);
+    server1 = mock(Server.class);
+    server2 = mock(Server.class);
+    clientInfo1 = mock(ClientInfo.class);
+    clientInfo2 = mock(ClientInfo.class);
+
+    when(clientTagProvider.getClientInfoTags(clientInfo1)).thenReturn(Tags.of("client", "one"));
+    when(clientTagProvider.getClientInfoTags(clientInfo2)).thenReturn(Tags.of("client", "two"));
+
+    List<Server> servers = Arrays.asList(server1, server2);
+    clientMetrics.init(servers, metricRegistry, meterRegistry, clientTagProvider);
+  }
+
+  @Nested
+  class MarkRequestProcessed {
+
+    @Test
+    public void happyPath() {
+      clientMetrics.markRequestProcessed(clientInfo1);
+      clientMetrics.markRequestProcessed(clientInfo1);
+      clientMetrics.markRequestProcessed(clientInfo2);
+
+      Counter c1 =
+          meterRegistry
+              .get("cql.org.apache.cassandra.metrics.Client.RequestsProcessed")
+              .tag("client", "one")
+              .counter();
+
+      assertThat(c1.count()).isEqualTo(2d);
+
+      Counter c2 =
+          meterRegistry
+              .get("cql.org.apache.cassandra.metrics.Client.RequestsProcessed")
+              .tag("client", "two")
+              .counter();
+
+      assertThat(c2.count()).isEqualTo(1d);
+    }
+  }
+
+  @Nested
+  class MarkRequestDiscarded {
+
+    @Test
+    public void happyPath() {
+      clientMetrics.markRequestDiscarded(clientInfo1);
+      clientMetrics.markRequestDiscarded(clientInfo1);
+      clientMetrics.markRequestDiscarded(clientInfo2);
+
+      Counter c1 =
+          meterRegistry
+              .get("cql.org.apache.cassandra.metrics.Client.RequestDiscarded")
+              .tag("client", "one")
+              .counter();
+
+      assertThat(c1.count()).isEqualTo(2d);
+
+      Counter c2 =
+          meterRegistry
+              .get("cql.org.apache.cassandra.metrics.Client.RequestDiscarded")
+              .tag("client", "two")
+              .counter();
+
+      assertThat(c2.count()).isEqualTo(1d);
+    }
+  }
+
+  @Nested
+  class MarkAuthSuccess {
+
+    @Test
+    public void happyPath() {
+      clientMetrics.markAuthSuccess(clientInfo1);
+      clientMetrics.markAuthSuccess(clientInfo1);
+      clientMetrics.markAuthSuccess(clientInfo2);
+
+      Counter c1 =
+          meterRegistry
+              .get("cql.org.apache.cassandra.metrics.Client.AuthSuccess")
+              .tag("client", "one")
+              .counter();
+
+      assertThat(c1.count()).isEqualTo(2d);
+
+      Counter c2 =
+          meterRegistry
+              .get("cql.org.apache.cassandra.metrics.Client.AuthSuccess")
+              .tag("client", "two")
+              .counter();
+
+      assertThat(c2.count()).isEqualTo(1d);
+    }
+  }
+
+  @Nested
+  class MarkAuthFailure {
+
+    @Test
+    public void happyPath() {
+      clientMetrics.markAuthFailure(clientInfo1);
+      clientMetrics.markAuthFailure(clientInfo1);
+      clientMetrics.markAuthFailure(clientInfo2);
+
+      Counter c1 =
+          meterRegistry
+              .get("cql.org.apache.cassandra.metrics.Client.AuthFailure")
+              .tag("client", "one")
+              .counter();
+
+      assertThat(c1.count()).isEqualTo(2d);
+
+      Counter c2 =
+          meterRegistry
+              .get("cql.org.apache.cassandra.metrics.Client.AuthFailure")
+              .tag("client", "two")
+              .counter();
+
+      assertThat(c2.count()).isEqualTo(1d);
+    }
+  }
+
+  @Nested
+  class MarkAuthError {
+
+    @Test
+    public void happyPath() {
+      clientMetrics.markAuthError(clientInfo1);
+      clientMetrics.markAuthError(clientInfo1);
+      clientMetrics.markAuthError(clientInfo2);
+
+      Counter c1 =
+          meterRegistry
+              .get("cql.org.apache.cassandra.metrics.Client.AuthError")
+              .tag("client", "one")
+              .counter();
+
+      assertThat(c1.count()).isEqualTo(2d);
+
+      Counter c2 =
+          meterRegistry
+              .get("cql.org.apache.cassandra.metrics.Client.AuthError")
+              .tag("client", "two")
+              .counter();
+
+      assertThat(c2.count()).isEqualTo(1d);
+    }
+  }
+
+  @Nested
+  class PauseConnections {
+
+    @Test
+    public void happyPath() {
+      clientMetrics.pauseConnection();
+      clientMetrics.pauseConnection();
+
+      Gauge g1 =
+          meterRegistry.get("cql.org.apache.cassandra.metrics.Client.PausedConnections").gauge();
+
+      assertThat(g1.value()).isEqualTo(2d);
+
+      clientMetrics.unpauseConnection();
+
+      Gauge g2 =
+          meterRegistry.get("cql.org.apache.cassandra.metrics.Client.PausedConnections").gauge();
+
+      assertThat(g2.value()).isEqualTo(1d);
+    }
+  }
+
+  @Nested
+  class IncrementTotalBytesRead {
+
+    @Test
+    public void happyPath() {
+      clientMetrics.incrementTotalBytesRead(11);
+      clientMetrics.incrementTotalBytesRead(22);
+
+      Counter c1 =
+          meterRegistry.get("cql.org.apache.cassandra.metrics.Client.TotalBytesRead").counter();
+
+      assertThat(c1.count()).isEqualTo(33);
+    }
+  }
+
+  @Nested
+  class IncrementTotalBytesWritten {
+
+    @Test
+    public void happyPath() {
+      clientMetrics.incrementTotalBytesWritten(22);
+      clientMetrics.incrementTotalBytesWritten(33);
+
+      Counter c1 =
+          meterRegistry.get("cql.org.apache.cassandra.metrics.Client.TotalBytesWritten").counter();
+
+      assertThat(c1.count()).isEqualTo(55);
+    }
+  }
+
+  @Nested
+  class RecordBytesReceivedPerFrame {
+
+    @Test
+    public void happyPath() {
+      clientMetrics.recordBytesReceivedPerFrame(11);
+      clientMetrics.recordBytesReceivedPerFrame(33);
+
+      DistributionSummary summary =
+          meterRegistry
+              .get("cql.org.apache.cassandra.metrics.Client.BytesReceivedPerFrame")
+              .summary();
+
+      assertThat(summary.count()).isEqualTo(2);
+      assertThat(summary.totalAmount()).isEqualTo(44);
+    }
+  }
+
+  @Nested
+  class RecordBytesTransmittedPerFrame {
+
+    @Test
+    public void happyPath() {
+      clientMetrics.recordBytesTransmittedPerFrame(22);
+      clientMetrics.recordBytesTransmittedPerFrame(44);
+
+      DistributionSummary summary =
+          meterRegistry
+              .get("cql.org.apache.cassandra.metrics.Client.BytesTransmittedPerFrame")
+              .summary();
+
+      assertThat(summary.count()).isEqualTo(2);
+      assertThat(summary.totalAmount()).isEqualTo(66);
+    }
+  }
+
+  @Nested
+  class UpdateConnectedClients {
+
+    @Test
+    public void happyPath() {
+      Map<ClientInfo, Integer> clientInfoConnectionMap = new HashMap<>();
+      clientInfoConnectionMap.put(clientInfo1, 10);
+      clientInfoConnectionMap.put(clientInfo2, 20);
+      when(server1.countConnectedClientsByClientInfo()).thenReturn(clientInfoConnectionMap);
+      when(server2.countConnectedClientsByClientInfo()).thenReturn(clientInfoConnectionMap);
+
+      clientMetrics.updateConnectedClients();
+
+      Gauge g1 =
+          meterRegistry
+              .get("cql.org.apache.cassandra.metrics.Client.connectedNativeClients")
+              .tag("client", "one")
+              .gauge();
+
+      assertThat(g1.value()).isEqualTo(20);
+
+      Gauge g2 =
+          meterRegistry
+              .get("cql.org.apache.cassandra.metrics.Client.connectedNativeClients")
+              .tag("client", "two")
+              .gauge();
+
+      assertThat(g2.value()).isEqualTo(40);
+    }
+
+    @Test
+    public void removedConnections() {
+      Map<ClientInfo, Integer> clientInfoConnectionMap = new HashMap<>();
+      clientInfoConnectionMap.put(clientInfo1, 10);
+      clientInfoConnectionMap.put(clientInfo2, 20);
+      when(server1.countConnectedClientsByClientInfo()).thenReturn(clientInfoConnectionMap);
+      when(server2.countConnectedClientsByClientInfo()).thenReturn(clientInfoConnectionMap);
+
+      clientMetrics.updateConnectedClients();
+
+      when(server1.countConnectedClientsByClientInfo()).thenReturn(clientInfoConnectionMap);
+      when(server2.countConnectedClientsByClientInfo()).thenReturn(Collections.emptyMap());
+
+      clientMetrics.updateConnectedClients();
+
+      Gauge g1 =
+          meterRegistry
+              .get("cql.org.apache.cassandra.metrics.Client.connectedNativeClients")
+              .tag("client", "one")
+              .gauge();
+
+      assertThat(g1.value()).isEqualTo(10);
+
+      Gauge g2 =
+          meterRegistry
+              .get("cql.org.apache.cassandra.metrics.Client.connectedNativeClients")
+              .tag("client", "two")
+              .gauge();
+
+      assertThat(g2.value()).isEqualTo(20);
+    }
+
+    @Test
+    public void noConnections() {
+      Map<ClientInfo, Integer> clientInfoConnectionMap = new HashMap<>();
+      clientInfoConnectionMap.put(clientInfo1, 10);
+      clientInfoConnectionMap.put(clientInfo2, 20);
+      when(server1.countConnectedClientsByClientInfo()).thenReturn(clientInfoConnectionMap);
+      when(server2.countConnectedClientsByClientInfo()).thenReturn(clientInfoConnectionMap);
+
+      clientMetrics.updateConnectedClients();
+
+      when(server1.countConnectedClientsByClientInfo()).thenReturn(Collections.emptyMap());
+      when(server2.countConnectedClientsByClientInfo()).thenReturn(Collections.emptyMap());
+
+      clientMetrics.updateConnectedClients();
+
+      Throwable throwable =
+          catchThrowable(
+              () ->
+                  meterRegistry
+                      .get("cql.org.apache.cassandra.metrics.Client.connectedNativeClients")
+                      .gauges());
+
+      assertThat(throwable).isInstanceOf(MeterNotFoundException.class);
+    }
+  }
+
+  @Nested
+  class State {
+
+    @Test
+    public void nettyDirectMemory() {
+      Gauge gauge =
+          meterRegistry.get("cql.org.apache.cassandra.metrics.Client.NettyDirectMemory").gauge();
+
+      assertThat(gauge).isNotNull();
+    }
+
+    @Test
+    public void nettyHeapMemory() {
+      Gauge gauge =
+          meterRegistry.get("cql.org.apache.cassandra.metrics.Client.NettyHeapMemory").gauge();
+
+      assertThat(gauge).isNotNull();
+    }
+  }
+}

--- a/persistence-api/pom.xml
+++ b/persistence-api/pom.xml
@@ -117,7 +117,8 @@
             <Bundle-Activator>io.stargate.db.DbActivator</Bundle-Activator>
             <Import-Package><![CDATA[
               org.osgi.framework,
-              io.stargate.core.*
+              io.stargate.core.*,
+              io.micrometer.core.*
             ]]></Import-Package>
             <Export-Package><![CDATA[
               io.stargate.db,

--- a/persistence-api/pom.xml
+++ b/persistence-api/pom.xml
@@ -122,6 +122,7 @@
             <Export-Package><![CDATA[
               io.stargate.db,
               io.stargate.db.datastore,
+              io.stargate.db.metrics.*,
               io.stargate.db.query,
               io.stargate.db.query.builder,
               io.stargate.db.schema,

--- a/persistence-api/src/main/java/io/stargate/db/DbActivator.java
+++ b/persistence-api/src/main/java/io/stargate/db/DbActivator.java
@@ -5,9 +5,7 @@ import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.datastore.PersistenceDataStoreFactory;
 import io.stargate.db.limiter.RateLimitingManager;
 import io.stargate.db.metrics.api.ClientInfoMetricsTagProvider;
-
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Hashtable;
 import java.util.List;
 
@@ -36,7 +34,7 @@ public class DbActivator extends BaseActivator {
       System.getProperty(RATE_LIMITING_ID_PROPERTY, "<none>");
 
   private static final String CLIENT_INFO_TAG_PROVIDER_ID =
-          System.getProperty("stargate.metrics.client_info_tag_provider.id");
+      System.getProperty("stargate.metrics.client_info_tag_provider.id");
 
   private final ServicePointer<Persistence> dbPersistence =
       BaseActivator.ServicePointer.create(
@@ -67,12 +65,17 @@ public class DbActivator extends BaseActivator {
     }
 
     List<ServiceAndProperties> services = new ArrayList<>();
-    services.add(new ServiceAndProperties(persistence, Persistence.class, stargatePersistenceProperties()));
-    services.add(new ServiceAndProperties(new PersistenceDataStoreFactory(persistence), DataStoreFactory.class));
+    services.add(
+        new ServiceAndProperties(persistence, Persistence.class, stargatePersistenceProperties()));
+    services.add(
+        new ServiceAndProperties(
+            new PersistenceDataStoreFactory(persistence), DataStoreFactory.class));
 
     // if no specific client info tag provider, add default
     if (null == CLIENT_INFO_TAG_PROVIDER_ID) {
-      services.add(new ServiceAndProperties(ClientInfoMetricsTagProvider.DEFAULT, ClientInfoMetricsTagProvider.class));
+      services.add(
+          new ServiceAndProperties(
+              ClientInfoMetricsTagProvider.DEFAULT, ClientInfoMetricsTagProvider.class));
     }
 
     return services;

--- a/persistence-api/src/main/java/io/stargate/db/metrics/api/ClientInfoMetricsTagProvider.java
+++ b/persistence-api/src/main/java/io/stargate/db/metrics/api/ClientInfoMetricsTagProvider.java
@@ -28,19 +28,18 @@ import io.stargate.db.ClientInfo;
  */
 public interface ClientInfoMetricsTagProvider {
 
-    /** Returns default interface implementation, which returns empty tags for all methods. */
-    ClientInfoMetricsTagProvider DEFAULT = new ClientInfoMetricsTagProvider() {};
+  /** Returns default interface implementation, which returns empty tags for all methods. */
+  ClientInfoMetricsTagProvider DEFAULT = new ClientInfoMetricsTagProvider() {};
 
-    /**
-     * Returns tags for a {@link ClientInfo}.
-     *
-     * <p>Note that the implementation must return constant amount of tags for any input.
-     *
-     * @param clientInfo {@link ClientInfo}
-     * @return Tags
-     */
-    default Tags getClientInfoTags(ClientInfo clientInfo) {
-        return Tags.empty();
-    }
-
+  /**
+   * Returns tags for a {@link ClientInfo}.
+   *
+   * <p>Note that the implementation must return constant amount of tags for any input.
+   *
+   * @param clientInfo {@link ClientInfo}
+   * @return Tags
+   */
+  default Tags getClientInfoTags(ClientInfo clientInfo) {
+    return Tags.empty();
+  }
 }

--- a/persistence-api/src/main/java/io/stargate/db/metrics/api/ClientInfoMetricsTagProvider.java
+++ b/persistence-api/src/main/java/io/stargate/db/metrics/api/ClientInfoMetricsTagProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.db.metrics.api;
+
+import io.micrometer.core.instrument.Tags;
+import io.stargate.db.ClientInfo;
+
+/**
+ * Provides extra micrometer {@link Tags} based on the {@link ClientInfo}.
+ *
+ * <p>Note that each method implementation must always return constant amount of tags regardless of
+ * the input.
+ */
+public interface ClientInfoMetricsTagProvider {
+
+    /** Returns default interface implementation, which returns empty tags for all methods. */
+    ClientInfoMetricsTagProvider DEFAULT = new ClientInfoMetricsTagProvider() {};
+
+    /**
+     * Returns tags for a {@link ClientInfo}.
+     *
+     * <p>Note that the implementation must return constant amount of tags for any input.
+     *
+     * @param clientInfo {@link ClientInfo}
+     * @return Tags
+     */
+    default Tags getClientInfoTags(ClientInfo clientInfo) {
+        return Tags.empty();
+    }
+
+}

--- a/testing-services/pom.xml
+++ b/testing-services/pom.xml
@@ -33,6 +33,12 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>io.stargate.db</groupId>
+      <artifactId>persistence-api</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -51,7 +57,9 @@
               org.osgi.framework,
               io.stargate.auth.*,
               io.stargate.core.*,
-              io.micrometer.core.*
+              io.stargate.db,
+              io.stargate.db.*,
+              io.micrometer.core.*,
             ]]></Import-Package>
             <Export-Package>!*</Export-Package>
             <Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>

--- a/testing-services/src/main/java/io/stargate/testing/TestingServicesActivator.java
+++ b/testing-services/src/main/java/io/stargate/testing/TestingServicesActivator.java
@@ -18,7 +18,9 @@ package io.stargate.testing;
 import io.stargate.auth.AuthorizationProcessor;
 import io.stargate.core.activator.BaseActivator;
 import io.stargate.core.metrics.api.HttpMetricsTagProvider;
+import io.stargate.db.metrics.api.ClientInfoMetricsTagProvider;
 import io.stargate.testing.auth.LoggingAuthorizationProcessorImpl;
+import io.stargate.testing.metrics.FixedClientInfoTagProvider;
 import io.stargate.testing.metrics.TagMeHttpMetricsTagProvider;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -32,6 +34,10 @@ public class TestingServicesActivator extends BaseActivator {
 
   public static final String HTTP_TAG_PROVIDER_PROPERTY = "stargate.metrics.http_tag_provider.id";
   public static final String TAG_ME_HTTP_TAG_PROVIDER = "TagMeProvider";
+
+  public static final String CLIENT_INFO_TAG_PROVIDER_PROPERTY =
+      "stargate.metrics.client_info_tag_provider.id";
+  public static final String FIXED_TAG_PROVIDER = "FixedProvider";
 
   public TestingServicesActivator() {
     super("testing-services");
@@ -53,7 +59,13 @@ public class TestingServicesActivator extends BaseActivator {
     if (TAG_ME_HTTP_TAG_PROVIDER.equals(System.getProperty(HTTP_TAG_PROVIDER_PROPERTY))) {
       TagMeHttpMetricsTagProvider tagProvider = new TagMeHttpMetricsTagProvider();
 
-      services.add(new ServiceAndProperties(tagProvider, HttpMetricsTagProvider.class, null));
+      services.add(new ServiceAndProperties(tagProvider, HttpMetricsTagProvider.class));
+    }
+
+    if (FIXED_TAG_PROVIDER.equals(System.getProperty(CLIENT_INFO_TAG_PROVIDER_PROPERTY))) {
+      FixedClientInfoTagProvider tagProvider = new FixedClientInfoTagProvider();
+
+      services.add(new ServiceAndProperties(tagProvider, ClientInfoMetricsTagProvider.class));
     }
 
     return services;

--- a/testing-services/src/main/java/io/stargate/testing/metrics/FixedClientInfoTagProvider.java
+++ b/testing-services/src/main/java/io/stargate/testing/metrics/FixedClientInfoTagProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.stargate.testing.metrics;
+
+import io.micrometer.core.instrument.Tags;
+import io.stargate.db.ClientInfo;
+import io.stargate.db.metrics.api.ClientInfoMetricsTagProvider;
+
+/**
+ * Simple {@link ClientInfoMetricsTagProvider} for testing that returns fixed tags for each client
+ * info.
+ */
+public class FixedClientInfoTagProvider implements ClientInfoMetricsTagProvider {
+
+  public static final String TAG_KEY = "clientInfo";
+  public static final String TAG_VALUE = "fixed";
+
+  @Override
+  public Tags getClientInfoTags(ClientInfo clientInfo) {
+    return Tags.of(TAG_KEY, TAG_VALUE);
+  }
+}

--- a/testing/src/main/java/io/stargate/it/MetricsTestsHelper.java
+++ b/testing/src/main/java/io/stargate/it/MetricsTestsHelper.java
@@ -16,11 +16,14 @@
 package io.stargate.it;
 
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class MetricsTestsHelper {
-  public static double getMetricValue(String body, String metricName, Pattern regexpPattern) {
+
+  public static Optional<Double> getMetricValueOptional(
+      String body, String metricName, Pattern regexpPattern) {
     return Arrays.stream(body.split("\n"))
         .filter(v -> v.contains(metricName))
         .filter(v -> regexpPattern.matcher(v).find())
@@ -34,7 +37,10 @@ public class MetricsTestsHelper {
                   String.format("Value: %s does not contain the numeric value for metric", v));
             })
         .map(Double::parseDouble)
-        .findAny()
-        .get();
+        .findAny();
+  }
+
+  public static double getMetricValue(String body, String metricName, Pattern regexpPattern) {
+    return getMetricValueOptional(body, metricName, regexpPattern).get();
   }
 }


### PR DESCRIPTION
PR provides a way to add additional tags from the `ClientInfo` into the `cql_` metrics. Details and open questions:

* same approach as for the HTTP tags, added one new interface in the `persistance-api`, provided default impl that s registered if no other impl is set via the props
* I refactored the `ClientMetrics`, so that we can use micrometer and the new interface together
   * my intention here is that we only use the micrometer and go away from the metric registry
   * I changed some signatures to relieve class clients from depending on metric impl behind (see bytes metrics)
* everything was quite easy except for the connected clients, Doug said `connectedNativeClients` should have tags as well, so I used the multi gauge to achieve this
   * it would be awesome if anybody can advise any other option than the timer?
* the rest of the connected clients metrics is quite confusing to me, in two cases we are returning the `List<Map<String, String>>` as the gauge value, how can this work?
   * can we dismiss any of those metrics? I am not sure how can we handle this with micrometer
   * do we actually need now `connectedNativeClientsByUser`, as we allow anybody to report tags based on the `ClientInfo` and thus distinguish users

I tried to keep everything to be backwards compatible wrt to naming (there is even a typo I kept -> `RequestDiscarded` vs `RequestsProcessed`). However in case of distribution summaries I am not exposing the `quantiles` as before, if this is needed I can add exactly the ones we had before.. Also the `Meter` concept in DW metrics does not exist in the Micrometer as it's not needed, so I moved there to classic counters for requests processed and discarded.