### PR TITLE
speed-up the BaseDocumentApiV2Test

### DIFF
--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -2,6 +2,7 @@ package io.stargate.it.http.docsapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -15,6 +16,7 @@ import io.stargate.auth.model.AuthTokenResponse;
 import io.stargate.it.BaseOsgiIntegrationTest;
 import io.stargate.it.driver.CqlSessionExtension;
 import io.stargate.it.driver.CqlSessionSpec;
+import io.stargate.it.driver.TestKeyspace;
 import io.stargate.it.http.RestUtils;
 import io.stargate.it.http.models.Credentials;
 import io.stargate.it.storage.StargateConnectionInfo;
@@ -31,47 +33,46 @@ import net.jcip.annotations.NotThreadSafe;
 import okhttp3.*;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @NotThreadSafe
 @ExtendWith(CqlSessionExtension.class)
-@CqlSessionSpec(
-    initQueries =
-        "create keyspace if not exists ks_docs_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 }")
+@CqlSessionSpec()
 public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
-  private static final String KEYSPACE = "ks_docs_test";
-  private static String authToken;
-  private static final ObjectMapper objectMapper = new ObjectMapper();
-  private static final OkHttpClient client =
+  private static final String TARGET_COLLECTION = "collection";
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final OkHttpClient CLIENT =
       new OkHttpClient().newBuilder().readTimeout(Duration.ofMinutes(3)).build();
 
-  private String host;
-  private String hostWithPort;
+  private static String authToken;
+  private static String host;
+  private static String hostWithPort;
+  private static String keyspace;
+  public static String collectionPath;
 
-  @BeforeEach
-  public void setup(StargateConnectionInfo cluster) throws IOException {
+  @BeforeAll
+  public static void setup(StargateConnectionInfo cluster, @TestKeyspace CqlIdentifier keyspaceIdentifier) throws IOException {
     host = "http://" + cluster.seedAddress();
     hostWithPort = host + ":8082";
-
-    if (null == authToken) {
-      initAuth();
-    }
+    keyspace = keyspaceIdentifier.toString();
+    collectionPath = hostWithPort + "/v2/namespaces/" + keyspace + "/collections/" + TARGET_COLLECTION;
+    initAuth();
   }
 
   @AfterEach
   public void truncateAllTables(CqlSession session) {
-    session.execute(String.format("TRUNCATE TABLE %s.%s", KEYSPACE, "collection"));
+    session.execute(String.format("TRUNCATE %s", TARGET_COLLECTION));
   }
 
-  private void initAuth() throws IOException {
-    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  private static void initAuth() throws IOException {
+    OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     RequestBody requestBody =
         RequestBody.create(
             MediaType.parse("application/json"),
-            objectMapper.writeValueAsString(new Credentials("cassandra", "cassandra")));
+            OBJECT_MAPPER.writeValueAsString(new Credentials("cassandra", "cassandra")));
 
     Request request =
         new Request.Builder()
@@ -79,12 +80,12 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             .post(requestBody)
             .addHeader("X-Cassandra-Request-Id", "foo")
             .build();
-    Response response = client.newCall(request).execute();
+    Response response = CLIENT.newCall(request).execute();
     ResponseBody body = response.body();
 
     assertThat(body).isNotNull();
     AuthTokenResponse authTokenResponse =
-        objectMapper.readValue(body.string(), AuthTokenResponse.class);
+        OBJECT_MAPPER.readValue(body.string(), AuthTokenResponse.class);
     authToken = authTokenResponse.getAuthToken();
     assertThat(authToken).isNotNull();
   }
@@ -92,111 +93,108 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   @Test
   public void testIt() throws IOException {
     JsonNode obj =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
 
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         obj.toString(),
         200);
 
     String resp =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
 
     resp =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/quiz/maths",
+            collectionPath + "/1/quiz/maths",
             200);
-    assertThat(objectMapper.readTree(resp))
+    assertThat(OBJECT_MAPPER.readTree(resp))
         .isEqualTo(wrapResponse(obj.requiredAt("/quiz/maths"), "1", null));
 
     resp =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection?where={\"products.electronics.Pixel_3a.price\":{\"$lt\": 800}}",
+            collectionPath + "?where={\"products.electronics.Pixel_3a.price\":{\"$lt\": 800}}",
             200);
-    ObjectNode expected = objectMapper.createObjectNode();
+    ObjectNode expected = OBJECT_MAPPER.createObjectNode();
     expected.set("1", obj);
-    assertThat(objectMapper.readTree(resp)).isEqualTo(wrapResponse(expected, null, null));
+    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(wrapResponse(expected, null, null));
   }
 
   @Test
   public void testUnauthorized() throws IOException {
     String data =
-        objectMapper
+        OBJECT_MAPPER
             .readTree(this.getClass().getClassLoader().getResource("example.json"))
             .toString();
 
     // Missing token header
     RestUtils.post(
-        null, hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection", data, 401);
+        null, collectionPath, data, 401);
     RestUtils.put(
-        null, hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1", data, 401);
+        null, collectionPath + "/1", data, 401);
     RestUtils.patch(
-        null, hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1", data, 401);
+        null, collectionPath + "/1", data, 401);
     RestUtils.delete(
-        null, hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1", 401);
+        null, collectionPath + "/1", 401);
     RestUtils.get(
-        null, hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1", 401);
+        null, collectionPath + "/1", 401);
     RestUtils.get(
-        null, hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection", 401);
+        null, collectionPath, 401);
 
     // Bad token header
     RestUtils.post(
         "garbage",
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection",
+        collectionPath,
         data,
         401);
     RestUtils.put(
         "garbage",
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         data,
         401);
     RestUtils.patch(
         "garbage",
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         data,
         401);
     RestUtils.delete(
-        "garbage", hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1", 401);
+        "garbage", collectionPath + "/1", 401);
     RestUtils.get(
-        "garbage", hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1", 401);
+        "garbage", collectionPath + "/1", 401);
     RestUtils.get(
-        "garbage", hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection", 401);
+        "garbage", collectionPath, 401);
   }
 
   @Test
   public void testBasicForms() throws IOException {
     RestUtils.putForm(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         "a=b&b=null&c.b=3.3&d.[0].[2]=true",
         200);
 
     String resp =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
     JsonNode expected =
-        objectMapper.readTree(
+        OBJECT_MAPPER.readTree(
             "{\"a\":\"b\", \"b\":null, \"c\":{\"b\": 3.3}, \"d\":[[null, null, true]]}");
-    assertThat(objectMapper.readTree(resp).toString())
+    assertThat(OBJECT_MAPPER.readTree(resp).toString())
         .isEqualTo(wrapResponse(expected, "1", null).toString());
   }
 
   @Test
   public void testInvalidKeyspaceAndTable() throws IOException {
     JsonNode obj =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
     String data = obj.toString();
     String resp =
         RestUtils.put(
@@ -211,7 +209,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     resp =
         RestUtils.put(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/invalid-character/1",
+            hostWithPort + "/v2/namespaces/" + keyspace + "/collections/invalid-character/1",
             data,
             400);
     assertThat(resp)
@@ -232,63 +230,63 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   public void testDocGetOnNotExistingCollection() throws IOException {
     String resp =
         RestUtils.get(
-            authToken, hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/unknown/1", 404);
+            authToken, hostWithPort + "/v2/namespaces/" + keyspace + "/collections/unknown/1", 404);
     assertThat(resp)
         .isEqualTo("{\"description\":\"Collection unknown does not exist.\",\"code\":404}");
   }
 
   @Test
   public void testInvalidKeyPut() throws IOException {
-    JsonNode obj = objectMapper.readTree("{ \"square[]braces\": \"are not allowed\" }");
+    JsonNode obj = OBJECT_MAPPER.readTree("{ \"square[]braces\": \"are not allowed\" }");
 
     String resp =
         RestUtils.put(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             obj.toString(),
             400);
     assertThat(resp)
         .isEqualTo(
             "{\"description\":\"The characters [`[`, `]`, `,`, `.`, `'`, `*`] are not permitted in JSON field names, invalid field square[]braces.\",\"code\":400}");
 
-    obj = objectMapper.readTree("{ \"commas,\": \"are not allowed\" }");
+    obj = OBJECT_MAPPER.readTree("{ \"commas,\": \"are not allowed\" }");
     resp =
         RestUtils.put(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             obj.toString(),
             400);
     assertThat(resp)
         .isEqualTo(
             "{\"description\":\"The characters [`[`, `]`, `,`, `.`, `'`, `*`] are not permitted in JSON field names, invalid field commas,.\",\"code\":400}");
 
-    obj = objectMapper.readTree("{ \"periods.\": \"are not allowed\" }");
+    obj = OBJECT_MAPPER.readTree("{ \"periods.\": \"are not allowed\" }");
     resp =
         RestUtils.put(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             obj.toString(),
             400);
     assertThat(resp)
         .isEqualTo(
             "{\"description\":\"The characters [`[`, `]`, `,`, `.`, `'`, `*`] are not permitted in JSON field names, invalid field periods..\",\"code\":400}");
 
-    obj = objectMapper.readTree("{ \"'quotes'\": \"are not allowed\" }");
+    obj = OBJECT_MAPPER.readTree("{ \"'quotes'\": \"are not allowed\" }");
     resp =
         RestUtils.put(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             obj.toString(),
             400);
     assertThat(resp)
         .isEqualTo(
             "{\"description\":\"The characters [`[`, `]`, `,`, `.`, `'`, `*`] are not permitted in JSON field names, invalid field 'quotes'.\",\"code\":400}");
 
-    obj = objectMapper.readTree("{ \"*asterisks*\": \"are not allowed\" }");
+    obj = OBJECT_MAPPER.readTree("{ \"*asterisks*\": \"are not allowed\" }");
     resp =
         RestUtils.put(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             obj.toString(),
             400);
     assertThat(resp)
@@ -298,166 +296,166 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
 
   @Test
   public void testWeirdButAllowedKeys() throws IOException {
-    JsonNode obj = objectMapper.readTree("{ \"$\": \"weird but allowed\" }");
+    JsonNode obj = OBJECT_MAPPER.readTree("{ \"$\": \"weird but allowed\" }");
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/path",
+        collectionPath + "/1/path",
         obj.toString(),
         200);
 
     String resp =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/path",
+            collectionPath + "/1/path",
             200);
-    assertThat(objectMapper.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
 
-    obj = objectMapper.readTree("{ \"$30\": \"not as weird\" }");
+    obj = OBJECT_MAPPER.readTree("{ \"$30\": \"not as weird\" }");
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/path",
+        collectionPath + "/1/path",
         obj.toString(),
         200);
 
     resp =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/path",
+            collectionPath + "/1/path",
             200);
-    assertThat(objectMapper.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
 
-    obj = objectMapper.readTree("{ \"@\": \"weird but allowed\" }");
+    obj = OBJECT_MAPPER.readTree("{ \"@\": \"weird but allowed\" }");
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/path",
+        collectionPath + "/1/path",
         obj.toString(),
         200);
 
     resp =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/path",
+            collectionPath + "/1/path",
             200);
-    assertThat(objectMapper.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
 
-    obj = objectMapper.readTree("{ \"meet me @ the place\": \"not as weird\" }");
+    obj = OBJECT_MAPPER.readTree("{ \"meet me @ the place\": \"not as weird\" }");
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/path",
+        collectionPath + "/1/path",
         obj.toString(),
         200);
 
     resp =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/path",
+            collectionPath + "/1/path",
             200);
-    assertThat(objectMapper.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
 
-    obj = objectMapper.readTree("{ \"?\": \"weird but allowed\" }");
+    obj = OBJECT_MAPPER.readTree("{ \"?\": \"weird but allowed\" }");
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/path",
+        collectionPath + "/1/path",
         obj.toString(),
         200);
 
     resp =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/path",
+            collectionPath + "/1/path",
             200);
-    assertThat(objectMapper.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
 
-    obj = objectMapper.readTree("{ \"spac es\": \"weird but allowed\" }");
+    obj = OBJECT_MAPPER.readTree("{ \"spac es\": \"weird but allowed\" }");
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/path",
+        collectionPath + "/1/path",
         obj.toString(),
         200);
 
     resp =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/path",
+            collectionPath + "/1/path",
             200);
-    assertThat(objectMapper.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
 
-    obj = objectMapper.readTree("{ \"3\": [\"totally allowed\"] }");
+    obj = OBJECT_MAPPER.readTree("{ \"3\": [\"totally allowed\"] }");
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/path",
+        collectionPath + "/1/path",
         obj.toString(),
         200);
 
     resp =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/path",
+            collectionPath + "/1/path",
             200);
-    assertThat(objectMapper.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
 
     resp =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/path/3/[0]",
+            collectionPath + "/1/path/3/[0]",
             200);
-    assertThat(objectMapper.readTree(resp))
-        .isEqualTo(wrapResponse(objectMapper.readTree("\"totally allowed\""), "1", null));
+    assertThat(OBJECT_MAPPER.readTree(resp))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree("\"totally allowed\""), "1", null));
 
-    obj = objectMapper.readTree("{ \"-1\": \"totally allowed\" }");
+    obj = OBJECT_MAPPER.readTree("{ \"-1\": \"totally allowed\" }");
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/path",
+        collectionPath + "/1/path",
         obj.toString(),
         200);
 
     resp =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/path",
+            collectionPath + "/1/path",
             200);
-    assertThat(objectMapper.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
 
     resp =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/path/-1",
+            collectionPath + "/1/path/-1",
             200);
-    assertThat(objectMapper.readTree(resp))
-        .isEqualTo(wrapResponse(objectMapper.readTree("\"totally allowed\""), "1", null));
+    assertThat(OBJECT_MAPPER.readTree(resp))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree("\"totally allowed\""), "1", null));
 
-    obj = objectMapper.readTree("{ \"Eric says \\\"hello\\\"\": \"totally allowed\" }");
+    obj = OBJECT_MAPPER.readTree("{ \"Eric says \\\"hello\\\"\": \"totally allowed\" }");
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/path",
+        collectionPath + "/1/path",
         obj.toString(),
         200);
 
     resp =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/path",
+            collectionPath + "/1/path",
             200);
-    assertThat(objectMapper.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
   }
 
   @Test
   public void testInvalidDepthAndLength() throws IOException {
     JsonNode obj =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("tooDeep.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("tooDeep.json"));
     String resp =
         RestUtils.put(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             obj.toString(),
             400);
     assertThat(resp).isEqualTo("{\"description\":\"Max depth of 64 exceeded.\",\"code\":400}");
 
-    obj = objectMapper.readTree("{ \"some\": \"json\" }");
+    obj = OBJECT_MAPPER.readTree("{ \"some\": \"json\" }");
     resp =
         RestUtils.put(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/[1000000]",
+            collectionPath + "/1/[1000000]",
             obj.toString(),
             400);
     assertThat(resp)
@@ -467,11 +465,11 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   @Test
   public void testArrayGet() throws IOException {
     JsonNode obj =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
     String resp =
         RestUtils.put(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             obj.toString(),
             200);
     assertThat(resp).isEqualTo("{\"documentId\":\"1\"}");
@@ -479,163 +477,148 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     resp =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/1/quiz/maths/q1/options/[0]",
+            collectionPath + "/1/quiz/maths/q1/options/[0]",
             200);
-    assertThat(objectMapper.readTree(resp))
+    assertThat(OBJECT_MAPPER.readTree(resp))
         .isEqualTo(wrapResponse(obj.requiredAt("/quiz/maths/q1/options/0"), "1", null));
 
     resp =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/1/quiz/maths/q1/options/[0]?raw=true",
+            collectionPath + "/1/quiz/maths/q1/options/[0]?raw=true",
             200);
-    assertThat(objectMapper.readTree(resp)).isEqualTo(obj.requiredAt("/quiz/maths/q1/options/0"));
+    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(obj.requiredAt("/quiz/maths/q1/options/0"));
 
     resp =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/1/quiz/nests/q1/options/[3]/this",
+            collectionPath + "/1/quiz/nests/q1/options/[3]/this",
             200);
-    assertThat(objectMapper.readTree(resp))
+    assertThat(OBJECT_MAPPER.readTree(resp))
         .isEqualTo(wrapResponse(obj.requiredAt("/quiz/nests/q1/options/3/this"), "1", null));
   }
 
   @Test
   public void testInvalidPathGet() throws IOException {
     JsonNode obj =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
     String resp =
         RestUtils.put(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             obj.toString(),
             200);
     assertThat(resp).isEqualTo("{\"documentId\":\"1\"}");
 
     RestUtils.get(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/nonexistent/path",
+        collectionPath + "/1/nonexistent/path",
         204);
 
     RestUtils.get(
         authToken,
-        hostWithPort
-            + "/v2/namespaces/"
-            + KEYSPACE
-            + "/collections/collection/1/nonexistent/path/[1]",
+        collectionPath + "/1/nonexistent/path/[1]",
         204);
 
     RestUtils.get(
         authToken,
-        hostWithPort
-            + "/v2/namespaces/"
-            + KEYSPACE
-            + "/collections/collection/1/quiz/maths/q1/options/[9999]",
+        collectionPath + "/1/quiz/maths/q1/options/[9999]",
         204); // out of bounds
   }
 
   @Test
   public void testPutNullsAndEmpties() throws IOException {
-    JsonNode obj = objectMapper.readTree("{\"abc\": null}");
+    JsonNode obj = OBJECT_MAPPER.readTree("{\"abc\": null}");
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         obj.toString(),
         200);
 
     String resp =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(wrapResponse(obj, "1", null));
 
-    obj = objectMapper.readTree("{\"abc\": {}}");
+    obj = OBJECT_MAPPER.readTree("{\"abc\": {}}");
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/2",
+        collectionPath + "/2",
         obj.toString(),
         200);
 
     resp =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/2",
+            collectionPath + "/2",
             200);
-    assertThat(objectMapper.readTree(resp)).isEqualTo(wrapResponse(obj, "2", null));
+    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(wrapResponse(obj, "2", null));
 
-    obj = objectMapper.readTree("{\"abc\": []}");
+    obj = OBJECT_MAPPER.readTree("{\"abc\": []}");
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/3",
+        collectionPath + "/3",
         obj.toString(),
         200);
 
     resp =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/3",
+            collectionPath + "/3",
             200);
-    assertThat(objectMapper.readTree(resp)).isEqualTo(wrapResponse(obj, "3", null));
+    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(wrapResponse(obj, "3", null));
 
     obj =
-        objectMapper.readTree(
+        OBJECT_MAPPER.readTree(
             "{\"abc\": [], \"bcd\": {}, \"cde\": null, \"abcd\": { \"nest1\": [], \"nest2\": {}}}");
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/4",
+        collectionPath + "/4",
         obj.toString(),
         200);
 
     resp =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/4",
+            collectionPath + "/4",
             200);
-    assertThat(objectMapper.readTree(resp)).isEqualTo(wrapResponse(obj, "4", null));
+    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(wrapResponse(obj, "4", null));
 
     resp =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/4/abc",
+            collectionPath + "/4/abc",
             200);
-    assertThat(objectMapper.readTree(resp))
-        .isEqualTo(wrapResponse(objectMapper.createArrayNode(), "4", null));
+    assertThat(OBJECT_MAPPER.readTree(resp))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.createArrayNode(), "4", null));
 
     resp =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/4/bcd",
+            collectionPath + "/4/bcd",
             200);
-    assertThat(objectMapper.readTree(resp))
-        .isEqualTo(wrapResponse(objectMapper.createObjectNode(), "4", null));
+    assertThat(OBJECT_MAPPER.readTree(resp))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.createObjectNode(), "4", null));
 
     resp =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/4/abcd/nest1",
+            collectionPath + "/4/abcd/nest1",
             200);
-    assertThat(objectMapper.readTree(resp))
-        .isEqualTo(wrapResponse(objectMapper.createArrayNode(), "4", null));
+    assertThat(OBJECT_MAPPER.readTree(resp))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.createArrayNode(), "4", null));
   }
 
   @Test
   public void testPutReplacingObject() throws IOException {
     JsonNode fullObj =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
     String r =
         RestUtils.put(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             fullObj.toString(),
             200);
     assertThat(r).isEqualTo("{\"documentId\":\"1\"}");
@@ -643,47 +626,47 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(r)).isEqualTo(wrapResponse(fullObj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(wrapResponse(fullObj, "1", null));
 
     JsonNode obj;
-    obj = objectMapper.readTree("{\"q5000\": \"hello?\"}");
+    obj = OBJECT_MAPPER.readTree("{\"q5000\": \"hello?\"}");
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/quiz/sport",
+        collectionPath + "/1/quiz/sport",
         obj.toString(),
         200);
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/quiz/sport",
+            collectionPath + "/1/quiz/sport",
             200);
-    assertThat(objectMapper.readTree(r)).isEqualTo(wrapResponse(obj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(wrapResponse(obj, "1", null));
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
 
-    ObjectNode sportNode = objectMapper.createObjectNode();
+    ObjectNode sportNode = OBJECT_MAPPER.createObjectNode();
     sportNode.set("q5000", TextNode.valueOf("hello?"));
 
     ObjectNode fullObjNode = (ObjectNode) fullObj;
     ((ObjectNode) fullObjNode.get("quiz")).set("sport", sportNode);
-    assertThat(objectMapper.readTree(r)).isEqualTo(wrapResponse(fullObjNode, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(wrapResponse(fullObjNode, "1", null));
   }
 
   @Test
   public void testPutReplacingArrayElement() throws IOException {
     JsonNode fullObj =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
     String r =
         RestUtils.put(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             fullObj.toString(),
             200);
     assertThat(r).isEqualTo("{\"documentId\":\"1\"}");
@@ -691,53 +674,47 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(r)).isEqualTo(wrapResponse(fullObj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(wrapResponse(fullObj, "1", null));
 
     JsonNode obj;
-    obj = objectMapper.readTree("{\"q5000\": \"hello?\"}");
+    obj = OBJECT_MAPPER.readTree("{\"q5000\": \"hello?\"}");
     RestUtils.put(
         authToken,
-        hostWithPort
-            + "/v2/namespaces/"
-            + KEYSPACE
-            + "/collections/collection/1/quiz/nests/q1/options/[0]",
+        collectionPath + "/1/quiz/nests/q1/options/[0]",
         obj.toString(),
         200);
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/1/quiz/nests/q1/options/[0]",
+            collectionPath + "/1/quiz/nests/q1/options/[0]",
             200);
-    assertThat(objectMapper.readTree(r)).isEqualTo(wrapResponse(obj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(wrapResponse(obj, "1", null));
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
 
-    ObjectNode optionNode = objectMapper.createObjectNode();
+    ObjectNode optionNode = OBJECT_MAPPER.createObjectNode();
     optionNode.set("q5000", TextNode.valueOf("hello?"));
 
     ObjectNode fullObjNode = (ObjectNode) fullObj;
     ((ArrayNode) fullObjNode.at("/quiz/nests/q1/options")).set(0, optionNode);
-    assertThat(objectMapper.readTree(r)).isEqualTo(wrapResponse(fullObjNode, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(wrapResponse(fullObjNode, "1", null));
   }
 
   @Test
   public void testPutReplacingWithArray() throws IOException {
     JsonNode fullObj =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
     String r =
         RestUtils.put(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             fullObj.toString(),
             200);
     assertThat(r).isEqualTo("{\"documentId\":\"1\"}");
@@ -745,86 +722,86 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(r)).isEqualTo(wrapResponse(fullObj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(wrapResponse(fullObj, "1", null));
 
-    JsonNode obj = objectMapper.readTree("[{\"array\": \"at\"}, \"sub\", \"doc\"]");
+    JsonNode obj = OBJECT_MAPPER.readTree("[{\"array\": \"at\"}, \"sub\", \"doc\"]");
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/quiz",
+        collectionPath + "/1/quiz",
         obj.toString(),
         200);
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/quiz",
+            collectionPath + "/1/quiz",
             200);
-    assertThat(objectMapper.readTree(r)).isEqualTo(wrapResponse(obj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(wrapResponse(obj, "1", null));
 
-    obj = objectMapper.readTree("[0, \"a\", \"2\", true]");
+    obj = OBJECT_MAPPER.readTree("[0, \"a\", \"2\", true]");
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/quiz/nests/q1",
+        collectionPath + "/1/quiz/nests/q1",
         obj.toString(),
         200);
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/quiz/nests/q1",
+            collectionPath + "/1/quiz/nests/q1",
             200);
-    assertThat(objectMapper.readTree(r)).isEqualTo(wrapResponse(obj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(wrapResponse(obj, "1", null));
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
     ObjectNode nestsNode =
-        (ObjectNode) objectMapper.readTree("{\"nests\":{\"q1\":[0,\"a\",\"2\",true]}}");
+        (ObjectNode) OBJECT_MAPPER.readTree("{\"nests\":{\"q1\":[0,\"a\",\"2\",true]}}");
     ObjectNode fullObjNode = (ObjectNode) fullObj;
     fullObjNode.set("quiz", nestsNode);
-    assertThat(objectMapper.readTree(r)).isEqualTo(wrapResponse(fullObjNode, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(wrapResponse(fullObjNode, "1", null));
 
-    obj = objectMapper.readTree("[{\"array\": \"at\"}, \"\", \"doc\"]");
+    obj = OBJECT_MAPPER.readTree("[{\"array\": \"at\"}, \"\", \"doc\"]");
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/quiz",
+        collectionPath + "/1/quiz",
         obj.toString(),
         200);
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/quiz",
+            collectionPath + "/1/quiz",
             200);
-    assertThat(objectMapper.readTree(r)).isEqualTo(wrapResponse(obj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(wrapResponse(obj, "1", null));
 
-    obj = objectMapper.readTree("{\"we\": {\"are\": \"done\"}}");
+    obj = OBJECT_MAPPER.readTree("{\"we\": {\"are\": \"done\"}}");
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/quiz",
+        collectionPath + "/1/quiz",
         obj.toString(),
         200);
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/quiz",
+            collectionPath + "/1/quiz",
             200);
-    assertThat(objectMapper.readTree(r)).isEqualTo(wrapResponse(obj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(wrapResponse(obj, "1", null));
   }
 
   @Test
   public void testInvalidPuts() throws IOException {
     JsonNode fullObj =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
     String r =
         RestUtils.put(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             fullObj.toString(),
             200);
     assertThat(r).isEqualTo("{\"documentId\":\"1\"}");
@@ -832,49 +809,49 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(r)).isEqualTo(wrapResponse(fullObj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(wrapResponse(fullObj, "1", null));
 
     JsonNode obj;
-    obj = objectMapper.readTree("3");
+    obj = OBJECT_MAPPER.readTree("3");
     r =
         RestUtils.put(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             obj.toString(),
             400);
     assertThat(r)
         .isEqualTo(
             "{\"description\":\"Updating a key with just a JSON primitive, empty object, or empty array is not allowed. Found: 3. Hint: update the parent path with a defined object instead.\",\"code\":400}");
 
-    obj = objectMapper.readTree("true");
+    obj = OBJECT_MAPPER.readTree("true");
     r =
         RestUtils.put(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/quiz",
+            collectionPath + "/1/quiz",
             obj.toString(),
             400);
     assertThat(r)
         .isEqualTo(
             "{\"description\":\"Updating a key with just a JSON primitive, empty object, or empty array is not allowed. Found: true. Hint: update the parent path with a defined object instead.\",\"code\":400}");
 
-    obj = objectMapper.readTree("null");
+    obj = OBJECT_MAPPER.readTree("null");
     r =
         RestUtils.put(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/quiz",
+            collectionPath + "/1/quiz",
             obj.toString(),
             400);
     assertThat(r)
         .isEqualTo(
             "{\"description\":\"Updating a key with just a JSON primitive, empty object, or empty array is not allowed. Found: null. Hint: update the parent path with a defined object instead.\",\"code\":400}");
 
-    obj = objectMapper.readTree("\"Eric\"");
+    obj = OBJECT_MAPPER.readTree("\"Eric\"");
     r =
         RestUtils.put(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/quiz/sport",
+            collectionPath + "/1/quiz/sport",
             obj.toString(),
             400);
     assertThat(r)
@@ -885,11 +862,11 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   @Test
   public void testDelete() throws IOException {
     JsonNode fullObj =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
     String r =
         RestUtils.put(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             fullObj.toString(),
             200);
     assertThat(r).isEqualTo("{\"documentId\":\"1\"}");
@@ -897,222 +874,210 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(r)).isEqualTo(wrapResponse(fullObj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(wrapResponse(fullObj, "1", null));
 
     RestUtils.delete(
         authToken,
-        hostWithPort
-            + "/v2/namespaces/"
-            + KEYSPACE
-            + "/collections/collection/1/quiz/sport/q1/question",
+        collectionPath + "/1/quiz/sport/q1/question",
         204);
 
     RestUtils.get(
         authToken,
-        hostWithPort
-            + "/v2/namespaces/"
-            + KEYSPACE
-            + "/collections/collection/1/quiz/sport/q1/question",
+            collectionPath + "/1/quiz/sport/q1/question",
         204);
 
     RestUtils.delete(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/quiz/maths",
+        collectionPath + "/1/quiz/maths",
         204);
 
     RestUtils.get(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/quiz/maths",
+        collectionPath + "/1/quiz/maths",
         204);
 
     RestUtils.delete(
         authToken,
-        hostWithPort
-            + "/v2/namespaces/"
-            + KEYSPACE
-            + "/collections/collection/1/quiz/nests/q1/options/[0]",
+            collectionPath + "/1/quiz/nests/q1/options/[0]",
         204);
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/1/quiz/nests/q1/options",
+            collectionPath + "/1/quiz/nests/q1/options",
             200);
-    assertThat(objectMapper.readTree(r))
+    assertThat(OBJECT_MAPPER.readTree(r))
         .isEqualTo(
             wrapResponse(
-                objectMapper.readTree(
+                OBJECT_MAPPER.readTree(
                     "[null,\"not a nest\",\"definitely not a nest\",{ \"this\":  true }]"),
                 "1",
                 null));
 
     RestUtils.delete(
-        authToken, hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1", 204);
+        authToken, collectionPath + "/1", 204);
 
     RestUtils.get(
-        authToken, hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1", 204);
+        authToken, collectionPath + "/1", 204);
   }
 
   @Test
   public void testPost() throws IOException {
     JsonNode fullObj =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
     Response resp =
         RestUtils.postRaw(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection",
+            collectionPath,
             fullObj.toString(),
             201);
     String newLocation = resp.header("location");
     String body = resp.body().string();
-    String newId = objectMapper.readTree(body).requiredAt("/documentId").asText();
+    String newId = OBJECT_MAPPER.readTree(body).requiredAt("/documentId").asText();
     assertThat(newId).isNotNull();
 
     String r = RestUtils.get(authToken, newLocation, 200);
-    assertThat(objectMapper.readTree(r)).isEqualTo(wrapResponse(fullObj, newId, null));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(wrapResponse(fullObj, newId, null));
   }
 
   @Test
   public void testRootDocumentPatch() throws IOException {
-    JsonNode obj = objectMapper.readTree("{\"abc\": 1}");
+    JsonNode obj = OBJECT_MAPPER.readTree("{\"abc\": 1}");
     RestUtils.patch(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         obj.toString(),
         200);
 
     String r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(r)).isEqualTo(wrapResponse(obj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(wrapResponse(obj, "1", null));
 
-    obj = objectMapper.readTree("{\"bcd\": true}");
+    obj = OBJECT_MAPPER.readTree("{\"bcd\": true}");
     RestUtils.patch(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         obj.toString(),
         200);
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(r))
-        .isEqualTo(wrapResponse(objectMapper.readTree("{ \"abc\": 1, \"bcd\": true }"), "1", null));
+    assertThat(OBJECT_MAPPER.readTree(r))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree("{ \"abc\": 1, \"bcd\": true }"), "1", null));
 
-    obj = objectMapper.readTree("{\"bcd\": {\"a\": {\"b\": 0 }}}");
+    obj = OBJECT_MAPPER.readTree("{\"bcd\": {\"a\": {\"b\": 0 }}}");
     RestUtils.patch(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         obj.toString(),
         200);
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(r))
+    assertThat(OBJECT_MAPPER.readTree(r))
         .isEqualTo(
             wrapResponse(
-                objectMapper.readTree("{ \"abc\": 1, \"bcd\": {\"a\": {\"b\": 0 }} }"), "1", null));
+                OBJECT_MAPPER.readTree("{ \"abc\": 1, \"bcd\": {\"a\": {\"b\": 0 }} }"), "1", null));
 
-    obj = objectMapper.readTree("{\"bcd\": [1,2,3,4]}");
+    obj = OBJECT_MAPPER.readTree("{\"bcd\": [1,2,3,4]}");
     RestUtils.patch(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         obj.toString(),
         200);
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(r))
+    assertThat(OBJECT_MAPPER.readTree(r))
         .isEqualTo(
-            wrapResponse(objectMapper.readTree("{ \"abc\": 1, \"bcd\": [1,2,3,4] }"), "1", null));
+            wrapResponse(OBJECT_MAPPER.readTree("{ \"abc\": 1, \"bcd\": [1,2,3,4] }"), "1", null));
 
-    obj = objectMapper.readTree("{\"bcd\": [5,{\"a\": 23},7,8]}");
+    obj = OBJECT_MAPPER.readTree("{\"bcd\": [5,{\"a\": 23},7,8]}");
     RestUtils.patch(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         obj.toString(),
         200);
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(r))
-        .isEqualTo(
-            wrapResponse(
-                objectMapper.readTree("{ \"abc\": 1, \"bcd\": [5,{\"a\": 23},7,8] }"), "1", null));
-
-    obj = objectMapper.readTree("{\"bcd\": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]}");
-    RestUtils.patch(
-        authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
-        obj.toString(),
-        200);
-
-    r =
-        RestUtils.get(
-            authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
-            200);
-    assertThat(objectMapper.readTree(r))
+    assertThat(OBJECT_MAPPER.readTree(r))
         .isEqualTo(
             wrapResponse(
-                objectMapper.readTree(
+                OBJECT_MAPPER.readTree("{ \"abc\": 1, \"bcd\": [5,{\"a\": 23},7,8] }"), "1", null));
+
+    obj = OBJECT_MAPPER.readTree("{\"bcd\": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]}");
+    RestUtils.patch(
+        authToken,
+        collectionPath + "/1",
+        obj.toString(),
+        200);
+
+    r =
+        RestUtils.get(
+            authToken,
+            collectionPath + "/1",
+            200);
+    assertThat(OBJECT_MAPPER.readTree(r))
+        .isEqualTo(
+            wrapResponse(
+                OBJECT_MAPPER.readTree(
                     "{ \"abc\": 1, \"bcd\": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] }"),
                 "1",
                 null));
 
-    obj = objectMapper.readTree("{\"bcd\": {\"replace\": \"array\"}}");
+    obj = OBJECT_MAPPER.readTree("{\"bcd\": {\"replace\": \"array\"}}");
     RestUtils.patch(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         obj.toString(),
         200);
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(r))
+    assertThat(OBJECT_MAPPER.readTree(r))
         .isEqualTo(
             wrapResponse(
-                objectMapper.readTree("{ \"abc\": 1, \"bcd\": {\"replace\": \"array\"} }"),
+                OBJECT_MAPPER.readTree("{ \"abc\": 1, \"bcd\": {\"replace\": \"array\"} }"),
                 "1",
                 null));
 
-    obj = objectMapper.readTree("{\"done\": \"done\"}");
+    obj = OBJECT_MAPPER.readTree("{\"done\": \"done\"}");
     RestUtils.patch(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         obj.toString(),
         200);
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(r))
+    assertThat(OBJECT_MAPPER.readTree(r))
         .isEqualTo(
             wrapResponse(
-                objectMapper.readTree(
+                OBJECT_MAPPER.readTree(
                     "{ \"abc\": 1, \"bcd\": {\"replace\": \"array\"}, \"done\": \"done\" }"),
                 "1",
                 null));
@@ -1120,123 +1085,123 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
 
   @Test
   public void testRootDocumentPatchNulls() throws IOException {
-    JsonNode obj = objectMapper.readTree("{\"abc\": null}");
+    JsonNode obj = OBJECT_MAPPER.readTree("{\"abc\": null}");
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         obj.toString(),
         200);
 
     String r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(r)).isEqualTo(wrapResponse(obj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(wrapResponse(obj, "1", null));
 
-    obj = objectMapper.readTree("{\"bcd\": null}");
+    obj = OBJECT_MAPPER.readTree("{\"bcd\": null}");
     RestUtils.patch(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         obj.toString(),
         200);
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(r))
+    assertThat(OBJECT_MAPPER.readTree(r))
         .isEqualTo(
-            wrapResponse(objectMapper.readTree("{ \"abc\": null, \"bcd\": null }"), "1", null));
+            wrapResponse(OBJECT_MAPPER.readTree("{ \"abc\": null, \"bcd\": null }"), "1", null));
 
-    obj = objectMapper.readTree("{\"bcd\": {\"a\": {\"b\": null }}}");
+    obj = OBJECT_MAPPER.readTree("{\"bcd\": {\"a\": {\"b\": null }}}");
     RestUtils.patch(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         obj.toString(),
         200);
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(r))
+    assertThat(OBJECT_MAPPER.readTree(r))
         .isEqualTo(
             wrapResponse(
-                objectMapper.readTree("{ \"abc\": null, \"bcd\": {\"a\": {\"b\": null }} }"),
+                OBJECT_MAPPER.readTree("{ \"abc\": null, \"bcd\": {\"a\": {\"b\": null }} }"),
                 "1",
                 null));
 
-    obj = objectMapper.readTree("{\"bcd\": [null,2,null,4]}");
+    obj = OBJECT_MAPPER.readTree("{\"bcd\": [null,2,null,4]}");
     RestUtils.patch(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         obj.toString(),
         200);
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(r))
+    assertThat(OBJECT_MAPPER.readTree(r))
         .isEqualTo(
             wrapResponse(
-                objectMapper.readTree("{ \"abc\": null, \"bcd\": [null,2,null,4] }"), "1", null));
+                OBJECT_MAPPER.readTree("{ \"abc\": null, \"bcd\": [null,2,null,4] }"), "1", null));
 
-    obj = objectMapper.readTree("{\"bcd\": [1,{\"a\": null},3,4]}");
+    obj = OBJECT_MAPPER.readTree("{\"bcd\": [1,{\"a\": null},3,4]}");
     RestUtils.patch(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         obj.toString(),
         200);
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(r))
+    assertThat(OBJECT_MAPPER.readTree(r))
         .isEqualTo(
             wrapResponse(
-                objectMapper.readTree("{ \"abc\": null, \"bcd\": [1,{\"a\": null},3,4] }"),
+                OBJECT_MAPPER.readTree("{ \"abc\": null, \"bcd\": [1,{\"a\": null},3,4] }"),
                 "1",
                 null));
 
-    obj = objectMapper.readTree("{\"bcd\": [null]}");
+    obj = OBJECT_MAPPER.readTree("{\"bcd\": [null]}");
     RestUtils.patch(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         obj.toString(),
         200);
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(r))
+    assertThat(OBJECT_MAPPER.readTree(r))
         .isEqualTo(
-            wrapResponse(objectMapper.readTree("{ \"abc\": null, \"bcd\": [null] }"), "1", null));
+            wrapResponse(OBJECT_MAPPER.readTree("{ \"abc\": null, \"bcd\": [null] }"), "1", null));
 
-    obj = objectMapper.readTree("{\"null\": null}");
+    obj = OBJECT_MAPPER.readTree("{\"null\": null}");
     RestUtils.patch(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         obj.toString(),
         200);
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(r))
+    assertThat(OBJECT_MAPPER.readTree(r))
         .isEqualTo(
             wrapResponse(
-                objectMapper.readTree("{ \"abc\": null, \"bcd\": [null], \"null\": null }"),
+                OBJECT_MAPPER.readTree("{ \"abc\": null, \"bcd\": [null], \"null\": null }"),
                 "1",
                 null));
   }
@@ -1244,11 +1209,11 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   @Test
   public void testInvalidPatches() throws IOException {
     JsonNode fullObj =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
     String r =
         RestUtils.put(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             fullObj.toString(),
             200);
     assertThat(r).isEqualTo("{\"documentId\":\"1\"}");
@@ -1256,16 +1221,16 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             200);
-    assertThat(objectMapper.readTree(r)).isEqualTo(wrapResponse(fullObj, "1", null));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(wrapResponse(fullObj, "1", null));
 
     JsonNode obj;
-    obj = objectMapper.readTree("[{\"array\": \"at\"}, \"root\", \"doc\"]");
+    obj = OBJECT_MAPPER.readTree("[{\"array\": \"at\"}, \"root\", \"doc\"]");
     r =
         RestUtils.patch(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             obj.toString(),
             400);
     assertThat(r)
@@ -1276,51 +1241,51 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     r =
         RestUtils.patch(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/quiz/sport/q1",
+            collectionPath + "/1/quiz/sport/q1",
             obj.toString(),
             400);
     assertThat(r)
         .isEqualTo(
             "{\"description\":\"A patch operation must be done with a JSON object, not an array.\",\"code\":400}");
 
-    obj = objectMapper.readTree("3");
+    obj = OBJECT_MAPPER.readTree("3");
     r =
         RestUtils.patch(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+            collectionPath + "/1",
             obj.toString(),
             400);
     assertThat(r)
         .isEqualTo(
             "{\"description\":\"Updating a key with just a JSON primitive, empty object, or empty array is not allowed. Found: 3. Hint: update the parent path with a defined object instead.\",\"code\":400}");
 
-    obj = objectMapper.readTree("true");
+    obj = OBJECT_MAPPER.readTree("true");
     r =
         RestUtils.patch(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/quiz",
+            collectionPath + "/1/quiz",
             obj.toString(),
             400);
     assertThat(r)
         .isEqualTo(
             "{\"description\":\"Updating a key with just a JSON primitive, empty object, or empty array is not allowed. Found: true. Hint: update the parent path with a defined object instead.\",\"code\":400}");
 
-    obj = objectMapper.readTree("null");
+    obj = OBJECT_MAPPER.readTree("null");
     r =
         RestUtils.patch(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/quiz",
+            collectionPath + "/1/quiz",
             obj.toString(),
             400);
     assertThat(r)
         .isEqualTo(
             "{\"description\":\"Updating a key with just a JSON primitive, empty object, or empty array is not allowed. Found: null. Hint: update the parent path with a defined object instead.\",\"code\":400}");
 
-    obj = objectMapper.readTree("\"Eric\"");
+    obj = OBJECT_MAPPER.readTree("\"Eric\"");
     r =
         RestUtils.patch(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1/quiz/sport",
+            collectionPath + "/1/quiz/sport",
             obj.toString(),
             400);
     assertThat(r)
@@ -1331,10 +1296,10 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   @Test
   public void testBasicSearch() throws IOException {
     JsonNode fullObj =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/cool-search-id",
+        collectionPath + "/cool-search-id",
         fullObj.toString(),
         200);
 
@@ -1342,89 +1307,68 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     String r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.electronics.Pixel_3a.price\": {\"$eq\": 600}}",
+            collectionPath + "/cool-search-id?where={\"products.electronics.Pixel_3a.price\": {\"$eq\": 600}}",
             200);
 
     String searchResultStr =
         "[{\"products\": {\"electronics\": {\"Pixel_3a\": {\"price\": 600}}}}]";
-    assertThat(objectMapper.readTree(r))
-        .isEqualTo(wrapResponse(objectMapper.readTree(searchResultStr), "cool-search-id", null));
+    assertThat(OBJECT_MAPPER.readTree(r))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree(searchResultStr), "cool-search-id", null));
 
     RestUtils.get(
         authToken,
-        hostWithPort
-            + "/v2/namespaces/"
-            + KEYSPACE
-            + "/collections/collection/cool-search-id?where={\"price\": {\"$eq\": 600}}&raw=true",
+            collectionPath + "/cool-search-id?where={\"price\": {\"$eq\": 600}}&raw=true",
         204);
 
     // LT
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.food.*.price\": {\"$lt\": 600}}&raw=true",
+            collectionPath + "/cool-search-id?where={\"products.food.*.price\": {\"$lt\": 600}}&raw=true",
             200);
 
     searchResultStr =
         "[{\"products\": {\"food\": {\"Apple\": {\"price\": 0.99}}}}, {\"products\": {\"food\": { \"Pear\": {\"price\": 0.89}}}}]";
-    assertThat(objectMapper.readTree(r)).isEqualTo(objectMapper.readTree(searchResultStr));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(searchResultStr));
 
     // LTE
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.food.*.price\": {\"$lte\": 600}}",
+            collectionPath + "/cool-search-id?where={\"products.food.*.price\": {\"$lte\": 600}}",
             200);
 
     searchResultStr =
         "[{\"products\": {\"food\": {\"Apple\": {\"price\": 0.99}}}}, {\"products\": {\"food\": { \"Pear\": {\"price\": 0.89}}}}]";
-    assertThat(objectMapper.readTree(r))
-        .isEqualTo(wrapResponse(objectMapper.readTree(searchResultStr), "cool-search-id", null));
+    assertThat(OBJECT_MAPPER.readTree(r))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree(searchResultStr), "cool-search-id", null));
 
     // GT
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.price\": {\"$gt\": 600}}&raw=true",
+            collectionPath + "/cool-search-id?where={\"products.electronics.*.price\": {\"$gt\": 600}}&raw=true",
             200);
 
     searchResultStr = "[{\"products\": {\"electronics\": {\"iPhone_11\": {\"price\": 900}}}}]";
-    assertThat(objectMapper.readTree(r)).isEqualTo(objectMapper.readTree(searchResultStr));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(searchResultStr));
 
     // GTE
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.price\": {\"$gte\": 600}}&raw=true",
+            collectionPath + "/cool-search-id?where={\"products.electronics.*.price\": {\"$gte\": 600}}&raw=true",
             200);
 
     searchResultStr =
         "[{\"products\": {\"electronics\": {\"Pixel_3a\": {\"price\": 600}}}}, {\"products\": {\"electronics\": { \"iPhone_11\": {\"price\": 900}}}}]";
-    assertThat(objectMapper.readTree(r)).isEqualTo(objectMapper.readTree(searchResultStr));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(searchResultStr));
 
     // EXISTS
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$exists\": true}}&raw=true",
+            collectionPath + "/cool-search-id?where={\"products.*.*.price\": {\"$exists\": true}}&raw=true",
             200);
     searchResultStr =
         "["
@@ -1433,16 +1377,16 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             + "{\"products\":{\"food\":{\"Apple\":{\"price\":0.99}}}},"
             + "{\"products\":{\"food\":{\"Pear\":{\"price\":0.89}}}}"
             + "]";
-    assertThat(objectMapper.readTree(r)).isEqualTo(objectMapper.readTree(searchResultStr));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(searchResultStr));
   }
 
   @Test
   public void testBasicSearchSelectionSet() throws IOException {
     JsonNode fullObj =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/cool-search-id",
+        collectionPath + "/cool-search-id",
         fullObj.toString(),
         200);
 
@@ -1450,81 +1394,63 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     String r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.electronics.Pixel_3a.price\": {\"$eq\": 600}}&fields=[\"name\", \"price\", \"model\", \"manufacturer\"]",
+            collectionPath + "/cool-search-id?where={\"products.electronics.Pixel_3a.price\": {\"$eq\": 600}}&fields=[\"name\", \"price\", \"model\", \"manufacturer\"]",
             200);
 
     String searchResultStr =
         "[{\"products\": {\"electronics\": {\"Pixel_3a\": {\"name\": \"Pixel\", \"manufacturer\": \"Google\", \"model\": \"3a\", \"price\": 600}}}}]";
-    assertThat(objectMapper.readTree(r))
-        .isEqualTo(wrapResponse(objectMapper.readTree(searchResultStr), "cool-search-id", null));
+    assertThat(OBJECT_MAPPER.readTree(r))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree(searchResultStr), "cool-search-id", null));
 
     // LT
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.food.*.price\": {\"$lt\": 600}}&fields=[\"name\", \"price\", \"model\"]&raw=true",
+            collectionPath + "/cool-search-id?where={\"products.food.*.price\": {\"$lt\": 600}}&fields=[\"name\", \"price\", \"model\"]&raw=true",
             200);
 
     searchResultStr =
         "[{\"products\": {\"food\": {\"Apple\": {\"name\": \"apple\", \"price\": 0.99}}}}, {\"products\": {\"food\": { \"Pear\": {\"name\": \"pear\", \"price\": 0.89}}}}]";
-    assertThat(objectMapper.readTree(r)).isEqualTo(objectMapper.readTree(searchResultStr));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(searchResultStr));
 
     // LTE
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.food.*.price\": {\"$lte\": 600}}&fields=[\"price\", \"sku\"]",
+            collectionPath + "/cool-search-id?where={\"products.food.*.price\": {\"$lte\": 600}}&fields=[\"price\", \"sku\"]",
             200);
 
     searchResultStr =
         "[{\"products\": {\"food\": {\"Apple\": {\"price\": 0.99, \"sku\": \"100100010101001\"}}}}, {\"products\": {\"food\": { \"Pear\": {\"price\": 0.89, \"sku\": null}}}}]";
-    assertThat(objectMapper.readTree(r))
-        .isEqualTo(wrapResponse(objectMapper.readTree(searchResultStr), "cool-search-id", null));
+    assertThat(OBJECT_MAPPER.readTree(r))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree(searchResultStr), "cool-search-id", null));
 
     // GT
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.price\": {\"$gt\": 600}}&fields=[\"price\", \"throwaway\"]&raw=true",
+            collectionPath + "/cool-search-id?where={\"products.electronics.*.price\": {\"$gt\": 600}}&fields=[\"price\", \"throwaway\"]&raw=true",
             200);
 
     searchResultStr = "[{\"products\": {\"electronics\": {\"iPhone_11\": {\"price\": 900}}}}]";
-    assertThat(objectMapper.readTree(r)).isEqualTo(objectMapper.readTree(searchResultStr));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(searchResultStr));
 
     // GTE
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.price\": {\"$gte\": 600}}&fields=[\"price\"]&raw=true",
+            collectionPath + "/cool-search-id?where={\"products.electronics.*.price\": {\"$gte\": 600}}&fields=[\"price\"]&raw=true",
             200);
 
     searchResultStr =
         "[{\"products\": {\"electronics\": {\"Pixel_3a\": {\"price\": 600}}}}, {\"products\": {\"electronics\": { \"iPhone_11\": {\"price\": 900}}}}]";
-    assertThat(objectMapper.readTree(r)).isEqualTo(objectMapper.readTree(searchResultStr));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(searchResultStr));
 
     // EXISTS
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$exists\": true}}&fields=[\"price\", \"name\", \"manufacturer\", \"model\", \"sku\"]&raw=true",
+            collectionPath + "/cool-search-id?where={\"products.*.*.price\": {\"$exists\": true}}&fields=[\"price\", \"name\", \"manufacturer\", \"model\", \"sku\"]&raw=true",
             200);
     searchResultStr =
         "["
@@ -1533,16 +1459,16 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             + "{\"products\":{\"food\":{\"Apple\":{\"name\": \"apple\", \"price\":0.99, \"sku\": \"100100010101001\"}}}},"
             + "{\"products\":{\"food\":{\"Pear\":{\"name\": \"pear\", \"price\":0.89, \"sku\": null}}}}"
             + "]";
-    assertThat(objectMapper.readTree(r)).isEqualTo(objectMapper.readTree(searchResultStr));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(searchResultStr));
   }
 
   @Test
   public void testSearchNotEquals() throws IOException {
     JsonNode fullObj =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/cool-search-id",
+        collectionPath + "/cool-search-id",
         fullObj.toString(),
         200);
 
@@ -1550,83 +1476,68 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     String r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$ne\": \"3a\"}}",
+            collectionPath + "/cool-search-id?where={\"products.electronics.*.model\": {\"$ne\": \"3a\"}}",
             200);
 
     String searchResultStr =
         "[{\"products\": {\"electronics\": { \"iPhone_11\": {\"model\": \"11\"}}}}]";
-    assertThat(objectMapper.readTree(r))
-        .isEqualTo(wrapResponse(objectMapper.readTree(searchResultStr), "cool-search-id", null));
+    assertThat(OBJECT_MAPPER.readTree(r))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree(searchResultStr), "cool-search-id", null));
 
     // NE with Boolean
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"quiz.nests.q1.options.[3].this\": {\"$ne\": false}}",
+            collectionPath + "/cool-search-id?where={\"quiz.nests.q1.options.[3].this\": {\"$ne\": false}}",
             200);
 
     searchResultStr =
         "[{\"quiz\": {\"nests\": { \"q1\": {\"options\": {\"[3]\": {\"this\": true}}}}}}]";
-    assertThat(objectMapper.readTree(r))
-        .isEqualTo(wrapResponse(objectMapper.readTree(searchResultStr), "cool-search-id", null));
+    assertThat(OBJECT_MAPPER.readTree(r))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree(searchResultStr), "cool-search-id", null));
 
     // NE with integer compared to double
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"quiz.maths.q1.answer\": {\"$ne\": 12}}",
+            collectionPath + "/cool-search-id?where={\"quiz.maths.q1.answer\": {\"$ne\": 12}}",
             200);
 
     searchResultStr = "[{\"quiz\": {\"maths\": { \"q1\": {\"answer\": 12.2}}}}]";
-    assertThat(objectMapper.readTree(r))
-        .isEqualTo(wrapResponse(objectMapper.readTree(searchResultStr), "cool-search-id", null));
+    assertThat(OBJECT_MAPPER.readTree(r))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree(searchResultStr), "cool-search-id", null));
 
     // NE with double compared to integer
     RestUtils.get(
         authToken,
-        hostWithPort
-            + "/v2/namespaces/"
-            + KEYSPACE
-            + "/collections/collection/cool-search-id?where={\"quiz.maths.q2.answer\": {\"$ne\": 4.0}}",
+            collectionPath + "/cool-search-id?where={\"quiz.maths.q2.answer\": {\"$ne\": 4.0}}",
         204);
 
     // NE with null
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.food.*.sku\": {\"$ne\": null}}",
+            collectionPath + "/cool-search-id?where={\"products.food.*.sku\": {\"$ne\": null}}",
             200);
 
     searchResultStr = "[{\"products\": {\"food\": { \"Apple\": {\"sku\": \"100100010101001\"}}}}]";
-    assertThat(objectMapper.readTree(r))
-        .isEqualTo(wrapResponse(objectMapper.readTree(searchResultStr), "cool-search-id", null));
+    assertThat(OBJECT_MAPPER.readTree(r))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree(searchResultStr), "cool-search-id", null));
   }
 
   @Test
   public void testFullCollectionSearchFilterNesting() throws IOException {
     JsonNode fullObj1 =
-        objectMapper.readTree("{\"someStuff\": {\"someOtherStuff\": {\"value\": \"a\"}}}");
-    JsonNode fullObj2 = objectMapper.readTree("{\"value\": \"a\"}");
+        OBJECT_MAPPER.readTree("{\"someStuff\": {\"someOtherStuff\": {\"value\": \"a\"}}}");
+    JsonNode fullObj2 = OBJECT_MAPPER.readTree("{\"value\": \"a\"}");
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/cool-search-id",
+        collectionPath + "/cool-search-id",
         fullObj1.toString(),
         200);
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/cool-search-id-2",
+        collectionPath + "/cool-search-id-2",
         fullObj2.toString(),
         200);
 
@@ -1637,45 +1548,45 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             authToken,
             hostWithPort
                 + "/v2/namespaces/"
-                + KEYSPACE
+                + keyspace
                 + "/collections/collection?page-size=2&where={\"value\": {\"$eq\": \"a\"}}&raw=true",
             200);
 
     String expected = "{\"cool-search-id-2\":{\"value\":\"a\"}}";
-    assertThat(objectMapper.readTree(r)).isEqualTo(objectMapper.readTree(expected));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(expected));
 
     r =
         RestUtils.get(
             authToken,
             hostWithPort
                 + "/v2/namespaces/"
-                + KEYSPACE
+                + keyspace
                 + "/collections/collection?page-size=2&where={\"someStuff.someOtherStuff.value\": {\"$eq\": \"a\"}}&raw=true",
             200);
 
     expected = "{\"cool-search-id\":{\"someStuff\": {\"someOtherStuff\": {\"value\": \"a\"}}}}";
-    assertThat(objectMapper.readTree(r)).isEqualTo(objectMapper.readTree(expected));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(expected));
 
     r =
         RestUtils.get(
             authToken,
             hostWithPort
                 + "/v2/namespaces/"
-                + KEYSPACE
+                + keyspace
                 + "/collections/collection?page-size=2&where={\"someStuff.*.value\": {\"$eq\": \"a\"}}&raw=true",
             200);
 
     expected = "{\"cool-search-id\":{\"someStuff\": {\"someOtherStuff\": {\"value\": \"a\"}}}}";
-    assertThat(objectMapper.readTree(r)).isEqualTo(objectMapper.readTree(expected));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(expected));
   }
 
   @Test
   public void testSearchIn() throws IOException {
     JsonNode fullObj =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/cool-search-id",
+        collectionPath + "/cool-search-id",
         fullObj.toString(),
         200);
 
@@ -1683,69 +1594,57 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     String r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$in\": [\"11\", \"3a\"]}}",
+            collectionPath + "/cool-search-id?where={\"products.electronics.*.model\": {\"$in\": [\"11\", \"3a\"]}}",
             200);
 
     String searchResultStr =
         "[{\"products\": {\"electronics\": { \"Pixel_3a\": {\"model\": \"3a\"}}}}, {\"products\": {\"electronics\": { \"iPhone_11\": {\"model\": \"11\"}}}}]";
-    assertThat(objectMapper.readTree(r))
-        .isEqualTo(wrapResponse(objectMapper.readTree(searchResultStr), "cool-search-id", null));
+    assertThat(OBJECT_MAPPER.readTree(r))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree(searchResultStr), "cool-search-id", null));
 
     // IN with int
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$in\": [600, 900]}}",
+            collectionPath + "/cool-search-id?where={\"products.*.*.price\": {\"$in\": [600, 900]}}",
             200);
 
     searchResultStr =
         "[{\"products\": {\"electronics\": { \"Pixel_3a\": {\"price\": 600}}}}, {\"products\": {\"electronics\": { \"iPhone_11\": {\"price\": 900}}}}]";
-    assertThat(objectMapper.readTree(r))
-        .isEqualTo(wrapResponse(objectMapper.readTree(searchResultStr), "cool-search-id", null));
+    assertThat(OBJECT_MAPPER.readTree(r))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree(searchResultStr), "cool-search-id", null));
 
     // IN with double
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$in\": [0.99, 0.89]}}",
+            collectionPath + "/cool-search-id?where={\"products.*.*.price\": {\"$in\": [0.99, 0.89]}}",
             200);
 
     searchResultStr =
         "[{\"products\": {\"food\": { \"Apple\": {\"price\": 0.99}}}}, {\"products\": {\"food\": { \"Pear\": {\"price\": 0.89}}}}]";
-    assertThat(objectMapper.readTree(r))
-        .isEqualTo(wrapResponse(objectMapper.readTree(searchResultStr), "cool-search-id", null));
+    assertThat(OBJECT_MAPPER.readTree(r))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree(searchResultStr), "cool-search-id", null));
 
     // IN with null
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.*.*.sku\": {\"$in\": [null]}}",
+            collectionPath + "/cool-search-id?where={\"products.*.*.sku\": {\"$in\": [null]}}",
             200);
 
     searchResultStr = "[{\"products\": {\"food\": { \"Pear\": {\"sku\": null}}}}]";
-    assertThat(objectMapper.readTree(r))
-        .isEqualTo(wrapResponse(objectMapper.readTree(searchResultStr), "cool-search-id", null));
+    assertThat(OBJECT_MAPPER.readTree(r))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree(searchResultStr), "cool-search-id", null));
   }
 
   @Test
   public void testSearchNotIn() throws IOException {
     JsonNode fullObj =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/cool-search-id",
+        collectionPath + "/cool-search-id",
         fullObj.toString(),
         200);
 
@@ -1753,69 +1652,57 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     String r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$nin\": [\"12\"]}}",
+            collectionPath + "/cool-search-id?where={\"products.electronics.*.model\": {\"$nin\": [\"12\"]}}",
             200);
 
     String searchResultStr =
         "[{\"products\": {\"electronics\": { \"Pixel_3a\": {\"model\": \"3a\"}}}}, {\"products\": {\"electronics\": { \"iPhone_11\": {\"model\": \"11\"}}}}]";
-    assertThat(objectMapper.readTree(r))
-        .isEqualTo(wrapResponse(objectMapper.readTree(searchResultStr), "cool-search-id", null));
+    assertThat(OBJECT_MAPPER.readTree(r))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree(searchResultStr), "cool-search-id", null));
 
     // NIN with int
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$nin\": [600, 900]}}",
+            collectionPath + "/cool-search-id?where={\"products.*.*.price\": {\"$nin\": [600, 900]}}",
             200);
 
     searchResultStr =
         "[{\"products\": {\"food\": { \"Apple\": {\"price\": 0.99}}}}, {\"products\": {\"food\": { \"Pear\": {\"price\": 0.89}}}}]";
-    assertThat(objectMapper.readTree(r))
-        .isEqualTo(wrapResponse(objectMapper.readTree(searchResultStr), "cool-search-id", null));
+    assertThat(OBJECT_MAPPER.readTree(r))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree(searchResultStr), "cool-search-id", null));
 
     // NIN with double
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.*.*.price\": {\"$nin\": [0.99, 0.89]}}",
+            collectionPath + "/cool-search-id?where={\"products.*.*.price\": {\"$nin\": [0.99, 0.89]}}",
             200);
 
     searchResultStr =
         "[{\"products\": {\"electronics\": { \"Pixel_3a\": {\"price\": 600}}}}, {\"products\": {\"electronics\": { \"iPhone_11\": {\"price\": 900}}}}]";
-    assertThat(objectMapper.readTree(r))
-        .isEqualTo(wrapResponse(objectMapper.readTree(searchResultStr), "cool-search-id", null));
+    assertThat(OBJECT_MAPPER.readTree(r))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree(searchResultStr), "cool-search-id", null));
 
     // NIN with null
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.*.*.sku\": {\"$nin\": [null]}}",
+            collectionPath + "/cool-search-id?where={\"products.*.*.sku\": {\"$nin\": [null]}}",
             200);
 
     searchResultStr = "[{\"products\": {\"food\": { \"Apple\": {\"sku\": \"100100010101001\"}}}}]";
-    assertThat(objectMapper.readTree(r))
-        .isEqualTo(wrapResponse(objectMapper.readTree(searchResultStr), "cool-search-id", null));
+    assertThat(OBJECT_MAPPER.readTree(r))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree(searchResultStr), "cool-search-id", null));
   }
 
   @Test
   public void testFilterCombos() throws IOException {
     JsonNode fullObj =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/cool-search-id",
+        collectionPath + "/cool-search-id",
         fullObj.toString(),
         200);
 
@@ -1823,49 +1710,37 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     String r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$nin\": [\"11\"], \"$gt\": \"\"}}",
+            collectionPath + "/cool-search-id?where={\"products.electronics.*.model\": {\"$nin\": [\"11\"], \"$gt\": \"\"}}",
             200);
 
     String searchResultStr =
         "[{\"products\": {\"electronics\": { \"Pixel_3a\": {\"model\": \"3a\"}}}}]";
-    assertThat(objectMapper.readTree(r))
-        .isEqualTo(wrapResponse(objectMapper.readTree(searchResultStr), "cool-search-id", null));
+    assertThat(OBJECT_MAPPER.readTree(r))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree(searchResultStr), "cool-search-id", null));
 
     // IN (limited support) with NE (limited support)
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.electronics.*.model\": {\"$in\": [\"11\", \"3a\"], \"$ne\": \"11\"}}",
+            collectionPath + "/cool-search-id?where={\"products.electronics.*.model\": {\"$in\": [\"11\", \"3a\"], \"$ne\": \"11\"}}",
             200);
 
     searchResultStr = "[{\"products\": {\"electronics\": { \"Pixel_3a\": {\"model\": \"3a\"}}}}]";
-    assertThat(objectMapper.readTree(r))
-        .isEqualTo(wrapResponse(objectMapper.readTree(searchResultStr), "cool-search-id", null));
+    assertThat(OBJECT_MAPPER.readTree(r))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree(searchResultStr), "cool-search-id", null));
   }
 
   @Test
   public void testInvalidSearch() throws IOException {
     RestUtils.get(
         authToken,
-        hostWithPort
-            + "/v2/namespaces/"
-            + KEYSPACE
-            + "/collections/collection/cool-search-id?where=hello",
+            collectionPath + "/cool-search-id?where=hello",
         500);
 
     String r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where=[\"a\"]}",
+            collectionPath + "/cool-search-id?where=[\"a\"]}",
             400);
     assertThat(r)
         .isEqualTo(
@@ -1874,10 +1749,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"a\": true}}",
+            collectionPath + "/cool-search-id?where={\"a\": true}}",
             400);
     assertThat(r)
         .isEqualTo(
@@ -1886,10 +1758,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"a\": {\"$exists\": false}}}",
+            collectionPath + "/cool-search-id?where={\"a\": {\"$exists\": false}}}",
             400);
     assertThat(r)
         .isEqualTo(
@@ -1898,20 +1767,14 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"a\": {\"exists\": true}}}",
+            collectionPath + "/cool-search-id?where={\"a\": {\"exists\": true}}}",
             400);
     assertThat(r).startsWith("{\"description\":\"Invalid operator: exists, valid operators are:");
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"a\": {\"$eq\": null}}}",
+            collectionPath + "/cool-search-id?where={\"a\": {\"$eq\": null}}}",
             400);
     assertThat(r)
         .isEqualTo(
@@ -1920,10 +1783,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"a\": {\"$eq\": {}}}}",
+            collectionPath + "/cool-search-id?where={\"a\": {\"$eq\": {}}}}",
             400);
     assertThat(r)
         .isEqualTo(
@@ -1932,10 +1792,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"a\": {\"$eq\": []}}}",
+            collectionPath + "/cool-search-id?where={\"a\": {\"$eq\": []}}}",
             400);
     assertThat(r)
         .isEqualTo(
@@ -1944,10 +1801,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"a\": {\"$in\": 2}}}",
+            collectionPath + "/cool-search-id?where={\"a\": {\"$in\": 2}}}",
             400);
     assertThat(r)
         .isEqualTo(
@@ -1956,10 +1810,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"a\": {\"$eq\": 300}, \"b\": {\"$lt\": 500}}",
+            collectionPath + "/cool-search-id?where={\"a\": {\"$eq\": 300}, \"b\": {\"$lt\": 500}}",
             400);
     assertThat(r)
         .contains("{\"description\":\"Conditions across multiple fields are not yet supported");
@@ -1967,10 +1818,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"a\": {\"$in\": [1]}}&fields=[\"b\"]",
+            collectionPath + "/cool-search-id?where={\"a\": {\"$in\": [1]}}&fields=[\"b\"]",
             400);
     assertThat(r)
         .contains(
@@ -1979,10 +1827,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?fields=[\"b\"]",
+            collectionPath + "/cool-search-id?fields=[\"b\"]",
             400);
     assertThat(r)
         .contains(
@@ -1992,10 +1837,10 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   @Test
   public void testMultiSearch() throws IOException {
     JsonNode fullObj =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/cool-search-id",
+        collectionPath + "/cool-search-id",
         fullObj.toString(),
         200);
 
@@ -2003,77 +1848,62 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     String r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"products.food.Orange.info.price\": {\"$gt\": 600, \"$lt\": 600.05}}&raw=true",
+            collectionPath + "/cool-search-id?where={\"products.food.Orange.info.price\": {\"$gt\": 600, \"$lt\": 600.05}}&raw=true",
             200);
 
     String searchResultStr =
         "[{\"products\": {\"food\": {\"Orange\": {\"info\": {\"price\": 600.01}}}}}]";
-    assertThat(objectMapper.readTree(r)).isEqualTo(objectMapper.readTree(searchResultStr));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(searchResultStr));
 
     // Array paths
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"quiz.maths.q1.options.[0]\": {\"$lt\": 13.3}}&raw=true",
+            collectionPath + "/cool-search-id?where={\"quiz.maths.q1.options.[0]\": {\"$lt\": 13.3}}&raw=true",
             200);
     searchResultStr = "[{\"quiz\":{\"maths\":{\"q1\":{\"options\":{\"[0]\":10.2}}}}}]";
-    assertThat(objectMapper.readTree(r)).isEqualTo(objectMapper.readTree(searchResultStr));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(searchResultStr));
 
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"quiz.nests.q2.options.*.this.that.them\": {\"$eq\": false}}&raw=true",
+            collectionPath + "/cool-search-id?where={\"quiz.nests.q2.options.*.this.that.them\": {\"$eq\": false}}&raw=true",
             200);
     searchResultStr =
         "[{\"quiz\":{\"nests\":{\"q2\":{\"options\":{\"[3]\":{\"this\":{\"that\":{\"them\":false}}}}}}}}]";
-    assertThat(objectMapper.readTree(r)).isEqualTo(objectMapper.readTree(searchResultStr));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(searchResultStr));
 
     // Multi-path
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"quiz.nests.q1,q2.options.[0]\": {\"$eq\": \"nest\"}}&raw=true",
+            collectionPath + "/cool-search-id?where={\"quiz.nests.q1,q2.options.[0]\": {\"$eq\": \"nest\"}}&raw=true",
             200);
     searchResultStr =
         "["
             + "{\"quiz\":{\"nests\":{\"q1\":{\"options\":{\"[0]\":\"nest\"}}}}},"
             + "{\"quiz\":{\"nests\":{\"q2\":{\"options\":{\"[0]\":\"nest\"}}}}}"
             + "]";
-    assertThat(objectMapper.readTree(r)).isEqualTo(objectMapper.readTree(searchResultStr));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(searchResultStr));
 
     // Multi-path...and glob?!?
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"quiz.nests.q2,q3.options.*.this.them\": {\"$eq\": false}}&raw=true",
+            collectionPath + "/cool-search-id?where={\"quiz.nests.q2,q3.options.*.this.them\": {\"$eq\": false}}&raw=true",
             200);
     searchResultStr =
         "[{\"quiz\":{\"nests\":{\"q3\":{\"options\":{\"[2]\":{\"this\":{\"them\":false}}}}}}}]";
-    assertThat(objectMapper.readTree(r)).isEqualTo(objectMapper.readTree(searchResultStr));
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(searchResultStr));
   }
 
   @Test
   public void testPaginationSingleDocSearch() throws IOException {
     JsonNode fullObj =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("longSearch.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("longSearch.json"));
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/cool-search-id",
+        collectionPath + "/cool-search-id",
         fullObj.toString(),
         200);
 
@@ -2081,12 +1911,9 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     String r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?page-size=20&where={\"*.value\": {\"$gt\": 0}}",
+            collectionPath + "/cool-search-id?page-size=20&where={\"*.value\": {\"$gt\": 0}}",
             200);
-    JsonNode responseBody1 = objectMapper.readTree(r);
+    JsonNode responseBody1 = OBJECT_MAPPER.readTree(r);
 
     assertThat(responseBody1.requiredAt("/data").size()).isEqualTo(20);
     String pageState = responseBody1.requiredAt("/pageState").requireNonNull().asText();
@@ -2094,13 +1921,10 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?page-size=20&where={\"*.value\": {\"$gt\": 0}}&page-state="
+            collectionPath + "/cool-search-id?page-size=20&where={\"*.value\": {\"$gt\": 0}}&page-state="
                 + URLEncoder.encode(pageState, "UTF-8"),
             200);
-    JsonNode responseBody2 = objectMapper.readTree(r);
+    JsonNode responseBody2 = OBJECT_MAPPER.readTree(r);
 
     assertThat(responseBody2.requiredAt("/data").size()).isEqualTo(20);
 
@@ -2118,12 +1942,9 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"*.value\": {\"$gt\": 1}}&page-size=10",
+            collectionPath + "/cool-search-id?where={\"*.value\": {\"$gt\": 1}}&page-size=10",
             200);
-    responseBody1 = objectMapper.readTree(r);
+    responseBody1 = OBJECT_MAPPER.readTree(r);
 
     assertThat(responseBody1.requiredAt("/data").size()).isEqualTo(10);
     pageState = responseBody1.requiredAt("/pageState").requireNonNull().asText();
@@ -2131,13 +1952,10 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/cool-search-id?where={\"*.value\": {\"$gt\": 1}}&page-size=10&page-state="
+            collectionPath + "/cool-search-id?where={\"*.value\": {\"$gt\": 1}}&page-size=10&page-state="
                 + URLEncoder.encode(pageState, "UTF-8"),
             200);
-    responseBody2 = objectMapper.readTree(r);
+    responseBody2 = OBJECT_MAPPER.readTree(r);
 
     assertThat(responseBody2.requiredAt("/data").size()).isEqualTo(10);
 
@@ -2155,19 +1973,19 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   @Test
   public void testGetFullDocMultiFilter() throws IOException {
     JsonNode doc =
-        objectMapper.readTree(
+        OBJECT_MAPPER.readTree(
             "{\"a\": \"b\", \"c\": 2, \"quiz\": {\"sport\": {\"q1\": {\"question\": \"Which one is correct team name in NBA?\"}}}}");
     JsonNode doc2 =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
 
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         doc.toString(),
         200);
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/2",
+        collectionPath + "/2",
         doc2.toString(),
         200);
 
@@ -2176,11 +1994,11 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             authToken,
             hostWithPort
                 + "/v2/namespaces/"
-                + KEYSPACE
+                + keyspace
                 + "/collections/collection?where={\"a\":{\"$eq\":\"b\"},\"c\":{\"$lt\":3}}",
             200);
 
-    JsonNode resp = objectMapper.readTree(r);
+    JsonNode resp = OBJECT_MAPPER.readTree(r);
     JsonNode data = resp.requiredAt("/data");
     assertThat(data.requiredAt("/1")).isEqualTo(doc);
 
@@ -2189,15 +2007,15 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             authToken,
             hostWithPort
                 + "/v2/namespaces/"
-                + KEYSPACE
+                + keyspace
                 + "/collections/collection?where={\"a\":{\"$eq\":\"b\"},\"c\":{\"$lt\":0}}",
             200);
 
     // resulting JSON should be empty
-    resp = objectMapper.readTree(r);
+    resp = OBJECT_MAPPER.readTree(r);
     data = resp.requiredAt("/data");
 
-    JsonNode expected = objectMapper.createObjectNode();
+    JsonNode expected = OBJECT_MAPPER.createObjectNode();
     assertThat(data).isEqualTo(expected);
 
     r =
@@ -2205,11 +2023,11 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             authToken,
             hostWithPort
                 + "/v2/namespaces/"
-                + KEYSPACE
+                + keyspace
                 + "/collections/collection?page-size=3&where={\"quiz.sport.q1.question\":{\"$in\": [\"Which one is correct team name in NBA?\"]}}",
             200);
 
-    resp = objectMapper.readTree(r);
+    resp = OBJECT_MAPPER.readTree(r);
     data = resp.requiredAt("/data");
     assertThat(data.requiredAt("/1")).isEqualTo(doc);
     assertThat(data.requiredAt("/2")).isEqualTo(doc2);
@@ -2218,12 +2036,12 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   @Test
   public void testPaginationGetFullDoc() throws IOException {
     JsonNode doc1 =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("longSearch.json"));
-    JsonNode doc2 = objectMapper.readTree("{\"a\": \"b\"}");
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("longSearch.json"));
+    JsonNode doc2 = OBJECT_MAPPER.readTree("{\"a\": \"b\"}");
     JsonNode doc3 =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
 
-    ObjectNode docsByKey = objectMapper.createObjectNode();
+    ObjectNode docsByKey = OBJECT_MAPPER.createObjectNode();
     docsByKey.set("1", doc1);
     docsByKey.set("2", doc2);
     docsByKey.set("3", doc3);
@@ -2232,17 +2050,17 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         doc1.toString(),
         200);
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/2",
+        collectionPath + "/2",
         doc2.toString(),
         200);
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/3",
+        collectionPath + "/3",
         doc3.toString(),
         200);
 
@@ -2250,9 +2068,9 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     String r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection",
+            collectionPath,
             200);
-    JsonNode resp = objectMapper.readTree(r);
+    JsonNode resp = OBJECT_MAPPER.readTree(r);
     String pageState = resp.requiredAt("/pageState").requireNonNull().asText();
     JsonNode data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
@@ -2266,11 +2084,11 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             authToken,
             hostWithPort
                 + "/v2/namespaces/"
-                + KEYSPACE
+                + keyspace
                 + "/collections/collection?page-state="
                 + URLEncoder.encode(pageState, "UTF-8"),
             200);
-    resp = objectMapper.readTree(r);
+    resp = OBJECT_MAPPER.readTree(r);
     pageState = resp.requiredAt("/pageState").requireNonNull().asText();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
@@ -2284,11 +2102,11 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             authToken,
             hostWithPort
                 + "/v2/namespaces/"
-                + KEYSPACE
+                + keyspace
                 + "/collections/collection?page-state="
                 + URLEncoder.encode(pageState, "UTF-8"),
             200);
-    resp = objectMapper.readTree(r);
+    resp = OBJECT_MAPPER.readTree(r);
     assertThat(resp.at("/pageState").isMissingNode()).isTrue();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
@@ -2305,9 +2123,9 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection?page-size=2",
+            collectionPath + "?page-size=2",
             200);
-    resp = objectMapper.readTree(r);
+    resp = OBJECT_MAPPER.readTree(r);
     pageState = resp.requiredAt("/pageState").requireNonNull().asText();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(2);
@@ -2325,11 +2143,11 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             authToken,
             hostWithPort
                 + "/v2/namespaces/"
-                + KEYSPACE
+                + keyspace
                 + "/collections/collection?page-size=2&page-state="
                 + URLEncoder.encode(pageState, "UTF-8"),
             200);
-    resp = objectMapper.readTree(r);
+    resp = OBJECT_MAPPER.readTree(r);
     assertThat(resp.at("/pageState").isMissingNode()).isTrue();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
@@ -2347,9 +2165,9 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection?page-size=4",
+            collectionPath + "?page-size=4",
             200);
-    resp = objectMapper.readTree(r);
+    resp = OBJECT_MAPPER.readTree(r);
     assertThat(resp.at("/pageState").isMissingNode()).isTrue();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(3);
@@ -2368,12 +2186,12 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   @Test
   public void testPaginationGetFullDocWithFields() throws IOException {
     JsonNode doc1 =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("longSearch.json"));
-    JsonNode doc2 = objectMapper.readTree("{\"a\": \"b\"}");
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("longSearch.json"));
+    JsonNode doc2 = OBJECT_MAPPER.readTree("{\"a\": \"b\"}");
     JsonNode doc3 =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
 
-    ObjectNode docsByKey = objectMapper.createObjectNode();
+    ObjectNode docsByKey = OBJECT_MAPPER.createObjectNode();
     docsByKey.set("1", doc1);
     docsByKey.set("2", doc2);
     docsByKey.set("3", doc3);
@@ -2382,17 +2200,17 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         doc1.toString(),
         200);
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/2",
+        collectionPath + "/2",
         doc2.toString(),
         200);
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/3",
+        collectionPath + "/3",
         doc3.toString(),
         200);
 
@@ -2400,9 +2218,9 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     String r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection?fields=[\"a\"]",
+            collectionPath + "?fields=[\"a\"]",
             200);
-    JsonNode resp = objectMapper.readTree(r);
+    JsonNode resp = OBJECT_MAPPER.readTree(r);
     String pageState = resp.requiredAt("/pageState").requireNonNull().asText();
     JsonNode data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
@@ -2410,11 +2228,11 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     String key = data.fieldNames().next();
     if (key.equals("1")) {
       assertThat(data.requiredAt("/" + key))
-          .isEqualTo(objectMapper.readTree("{\"a\": {\"value\": 1}}"));
+          .isEqualTo(OBJECT_MAPPER.readTree("{\"a\": {\"value\": 1}}"));
     } else if (key.equals("2")) {
       assertThat(data.requiredAt("/" + key)).isEqualTo(docsByKey.requiredAt("/" + key));
     } else {
-      assertThat(data.requiredAt("/" + key)).isEqualTo(objectMapper.readTree("{}"));
+      assertThat(data.requiredAt("/" + key)).isEqualTo(OBJECT_MAPPER.readTree("{}"));
     }
 
     docsSeen.add(key);
@@ -2424,11 +2242,11 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             authToken,
             hostWithPort
                 + "/v2/namespaces/"
-                + KEYSPACE
+                + keyspace
                 + "/collections/collection?fields=[\"a\"]&page-state="
                 + URLEncoder.encode(pageState, "UTF-8"),
             200);
-    resp = objectMapper.readTree(r);
+    resp = OBJECT_MAPPER.readTree(r);
     pageState = resp.requiredAt("/pageState").requireNonNull().asText();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
@@ -2436,11 +2254,11 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     key = data.fieldNames().next();
     if (key.equals("1")) {
       assertThat(data.requiredAt("/" + key))
-          .isEqualTo(objectMapper.readTree("{\"a\": {\"value\": 1}}"));
+          .isEqualTo(OBJECT_MAPPER.readTree("{\"a\": {\"value\": 1}}"));
     } else if (key.equals("2")) {
       assertThat(data.requiredAt("/" + key)).isEqualTo(docsByKey.requiredAt("/" + key));
     } else {
-      assertThat(data.requiredAt("/" + key)).isEqualTo(objectMapper.readTree("{}"));
+      assertThat(data.requiredAt("/" + key)).isEqualTo(OBJECT_MAPPER.readTree("{}"));
     }
     docsSeen.add(key);
 
@@ -2449,11 +2267,11 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             authToken,
             hostWithPort
                 + "/v2/namespaces/"
-                + KEYSPACE
+                + keyspace
                 + "/collections/collection?fields=[\"a\"]&page-state="
                 + URLEncoder.encode(pageState, "UTF-8"),
             200);
-    resp = objectMapper.readTree(r);
+    resp = OBJECT_MAPPER.readTree(r);
     assertThat(resp.at("/pageState").isMissingNode()).isTrue();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
@@ -2461,11 +2279,11 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     key = data.fieldNames().next();
     if (key.equals("1")) {
       assertThat(data.requiredAt("/" + key))
-          .isEqualTo(objectMapper.readTree("{\"a\": {\"value\": 1}}"));
+          .isEqualTo(OBJECT_MAPPER.readTree("{\"a\": {\"value\": 1}}"));
     } else if (key.equals("2")) {
       assertThat(data.requiredAt("/" + key)).isEqualTo(docsByKey.requiredAt("/" + key));
     } else {
-      assertThat(data.requiredAt("/" + key)).isEqualTo(objectMapper.readTree("{}"));
+      assertThat(data.requiredAt("/" + key)).isEqualTo(OBJECT_MAPPER.readTree("{}"));
     }
     docsSeen.add(key);
 
@@ -2479,10 +2297,10 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             authToken,
             hostWithPort
                 + "/v2/namespaces/"
-                + KEYSPACE
+                + keyspace
                 + "/collections/collection?fields=[\"a\"]&page-size=2",
             200);
-    resp = objectMapper.readTree(r);
+    resp = OBJECT_MAPPER.readTree(r);
     pageState = resp.requiredAt("/pageState").requireNonNull().asText();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(2);
@@ -2491,21 +2309,21 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     key = fieldNames.next();
     if (key.equals("1")) {
       assertThat(data.requiredAt("/" + key))
-          .isEqualTo(objectMapper.readTree("{\"a\": {\"value\": 1}}"));
+          .isEqualTo(OBJECT_MAPPER.readTree("{\"a\": {\"value\": 1}}"));
     } else if (key.equals("2")) {
       assertThat(data.requiredAt("/" + key)).isEqualTo(docsByKey.requiredAt("/" + key));
     } else {
-      assertThat(data.requiredAt("/" + key)).isEqualTo(objectMapper.readTree("{}"));
+      assertThat(data.requiredAt("/" + key)).isEqualTo(OBJECT_MAPPER.readTree("{}"));
     }
     docsSeen.add(key);
     key = fieldNames.next();
     if (key.equals("1")) {
       assertThat(data.requiredAt("/" + key))
-          .isEqualTo(objectMapper.readTree("{\"a\": {\"value\": 1}}"));
+          .isEqualTo(OBJECT_MAPPER.readTree("{\"a\": {\"value\": 1}}"));
     } else if (key.equals("2")) {
       assertThat(data.requiredAt("/" + key)).isEqualTo(docsByKey.requiredAt("/" + key));
     } else {
-      assertThat(data.requiredAt("/" + key)).isEqualTo(objectMapper.readTree("{}"));
+      assertThat(data.requiredAt("/" + key)).isEqualTo(OBJECT_MAPPER.readTree("{}"));
     }
     docsSeen.add(key);
 
@@ -2514,11 +2332,11 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             authToken,
             hostWithPort
                 + "/v2/namespaces/"
-                + KEYSPACE
+                + keyspace
                 + "/collections/collection?fields=[\"a\"]&page-size=2&page-state="
                 + URLEncoder.encode(pageState, "UTF-8"),
             200);
-    resp = objectMapper.readTree(r);
+    resp = OBJECT_MAPPER.readTree(r);
     assertThat(resp.at("/pageState").isMissingNode()).isTrue();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
@@ -2526,11 +2344,11 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     key = data.fieldNames().next();
     if (key.equals("1")) {
       assertThat(data.requiredAt("/" + key))
-          .isEqualTo(objectMapper.readTree("{\"a\": {\"value\": 1}}"));
+          .isEqualTo(OBJECT_MAPPER.readTree("{\"a\": {\"value\": 1}}"));
     } else if (key.equals("2")) {
       assertThat(data.requiredAt("/" + key)).isEqualTo(docsByKey.requiredAt("/" + key));
     } else {
-      assertThat(data.requiredAt("/" + key)).isEqualTo(objectMapper.readTree("{}"));
+      assertThat(data.requiredAt("/" + key)).isEqualTo(OBJECT_MAPPER.readTree("{}"));
     }
     docsSeen.add(key);
 
@@ -2545,10 +2363,10 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             authToken,
             hostWithPort
                 + "/v2/namespaces/"
-                + KEYSPACE
+                + keyspace
                 + "/collections/collection?fields=[\"a\"]&page-size=4",
             200);
-    resp = objectMapper.readTree(r);
+    resp = OBJECT_MAPPER.readTree(r);
     assertThat(resp.at("/pageState").isMissingNode()).isTrue();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(3);
@@ -2558,11 +2376,11 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
       docsSeen.add(field);
       JsonNode node = data.requiredAt("/" + field);
       if (field.equals("1")) {
-        assertThat(node).isEqualTo(objectMapper.readTree("{\"a\": {\"value\": 1}}"));
+        assertThat(node).isEqualTo(OBJECT_MAPPER.readTree("{\"a\": {\"value\": 1}}"));
       } else if (field.equals("2")) {
         assertThat(node).isEqualTo(docsByKey.requiredAt("/" + field));
       } else {
-        assertThat(node).isEqualTo(objectMapper.readTree("{}"));
+        assertThat(node).isEqualTo(OBJECT_MAPPER.readTree("{}"));
       }
     }
 
@@ -2573,11 +2391,11 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   @Test
   public void testSearchFullDocWithNestedFields() throws IOException {
     JsonNode doc1 =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("longSearch.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("longSearch.json"));
 
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         doc1.toString(),
         200);
 
@@ -2586,30 +2404,30 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             authToken,
             hostWithPort
                 + "/v2/namespaces/"
-                + KEYSPACE
+                + keyspace
                 + "/collections/collection?fields=[\"a.value\",\"b.value\",\"bb.value\"]",
             200);
-    JsonNode resp = objectMapper.readTree(r);
+    JsonNode resp = OBJECT_MAPPER.readTree(r);
     JsonNode data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
 
     assertThat(data.requiredAt("/1"))
         .isEqualTo(
-            objectMapper.readTree(
+            OBJECT_MAPPER.readTree(
                 "{\"a\": {\"value\": 1},\"b\": {\"value\": 2}, \"bb\": {\"value\": 4}}"));
   }
 
   @Test
   public void testPaginationFilterDocWithFields() throws IOException {
     JsonNode doc1 =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("longSearch.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("longSearch.json"));
     JsonNode doc2 =
-        objectMapper.readTree(
+        OBJECT_MAPPER.readTree(
             "{\"a\": \"b\", \"quiz\": {\"sport\": {\"q1\": {\"question\": \"hello?\"}}}}");
     JsonNode doc3 =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("example.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
 
-    ObjectNode docsByKey = objectMapper.createObjectNode();
+    ObjectNode docsByKey = OBJECT_MAPPER.createObjectNode();
     docsByKey.set("1", doc1);
     docsByKey.set("2", doc2);
     docsByKey.set("3", doc3);
@@ -2618,17 +2436,17 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         doc1.toString(),
         200);
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/2",
+        collectionPath + "/2",
         doc2.toString(),
         200);
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/3",
+        collectionPath + "/3",
         doc3.toString(),
         200);
 
@@ -2638,10 +2456,10 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             authToken,
             hostWithPort
                 + "/v2/namespaces/"
-                + KEYSPACE
+                + keyspace
                 + "/collections/collection?where={\"b.value\": {\"$eq\": 2}}&fields=[\"a\"]",
             200);
-    JsonNode resp = objectMapper.readTree(r);
+    JsonNode resp = OBJECT_MAPPER.readTree(r);
     assertThat(resp.at("/pageState").isMissingNode()).isTrue();
     JsonNode data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
@@ -2649,7 +2467,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     String key = data.fieldNames().next();
     assertThat(key).isEqualTo("1");
     assertThat(data.requiredAt("/" + key))
-        .isEqualTo(objectMapper.readTree("{\"a\": {\"value\": 1}}"));
+        .isEqualTo(OBJECT_MAPPER.readTree("{\"a\": {\"value\": 1}}"));
 
     // Return all documents where quiz.sport.q1.question exists, but only the `quiz` field on each
     // doc
@@ -2658,10 +2476,10 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             authToken,
             hostWithPort
                 + "/v2/namespaces/"
-                + KEYSPACE
+                + keyspace
                 + "/collections/collection?where={\"quiz.sport.q1.question\": {\"$exists\": true}}&fields=[\"quiz\"]",
             200);
-    resp = objectMapper.readTree(r);
+    resp = OBJECT_MAPPER.readTree(r);
     String pageState = resp.requiredAt("/pageState").requireNonNull().asText();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
@@ -2670,10 +2488,10 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     if (key.equals("2")) {
       assertThat(data.requiredAt("/" + key))
           .isEqualTo(
-              objectMapper.readTree(
+              OBJECT_MAPPER.readTree(
                   "{\"quiz\": {\"sport\": {\"q1\": {\"question\": \"hello?\"}}}}"));
     } else {
-      ObjectNode expected = objectMapper.createObjectNode();
+      ObjectNode expected = OBJECT_MAPPER.createObjectNode();
       expected.set("quiz", doc3.requiredAt("/quiz"));
       assertThat(data.requiredAt("/" + key)).isEqualTo(expected);
     }
@@ -2684,11 +2502,11 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             authToken,
             hostWithPort
                 + "/v2/namespaces/"
-                + KEYSPACE
+                + keyspace
                 + "/collections/collection?where={\"quiz.sport.q1.question\": {\"$exists\": true}}&fields=[\"quiz\"]&page-state="
                 + URLEncoder.encode(pageState, "UTF-8"),
             200);
-    resp = objectMapper.readTree(r);
+    resp = OBJECT_MAPPER.readTree(r);
     assertThat(resp.at("/pageState").isMissingNode()).isTrue();
     data = resp.requiredAt("/data");
     assertThat(data.size()).isEqualTo(1);
@@ -2696,10 +2514,10 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     if (docsSeen.contains("3")) {
       assertThat(data.requiredAt("/" + key))
           .isEqualTo(
-              objectMapper.readTree(
+              OBJECT_MAPPER.readTree(
                   "{\"quiz\": {\"sport\": {\"q1\": {\"question\": \"hello?\"}}}}"));
     } else if (docsSeen.contains("2")) {
-      ObjectNode expected = objectMapper.createObjectNode();
+      ObjectNode expected = OBJECT_MAPPER.createObjectNode();
       expected.set("quiz", doc3.requiredAt("/quiz"));
       assertThat(data.requiredAt("/" + key)).isEqualTo(expected);
     }
@@ -2713,7 +2531,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     String r =
         RestUtils.get(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection?page-size=21",
+            collectionPath + "?page-size=21",
             400);
     assertThat(r)
         .isEqualTo(
@@ -2723,20 +2541,17 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   @Test
   public void testPaginationDisallowedLimitedSupport() throws IOException {
     JsonNode doc1 =
-        objectMapper.readTree(this.getClass().getClassLoader().getResource("longSearch.json"));
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("longSearch.json"));
     RestUtils.put(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections/collection/1",
+        collectionPath + "/1",
         doc1.toString(),
         200);
 
     String r =
         RestUtils.get(
             authToken,
-            hostWithPort
-                + "/v2/namespaces/"
-                + KEYSPACE
-                + "/collections/collection/1?where={\"*.value\":{\"$nin\": [3]}}&page-size=5",
+            collectionPath + "/1?where={\"*.value\":{\"$nin\": [3]}}&page-size=5",
             400);
     assertThat(r)
         .isEqualTo(
@@ -2750,9 +2565,9 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
         RestUtils.get(
             authToken, String.format("%s:8082/v2/schemas/namespaces", host), HttpStatus.SC_OK);
 
-    ResponseWrapper response = objectMapper.readValue(body, ResponseWrapper.class);
+    ResponseWrapper response = OBJECT_MAPPER.readValue(body, ResponseWrapper.class);
     List<Keyspace> keyspaces =
-        objectMapper.convertValue(response.getData(), new TypeReference<List<Keyspace>>() {});
+        OBJECT_MAPPER.convertValue(response.getData(), new TypeReference<List<Keyspace>>() {});
     assertThat(keyspaces)
         .anySatisfy(
             value ->
@@ -2779,7 +2594,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             String.format("%s:8082/v2/schemas/namespaces?raw=true", host),
             HttpStatus.SC_OK);
 
-    List<Keyspace> keyspaces = objectMapper.readValue(body, new TypeReference<List<Keyspace>>() {});
+    List<Keyspace> keyspaces = OBJECT_MAPPER.readValue(body, new TypeReference<List<Keyspace>>() {});
     assertThat(keyspaces)
         .anySatisfy(
             value ->
@@ -2795,8 +2610,8 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             String.format("%s:8082/v2/schemas/namespaces/system", host),
             HttpStatus.SC_OK);
 
-    ResponseWrapper response = objectMapper.readValue(body, ResponseWrapper.class);
-    Keyspace keyspace = objectMapper.convertValue(response.getData(), Keyspace.class);
+    ResponseWrapper response = OBJECT_MAPPER.readValue(body, ResponseWrapper.class);
+    Keyspace keyspace = OBJECT_MAPPER.convertValue(response.getData(), Keyspace.class);
 
     assertThat(keyspace).isEqualToComparingFieldByField(new Keyspace("system", null));
   }
@@ -2809,7 +2624,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             String.format("%s:8082/v2/schemas/namespaces/system?raw=true", host),
             HttpStatus.SC_OK);
 
-    Keyspace keyspace = objectMapper.readValue(body, Keyspace.class);
+    Keyspace keyspace = OBJECT_MAPPER.readValue(body, Keyspace.class);
 
     assertThat(keyspace).isEqualToComparingFieldByField(new Keyspace("system", null));
   }
@@ -2833,7 +2648,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             String.format("%s:8082/v2/schemas/namespaces/%s?raw=true", host, keyspaceName),
             HttpStatus.SC_OK);
 
-    Keyspace keyspace = objectMapper.readValue(body, Keyspace.class);
+    Keyspace keyspace = OBJECT_MAPPER.readValue(body, Keyspace.class);
 
     assertThat(keyspace).isEqualToComparingFieldByField(new Keyspace(keyspaceName, null));
   }
@@ -2865,7 +2680,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     RestUtils.post(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections",
+        hostWithPort + "/v2/namespaces/" + keyspace + "/collections",
         "{\"name\" : \"" + tableName + "\"}",
         201);
   }
@@ -2877,14 +2692,14 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     RestUtils.post(
         authToken,
-        hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections",
+        hostWithPort + "/v2/namespaces/" + keyspace + "/collections",
         "{\"name\" : \"" + tableName + "\"}",
         201);
 
     String response =
         RestUtils.post(
             authToken,
-            hostWithPort + "/v2/namespaces/" + KEYSPACE + "/collections",
+            hostWithPort + "/v2/namespaces/" + keyspace + "/collections",
             "{\"name\" : \"" + tableName + "\"}",
             409);
 
@@ -2896,7 +2711,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   }
 
   private JsonNode wrapResponse(JsonNode node, String id, String pagingState) {
-    ObjectNode wrapperNode = objectMapper.createObjectNode();
+    ObjectNode wrapperNode = OBJECT_MAPPER.createObjectNode();
 
     if (id != null) {
       wrapperNode.set("documentId", TextNode.valueOf(id));


### PR DESCRIPTION
So the speed-up for my machine is from ~10min to ~40sec:

* used `@ExtendWith(CqlSessionExtension.class) & @CqlSessionSpec()` to create sessions and keyspace only once
* fixed the keyspace name to constant
* in after test, don't drop the keyspace, but truncate the `collection` table (not sure if there is any other table created, I guess not)
* don't get auth token if we already have it..

Fun fact: `10 PRs checks a day x 3 builds x 260 working days x 9 mins savings = 4,212,000 seconds saved or ~$1322 a year for n1-highcpu-32 machine` :smile: 