### PR TITLE
Prevent "USE <keyspace>" requests

### DIFF
--- a/grpc/src/main/java/io/stargate/grpc/service/Service.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/Service.java
@@ -227,6 +227,7 @@ public class Service extends io.stargate.proto.StargateGrpc.StargateImplBase {
                     Result.Builder resultBuilder = makeResultBuilder(result);
                     switch (result.kind) {
                       case Void:
+                      case SchemaChange: // Fallthrough intended
                         break;
                       case Rows:
                         Rows rows = (Rows) result;
@@ -240,14 +241,8 @@ public class Service extends io.stargate.proto.StargateGrpc.StargateImplBase {
                               handler.processResult((Rows) result, parameters));
                         }
                         break;
-                      case SchemaChange:
-                        // TODO: Wait for schema agreement, etc. Could this be made async? This is
-                        // blocking the gRPC thread.
-                        persistence.waitForSchemaAgreement();
-                        break;
                       case SetKeyspace:
-                        // TODO: Prevent "USE <keyspace>" from happening
-                        throw Status.INTERNAL
+                        throw Status.INVALID_ARGUMENT
                             .withDescription("USE <keyspace> not supported")
                             .asException();
                       default:


### PR DESCRIPTION
Because we create a new `ClientInfo` and `QueryState` on every request
it's okay to just allow the query then return an error when a set
keyspace result type is detected. The keyspace state will not persist
between requests.