### PR TITLE
GraphQL: pass all fetcher dependencies through environment.getContext() (fixes #945)

### DIFF
--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/SchemaFactory.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/SchemaFactory.java
@@ -16,8 +16,6 @@
 package io.stargate.graphql.schema.cqlfirst;
 
 import graphql.schema.GraphQLSchema;
-import io.stargate.auth.AuthorizationService;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.schema.Keyspace;
 import io.stargate.graphql.schema.cqlfirst.ddl.DdlSchemaBuilder;
 import io.stargate.graphql.schema.cqlfirst.dml.DmlSchemaBuilder;
@@ -30,11 +28,8 @@ public class SchemaFactory {
    *
    * <p>This is the API exposed at {@code /graphql/<keyspaceName>}.
    */
-  public static GraphQLSchema newDmlSchema(
-      AuthorizationService authorizationService,
-      Keyspace keyspace,
-      DataStoreFactory dataStoreFactory) {
-    return new DmlSchemaBuilder(authorizationService, keyspace, dataStoreFactory).build();
+  public static GraphQLSchema newDmlSchema(Keyspace keyspace) {
+    return new DmlSchemaBuilder(keyspace).build();
   }
 
   /**
@@ -43,8 +38,7 @@ public class SchemaFactory {
    *
    * <p>This is the API exposed at {@code /graphql-schema}.
    */
-  public static GraphQLSchema newDdlSchema(
-      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
-    return new DdlSchemaBuilder(authorizationService, dataStoreFactory).build();
+  public static GraphQLSchema newDdlSchema() {
+    return new DdlSchemaBuilder().build();
   }
 }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/DdlSchemaBuilder.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/DdlSchemaBuilder.java
@@ -30,8 +30,6 @@ import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLTypeReference;
-import io.stargate.auth.AuthorizationService;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.graphql.schema.cqlfirst.ddl.fetchers.AllKeyspacesFetcher;
 import io.stargate.graphql.schema.cqlfirst.ddl.fetchers.AlterTableAddFetcher;
 import io.stargate.graphql.schema.cqlfirst.ddl.fetchers.AlterTableDropFetcher;
@@ -49,14 +47,9 @@ import java.util.HashMap;
 public class DdlSchemaBuilder {
 
   private final HashMap<String, GraphQLType> objects;
-  private final DataStoreFactory dataStoreFactory;
-  private final AuthorizationService authorizationService;
 
-  public DdlSchemaBuilder(
-      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
-    this.dataStoreFactory = dataStoreFactory;
+  public DdlSchemaBuilder() {
     this.objects = new HashMap<>();
-    this.authorizationService = authorizationService;
   }
 
   public GraphQLSchema build() {
@@ -87,7 +80,7 @@ public class DdlSchemaBuilder {
         .argument(
             GraphQLArgument.newArgument().name("toAdd").type(nonNull(list(buildColumnInput()))))
         .type(Scalars.GraphQLBoolean)
-        .dataFetcher(new AlterTableAddFetcher(authorizationService, dataStoreFactory))
+        .dataFetcher(new AlterTableAddFetcher())
         .build();
   }
 
@@ -101,7 +94,7 @@ public class DdlSchemaBuilder {
         .argument(
             GraphQLArgument.newArgument().name("toDrop").type(nonNull(list(Scalars.GraphQLString))))
         .type(Scalars.GraphQLBoolean)
-        .dataFetcher(new AlterTableDropFetcher(authorizationService, dataStoreFactory))
+        .dataFetcher(new AlterTableDropFetcher())
         .build();
   }
 
@@ -114,7 +107,7 @@ public class DdlSchemaBuilder {
             GraphQLArgument.newArgument().name("tableName").type(nonNull(Scalars.GraphQLString)))
         .argument(GraphQLArgument.newArgument().name("ifExists").type(Scalars.GraphQLBoolean))
         .type(Scalars.GraphQLBoolean)
-        .dataFetcher(new DropTableFetcher(authorizationService, dataStoreFactory))
+        .dataFetcher(new DropTableFetcher())
         .build();
   }
 
@@ -129,7 +122,7 @@ public class DdlSchemaBuilder {
             GraphQLArgument.newArgument().name("fields").type(nonNull(list(buildColumnInput()))))
         .argument(GraphQLArgument.newArgument().name("ifNotExists").type(Scalars.GraphQLBoolean))
         .type(Scalars.GraphQLBoolean)
-        .dataFetcher(new CreateTypeFetcher(authorizationService, dataStoreFactory))
+        .dataFetcher(new CreateTypeFetcher())
         .build();
   }
 
@@ -142,7 +135,7 @@ public class DdlSchemaBuilder {
             GraphQLArgument.newArgument().name("typeName").type(nonNull(Scalars.GraphQLString)))
         .argument(GraphQLArgument.newArgument().name("ifExists").type(Scalars.GraphQLBoolean))
         .type(Scalars.GraphQLBoolean)
-        .dataFetcher(new DropTypeFetcher(authorizationService, dataStoreFactory))
+        .dataFetcher(new DropTypeFetcher())
         .build();
   }
 
@@ -179,7 +172,7 @@ public class DdlSchemaBuilder {
                         + "You must specify either this or 'replicas', but not both.")
                 .build())
         .type(Scalars.GraphQLBoolean)
-        .dataFetcher(new CreateKeyspaceFetcher(authorizationService, dataStoreFactory))
+        .dataFetcher(new CreateKeyspaceFetcher())
         .build();
   }
 
@@ -200,7 +193,7 @@ public class DdlSchemaBuilder {
                     "Whether the operation will succeed if the keyspace does not exist. "
                         + "Defaults to false if absent."))
         .type(Scalars.GraphQLBoolean)
-        .dataFetcher(new DropKeyspaceFetcher(authorizationService, dataStoreFactory))
+        .dataFetcher(new DropKeyspaceFetcher())
         .build();
   }
 
@@ -217,7 +210,7 @@ public class DdlSchemaBuilder {
         .name("keyspace")
         .argument(GraphQLArgument.newArgument().name("name").type(nonNull(Scalars.GraphQLString)))
         .type(buildKeyspace())
-        .dataFetcher(new SingleKeyspaceFetcher(authorizationService, dataStoreFactory))
+        .dataFetcher(new SingleKeyspaceFetcher())
         .build();
   }
 
@@ -405,7 +398,7 @@ public class DdlSchemaBuilder {
     return GraphQLFieldDefinition.newFieldDefinition()
         .name("keyspaces")
         .type(list(buildKeyspace()))
-        .dataFetcher(new AllKeyspacesFetcher(authorizationService, dataStoreFactory))
+        .dataFetcher(new AllKeyspacesFetcher())
         .build();
   }
 
@@ -435,7 +428,7 @@ public class DdlSchemaBuilder {
         .argument(GraphQLArgument.newArgument().name("values").type(list(buildColumnInput())))
         .argument(GraphQLArgument.newArgument().name("ifNotExists").type(Scalars.GraphQLBoolean))
         .type(Scalars.GraphQLBoolean)
-        .dataFetcher(new CreateTableFetcher(authorizationService, dataStoreFactory))
+        .dataFetcher(new CreateTableFetcher())
         .build();
   }
 
@@ -467,7 +460,7 @@ public class DdlSchemaBuilder {
                         + " FULL (full index of a frozen collection)")
                 .type(buildIndexKind()))
         .type(Scalars.GraphQLBoolean)
-        .dataFetcher(new CreateIndexFetcher(authorizationService, dataStoreFactory))
+        .dataFetcher(new CreateIndexFetcher())
         .build();
   }
 
@@ -480,7 +473,7 @@ public class DdlSchemaBuilder {
             GraphQLArgument.newArgument().name("indexName").type(nonNull(Scalars.GraphQLString)))
         .argument(GraphQLArgument.newArgument().name("ifExists").type(Scalars.GraphQLBoolean))
         .type(Scalars.GraphQLBoolean)
-        .dataFetcher(new DropIndexFetcher(authorizationService, dataStoreFactory))
+        .dataFetcher(new DropIndexFetcher())
         .build();
   }
 

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/AlterTableAddFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/AlterTableAddFetcher.java
@@ -16,8 +16,6 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthorizationService;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.query.Query;
 import io.stargate.db.query.builder.QueryBuilder;
 import io.stargate.db.schema.Column.Kind;
@@ -26,18 +24,13 @@ import java.util.Map;
 
 public class AlterTableAddFetcher extends TableFetcher {
 
-  public AlterTableAddFetcher(
-      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
-    super(authorizationService, dataStoreFactory);
-  }
-
   @Override
   protected Query<?> buildQuery(
-      DataFetchingEnvironment dataFetchingEnvironment,
+      DataFetchingEnvironment environment,
       QueryBuilder builder,
       String keyspaceName,
       String tableName) {
-    List<Map<String, Object>> toAdd = dataFetchingEnvironment.getArgument("toAdd");
+    List<Map<String, Object>> toAdd = environment.getArgument("toAdd");
     if (toAdd.isEmpty()) {
       // TODO see if we can enforce that through the schema instead
       throw new IllegalArgumentException("toAdd must contain at least one element");

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/AlterTableDropFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/AlterTableDropFetcher.java
@@ -16,26 +16,19 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthorizationService;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.query.Query;
 import io.stargate.db.query.builder.QueryBuilder;
 import java.util.List;
 
 public class AlterTableDropFetcher extends TableFetcher {
 
-  public AlterTableDropFetcher(
-      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
-    super(authorizationService, dataStoreFactory);
-  }
-
   @Override
   protected Query<?> buildQuery(
-      DataFetchingEnvironment dataFetchingEnvironment,
+      DataFetchingEnvironment environment,
       QueryBuilder builder,
       String keyspaceName,
       String tableName) {
-    List<String> toDrop = dataFetchingEnvironment.getArgument("toDrop");
+    List<String> toDrop = environment.getArgument("toDrop");
     if (toDrop.isEmpty()) {
       // TODO see if we can enforce that through the schema instead
       throw new IllegalArgumentException("toDrop must contain at least one element");

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/CreateIndexFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/CreateIndexFetcher.java
@@ -16,35 +16,31 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.query.Query;
 import io.stargate.db.query.builder.QueryBuilder;
 import io.stargate.db.schema.CollectionIndexingType;
 import io.stargate.db.schema.ImmutableCollectionIndexingType;
 
 public class CreateIndexFetcher extends IndexFetcher {
-  public CreateIndexFetcher(
-      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
-    super(authorizationService, dataStoreFactory, Scope.CREATE);
+  public CreateIndexFetcher() {
+    super(Scope.CREATE);
   }
 
   @Override
   protected Query<?> buildQuery(
-      DataFetchingEnvironment dataFetchingEnvironment,
+      DataFetchingEnvironment environment,
       QueryBuilder builder,
       String keyspaceName,
       String tableName) {
-    String columnName = dataFetchingEnvironment.getArgument("columnName");
+    String columnName = environment.getArgument("columnName");
 
-    String indexName = dataFetchingEnvironment.getArgument("indexName");
+    String indexName = environment.getArgument("indexName");
 
-    boolean ifNotExists =
-        dataFetchingEnvironment.getArgumentOrDefault("ifNotExists", Boolean.FALSE);
-    String customIndexClass = dataFetchingEnvironment.getArgumentOrDefault("indexType", null);
+    boolean ifNotExists = environment.getArgumentOrDefault("ifNotExists", Boolean.FALSE);
+    String customIndexClass = environment.getArgumentOrDefault("indexType", null);
 
-    String indexKind = dataFetchingEnvironment.getArgumentOrDefault("indexKind", null);
+    String indexKind = environment.getArgumentOrDefault("indexKind", null);
     boolean indexKeys = false;
     boolean indexEntries = false;
     boolean indexValues = false;

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/CreateKeyspaceFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/CreateKeyspaceFetcher.java
@@ -16,47 +16,39 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationSubject;
-import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.UnauthorizedException;
 import io.stargate.auth.entity.ResourceKind;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.query.Query;
 import io.stargate.db.query.builder.QueryBuilder;
 import io.stargate.db.query.builder.Replication;
+import io.stargate.graphql.web.StargateGraphqlContext;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class CreateKeyspaceFetcher extends DdlQueryFetcher {
 
-  public CreateKeyspaceFetcher(
-      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
-    super(authorizationService, dataStoreFactory);
-  }
-
   @Override
   protected Query<?> buildQuery(
-      DataFetchingEnvironment dataFetchingEnvironment,
-      QueryBuilder builder,
-      AuthenticationSubject authenticationSubject)
+      DataFetchingEnvironment environment, QueryBuilder builder, StargateGraphqlContext context)
       throws UnauthorizedException {
-    String keyspaceName = dataFetchingEnvironment.getArgument("name");
+    String keyspaceName = environment.getArgument("name");
 
-    authorizationService.authorizeSchemaWrite(
-        authenticationSubject,
-        keyspaceName,
-        null,
-        Scope.CREATE,
-        SourceAPI.GRAPHQL,
-        ResourceKind.KEYSPACE);
+    context
+        .getAuthorizationService()
+        .authorizeSchemaWrite(
+            context.getSubject(),
+            keyspaceName,
+            null,
+            Scope.CREATE,
+            SourceAPI.GRAPHQL,
+            ResourceKind.KEYSPACE);
 
-    boolean ifNotExists =
-        dataFetchingEnvironment.getArgumentOrDefault("ifNotExists", Boolean.FALSE);
-    Integer replicas = dataFetchingEnvironment.getArgument("replicas");
-    List<Map<String, Object>> datacenters = dataFetchingEnvironment.getArgument("datacenters");
+    boolean ifNotExists = environment.getArgumentOrDefault("ifNotExists", Boolean.FALSE);
+    Integer replicas = environment.getArgument("replicas");
+    List<Map<String, Object>> datacenters = environment.getArgument("datacenters");
     if (replicas == null && datacenters == null) {
       throw new IllegalArgumentException("You must specify either replicas or datacenters");
     }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/CreateTableFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/CreateTableFetcher.java
@@ -16,8 +16,6 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthorizationService;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.query.Query;
 import io.stargate.db.query.builder.QueryBuilder;
 import io.stargate.db.schema.Column;
@@ -27,26 +25,20 @@ import java.util.Map;
 
 public class CreateTableFetcher extends TableFetcher {
 
-  public CreateTableFetcher(
-      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
-    super(authorizationService, dataStoreFactory);
-  }
-
   @Override
   protected Query<?> buildQuery(
-      DataFetchingEnvironment dataFetchingEnvironment,
+      DataFetchingEnvironment environment,
       QueryBuilder builder,
       String keyspaceName,
       String tableName) {
-    Boolean ifNotExists = dataFetchingEnvironment.getArgument("ifNotExists");
-    List<Map<String, Object>> partitionKeys = dataFetchingEnvironment.getArgument("partitionKeys");
+    Boolean ifNotExists = environment.getArgument("ifNotExists");
+    List<Map<String, Object>> partitionKeys = environment.getArgument("partitionKeys");
     if (partitionKeys.isEmpty()) {
       // TODO see if we can enforce that through the schema instead
       throw new IllegalArgumentException("partitionKeys must contain at least one element");
     }
-    List<Map<String, Object>> clusteringKeys =
-        dataFetchingEnvironment.getArgument("clusteringKeys");
-    List<Map<String, Object>> values = dataFetchingEnvironment.getArgument("values");
+    List<Map<String, Object>> clusteringKeys = environment.getArgument("clusteringKeys");
+    List<Map<String, Object>> values = environment.getArgument("values");
 
     List<Column> partitionKeyColumns = decodeColumns(partitionKeys, Kind.PartitionKey);
     List<Column> clusteringColumns = decodeColumns(clusteringKeys, Kind.Clustering);

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DdlQueryFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DdlQueryFetcher.java
@@ -16,11 +16,8 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationSubject;
-import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.UnauthorizedException;
 import io.stargate.db.datastore.DataStore;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.query.Query;
 import io.stargate.db.query.builder.QueryBuilder;
 import io.stargate.db.schema.Column;
@@ -30,6 +27,7 @@ import io.stargate.db.schema.Column.Order;
 import io.stargate.db.schema.Column.Type;
 import io.stargate.db.schema.UserDefinedType;
 import io.stargate.graphql.schema.CassandraFetcher;
+import io.stargate.graphql.web.StargateGraphqlContext;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -40,27 +38,16 @@ import java.util.Map;
  */
 public abstract class DdlQueryFetcher extends CassandraFetcher<Boolean> {
 
-  protected DdlQueryFetcher(
-      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
-    super(authorizationService, dataStoreFactory);
-  }
-
   @Override
   protected Boolean get(
-      DataFetchingEnvironment environment,
-      DataStore dataStore,
-      AuthenticationSubject authenticationSubject)
+      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
       throws Exception {
-    dataStore
-        .execute(buildQuery(environment, dataStore.queryBuilder(), authenticationSubject).bind())
-        .get();
+    dataStore.execute(buildQuery(environment, dataStore.queryBuilder(), context).bind()).get();
     return true;
   }
 
   protected abstract Query<?> buildQuery(
-      DataFetchingEnvironment dataFetchingEnvironment,
-      QueryBuilder builder,
-      AuthenticationSubject authenticationSubject)
+      DataFetchingEnvironment environment, QueryBuilder builder, StargateGraphqlContext context)
       throws UnauthorizedException;
 
   protected ColumnType decodeType(Object typeObject) {

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DropIndexFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DropIndexFetcher.java
@@ -16,28 +16,25 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.query.Query;
 import io.stargate.db.query.builder.QueryBuilder;
 
 public class DropIndexFetcher extends IndexFetcher {
 
-  public DropIndexFetcher(
-      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
-    super(authorizationService, dataStoreFactory, Scope.DROP);
+  public DropIndexFetcher() {
+    super(Scope.DROP);
   }
 
   @Override
   protected Query<?> buildQuery(
-      DataFetchingEnvironment dataFetchingEnvironment,
+      DataFetchingEnvironment environment,
       QueryBuilder builder,
       String keyspaceName,
       String tableName) {
 
-    String indexName = dataFetchingEnvironment.getArgument("indexName");
-    boolean ifExists = dataFetchingEnvironment.getArgumentOrDefault("ifExists", Boolean.FALSE);
+    String indexName = environment.getArgument("indexName");
+    boolean ifExists = environment.getArgumentOrDefault("ifExists", Boolean.FALSE);
 
     return builder.drop().index(keyspaceName, indexName).ifExists(ifExists).build();
   }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DropKeyspaceFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DropKeyspaceFetcher.java
@@ -16,40 +16,33 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationSubject;
-import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.UnauthorizedException;
 import io.stargate.auth.entity.ResourceKind;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.query.Query;
 import io.stargate.db.query.builder.QueryBuilder;
+import io.stargate.graphql.web.StargateGraphqlContext;
 
 public class DropKeyspaceFetcher extends DdlQueryFetcher {
 
-  public DropKeyspaceFetcher(
-      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
-    super(authorizationService, dataStoreFactory);
-  }
-
   @Override
   protected Query<?> buildQuery(
-      DataFetchingEnvironment dataFetchingEnvironment,
-      QueryBuilder builder,
-      AuthenticationSubject authenticationSubject)
+      DataFetchingEnvironment environment, QueryBuilder builder, StargateGraphqlContext context)
       throws UnauthorizedException {
-    String keyspaceName = dataFetchingEnvironment.getArgument("name");
+    String keyspaceName = environment.getArgument("name");
 
-    authorizationService.authorizeSchemaWrite(
-        authenticationSubject,
-        keyspaceName,
-        null,
-        Scope.DROP,
-        SourceAPI.GRAPHQL,
-        ResourceKind.KEYSPACE);
+    context
+        .getAuthorizationService()
+        .authorizeSchemaWrite(
+            context.getSubject(),
+            keyspaceName,
+            null,
+            Scope.DROP,
+            SourceAPI.GRAPHQL,
+            ResourceKind.KEYSPACE);
 
-    boolean ifExists = dataFetchingEnvironment.getArgumentOrDefault("ifExists", Boolean.FALSE);
+    boolean ifExists = environment.getArgumentOrDefault("ifExists", Boolean.FALSE);
 
     return builder.drop().keyspace(keyspaceName).ifExists(ifExists).build();
   }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DropTableFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DropTableFetcher.java
@@ -16,25 +16,18 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthorizationService;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.query.Query;
 import io.stargate.db.query.builder.QueryBuilder;
 
 public class DropTableFetcher extends TableFetcher {
 
-  public DropTableFetcher(
-      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
-    super(authorizationService, dataStoreFactory);
-  }
-
   @Override
   protected Query<?> buildQuery(
-      DataFetchingEnvironment dataFetchingEnvironment,
+      DataFetchingEnvironment environment,
       QueryBuilder builder,
       String keyspaceName,
       String tableName) {
-    Boolean ifExists = dataFetchingEnvironment.getArgument("ifExists");
+    Boolean ifExists = environment.getArgument("ifExists");
     return builder
         .drop()
         .table(keyspaceName, tableName)

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DropTypeFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DropTypeFetcher.java
@@ -16,44 +16,37 @@
 package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationSubject;
-import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.UnauthorizedException;
 import io.stargate.auth.entity.ResourceKind;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.query.Query;
 import io.stargate.db.query.builder.QueryBuilder;
 import io.stargate.db.schema.UserDefinedType;
+import io.stargate.graphql.web.StargateGraphqlContext;
 
 public class DropTypeFetcher extends DdlQueryFetcher {
 
-  public DropTypeFetcher(
-      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
-    super(authorizationService, dataStoreFactory);
-  }
-
   @Override
   protected Query<?> buildQuery(
-      DataFetchingEnvironment dataFetchingEnvironment,
-      QueryBuilder builder,
-      AuthenticationSubject authenticationSubject)
+      DataFetchingEnvironment environment, QueryBuilder builder, StargateGraphqlContext context)
       throws UnauthorizedException {
 
-    String keyspaceName = dataFetchingEnvironment.getArgument("keyspaceName");
-    String typeName = dataFetchingEnvironment.getArgument("typeName");
+    String keyspaceName = environment.getArgument("keyspaceName");
+    String typeName = environment.getArgument("typeName");
 
     // Permissions on a type are the same as keyspace
-    authorizationService.authorizeSchemaWrite(
-        authenticationSubject,
-        keyspaceName,
-        null,
-        Scope.DROP,
-        SourceAPI.GRAPHQL,
-        ResourceKind.TYPE);
+    context
+        .getAuthorizationService()
+        .authorizeSchemaWrite(
+            context.getSubject(),
+            keyspaceName,
+            null,
+            Scope.DROP,
+            SourceAPI.GRAPHQL,
+            ResourceKind.TYPE);
 
-    Boolean ifExists = dataFetchingEnvironment.getArgument("ifExists");
+    Boolean ifExists = environment.getArgument("ifExists");
     return builder
         .drop()
         .type(keyspaceName, UserDefinedType.reference(typeName))

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/DeleteMutationFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/DeleteMutationFetcher.java
@@ -1,34 +1,26 @@
 package io.stargate.graphql.schema.cqlfirst.dml.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationSubject;
-import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.TypedKeyValue;
 import io.stargate.auth.UnauthorizedException;
 import io.stargate.db.datastore.DataStore;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.query.BoundDelete;
 import io.stargate.db.query.BoundQuery;
 import io.stargate.db.schema.Table;
 import io.stargate.graphql.schema.cqlfirst.dml.NameMapping;
+import io.stargate.graphql.web.StargateGraphqlContext;
 
 public class DeleteMutationFetcher extends MutationFetcher {
 
-  public DeleteMutationFetcher(
-      Table table,
-      NameMapping nameMapping,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    super(table, nameMapping, authorizationService, dataStoreFactory);
+  public DeleteMutationFetcher(Table table, NameMapping nameMapping) {
+    super(table, nameMapping);
   }
 
   @Override
   protected BoundQuery buildQuery(
-      DataFetchingEnvironment environment,
-      DataStore dataStore,
-      AuthenticationSubject authenticationSubject)
+      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
       throws UnauthorizedException {
 
     boolean ifExists =
@@ -48,13 +40,15 @@ public class DeleteMutationFetcher extends MutationFetcher {
             .bind();
 
     assert bound instanceof BoundDelete;
-    authorizationService.authorizeDataWrite(
-        authenticationSubject,
-        table.keyspace(),
-        table.name(),
-        TypedKeyValue.forDML((BoundDelete) bound),
-        Scope.DELETE,
-        SourceAPI.GRAPHQL);
+    context
+        .getAuthorizationService()
+        .authorizeDataWrite(
+            context.getSubject(),
+            table.keyspace(),
+            table.name(),
+            TypedKeyValue.forDML((BoundDelete) bound),
+            Scope.DELETE,
+            SourceAPI.GRAPHQL);
     return bound;
   }
 }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/DmlFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/DmlFetcher.java
@@ -6,11 +6,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import graphql.language.OperationDefinition;
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthorizationService;
 import io.stargate.db.ImmutableParameters;
 import io.stargate.db.Parameters;
 import io.stargate.db.datastore.DataStore;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.datastore.ResultSet;
 import io.stargate.db.datastore.Row;
 import io.stargate.db.query.BoundQuery;
@@ -22,7 +20,10 @@ import io.stargate.db.schema.Table;
 import io.stargate.graphql.schema.CassandraFetcher;
 import io.stargate.graphql.schema.cqlfirst.dml.NameMapping;
 import java.nio.ByteBuffer;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.apache.cassandra.stargate.db.ConsistencyLevel;
 import org.slf4j.Logger;
@@ -34,12 +35,7 @@ public abstract class DmlFetcher<ResultT> extends CassandraFetcher<ResultT> {
   protected final NameMapping nameMapping;
   protected final DbColumnGetter dbColumnGetter;
 
-  protected DmlFetcher(
-      Table table,
-      NameMapping nameMapping,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    super(authorizationService, dataStoreFactory);
+  protected DmlFetcher(Table table, NameMapping nameMapping) {
     this.table = table;
     this.nameMapping = nameMapping;
     this.dbColumnGetter = new DbColumnGetter(nameMapping);

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/UpdateMutationFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/UpdateMutationFetcher.java
@@ -3,14 +3,11 @@ package io.stargate.graphql.schema.cqlfirst.dml.fetchers;
 import static io.stargate.graphql.schema.cqlfirst.dml.fetchers.TtlFromOptionsExtractor.getTTL;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationSubject;
-import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.TypedKeyValue;
 import io.stargate.auth.UnauthorizedException;
 import io.stargate.db.datastore.DataStore;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.query.BoundDMLQuery;
 import io.stargate.db.query.BoundQuery;
 import io.stargate.db.query.Predicate;
@@ -19,25 +16,20 @@ import io.stargate.db.query.builder.ValueModifier;
 import io.stargate.db.schema.Column;
 import io.stargate.db.schema.Table;
 import io.stargate.graphql.schema.cqlfirst.dml.NameMapping;
+import io.stargate.graphql.web.StargateGraphqlContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 public class UpdateMutationFetcher extends MutationFetcher {
 
-  public UpdateMutationFetcher(
-      Table table,
-      NameMapping nameMapping,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    super(table, nameMapping, authorizationService, dataStoreFactory);
+  public UpdateMutationFetcher(Table table, NameMapping nameMapping) {
+    super(table, nameMapping);
   }
 
   @Override
   protected BoundQuery buildQuery(
-      DataFetchingEnvironment environment,
-      DataStore dataStore,
-      AuthenticationSubject authenticationSubject)
+      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
       throws UnauthorizedException {
     boolean ifExists =
         environment.containsArgument("ifExists")
@@ -56,13 +48,15 @@ public class UpdateMutationFetcher extends MutationFetcher {
             .build()
             .bind();
 
-    authorizationService.authorizeDataWrite(
-        authenticationSubject,
-        table.keyspace(),
-        table.name(),
-        TypedKeyValue.forDML((BoundDMLQuery) query),
-        Scope.MODIFY,
-        SourceAPI.GRAPHQL);
+    context
+        .getAuthorizationService()
+        .authorizeDataWrite(
+            context.getSubject(),
+            table.keyspace(),
+            table.name(),
+            TypedKeyValue.forDML((BoundDMLQuery) query),
+            Scope.MODIFY,
+            SourceAPI.GRAPHQL);
 
     return query;
   }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/AllSchemasFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/AllSchemasFetcher.java
@@ -17,41 +17,32 @@ package io.stargate.graphql.schema.graphqlfirst.fetchers.admin;
 
 import com.google.common.annotations.VisibleForTesting;
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationSubject;
-import io.stargate.auth.AuthorizationService;
 import io.stargate.db.datastore.DataStore;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.graphql.persistence.graphqlfirst.SchemaSource;
 import io.stargate.graphql.persistence.graphqlfirst.SchemaSourceDao;
+import io.stargate.graphql.web.StargateGraphqlContext;
 import java.util.List;
 import java.util.function.Function;
 
 public class AllSchemasFetcher extends SchemaFetcher<List<SchemaSource>> {
   private final Function<DataStore, SchemaSourceDao> schemaSourceDaoProvider;
 
-  public AllSchemasFetcher(
-      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
-    this(authorizationService, dataStoreFactory, (SchemaSourceDao::new));
+  public AllSchemasFetcher() {
+    this(SchemaSourceDao::new);
   }
 
   @VisibleForTesting
-  public AllSchemasFetcher(
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory,
-      Function<DataStore, SchemaSourceDao> schemaSourceDaoProvider) {
-    super(authorizationService, dataStoreFactory);
+  public AllSchemasFetcher(Function<DataStore, SchemaSourceDao> schemaSourceDaoProvider) {
     this.schemaSourceDaoProvider = schemaSourceDaoProvider;
   }
 
   @Override
   protected List<SchemaSource> get(
-      DataFetchingEnvironment environment,
-      DataStore dataStore,
-      AuthenticationSubject authenticationSubject)
+      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
       throws Exception {
     String keyspace = getKeyspace(environment, dataStore);
 
-    authorize(authenticationSubject, keyspace);
+    authorize(context, keyspace);
 
     return schemaSourceDaoProvider.apply(dataStore).getAllVersions(keyspace);
   }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/DeploySchemaFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/DeploySchemaFetcher.java
@@ -16,15 +16,8 @@
 package io.stargate.graphql.schema.graphqlfirst.fetchers.admin;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthorizationService;
-import io.stargate.db.datastore.DataStoreFactory;
 
 public class DeploySchemaFetcher extends DeploySchemaFetcherBase {
-
-  public DeploySchemaFetcher(
-      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
-    super(authorizationService, dataStoreFactory);
-  }
 
   @Override
   protected String getSchemaContents(DataFetchingEnvironment environment) {

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/DeploySchemaFileFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/DeploySchemaFileFetcher.java
@@ -17,19 +17,12 @@ package io.stargate.graphql.schema.graphqlfirst.fetchers.admin;
 
 import com.google.common.io.CharStreams;
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthorizationService;
-import io.stargate.db.datastore.DataStoreFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 
 public class DeploySchemaFileFetcher extends DeploySchemaFetcherBase {
-
-  public DeploySchemaFileFetcher(
-      AuthorizationService authorizationService, DataStoreFactory dataStoreFactory) {
-    super(authorizationService, dataStoreFactory);
-  }
 
   @Override
   protected String getSchemaContents(DataFetchingEnvironment environment) throws IOException {

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/DeleteFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/DeleteFetcher.java
@@ -17,14 +17,11 @@ package io.stargate.graphql.schema.graphqlfirst.fetchers.deployed;
 
 import com.google.common.collect.ImmutableMap;
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationSubject;
-import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.TypedKeyValue;
 import io.stargate.auth.UnauthorizedException;
 import io.stargate.db.datastore.DataStore;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.datastore.ResultSet;
 import io.stargate.db.query.BoundDelete;
 import io.stargate.db.query.builder.AbstractBound;
@@ -37,6 +34,7 @@ import io.stargate.graphql.schema.graphqlfirst.processor.OperationModel.ReturnTy
 import io.stargate.graphql.schema.graphqlfirst.processor.OperationModel.SimpleReturnType;
 import io.stargate.graphql.schema.graphqlfirst.processor.ResponsePayloadModel;
 import io.stargate.graphql.schema.graphqlfirst.processor.ResponsePayloadModel.TechnicalField;
+import io.stargate.graphql.web.StargateGraphqlContext;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -47,20 +45,14 @@ public class DeleteFetcher extends DeployedFetcher<Object> {
 
   private final DeleteModel model;
 
-  public DeleteFetcher(
-      DeleteModel model,
-      MappingModel mappingModel,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    super(mappingModel, authorizationService, dataStoreFactory);
+  public DeleteFetcher(DeleteModel model, MappingModel mappingModel) {
+    super(mappingModel);
     this.model = model;
   }
 
   @Override
   protected Object get(
-      DataFetchingEnvironment environment,
-      DataStore dataStore,
-      AuthenticationSubject authenticationSubject)
+      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
       throws UnauthorizedException {
 
     EntityModel entityModel = model.getEntity();
@@ -91,13 +83,15 @@ public class DeleteFetcher extends DeployedFetcher<Object> {
             .build()
             .bind();
 
-    authorizationService.authorizeDataWrite(
-        authenticationSubject,
-        entityModel.getKeyspaceName(),
-        entityModel.getCqlName(),
-        TypedKeyValue.forDML((BoundDelete) query),
-        Scope.DELETE,
-        SourceAPI.GRAPHQL);
+    context
+        .getAuthorizationService()
+        .authorizeDataWrite(
+            context.getSubject(),
+            entityModel.getKeyspaceName(),
+            entityModel.getCqlName(),
+            TypedKeyValue.forDML((BoundDelete) query),
+            Scope.DELETE,
+            SourceAPI.GRAPHQL);
 
     ResultSet resultSet = executeUnchecked(query, Optional.empty(), Optional.empty(), dataStore);
     boolean applied = !model.ifExists() || resultSet.one().getBoolean("[applied]");

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/QueryFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/QueryFetcher.java
@@ -17,11 +17,8 @@ package io.stargate.graphql.schema.graphqlfirst.fetchers.deployed;
 
 import graphql.schema.Coercing;
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationSubject;
-import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.UnauthorizedException;
 import io.stargate.db.datastore.DataStore;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.datastore.ResultSet;
 import io.stargate.db.query.builder.BuiltCondition;
 import io.stargate.db.schema.Keyspace;
@@ -31,6 +28,7 @@ import io.stargate.graphql.schema.graphqlfirst.processor.QueryModel;
 import io.stargate.graphql.schema.graphqlfirst.processor.ResponsePayloadModel;
 import io.stargate.graphql.schema.graphqlfirst.processor.ResponsePayloadModel.TechnicalField;
 import io.stargate.graphql.schema.scalars.CqlScalar;
+import io.stargate.graphql.web.StargateGraphqlContext;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.List;
@@ -45,20 +43,14 @@ public class QueryFetcher extends DeployedFetcher<Object> {
 
   private final QueryModel model;
 
-  public QueryFetcher(
-      QueryModel model,
-      MappingModel mappingModel,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    super(mappingModel, authorizationService, dataStoreFactory);
+  public QueryFetcher(QueryModel model, MappingModel mappingModel) {
+    super(mappingModel);
     this.model = model;
   }
 
   @Override
   protected Object get(
-      DataFetchingEnvironment environment,
-      DataStore dataStore,
-      AuthenticationSubject authenticationSubject)
+      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
       throws UnauthorizedException {
     Keyspace keyspace = dataStore.schema().keyspace(model.getEntity().getKeyspaceName());
 
@@ -86,7 +78,7 @@ public class QueryFetcher extends DeployedFetcher<Object> {
             model.getLimit(),
             model.getPageSize(),
             dataStore,
-            authenticationSubject);
+            environment.getContext());
     Object entityData =
         returnType.isEntityList()
             ? toEntities(resultSet, model.getEntity())

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/DeleteModel.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/DeleteModel.java
@@ -17,8 +17,6 @@ package io.stargate.graphql.schema.graphqlfirst.processor;
 
 import graphql.language.FieldDefinition;
 import graphql.schema.DataFetcher;
-import io.stargate.auth.AuthorizationService;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.graphql.schema.graphqlfirst.fetchers.deployed.DeleteFetcher;
 import java.util.List;
 import java.util.Optional;
@@ -76,10 +74,7 @@ public class DeleteModel extends MutationModel {
   }
 
   @Override
-  public DataFetcher<?> getDataFetcher(
-      MappingModel mappingModel,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    return new DeleteFetcher(this, mappingModel, authorizationService, dataStoreFactory);
+  public DataFetcher<?> getDataFetcher(MappingModel mappingModel) {
+    return new DeleteFetcher(this, mappingModel);
   }
 }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/InsertModel.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/InsertModel.java
@@ -17,8 +17,6 @@ package io.stargate.graphql.schema.graphqlfirst.processor;
 
 import graphql.language.FieldDefinition;
 import graphql.schema.DataFetcher;
-import io.stargate.auth.AuthorizationService;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.graphql.schema.graphqlfirst.fetchers.deployed.InsertFetcher;
 import java.util.Optional;
 
@@ -60,10 +58,7 @@ public class InsertModel extends MutationModel {
   }
 
   @Override
-  public DataFetcher<?> getDataFetcher(
-      MappingModel mappingModel,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    return new InsertFetcher(this, mappingModel, authorizationService, dataStoreFactory);
+  public DataFetcher<?> getDataFetcher(MappingModel mappingModel) {
+    return new InsertFetcher(this, mappingModel);
   }
 }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/OperationModel.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/OperationModel.java
@@ -19,8 +19,6 @@ import graphql.Scalars;
 import graphql.language.FieldDefinition;
 import graphql.schema.DataFetcher;
 import graphql.schema.FieldCoordinates;
-import io.stargate.auth.AuthorizationService;
-import io.stargate.db.datastore.DataStoreFactory;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
@@ -40,10 +38,7 @@ public abstract class OperationModel {
     return coordinates;
   }
 
-  public abstract DataFetcher<?> getDataFetcher(
-      MappingModel mappingModel,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory);
+  public abstract DataFetcher<?> getDataFetcher(MappingModel mappingModel);
 
   public interface ReturnType {
     Optional<EntityModel> getEntity();

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/QueryModel.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/QueryModel.java
@@ -17,8 +17,6 @@ package io.stargate.graphql.schema.graphqlfirst.processor;
 
 import graphql.language.FieldDefinition;
 import graphql.schema.DataFetcher;
-import io.stargate.auth.AuthorizationService;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.graphql.schema.graphqlfirst.fetchers.deployed.QueryFetcher;
 import java.util.List;
 import java.util.Optional;
@@ -84,10 +82,7 @@ public class QueryModel extends OperationModel {
   }
 
   @Override
-  public DataFetcher<?> getDataFetcher(
-      MappingModel mappingModel,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    return new QueryFetcher(this, mappingModel, authorizationService, dataStoreFactory);
+  public DataFetcher<?> getDataFetcher(MappingModel mappingModel) {
+    return new QueryFetcher(this, mappingModel);
   }
 }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/UpdateModel.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/UpdateModel.java
@@ -17,8 +17,6 @@ package io.stargate.graphql.schema.graphqlfirst.processor;
 
 import graphql.language.FieldDefinition;
 import graphql.schema.DataFetcher;
-import io.stargate.auth.AuthorizationService;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.graphql.schema.graphqlfirst.fetchers.deployed.UpdateFetcher;
 
 public class UpdateModel extends MutationModel {
@@ -42,10 +40,7 @@ public class UpdateModel extends MutationModel {
   }
 
   @Override
-  public DataFetcher<?> getDataFetcher(
-      MappingModel mappingModel,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory) {
-    return new UpdateFetcher(this, mappingModel, authorizationService, dataStoreFactory);
+  public DataFetcher<?> getDataFetcher(MappingModel mappingModel) {
+    return new UpdateFetcher(this, mappingModel);
   }
 }

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/DropwizardServer.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/DropwizardServer.java
@@ -94,8 +94,7 @@ public class DropwizardServer extends Application<Configuration> {
   @Override
   public void run(final Configuration config, final Environment environment) throws Exception {
 
-    GraphqlCache graphqlCache =
-        new GraphqlCache(persistence, authorizationService, dataStoreFactory, enableGraphqlFirst);
+    GraphqlCache graphqlCache = new GraphqlCache(persistence, dataStoreFactory, enableGraphqlFirst);
     environment
         .jersey()
         .register(

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/StargateGraphqlContext.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/StargateGraphqlContext.java
@@ -16,8 +16,10 @@
 package io.stargate.graphql.web;
 
 import io.stargate.auth.AuthenticationSubject;
+import io.stargate.auth.AuthorizationService;
 import io.stargate.db.Persistence;
 import io.stargate.db.datastore.DataStore;
+import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.datastore.ResultSet;
 import io.stargate.db.query.BoundQuery;
 import io.stargate.graphql.web.resources.AuthenticationFilter;
@@ -29,10 +31,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.servlet.http.HttpServletRequest;
 
-public class HttpAwareContext {
+public class StargateGraphqlContext {
 
   private final HttpServletRequest request;
   private final AuthenticationSubject subject;
+  private final AuthorizationService authorizationService;
+  private final DataStoreFactory dataStoreFactory;
   private final Persistence persistence;
 
   // We need to manually maintain state between multiple selections in a single mutation
@@ -43,9 +47,15 @@ public class HttpAwareContext {
   // For more information.
   private final BatchContext batchContext = new BatchContext();
 
-  public HttpAwareContext(HttpServletRequest request, Persistence persistence) {
+  public StargateGraphqlContext(
+      HttpServletRequest request,
+      AuthorizationService authorizationService,
+      DataStoreFactory dataStoreFactory,
+      Persistence persistence) {
     this.request = request;
     this.subject = (AuthenticationSubject) request.getAttribute(AuthenticationFilter.SUBJECT_KEY);
+    this.authorizationService = authorizationService;
+    this.dataStoreFactory = dataStoreFactory;
     this.persistence = persistence;
     if (this.subject == null) {
       // This happens if a GraphQL resource is not annotated with @Authenticated
@@ -63,6 +73,14 @@ public class HttpAwareContext {
 
   public BatchContext getBatchContext() {
     return batchContext;
+  }
+
+  public AuthorizationService getAuthorizationService() {
+    return authorizationService;
+  }
+
+  public DataStoreFactory getDataStoreFactory() {
+    return dataStoreFactory;
   }
 
   public Persistence getPersistence() {

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/resources/GraphqlCache.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/resources/GraphqlCache.java
@@ -22,7 +22,6 @@ import graphql.GraphQL;
 import graphql.execution.AsyncExecutionStrategy;
 import graphql.schema.GraphQLSchema;
 import io.stargate.auth.AuthenticationSubject;
-import io.stargate.auth.AuthorizationService;
 import io.stargate.db.Persistence;
 import io.stargate.db.datastore.DataStore;
 import io.stargate.db.datastore.DataStoreFactory;
@@ -60,7 +59,6 @@ public class GraphqlCache implements KeyspaceChangeListener {
       Boolean.getBoolean("stargate.graphql.default_keyspace.disabled");
 
   private final Persistence persistence;
-  private final AuthorizationService authorizationService;
   private final DataStoreFactory dataStoreFactory;
   private final boolean enableGraphqlFirst;
 
@@ -70,20 +68,13 @@ public class GraphqlCache implements KeyspaceChangeListener {
   private final ConcurrentMap<String, DmlGraphqlHolder> dmlGraphqls = new ConcurrentHashMap<>();
 
   public GraphqlCache(
-      Persistence persistence,
-      AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory,
-      boolean enableGraphqlFirst) {
+      Persistence persistence, DataStoreFactory dataStoreFactory, boolean enableGraphqlFirst) {
     this.persistence = persistence;
-    this.authorizationService = authorizationService;
     this.dataStoreFactory = dataStoreFactory;
     this.enableGraphqlFirst = enableGraphqlFirst;
 
-    this.ddlGraphql =
-        newGraphql(SchemaFactory.newDdlSchema(authorizationService, dataStoreFactory));
-    this.schemaFirstAdminGraphql =
-        GraphQL.newGraphQL(new AdminSchemaBuilder(authorizationService, dataStoreFactory).build())
-            .build();
+    this.ddlGraphql = newGraphql(SchemaFactory.newDdlSchema());
+    this.schemaFirstAdminGraphql = GraphQL.newGraphQL(new AdminSchemaBuilder().build()).build();
     this.defaultKeyspace = findDefaultKeyspace(dataStoreFactory.createInternal());
 
     persistence.registerEventListener(this);
@@ -252,12 +243,10 @@ public class GraphqlCache implements KeyspaceChangeListener {
     private GraphQL buildGraphql() {
 
       if (source == null) {
-        return newGraphql(
-            SchemaFactory.newDmlSchema(authorizationService, keyspace, dataStoreFactory));
+        return newGraphql(SchemaFactory.newDmlSchema(keyspace));
       } else {
         ProcessedSchema processedSchema =
-            new SchemaProcessor(authorizationService, dataStoreFactory, persistence, true)
-                .process(source.getContents(), keyspace);
+            new SchemaProcessor(persistence, true).process(source.getContents(), keyspace);
         // Check that the data model still matches
         CassandraMigrator.forPersisted().compute(processedSchema.getMappingModel(), keyspace);
 

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/resources/GraphqlResourceBase.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/resources/GraphqlResourceBase.java
@@ -32,7 +32,8 @@ import io.stargate.auth.SourceAPI;
 import io.stargate.auth.UnauthorizedException;
 import io.stargate.auth.entity.ResourceKind;
 import io.stargate.db.Persistence;
-import io.stargate.graphql.web.HttpAwareContext;
+import io.stargate.db.datastore.DataStoreFactory;
+import io.stargate.graphql.web.StargateGraphqlContext;
 import io.stargate.graphql.web.models.GraphqlJsonBody;
 import java.io.IOException;
 import java.io.InputStream;
@@ -68,6 +69,7 @@ public class GraphqlResourceBase {
   private static final Splitter PATH_SPLITTER = Splitter.on(".");
 
   @Inject protected AuthorizationService authorizationService;
+  @Inject protected DataStoreFactory dataStoreFactory;
   @Inject protected Persistence persistence;
 
   /**
@@ -93,7 +95,9 @@ public class GraphqlResourceBase {
       ExecutionInput.Builder input =
           ExecutionInput.newExecutionInput(query)
               .operationName(operationName)
-              .context(new HttpAwareContext(httpRequest, persistence));
+              .context(
+                  new StargateGraphqlContext(
+                      httpRequest, authorizationService, dataStoreFactory, persistence));
 
       if (!Strings.isNullOrEmpty(variables)) {
         @SuppressWarnings("unchecked")
@@ -149,7 +153,9 @@ public class GraphqlResourceBase {
     ExecutionInput.Builder input =
         ExecutionInput.newExecutionInput(query)
             .operationName(operationName)
-            .context(new HttpAwareContext(httpRequest, persistence));
+            .context(
+                new StargateGraphqlContext(
+                    httpRequest, authorizationService, dataStoreFactory, persistence));
     if (variables != null) {
       input = input.variables(variables);
     }
@@ -325,7 +331,9 @@ public class GraphqlResourceBase {
 
     ExecutionInput input =
         ExecutionInput.newExecutionInput(query)
-            .context(new HttpAwareContext(httpRequest, persistence))
+            .context(
+                new StargateGraphqlContext(
+                    httpRequest, authorizationService, dataStoreFactory, persistence))
             .build();
     executeAsync(input, graphql, asyncResponse);
   }

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/GraphQlTestBase.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/GraphQlTestBase.java
@@ -31,8 +31,8 @@ import io.stargate.db.query.TypedValue.Codec;
 import io.stargate.db.query.builder.AbstractBound;
 import io.stargate.db.query.builder.QueryBuilder;
 import io.stargate.db.schema.Schema;
-import io.stargate.graphql.web.HttpAwareContext;
-import io.stargate.graphql.web.HttpAwareContext.BatchContext;
+import io.stargate.graphql.web.StargateGraphqlContext;
+import io.stargate.graphql.web.StargateGraphqlContext.BatchContext;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -131,13 +131,16 @@ public abstract class GraphQlTestBase {
    */
   protected ExecutionResult executeGraphQl(String query) {
     // Use a context mock per execution
-    HttpAwareContext context = mock(HttpAwareContext.class);
+    StargateGraphqlContext context = mock(StargateGraphqlContext.class);
 
     // Use a dedicated batch executor per execution
     BatchContext batchContext = new BatchContext();
+    when(context.getBatchContext()).thenReturn(batchContext);
 
     when(context.getSubject()).thenReturn(authenticationSubject);
-    when(context.getBatchContext()).thenReturn(batchContext);
+    when(context.getAuthorizationService()).thenReturn(authorizationService);
+    when(context.getDataStoreFactory()).thenReturn(dataStoreFactory);
+
     return graphQl.execute(ExecutionInput.newExecutionInput(query).context(context).build());
   }
 

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/cqlfirst/ddl/DdlTestBase.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/cqlfirst/ddl/DdlTestBase.java
@@ -8,6 +8,6 @@ public abstract class DdlTestBase extends GraphQlTestBase {
 
   @Override
   protected GraphQLSchema createGraphQlSchema() {
-    return SchemaFactory.newDdlSchema(authorizationService, dataStoreFactory);
+    return SchemaFactory.newDdlSchema();
   }
 }

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/cqlfirst/dml/DmlTestBase.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/cqlfirst/dml/DmlTestBase.java
@@ -16,8 +16,7 @@ public abstract class DmlTestBase extends GraphQlTestBase {
 
   @Override
   protected GraphQLSchema createGraphQlSchema() {
-    return SchemaFactory.newDmlSchema(
-        authorizationService, getCQLSchema().keyspaces().iterator().next(), dataStoreFactory);
+    return SchemaFactory.newDmlSchema(getCQLSchema().keyspaces().iterator().next());
   }
 
   /** Creates a basic row suitable for faking result sets. */

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/AllSchemasFetcherTest.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/AllSchemasFetcherTest.java
@@ -22,11 +22,11 @@ import graphql.schema.DataFetchingEnvironment;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.db.datastore.DataStore;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.schema.Schema;
 import io.stargate.graphql.persistence.graphqlfirst.SchemaSource;
 import io.stargate.graphql.persistence.graphqlfirst.SchemaSourceDao;
 import io.stargate.graphql.schema.graphqlfirst.util.Uuids;
+import io.stargate.graphql.web.StargateGraphqlContext;
 import java.util.*;
 import org.junit.jupiter.api.Test;
 
@@ -42,19 +42,19 @@ class AllSchemasFetcherTest {
     SchemaSourceDao schemaSourceDao = mock(SchemaSourceDao.class);
     when(schemaSourceDao.getAllVersions(keyspace))
         .thenReturn(Arrays.asList(schemaSource1, schemaSource2));
-    AllSchemasFetcher allSchemasFetcher =
-        new AllSchemasFetcher(
-            mock(AuthorizationService.class),
-            mock(DataStoreFactory.class),
-            (ds) -> schemaSourceDao);
+    AllSchemasFetcher allSchemasFetcher = new AllSchemasFetcher((ds) -> schemaSourceDao);
 
     DataFetchingEnvironment dataFetchingEnvironment = mockDataFetchingEnvironment(keyspace);
     DataStore dataStore = mockDataStore(keyspace);
 
+    StargateGraphqlContext context = mock(StargateGraphqlContext.class);
+    AuthorizationService authorizationService = mock(AuthorizationService.class);
+    AuthenticationSubject subject = mock(AuthenticationSubject.class);
+    when(context.getAuthorizationService()).thenReturn(authorizationService);
+    when(context.getSubject()).thenReturn(subject);
+
     // when
-    List<SchemaSource> result =
-        allSchemasFetcher.get(
-            dataFetchingEnvironment, dataStore, mock(AuthenticationSubject.class));
+    List<SchemaSource> result = allSchemasFetcher.get(dataFetchingEnvironment, dataStore, context);
 
     // then
     assertThat(result).containsExactly(schemaSource1, schemaSource2);


### PR DESCRIPTION
This is just refactoring, there are no functional changes.

* rename `HttpAwareContext` to `StargateGraphqlContext`
* make `authorizationService` and `dataStoreFactory` fields of that object.
* don't pass them to fetcher constructors anymore (and transitively remove them from other components where the only goal was to propagate them to the fetchers, e.g. `DmlSchemaBuilder`)
* `StargateGraphqlContext` is initialized in `GraphqlResourceBase`