### PR TITLE
relates to #947: added validations for NamespacesResource

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/models/dto/CreateCollection.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/models/dto/CreateCollection.java
@@ -44,6 +44,6 @@ public class CreateCollection {
 
   @Override
   public String toString() {
-    return String.format("CreateCollectionDto(name=%s)", name);
+    return String.format("CreateCollection(name=%s)", name);
   }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/models/dto/CreateNamespace.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/models/dto/CreateNamespace.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.web.docsapi.models.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.stargate.db.query.builder.Replication;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+/** The DTO for the namespace creation. */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CreateNamespace {
+
+  @JsonProperty("name")
+  @NotNull(message = "`name` is required to create a namespace")
+  @NotBlank(message = "`name` is required to create a namespace")
+  private final String name;
+
+  @JsonProperty("replicas")
+  @Min(value = 1, message = "minimum amount of `replicas` for `SimpleStrategy` is one")
+  private final Integer replicas;
+
+  @JsonProperty("datacenters")
+  @Valid
+  private final Collection<Datacenter> datacenters;
+
+  @JsonCreator
+  public CreateNamespace(
+      @JsonProperty("name") String name,
+      @JsonProperty("replicas") Integer replicas,
+      @JsonProperty("datacenters") Collection<Datacenter> datacenters) {
+    this.name = name;
+    this.replicas = replicas;
+    this.datacenters = datacenters;
+  }
+
+  @JsonIgnore
+  public Replication getReplication() {
+    if (null == datacenters || datacenters.isEmpty()) {
+      int replicas = Optional.ofNullable(this.replicas).orElse(1);
+      return Replication.simpleStrategy(replicas);
+    } else {
+      Map<String, Integer> datacenterMap =
+          datacenters.stream()
+              .collect(
+                  Collectors.toMap(
+                      Datacenter::getName, dc -> Optional.ofNullable(dc.getReplicas()).orElse(3)));
+      return Replication.networkTopologyStrategy(datacenterMap);
+    }
+  }
+
+  @ApiModelProperty(required = true, value = "The name of the namespace.", example = "myspace")
+  @JsonProperty("name")
+  public String getName() {
+    return name;
+  }
+
+  @ApiModelProperty(
+      value =
+          "The amount of replicas to use with the `SimpleStrategy`. Ignored if `datacenters` is set. Defaults to 1.",
+      example = "1")
+  @JsonProperty("replicas")
+  public Integer getReplicas() {
+    return replicas;
+  }
+
+  @ApiModelProperty(value = "The datacenters description for the `NetworkTopologyStrategy`.")
+  @JsonProperty("datacenters")
+  public Collection<Datacenter> getDatacenters() {
+    return datacenters;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "CreateNamespace(name=%s,replicas=%s,datacenters=%s)", name, replicas, datacenters);
+  }
+
+  public static final class Datacenter {
+
+    @JsonProperty("name")
+    @NotNull(message = "a datacenter `name` is required when using `NetworkTopologyStrategy`")
+    @NotBlank(message = "a datacenter `name` is required when using `NetworkTopologyStrategy`")
+    private final String name;
+
+    @JsonProperty("replicas")
+    @Min(value = 1, message = "minimum amount of `replicas` for a datacenter is one")
+    private final Integer replicas;
+
+    @JsonCreator
+    public Datacenter(
+        @JsonProperty("name") String name, @JsonProperty("replicas") Integer replicas) {
+      this.name = name;
+      this.replicas = replicas;
+    }
+
+    @ApiModelProperty(required = true, value = "The name of the datacenter.", example = "dc1")
+    @JsonProperty("name")
+    public String getName() {
+      return name;
+    }
+
+    @ApiModelProperty(
+        required = true,
+        value = "The amount of replicas for the given `datacenter`. Defaults to 3.",
+        example = "3")
+    @JsonProperty("replicas")
+    public Integer getReplicas() {
+      return replicas;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("CreateNamespace.Datacenter(name=%s,replicas=%s)", name, replicas);
+    }
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/models/dto/CreateNamespace.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/models/dto/CreateNamespace.java
@@ -124,7 +124,6 @@ public class CreateNamespace {
     }
 
     @ApiModelProperty(
-        required = true,
         value = "The amount of replicas for the given `datacenter`. Defaults to 3.",
         example = "3")
     @JsonProperty("replicas")

--- a/restapi/src/main/java/io/stargate/web/docsapi/models/dto/UpgradeCollection.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/models/dto/UpgradeCollection.java
@@ -43,6 +43,6 @@ public class UpgradeCollection {
 
   @Override
   public String toString() {
-    return String.format("UpgradeCollectionDto(upgradeType=%s)", upgradeType);
+    return String.format("UpgradeCollection(upgradeType=%s)", upgradeType);
   }
 }

--- a/testing/src/main/java/io/stargate/it/http/docsapi/NamespaceResourceIntTest.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/NamespaceResourceIntTest.java
@@ -202,7 +202,7 @@ public class NamespaceResourceIntTest extends BaseOsgiIntegrationTest {
       String keyspace = RandomStringUtils.randomAlphanumeric(16);
       String payload =
           String.format(
-              "{\"name\": \"%s\", \"datacenters\": [ { \"name\": \"dc1\", \"replicas\": 1 }, { \"name\": \"dc2\" }]}",
+              "{\"name\": \"%s\", \"datacenters\": [ { \"name\": \"dc1\", \"replicas\": 1 } ]}",
               keyspace);
 
       String result = RestUtils.post(authToken, basePath, payload, HttpStatus.SC_CREATED);
@@ -222,16 +222,11 @@ public class NamespaceResourceIntTest extends BaseOsgiIntegrationTest {
                         ArrayNode.class,
                         dcs ->
                             assertThat(dcs)
-                                .hasSize(2)
+                                .hasSize(1)
                                 .anySatisfy(
                                     dc -> {
                                       assertThat(dc.findValuesAsText("name")).containsOnly("dc1");
                                       assertThat(dc.findValue("replicas").asInt()).isEqualTo(1);
-                                    })
-                                .anySatisfy(
-                                    dc -> {
-                                      assertThat(dc.findValuesAsText("name")).containsOnly("dc2");
-                                      assertThat(dc.findValue("replicas").asInt()).isEqualTo(3);
                                     }));
               });
     }

--- a/testing/src/main/java/io/stargate/it/http/docsapi/NamespaceResourceIntTest.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/NamespaceResourceIntTest.java
@@ -1,0 +1,311 @@
+package io.stargate.it.http.docsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.stargate.auth.model.AuthTokenResponse;
+import io.stargate.it.BaseOsgiIntegrationTest;
+import io.stargate.it.driver.CqlSessionExtension;
+import io.stargate.it.driver.CqlSessionSpec;
+import io.stargate.it.driver.TestKeyspace;
+import io.stargate.it.http.RestUtils;
+import io.stargate.it.http.models.Credentials;
+import io.stargate.it.storage.StargateConnectionInfo;
+import java.io.IOException;
+import java.time.Duration;
+import net.jcip.annotations.NotThreadSafe;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@NotThreadSafe
+public class NamespaceResourceIntTest extends BaseOsgiIntegrationTest {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final OkHttpClient CLIENT =
+      new OkHttpClient().newBuilder().readTimeout(Duration.ofMinutes(3)).build();
+
+  private static String authToken;
+  private static String host;
+  private static String hostWithPort;
+  private static String basePath;
+
+  @BeforeAll
+  public static void setup(StargateConnectionInfo cluster) throws IOException {
+    host = "http://" + cluster.seedAddress();
+    hostWithPort = host + ":8082";
+    basePath = String.format("%s/v2/schemas/namespaces", hostWithPort);
+
+    initAuth();
+  }
+
+  private static void initAuth() throws IOException {
+    OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    RequestBody requestBody =
+        RequestBody.create(
+            MediaType.parse("application/json"),
+            OBJECT_MAPPER.writeValueAsString(new Credentials("cassandra", "cassandra")));
+
+    Request request =
+        new Request.Builder()
+            .url(String.format("%s:8081/v1/auth/token/generate", host))
+            .post(requestBody)
+            .addHeader("X-Cassandra-Request-Id", "foo")
+            .build();
+    Response response = CLIENT.newCall(request).execute();
+    ResponseBody body = response.body();
+
+    assertThat(body).isNotNull();
+    AuthTokenResponse authTokenResponse =
+        OBJECT_MAPPER.readValue(body.string(), AuthTokenResponse.class);
+    authToken = authTokenResponse.getAuthToken();
+    assertThat(authToken).isNotNull();
+  }
+
+  // Below are "namespace" tests that should match the REST Api's keyspace tests
+  // plus some additional ones for the validation
+
+  @Nested
+  @ExtendWith(CqlSessionExtension.class)
+  @CqlSessionSpec(createKeyspace = false, createSession = false)
+  class GetAllNamespaces {
+
+    @Test
+    public void notRaw() throws IOException {
+      String body = RestUtils.get(authToken, basePath, HttpStatus.SC_OK);
+
+      JsonNode json = OBJECT_MAPPER.readTree(body);
+      assertThat(json.get("data"))
+          .isNotNull()
+          .isInstanceOfSatisfying(
+              ArrayNode.class,
+              dataArray ->
+                  assertThat(dataArray)
+                      .anySatisfy(
+                          namespace -> {
+                            assertThat(namespace.findValuesAsText("name")).containsOnly("system");
+                            assertThat(namespace.findValues("datacenters")).isNullOrEmpty();
+                          }));
+    }
+
+    @Test
+    public void raw() throws IOException {
+      String body = RestUtils.get(authToken, basePath + "?raw=true", HttpStatus.SC_OK);
+
+      JsonNode json = OBJECT_MAPPER.readTree(body);
+      assertThat(json)
+          .isInstanceOfSatisfying(
+              ArrayNode.class,
+              dataArray ->
+                  assertThat(dataArray)
+                      .anySatisfy(
+                          namespace -> {
+                            assertThat(namespace.findValuesAsText("name"))
+                                .containsOnly("system_schema");
+                            assertThat(namespace.findValues("datacenters")).isNullOrEmpty();
+                          }));
+    }
+
+    @Test
+    public void missingToken() throws IOException {
+      RestUtils.get(null, basePath, HttpStatus.SC_UNAUTHORIZED);
+    }
+
+    @Test
+    public void badToken() throws IOException {
+      RestUtils.get("foo", basePath, HttpStatus.SC_UNAUTHORIZED);
+    }
+  }
+
+  @Nested
+  @ExtendWith(CqlSessionExtension.class)
+  @CqlSessionSpec()
+  class GetOneNamespace {
+
+    @Test
+    public void notRaw(@TestKeyspace CqlIdentifier keyspace) throws IOException {
+      String body = RestUtils.get(authToken, basePath + "/" + keyspace, HttpStatus.SC_OK);
+
+      JsonNode json = OBJECT_MAPPER.readTree(body);
+      assertThat(json.get("data"))
+          .isInstanceOfSatisfying(
+              ObjectNode.class,
+              namespace -> {
+                assertThat(namespace.findValuesAsText("name")).containsOnly(keyspace.toString());
+                assertThat(namespace.findValues("datacenters")).isNullOrEmpty();
+              });
+    }
+
+    @Test
+    public void raw(@TestKeyspace CqlIdentifier keyspace) throws IOException {
+      String body =
+          RestUtils.get(authToken, basePath + "/" + keyspace + "?raw=true", HttpStatus.SC_OK);
+
+      JsonNode json = OBJECT_MAPPER.readTree(body);
+      assertThat(json)
+          .isInstanceOfSatisfying(
+              ObjectNode.class,
+              namespace -> {
+                assertThat(namespace.findValuesAsText("name")).containsOnly(keyspace.toString());
+                assertThat(namespace.findValues("datacenters")).isNullOrEmpty();
+              });
+    }
+
+    @Test
+    public void notExisting() throws IOException {
+      RestUtils.get(authToken, basePath + "/not_there", HttpStatus.SC_NOT_FOUND);
+    }
+  }
+
+  @Nested
+  @ExtendWith(CqlSessionExtension.class)
+  @CqlSessionSpec(createKeyspace = false, createSession = false)
+  class CreateNamespace {
+
+    @Test
+    public void simpleStrategy() throws IOException {
+      String keyspace = RandomStringUtils.randomAlphanumeric(16);
+      String payload = String.format("{\"name\": \"%s\", \"replicas\": 1}", keyspace);
+
+      String result = RestUtils.post(authToken, basePath, payload, HttpStatus.SC_CREATED);
+
+      assertThat(result).isEqualTo(String.format("{\"name\":\"%s\"}", keyspace));
+      // validate with get as well
+      String getResult =
+          RestUtils.get(authToken, basePath + "/" + keyspace + "?raw=true", HttpStatus.SC_OK);
+      JsonNode json = OBJECT_MAPPER.readTree(getResult);
+      assertThat(json)
+          .isInstanceOfSatisfying(
+              ObjectNode.class,
+              namespace -> {
+                assertThat(namespace.findValuesAsText("name")).containsOnly(keyspace);
+                assertThat(namespace.findValues("datacenters")).isNullOrEmpty();
+              });
+    }
+
+    @Test
+    public void networkTopologyStrategy() throws IOException {
+      String keyspace = RandomStringUtils.randomAlphanumeric(16);
+      String payload =
+          String.format(
+              "{\"name\": \"%s\", \"datacenters\": [ { \"name\": \"dc1\", \"replicas\": 1 }, { \"name\": \"dc2\" }]}",
+              keyspace);
+
+      String result = RestUtils.post(authToken, basePath, payload, HttpStatus.SC_CREATED);
+
+      assertThat(result).isEqualTo(String.format("{\"name\":\"%s\"}", keyspace));
+      // validate with get as well
+      String getResult =
+          RestUtils.get(authToken, basePath + "/" + keyspace + "?raw=true", HttpStatus.SC_OK);
+      JsonNode json = OBJECT_MAPPER.readTree(getResult);
+      assertThat(json)
+          .isInstanceOfSatisfying(
+              ObjectNode.class,
+              namespace -> {
+                assertThat(namespace.findValue("name").asText()).isEqualTo(keyspace);
+                assertThat(namespace.findValue("datacenters"))
+                    .isInstanceOfSatisfying(
+                        ArrayNode.class,
+                        dcs ->
+                            assertThat(dcs)
+                                .hasSize(2)
+                                .anySatisfy(
+                                    dc -> {
+                                      assertThat(dc.findValuesAsText("name")).containsOnly("dc1");
+                                      assertThat(dc.findValue("replicas").asInt()).isEqualTo(1);
+                                    })
+                                .anySatisfy(
+                                    dc -> {
+                                      assertThat(dc.findValuesAsText("name")).containsOnly("dc2");
+                                      assertThat(dc.findValue("replicas").asInt()).isEqualTo(3);
+                                    }));
+              });
+    }
+
+    @Test
+    public void noPayload() throws IOException {
+      String r = RestUtils.post(authToken, basePath, null, 422);
+
+      assertThat(r)
+          .isEqualTo("{\"description\":\"Request invalid: payload not provided.\",\"code\":422}");
+    }
+
+    @Test
+    public void noNamespaceName() throws IOException {
+      String r = RestUtils.post(authToken, basePath, "{}", 422);
+
+      assertThat(r)
+          .isEqualTo(
+              "{\"description\":\"Request invalid: `name` is required to create a namespace.\",\"code\":422}");
+    }
+
+    @Test
+    public void zeroReplicas() throws IOException {
+      String keyspace = RandomStringUtils.randomAlphanumeric(16);
+      String payload = String.format("{\"name\": \"%s\", \"replicas\": 0}", keyspace);
+
+      String r = RestUtils.post(authToken, basePath, payload, 422);
+
+      assertThat(r)
+          .isEqualTo(
+              "{\"description\":\"Request invalid: minimum amount of `replicas` for `SimpleStrategy` is one.\",\"code\":422}");
+    }
+
+    @Test
+    public void noDatacenterName() throws IOException {
+      String keyspace = RandomStringUtils.randomAlphanumeric(16);
+      String payload = String.format("{\"name\": \"%s\", \"datacenters\": [ {} ]}", keyspace);
+
+      String r = RestUtils.post(authToken, basePath, payload, 422);
+
+      assertThat(r)
+          .isEqualTo(
+              "{\"description\":\"Request invalid: a datacenter `name` is required when using `NetworkTopologyStrategy`.\",\"code\":422}");
+    }
+
+    @Test
+    public void zeroDatacenterReplicas() throws IOException {
+      String keyspace = RandomStringUtils.randomAlphanumeric(16);
+      String payload =
+          String.format(
+              "{\"name\": \"%s\", \"datacenters\": [ { \"name\": \"dc1\", \"replicas\": 0 } ]}",
+              keyspace);
+
+      String r = RestUtils.post(authToken, basePath, payload, 422);
+
+      assertThat(r)
+          .isEqualTo(
+              "{\"description\":\"Request invalid: minimum amount of `replicas` for a datacenter is one.\",\"code\":422}");
+    }
+  }
+
+  @Nested
+  @ExtendWith(CqlSessionExtension.class)
+  @CqlSessionSpec()
+  class DeleteNamespace {
+
+    @Test
+    public void happyPath(@TestKeyspace CqlIdentifier keyspace) throws IOException {
+      String path = basePath + "/" + keyspace.toString();
+
+      RestUtils.delete(authToken, path, HttpStatus.SC_NO_CONTENT);
+
+      // assert not found anymore
+      RestUtils.get(authToken, path, HttpStatus.SC_NOT_FOUND);
+    }
+  }
+}


### PR DESCRIPTION
Same as before, this time for the `NamespacesResource`:

* validate body, removed unused and unnecessary code
* added DTO for the creation with validation and extracted getting the `Replication`
* moved all tests from the `BaseDocumentApiV2Test` to a new class, with well defined structure, added more tests for validation

I know this heavily intersects with the `v2/schemas/keyspaces`, but the ticket was related to the docs api resource validation, we can merge as part of #101.