### PR TITLE
Change to 404 on empty GET

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
@@ -636,7 +636,7 @@ public class DocumentResourceV2 {
           if (filters.isEmpty()) {
             node = documentService.getJsonAtPath(db, namespace, collection, id, path);
             if (node == null) {
-              return Response.noContent().build();
+              return Response.status(Response.Status.NOT_FOUND).build();
             }
 
             String json;

--- a/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
@@ -403,7 +403,7 @@ public class DocumentResourceV2Test {
             pageStateParam,
             false,
             httpServletRequest);
-    assertThat(r.getStatus()).isEqualTo(204);
+    assertThat(r.getStatus()).isEqualTo(404);
     r =
         documentResourceV2.getDocPath(
             headers,
@@ -419,7 +419,7 @@ public class DocumentResourceV2Test {
             pageStateParam,
             true,
             httpServletRequest);
-    assertThat(r.getStatus()).isEqualTo(204);
+    assertThat(r.getStatus()).isEqualTo(404);
   }
 
   @Test

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -417,12 +417,12 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     String resp = RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);
     assertThat(resp).isEqualTo("{\"documentId\":\"1\"}");
 
-    RestUtils.get(authToken, collectionPath + "/1/nonexistent/path", 204);
+    RestUtils.get(authToken, collectionPath + "/1/nonexistent/path", 404);
 
-    RestUtils.get(authToken, collectionPath + "/1/nonexistent/path/[1]", 204);
+    RestUtils.get(authToken, collectionPath + "/1/nonexistent/path/[1]", 404);
 
     RestUtils.get(
-        authToken, collectionPath + "/1/quiz/maths/q1/options/[9999]", 204); // out of bounds
+        authToken, collectionPath + "/1/quiz/maths/q1/options/[9999]", 404); // out of bounds
   }
 
   @Test
@@ -610,11 +610,11 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     RestUtils.delete(authToken, collectionPath + "/1/quiz/sport/q1/question", 204);
 
-    RestUtils.get(authToken, collectionPath + "/1/quiz/sport/q1/question", 204);
+    RestUtils.get(authToken, collectionPath + "/1/quiz/sport/q1/question", 404);
 
     RestUtils.delete(authToken, collectionPath + "/1/quiz/maths", 204);
 
-    RestUtils.get(authToken, collectionPath + "/1/quiz/maths", 204);
+    RestUtils.get(authToken, collectionPath + "/1/quiz/maths", 404);
 
     RestUtils.delete(authToken, collectionPath + "/1/quiz/nests/q1/options/[0]", 204);
 
@@ -629,7 +629,7 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     RestUtils.delete(authToken, collectionPath + "/1", 204);
 
-    RestUtils.get(authToken, collectionPath + "/1", 204);
+    RestUtils.get(authToken, collectionPath + "/1", 404);
   }
 
   @Test


### PR DESCRIPTION
If a document (or path) request is empty, return a 404 instead of a 204 No Content

This would mean that either the data at the particular path is `null` or missing; if it is the empty object it will still be returned with a 200 OK