### PR TITLE
relates to #944: config prop for the http request metrics percentiles

### DIFF
--- a/core/src/main/java/io/stargate/core/metrics/impl/MeterRegistryConfiguration.java
+++ b/core/src/main/java/io/stargate/core/metrics/impl/MeterRegistryConfiguration.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.core.metrics.impl;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.stargate.core.metrics.StargateMetricConstants;
+import java.util.Arrays;
+import java.util.stream.DoubleStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class MeterRegistryConfiguration {
+
+  private static final Logger logger = LoggerFactory.getLogger(MeterRegistryConfiguration.class);
+
+  private static final String HTTP_PERCENTILES_PROPERTY =
+      "stargate.metrics.http_server_requests_percentiles";
+
+  private MeterRegistryConfiguration() {}
+
+  public static void configure(MeterRegistry registry) {
+    configureHttpPercentiles(registry.config());
+  }
+
+  public static void configure(MeterRegistry.Config config) {
+    configureHttpPercentiles(config);
+  }
+
+  private static void configureHttpPercentiles(MeterRegistry.Config config) {
+    String percentiles = System.getProperty(HTTP_PERCENTILES_PROPERTY);
+    if (null != percentiles) {
+      double[] finalPercentiles =
+          Arrays.stream(percentiles.split(","))
+              .map(String::trim)
+              .flatMapToDouble(
+                  p -> {
+                    try {
+                      double percentile = Double.parseDouble(p);
+                      if (percentile < 0
+                          || percentile > 1
+                          || Double.isNaN(percentile)
+                          || Double.isInfinite(percentile)) {
+                        logger.warn(
+                            "Value {} can not be used as the percentile for the http.server.request.metrics, was expecting a double [0, 1].",
+                            percentile);
+                        return DoubleStream.empty();
+                      } else {
+                        return DoubleStream.of(percentile);
+                      }
+                    } catch (Exception e) {
+                      logger.warn(
+                          "Value {} can not be used as the percentile for the http.server.request.metrics, was expecting a double [0, 1].",
+                          p,
+                          e);
+                      return DoubleStream.empty();
+                    }
+                  })
+              .toArray();
+
+      if (finalPercentiles.length > 0) {
+        config.meterFilter(
+            new PercentilesMeterFilter(
+                finalPercentiles, StargateMetricConstants.METRIC_HTTP_SERVER_REQUESTS));
+      }
+    }
+  }
+
+  /** Simple {@link MeterFilter} that adds set of percentiles to a specific metric. */
+  private static class PercentilesMeterFilter implements MeterFilter {
+
+    private final double[] percentiles;
+    private final String metricName;
+
+    public PercentilesMeterFilter(double[] percentiles, String metricName) {
+      this.percentiles = percentiles;
+      this.metricName = metricName;
+    }
+
+    @Override
+    public DistributionStatisticConfig configure(Meter.Id id, DistributionStatisticConfig config) {
+      if (id.getName().startsWith(metricName)) {
+        return DistributionStatisticConfig.builder().percentiles(percentiles).build().merge(config);
+      } else {
+        return config;
+      }
+    }
+  }
+}

--- a/core/src/main/java/io/stargate/core/metrics/impl/MetricsImpl.java
+++ b/core/src/main/java/io/stargate/core/metrics/impl/MetricsImpl.java
@@ -33,6 +33,7 @@ public class MetricsImpl implements Metrics, MetricsScraper {
 
     PrometheusMeterRegistry meterRegistry =
         new PrometheusMeterRegistry(PrometheusConfig.DEFAULT, collectorRegistry, Clock.SYSTEM);
+    MeterRegistryConfiguration.configure(meterRegistry);
     return meterRegistry;
   }
 

--- a/core/src/test/java/io/stargate/core/metrics/impl/MeterRegistryConfigurationTest.java
+++ b/core/src/test/java/io/stargate/core/metrics/impl/MeterRegistryConfigurationTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.core.metrics.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+import io.micrometer.core.instrument.distribution.ValueAtPercentile;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.stargate.core.metrics.StargateMetricConstants;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class MeterRegistryConfigurationTest {
+
+  MeterRegistry meterRegistry;
+
+  @BeforeEach
+  public void initMeterRegistry() {
+    meterRegistry = new SimpleMeterRegistry();
+  }
+
+  @Nested
+  class Configure {
+
+    @AfterEach
+    public void cleanUpProperties() {
+      System.clearProperty("stargate.metrics.http_server_requests_percentiles");
+    }
+
+    @Test
+    public void happyPath() {
+      System.setProperty(
+          "stargate.metrics.http_server_requests_percentiles", "0.9, 0.95,0.99 ,0.999");
+
+      MeterRegistryConfiguration.configure(meterRegistry);
+
+      meterRegistry.summary(StargateMetricConstants.METRIC_HTTP_SERVER_REQUESTS).record(100d);
+      HistogramSnapshot summary =
+          meterRegistry
+              .find(StargateMetricConstants.METRIC_HTTP_SERVER_REQUESTS)
+              .summary()
+              .takeSnapshot();
+
+      assertThat(summary.percentileValues())
+          .hasSize(4)
+          .extracting(ValueAtPercentile::percentile)
+          .containsOnly(0.9d, 0.95d, 0.99d, 0.999d);
+    }
+
+    @Test
+    public void otherMetricsNotInfluenced() {
+      System.setProperty(
+          "stargate.metrics.http_server_requests_percentiles", "0.9,0.95,0.99,0.999");
+
+      MeterRegistryConfiguration.configure(meterRegistry);
+
+      meterRegistry.summary("some.other").record(100d);
+      HistogramSnapshot summary = meterRegistry.find("some.other").summary().takeSnapshot();
+
+      assertThat(summary.percentileValues()).isEmpty();
+    }
+
+    @Test
+    public void propertyNotSet() {
+      MeterRegistryConfiguration.configure(meterRegistry);
+
+      meterRegistry.summary(StargateMetricConstants.METRIC_HTTP_SERVER_REQUESTS).record(100d);
+      HistogramSnapshot summary =
+          meterRegistry
+              .find(StargateMetricConstants.METRIC_HTTP_SERVER_REQUESTS)
+              .summary()
+              .takeSnapshot();
+
+      assertThat(summary.percentileValues()).isEmpty();
+    }
+
+    @Test
+    public void wrongProperty() {
+      System.setProperty("stargate.metrics.http_server_requests_percentiles", "something");
+
+      MeterRegistryConfiguration.configure(meterRegistry);
+
+      meterRegistry.summary(StargateMetricConstants.METRIC_HTTP_SERVER_REQUESTS).record(100d);
+      HistogramSnapshot summary =
+          meterRegistry
+              .find(StargateMetricConstants.METRIC_HTTP_SERVER_REQUESTS)
+              .summary()
+              .takeSnapshot();
+
+      assertThat(summary.percentileValues()).isEmpty();
+    }
+
+    @Test
+    public void ignoreInvalid() {
+      // only 0.5 is valid here
+      System.setProperty(
+          "stargate.metrics.http_server_requests_percentiles", "0.5,-0.5,,1.5,letters,NaN");
+
+      MeterRegistryConfiguration.configure(meterRegistry);
+
+      meterRegistry.summary(StargateMetricConstants.METRIC_HTTP_SERVER_REQUESTS).record(100d);
+      HistogramSnapshot summary =
+          meterRegistry
+              .find(StargateMetricConstants.METRIC_HTTP_SERVER_REQUESTS)
+              .summary()
+              .takeSnapshot();
+
+      assertThat(summary.percentileValues())
+          .hasSize(1)
+          .extracting(ValueAtPercentile::percentile)
+          .containsOnly(0.5);
+    }
+
+    @Test
+    public void edges() {
+      System.setProperty("stargate.metrics.http_server_requests_percentiles", "0,1");
+
+      MeterRegistryConfiguration.configure(meterRegistry);
+
+      meterRegistry.summary(StargateMetricConstants.METRIC_HTTP_SERVER_REQUESTS).record(100d);
+      HistogramSnapshot summary =
+          meterRegistry
+              .find(StargateMetricConstants.METRIC_HTTP_SERVER_REQUESTS)
+              .summary()
+              .takeSnapshot();
+
+      assertThat(summary.percentileValues())
+          .hasSize(2)
+          .extracting(ValueAtPercentile::percentile)
+          .containsOnly(0d, 1d);
+    }
+  }
+}

--- a/testing/src/main/java/io/stargate/it/http/MetricsTest.java
+++ b/testing/src/main/java/io/stargate/it/http/MetricsTest.java
@@ -48,6 +48,7 @@ public class MetricsTest extends BaseOsgiIntegrationTest {
     builder.putSystemProperties(
         TestingServicesActivator.HTTP_TAG_PROVIDER_PROPERTY,
         TestingServicesActivator.TAG_ME_HTTP_TAG_PROVIDER);
+    builder.putSystemProperties("stargate.metrics.http_server_requests_percentiles", "0.95,0.99");
   }
 
   @BeforeAll
@@ -83,7 +84,17 @@ public class MetricsTest extends BaseOsgiIntegrationTest {
                     .contains("module=\"restapi\"")
                     .contains("uri=\"/v1/keyspaces\"")
                     .contains(String.format("status=\"%d\"", status))
-                    .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY + "=\"test-value\""));
+                    .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY + "=\"test-value\"")
+                    .contains("quantile=\"0.95\""))
+        .anySatisfy(
+            metric ->
+                assertThat(metric)
+                    .contains("method=\"GET\"")
+                    .contains("module=\"restapi\"")
+                    .contains("uri=\"/v1/keyspaces\"")
+                    .contains(String.format("status=\"%d\"", status))
+                    .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY + "=\"test-value\"")
+                    .contains("quantile=\"0.99\""));
   }
 
   @Test
@@ -114,7 +125,17 @@ public class MetricsTest extends BaseOsgiIntegrationTest {
                     .contains("module=\"graphqlapi\"")
                     .contains("uri=\"/graphql\"")
                     .contains(String.format("status=\"%d\"", status))
-                    .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY + "=\"test-value\""));
+                    .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY + "=\"test-value\"")
+                    .contains("quantile=\"0.95\""))
+        .anySatisfy(
+            metric ->
+                assertThat(metric)
+                    .contains("method=\"GET\"")
+                    .contains("module=\"graphqlapi\"")
+                    .contains("uri=\"/graphql\"")
+                    .contains(String.format("status=\"%d\"", status))
+                    .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY + "=\"test-value\"")
+                    .contains("quantile=\"0.99\""));
   }
 
   @Test
@@ -145,7 +166,17 @@ public class MetricsTest extends BaseOsgiIntegrationTest {
                     .contains("module=\"authapi\"")
                     .contains("uri=\"/v1/auth\"")
                     .contains(String.format("status=\"%d\"", status))
-                    .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY + "=\"test-value\""));
+                    .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY + "=\"test-value\"")
+                    .contains("quantile=\"0.95\""))
+        .anySatisfy(
+            metric ->
+                assertThat(metric)
+                    .contains("method=\"POST\"")
+                    .contains("module=\"authapi\"")
+                    .contains("uri=\"/v1/auth\"")
+                    .contains(String.format("status=\"%d\"", status))
+                    .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY + "=\"test-value\"")
+                    .contains("quantile=\"0.99\""));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
As agreed in #944, I added a support to add percentiles to the `http.server.requests` metrics.. Done as a static configurer. Expects the system prop in format: `stargate.metrics.http_server_requests_percentiles=0.95,0.99,0.999`.

Path and header extraction to follow in separate PR - keeping them small..