### PR TITLE
Fix NPE caused by `AuthenticationInterceptor`

### DIFF
--- a/grpc/src/main/java/io/stargate/grpc/service/interceptors/AuthenticationInterceptor.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/interceptors/AuthenticationInterceptor.java
@@ -63,5 +63,5 @@ public class AuthenticationInterceptor implements ServerInterceptor {
     return new NopListener<>();
   }
 
-  private class NopListener<ReqT> extends ServerCall.Listener<ReqT> { }
+  private class NopListener<ReqT> extends ServerCall.Listener<ReqT> {}
 }

--- a/grpc/src/main/java/io/stargate/grpc/service/interceptors/AuthenticationInterceptor.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/interceptors/AuthenticationInterceptor.java
@@ -51,7 +51,7 @@ public class AuthenticationInterceptor implements ServerInterceptor {
       String token = headers.get(TOKEN_KEY);
       if (token == null) {
         call.close(Status.UNAUTHENTICATED.withDescription("No token provided"), new Metadata());
-        return null;
+        return new NopListener<>();
       }
       Context context = Context.current();
       context = context.withValue(Service.AUTHENTICATION_KEY, authentication.validateToken(token));
@@ -60,6 +60,8 @@ public class AuthenticationInterceptor implements ServerInterceptor {
       call.close(
           Status.UNAUTHENTICATED.withDescription("Invalid token").withCause(e), new Metadata());
     }
-    return null;
+    return new NopListener<>();
   }
+
+  private class NopListener<ReqT> extends ServerCall.Listener<ReqT> { }
 }


### PR DESCRIPTION
From the documentation `ServerInterceptor#interceptCall`: "... the
returned ServerCall.Listener must not be null.". Because the call is
finished after we close it there is nothing left to do so we return a
`ServerCall.Listener` that does nothing.