### PR TITLE
gRPC errors

### DIFF
--- a/grpc-proto/proto/query.proto
+++ b/grpc-proto/proto/query.proto
@@ -252,6 +252,12 @@ message AlreadyExists {
   string table = 2;
 }
 
+message CasWriteUnknown {
+  Consistency consistency = 1;
+  int32 received = 2;
+  int32 block_for = 3;
+}
+
 message Row {
   repeated Value values = 1;
 }

--- a/grpc/src/main/java/io/stargate/grpc/service/Service.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/Service.java
@@ -18,9 +18,12 @@ package io.stargate.grpc.service;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.grpc.Context;
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
 import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.ProtoUtils;
 import io.grpc.stub.StreamObserver;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.core.metrics.api.Metrics;
@@ -38,13 +41,22 @@ import io.stargate.db.Result.Rows;
 import io.stargate.db.Statement;
 import io.stargate.grpc.payload.PayloadHandler;
 import io.stargate.grpc.payload.PayloadHandlers;
+import io.stargate.grpc.service.Service.PrepareInfo;
+import io.stargate.proto.QueryOuterClass.AlreadyExists;
 import io.stargate.proto.QueryOuterClass.Batch;
 import io.stargate.proto.QueryOuterClass.BatchParameters;
 import io.stargate.proto.QueryOuterClass.BatchQuery;
+import io.stargate.proto.QueryOuterClass.CasWriteUnknown;
+import io.stargate.proto.QueryOuterClass.FunctionFailure;
 import io.stargate.proto.QueryOuterClass.Payload;
 import io.stargate.proto.QueryOuterClass.Query;
 import io.stargate.proto.QueryOuterClass.QueryParameters;
+import io.stargate.proto.QueryOuterClass.ReadFailure;
+import io.stargate.proto.QueryOuterClass.ReadTimeout;
 import io.stargate.proto.QueryOuterClass.Response;
+import io.stargate.proto.QueryOuterClass.Unavailable;
+import io.stargate.proto.QueryOuterClass.WriteFailure;
+import io.stargate.proto.QueryOuterClass.WriteTimeout;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
@@ -55,6 +67,16 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 import org.apache.cassandra.stargate.db.ConsistencyLevel;
+import org.apache.cassandra.stargate.exceptions.AlreadyExistsException;
+import org.apache.cassandra.stargate.exceptions.CasWriteUnknownResultException;
+import org.apache.cassandra.stargate.exceptions.FunctionExecutionException;
+import org.apache.cassandra.stargate.exceptions.PersistenceException;
+import org.apache.cassandra.stargate.exceptions.ReadFailureException;
+import org.apache.cassandra.stargate.exceptions.ReadTimeoutException;
+import org.apache.cassandra.stargate.exceptions.UnavailableException;
+import org.apache.cassandra.stargate.exceptions.WriteFailureException;
+import org.apache.cassandra.stargate.exceptions.WriteTimeoutException;
+import org.apache.tinkerpop.gremlin.structure.T;
 import org.immutables.value.Value;
 
 public class Service extends io.stargate.proto.StargateGrpc.StargateImplBase {
@@ -68,6 +90,23 @@ public class Service extends io.stargate.proto.StargateGrpc.StargateImplBase {
   /** The maximum number of batch queries to prepare simultaneously. */
   private static final int MAX_CONCURRENT_PREPARES_FOR_BATCH =
       Math.max(Integer.getInteger("stargate.grpc.max_concurrent_prepares_for_batch", 1), 1);
+
+  public static Key<Unavailable> UNAVAILABLE_KEY =
+      ProtoUtils.keyForProto(Unavailable.getDefaultInstance());
+  public static Key<WriteTimeout> WRITE_TIMEOUT_KEY =
+      ProtoUtils.keyForProto(WriteTimeout.getDefaultInstance());
+  public static Key<ReadTimeout> READ_TIMEOUT_KEY =
+      ProtoUtils.keyForProto(ReadTimeout.getDefaultInstance());
+  public static Key<ReadFailure> READ_FAILURE_KEY =
+      ProtoUtils.keyForProto(ReadFailure.getDefaultInstance());
+  public static Key<FunctionFailure> FUNCTION_FAILURE_KEY =
+      ProtoUtils.keyForProto(FunctionFailure.getDefaultInstance());
+  public static Key<WriteFailure> WRITE_FAILURE_KEY =
+      ProtoUtils.keyForProto(WriteFailure.getDefaultInstance());
+  public static Key<AlreadyExists> ALREADY_EXISTS_KEY =
+      ProtoUtils.keyForProto(AlreadyExists.getDefaultInstance());
+  public static Key<CasWriteUnknown> CAS_WRITE_UNKNOWN_KEY =
+      ProtoUtils.keyForProto(CasWriteUnknown.getDefaultInstance());
 
   // TODO: Add a maximum size and add tuning options
   private final Cache<PrepareInfo, Prepared> preparedCache = Caffeine.newBuilder().build();
@@ -122,8 +161,8 @@ public class Service extends io.stargate.proto.StargateGrpc.StargateImplBase {
                   executePrepared(connection, prepared, query, responseObserver);
                 }
               });
-    } catch (Exception e) {
-      handleError(e, responseObserver);
+    } catch (Throwable t) {
+      handleError(t, responseObserver);
     }
   }
 
@@ -153,14 +192,161 @@ public class Service extends io.stargate.proto.StargateGrpc.StargateImplBase {
                 }
               });
 
-    } catch (Exception e) {
-      handleError(e, responseObserver);
+    } catch (Throwable t) {
+      handleError(t, responseObserver);
     }
   }
 
   private void handleError(Throwable throwable, StreamObserver<?> responseObserver) {
     if (throwable instanceof StatusException || throwable instanceof StatusRuntimeException) {
       responseObserver.onError(throwable);
+    } else if (throwable instanceof PersistenceException) {
+      PersistenceException pe = (PersistenceException) throwable;
+      switch (pe.code()) {
+        case SERVER_ERROR:
+        case PROTOCOL_ERROR: // Fallthrough
+        case UNPREPARED: // Fallthrough
+          onError(responseObserver, Status.INTERNAL, pe);
+          break;
+        case INVALID:
+        case SYNTAX_ERROR: // Fallthrough
+          onError(responseObserver, Status.INVALID_ARGUMENT, pe);
+          break;
+        case TRUNCATE_ERROR:
+        case CDC_WRITE_FAILURE: // Fallthrough
+          onError(responseObserver, Status.ABORTED, pe);
+          break;
+        case BAD_CREDENTIALS:
+          onError(responseObserver, Status.UNAUTHENTICATED, pe);
+          break;
+        case UNAVAILABLE:
+          UnavailableException ue = (UnavailableException) pe;
+          onError(
+              responseObserver,
+              Status.UNAVAILABLE,
+              ue,
+              makeTrailer(
+                  UNAVAILABLE_KEY,
+                  Unavailable.newBuilder()
+                      .setConsistencyValue(ue.consistency.code)
+                      .setAlive(ue.alive)
+                      .setRequired(ue.required)
+                      .build()));
+          break;
+        case OVERLOADED:
+          onError(responseObserver, Status.RESOURCE_EXHAUSTED, pe);
+          break;
+        case IS_BOOTSTRAPPING:
+          onError(responseObserver, Status.UNAVAILABLE, pe);
+          break;
+        case WRITE_TIMEOUT:
+          WriteTimeoutException wte = (WriteTimeoutException) pe;
+          onError(
+              responseObserver,
+              Status.DEADLINE_EXCEEDED,
+              pe,
+              makeTrailer(
+                  WRITE_TIMEOUT_KEY,
+                  WriteTimeout.newBuilder()
+                      .setConsistencyValue(wte.consistency.code)
+                      .setBlockFor(wte.blockFor)
+                      .setReceived(wte.received)
+                      .setWriteType(wte.writeType.name())
+                      .build()));
+          break;
+        case READ_TIMEOUT:
+          ReadTimeoutException rte = (ReadTimeoutException) pe;
+          onError(
+              responseObserver,
+              Status.DEADLINE_EXCEEDED,
+              pe,
+              makeTrailer(
+                  READ_TIMEOUT_KEY,
+                  ReadTimeout.newBuilder()
+                      .setConsistencyValue(rte.consistency.code)
+                      .setBlockFor(rte.blockFor)
+                      .setReceived(rte.received)
+                      .setDataPresent(rte.dataPresent)
+                      .build()));
+          break;
+        case READ_FAILURE:
+          ReadFailureException rfe = (ReadFailureException) pe;
+          onError(
+              responseObserver,
+              Status.ABORTED,
+              pe,
+              makeTrailer(
+                  READ_FAILURE_KEY,
+                  ReadFailure.newBuilder()
+                      .setConsistencyValue(rfe.consistency.code)
+                      .setNumFailures(rfe.failureReasonByEndpoint.size())
+                      .setBlockFor(rfe.blockFor)
+                      .setReceived(rfe.received)
+                      .setDataPresent(rfe.dataPresent)
+                      .build()));
+          break;
+        case FUNCTION_FAILURE:
+          FunctionExecutionException fee = (FunctionExecutionException) pe;
+          onError(
+              responseObserver,
+              Status.FAILED_PRECONDITION,
+              pe,
+              makeTrailer(
+                  FUNCTION_FAILURE_KEY,
+                  FunctionFailure.newBuilder()
+                      .setKeyspace(fee.functionName.keyspace)
+                      .setFunction(fee.functionName.name)
+                      .addAllArgTypes(fee.argTypes)
+                      .build()));
+          break;
+        case WRITE_FAILURE:
+          WriteFailureException wfe = (WriteFailureException) pe;
+          onError(
+              responseObserver,
+              Status.ABORTED,
+              pe,
+              makeTrailer(
+                  WRITE_FAILURE_KEY,
+                  WriteFailure.newBuilder()
+                      .setConsistencyValue(wfe.consistency.code)
+                      .setNumFailures(wfe.failureReasonByEndpoint.size())
+                      .setBlockFor(wfe.blockFor)
+                      .setReceived(wfe.received)
+                      .setWriteType(wfe.writeType.name())
+                      .build()));
+          break;
+        case CAS_WRITE_UNKNOWN:
+          CasWriteUnknownResultException cwe = (CasWriteUnknownResultException) pe;
+          onError(
+              responseObserver,
+              Status.ABORTED,
+              pe,
+              makeTrailer(
+                  CAS_WRITE_UNKNOWN_KEY,
+                  CasWriteUnknown.newBuilder()
+                      .setConsistencyValue(cwe.consistency.code)
+                      .setBlockFor(cwe.blockFor)
+                      .setReceived(cwe.received)
+                      .build()));
+          break;
+        case UNAUTHORIZED:
+          onError(responseObserver, Status.PERMISSION_DENIED, pe);
+          break;
+        case CONFIG_ERROR:
+          onError(responseObserver, Status.FAILED_PRECONDITION, pe);
+          break;
+        case ALREADY_EXISTS:
+          onError(responseObserver, Status.ALREADY_EXISTS, pe);
+          AlreadyExistsException aee = (AlreadyExistsException) pe;
+          onError(
+              responseObserver,
+              Status.ALREADY_EXISTS,
+              pe,
+              makeTrailer(
+                  ALREADY_EXISTS_KEY,
+                  AlreadyExists.newBuilder().setKeyspace(aee.ksName).setTable(aee.cfName).build()));
+          break;
+      }
     } else {
       responseObserver.onError(
           Status.UNKNOWN
@@ -168,6 +354,24 @@ public class Service extends io.stargate.proto.StargateGrpc.StargateImplBase {
               .withCause(throwable)
               .asRuntimeException());
     }
+  }
+
+  private static void onError(
+      StreamObserver<?> responseObserver, Status status, Throwable throwable, Metadata trailer) {
+    status = status.withCause(throwable).withDescription(throwable.getMessage());
+    responseObserver.onError(
+        trailer != null ? status.asRuntimeException(trailer) : status.asRuntimeException());
+  }
+
+  public static void onError(
+      StreamObserver<?> responseObserver, Status status, Throwable throwable) {
+    onError(responseObserver, status, throwable, null);
+  }
+
+  private static <T> Metadata makeTrailer(Key<T> key, T value) {
+    Metadata trailer = new Metadata();
+    trailer.put(key, value);
+    return trailer;
   }
 
   private CompletableFuture<Prepared> prepareQuery(
@@ -245,13 +449,13 @@ public class Service extends io.stargate.proto.StargateGrpc.StargateImplBase {
                     }
                     responseObserver.onNext(responseBuilder.build());
                     responseObserver.onCompleted();
-                  } catch (Exception e) {
-                    handleError(e, responseObserver);
+                  } catch (Throwable th) {
+                    handleError(th, responseObserver);
                   }
                 }
               });
-    } catch (Exception e) {
-      handleError(e, responseObserver);
+    } catch (Throwable t) {
+      handleError(t, responseObserver);
     }
   }
 
@@ -277,13 +481,13 @@ public class Service extends io.stargate.proto.StargateGrpc.StargateImplBase {
                     }
                     responseObserver.onNext(responseBuilder.build());
                     responseObserver.onCompleted();
-                  } catch (Exception e) {
-                    handleError(e, responseObserver);
+                  } catch (Throwable th) {
+                    handleError(th, responseObserver);
                   }
                 }
               });
-    } catch (Exception e) {
-      handleError(e, responseObserver);
+    } catch (Throwable t) {
+      handleError(t, responseObserver);
     }
   }
 
@@ -450,8 +654,8 @@ public class Service extends io.stargate.proto.StargateGrpc.StargateImplBase {
                     PayloadHandler handler = PayloadHandlers.get(query.getValues().getType());
                     statements.add(bindValues(handler, prepared, query.getValues()));
                     next(); // Prepare the next query in the batch
-                  } catch (Exception e) {
-                    future.completeExceptionally(e);
+                  } catch (Throwable th) {
+                    future.completeExceptionally(th);
                   }
                 }
               });

--- a/grpc/src/test/java/io/stargate/grpc/service/PersistenceExceptionTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/PersistenceExceptionTest.java
@@ -1,0 +1,343 @@
+package io.stargate.grpc.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.stargate.db.Parameters;
+import io.stargate.db.Statement;
+import io.stargate.grpc.Utils;
+import io.stargate.proto.QueryOuterClass;
+import io.stargate.proto.QueryOuterClass.AlreadyExists;
+import io.stargate.proto.QueryOuterClass.CasWriteUnknown;
+import io.stargate.proto.QueryOuterClass.Consistency;
+import io.stargate.proto.QueryOuterClass.FunctionFailure;
+import io.stargate.proto.QueryOuterClass.ReadFailure;
+import io.stargate.proto.QueryOuterClass.ReadTimeout;
+import io.stargate.proto.QueryOuterClass.Unavailable;
+import io.stargate.proto.QueryOuterClass.WriteFailure;
+import io.stargate.proto.QueryOuterClass.WriteTimeout;
+import io.stargate.proto.StargateGrpc.StargateBlockingStub;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+import org.apache.cassandra.stargate.cql3.functions.FunctionName;
+import org.apache.cassandra.stargate.db.ConsistencyLevel;
+import org.apache.cassandra.stargate.db.WriteType;
+import org.apache.cassandra.stargate.exceptions.AlreadyExistsException;
+import org.apache.cassandra.stargate.exceptions.AuthenticationException;
+import org.apache.cassandra.stargate.exceptions.CDCWriteException;
+import org.apache.cassandra.stargate.exceptions.CasWriteUnknownResultException;
+import org.apache.cassandra.stargate.exceptions.ConfigurationException;
+import org.apache.cassandra.stargate.exceptions.FunctionExecutionException;
+import org.apache.cassandra.stargate.exceptions.InvalidRequestException;
+import org.apache.cassandra.stargate.exceptions.IsBootstrappingException;
+import org.apache.cassandra.stargate.exceptions.OverloadedException;
+import org.apache.cassandra.stargate.exceptions.PersistenceException;
+import org.apache.cassandra.stargate.exceptions.PreparedQueryNotFoundException;
+import org.apache.cassandra.stargate.exceptions.ReadFailureException;
+import org.apache.cassandra.stargate.exceptions.ReadTimeoutException;
+import org.apache.cassandra.stargate.exceptions.RequestFailureReason;
+import org.apache.cassandra.stargate.exceptions.SyntaxException;
+import org.apache.cassandra.stargate.exceptions.TruncateException;
+import org.apache.cassandra.stargate.exceptions.UnauthorizedException;
+import org.apache.cassandra.stargate.exceptions.UnavailableException;
+import org.apache.cassandra.stargate.exceptions.WriteFailureException;
+import org.apache.cassandra.stargate.exceptions.WriteTimeoutException;
+import org.apache.cassandra.stargate.locator.InetAddressAndPort;
+import org.apache.cassandra.stargate.transport.ProtocolException;
+import org.apache.cassandra.stargate.transport.ServerError;
+import org.apache.cassandra.stargate.utils.MD5Digest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class PersistenceExceptionTest extends BaseServiceTest {
+
+  private static MD5Digest UNPREPARED_ID = MD5Digest.compute(new byte[] {0});
+
+  @Test
+  public void unavailable() {
+    assertThatThrownBy(
+            () ->
+                executeQueryWithException(
+                    UnavailableException.create(ConsistencyLevel.QUORUM, 2, 1)))
+        .isInstanceOf(StatusRuntimeException.class)
+        .satisfies(
+            ex -> {
+              StatusRuntimeException se = (StatusRuntimeException) ex;
+              assertThat(se.getStatus().getCode()).isEqualTo(Status.UNAVAILABLE.getCode());
+              assertThat(se.getTrailers()).isNotNull();
+              Unavailable metadata = se.getTrailers().get(Service.UNAVAILABLE_KEY);
+              assertThat(metadata).isNotNull();
+              assertThat(metadata.getConsistency()).isEqualTo(Consistency.QUORUM);
+              assertThat(metadata.getRequired()).isEqualTo(2);
+              assertThat(metadata.getAlive()).isEqualTo(1);
+            })
+        .hasMessageContaining("Cannot achieve consistency level ");
+  }
+
+  @Test
+  public void writeTimeout() {
+    assertThatThrownBy(
+            () ->
+                executeQueryWithException(
+                    new WriteTimeoutException(
+                        WriteType.BATCH, ConsistencyLevel.LOCAL_QUORUM, 1, 2)))
+        .isInstanceOf(StatusRuntimeException.class)
+        .satisfies(
+            ex -> {
+              StatusRuntimeException se = (StatusRuntimeException) ex;
+              assertThat(se.getStatus().getCode()).isEqualTo(Status.DEADLINE_EXCEEDED.getCode());
+              assertThat(se.getTrailers()).isNotNull();
+              WriteTimeout metadata = se.getTrailers().get(Service.WRITE_TIMEOUT_KEY);
+              assertThat(metadata).isNotNull();
+              assertThat(metadata.getConsistency()).isEqualTo(Consistency.LOCAL_QUORUM);
+              assertThat(metadata.getWriteType()).isEqualTo("BATCH");
+              assertThat(metadata.getReceived()).isEqualTo(1);
+              assertThat(metadata.getBlockFor()).isEqualTo(2);
+            })
+        .hasMessageContaining("Operation timed out - received only 1 responses.");
+  }
+
+  @Test
+  public void readTimeout() {
+    assertThatThrownBy(
+            () ->
+                executeQueryWithException(
+                    new ReadTimeoutException(ConsistencyLevel.LOCAL_QUORUM, 1, 2, true)))
+        .isInstanceOf(StatusRuntimeException.class)
+        .satisfies(
+            ex -> {
+              StatusRuntimeException se = (StatusRuntimeException) ex;
+              assertThat(se.getStatus().getCode()).isEqualTo(Status.DEADLINE_EXCEEDED.getCode());
+              assertThat(se.getTrailers()).isNotNull();
+              ReadTimeout metadata = se.getTrailers().get(Service.READ_TIMEOUT_KEY);
+              assertThat(metadata).isNotNull();
+              assertThat(metadata.getConsistency()).isEqualTo(Consistency.LOCAL_QUORUM);
+              assertThat(metadata.getReceived()).isEqualTo(1);
+              assertThat(metadata.getBlockFor()).isEqualTo(2);
+              assertThat(metadata.getDataPresent()).isTrue();
+            })
+        .hasMessageContaining("Operation timed out - received only 1 responses.");
+  }
+
+  @Test
+  public void readFailure() {
+    assertThatThrownBy(
+            () ->
+                executeQueryWithException(
+                    new ReadFailureException(
+                        ConsistencyLevel.TWO,
+                        0,
+                        2,
+                        false,
+                        ImmutableMap.of(
+                            InetAddressAndPort.getByName("127.0.0.1"),
+                            RequestFailureReason.TIMEOUT,
+                            InetAddressAndPort.getByName("127.0.0.2"),
+                            RequestFailureReason.INCOMPATIBLE_SCHEMA))))
+        .isInstanceOf(StatusRuntimeException.class)
+        .satisfies(
+            ex -> {
+              StatusRuntimeException se = (StatusRuntimeException) ex;
+              assertThat(se.getStatus().getCode()).isEqualTo(Status.ABORTED.getCode());
+              assertThat(se.getTrailers()).isNotNull();
+              ReadFailure metadata = se.getTrailers().get(Service.READ_FAILURE_KEY);
+              assertThat(metadata).isNotNull();
+              assertThat(metadata.getConsistency()).isEqualTo(Consistency.TWO);
+              assertThat(metadata.getReceived()).isEqualTo(0);
+              assertThat(metadata.getBlockFor()).isEqualTo(2);
+              assertThat(metadata.getNumFailures()).isEqualTo(2);
+              assertThat(metadata.getDataPresent()).isFalse();
+            })
+        .hasMessageContaining("Operation failed - received 0 responses and 2 failures");
+  }
+
+  @Test
+  public void functionFailure() {
+    assertThatThrownBy(
+            () ->
+                executeQueryWithException(
+                    new FunctionExecutionException(
+                        new FunctionName("ks", "fn"),
+                        ImmutableList.of("int", "varchar"),
+                        "Some failure happened")))
+        .isInstanceOf(StatusRuntimeException.class)
+        .satisfies(
+            ex -> {
+              StatusRuntimeException se = (StatusRuntimeException) ex;
+              assertThat(se.getStatus().getCode()).isEqualTo(Status.FAILED_PRECONDITION.getCode());
+              assertThat(se.getTrailers()).isNotNull();
+              FunctionFailure metadata = se.getTrailers().get(Service.FUNCTION_FAILURE_KEY);
+              assertThat(metadata).isNotNull();
+              assertThat(metadata.getKeyspace()).isEqualTo("ks");
+              assertThat(metadata.getFunction()).isEqualTo("fn");
+              assertThat(metadata.getArgTypesList()).containsExactly("int", "varchar");
+            })
+        .hasMessageContaining("execution of 'ks.fn[int, varchar]' failed: Some failure happened");
+  }
+
+  @Test
+  public void writeFailure() {
+    assertThatThrownBy(
+            () ->
+                executeQueryWithException(
+                    new WriteFailureException(
+                        ConsistencyLevel.THREE,
+                        1,
+                        3,
+                        WriteType.SIMPLE,
+                        ImmutableMap.of(
+                            InetAddressAndPort.getByName("127.0.0.1"),
+                            RequestFailureReason.TIMEOUT,
+                            InetAddressAndPort.getByName("127.0.0.2"),
+                            RequestFailureReason.INCOMPATIBLE_SCHEMA))))
+        .isInstanceOf(StatusRuntimeException.class)
+        .satisfies(
+            ex -> {
+              StatusRuntimeException se = (StatusRuntimeException) ex;
+              assertThat(se.getStatus().getCode()).isEqualTo(Status.ABORTED.getCode());
+              assertThat(se.getTrailers()).isNotNull();
+              WriteFailure metadata = se.getTrailers().get(Service.WRITE_FAILURE_KEY);
+              assertThat(metadata).isNotNull();
+              assertThat(metadata.getConsistency()).isEqualTo(Consistency.THREE);
+              assertThat(metadata.getReceived()).isEqualTo(1);
+              assertThat(metadata.getBlockFor()).isEqualTo(3);
+              assertThat(metadata.getNumFailures()).isEqualTo(2);
+            })
+        .hasMessageContaining("Operation failed - received 1 responses and 2 failures");
+  }
+
+  @Test
+  public void alreadyExists() {
+    assertThatThrownBy(() -> executeQueryWithException(new AlreadyExistsException("ks", "table")))
+        .isInstanceOf(StatusRuntimeException.class)
+        .satisfies(
+            ex -> {
+              StatusRuntimeException se = (StatusRuntimeException) ex;
+              assertThat(se.getStatus().getCode()).isEqualTo(Status.ALREADY_EXISTS.getCode());
+              assertThat(se.getTrailers()).isNotNull();
+              AlreadyExists metadata = se.getTrailers().get(Service.ALREADY_EXISTS_KEY);
+              assertThat(metadata).isNotNull();
+              assertThat(metadata.getKeyspace()).isEqualTo("ks");
+              assertThat(metadata.getTable()).isEqualTo("table");
+            })
+        .hasMessageContaining("Cannot add already existing table \"table\" to keyspace \"ks\"");
+  }
+
+  @Test
+  public void casWriteUnknown() {
+    assertThatThrownBy(
+            () ->
+                executeQueryWithException(
+                    new CasWriteUnknownResultException(ConsistencyLevel.SERIAL, 2, 3)))
+        .isInstanceOf(StatusRuntimeException.class)
+        .satisfies(
+            ex -> {
+              StatusRuntimeException se = (StatusRuntimeException) ex;
+              assertThat(se.getStatus().getCode()).isEqualTo(Status.ABORTED.getCode());
+              assertThat(se.getTrailers()).isNotNull();
+              CasWriteUnknown metadata = se.getTrailers().get(Service.CAS_WRITE_UNKNOWN_KEY);
+              assertThat(metadata).isNotNull();
+              assertThat(metadata.getConsistency()).isEqualTo(Consistency.SERIAL);
+              assertThat(metadata.getReceived()).isEqualTo(2);
+              assertThat(metadata.getBlockFor()).isEqualTo(3);
+            })
+        .hasMessageContaining(
+            "CAS operation result is unknown - proposal accepted by 2 but not a quorum.");
+  }
+
+  @ParameterizedTest
+  @MethodSource("persistenceExceptionValues")
+  public void persistenceException(
+      PersistenceException pe, Status expectedStatus, String expectedMessage) {
+    assertThatThrownBy(() -> executeQueryWithException(pe))
+        .isInstanceOf(StatusRuntimeException.class)
+        .satisfies(
+            ex -> {
+              StatusRuntimeException se = (StatusRuntimeException) ex;
+              assertThat(se.getStatus().getCode()).isEqualTo(expectedStatus.getCode());
+            })
+        .hasMessageContaining(expectedMessage);
+  }
+
+  public static Stream<Arguments> persistenceExceptionValues() {
+    return Stream.of(
+        Arguments.of(
+            new ServerError("Some internal problem"), Status.INTERNAL, "Some internal problem"),
+        Arguments.of(
+            new ProtocolException("Some protocol problem"),
+            Status.INTERNAL,
+            "Some protocol problem"),
+        Arguments.of(
+            new PreparedQueryNotFoundException(UNPREPARED_ID),
+            Status.INTERNAL,
+            String.format("Prepared query with ID %s not found", UNPREPARED_ID)),
+        Arguments.of(
+            new InvalidRequestException("Some request problem"),
+            Status.INVALID_ARGUMENT,
+            "Some request problem"),
+        Arguments.of(
+            new SyntaxException("Some query syntax problem"),
+            Status.INVALID_ARGUMENT,
+            "Some query syntax problem"),
+        Arguments.of(
+            new TruncateException("Some truncate problem"),
+            Status.ABORTED,
+            "Some truncate problem"),
+        Arguments.of(
+            new CDCWriteException("Some CDC write problem"),
+            Status.ABORTED,
+            "Some CDC write problem"),
+        Arguments.of(
+            new AuthenticationException("Some credentials problem"),
+            Status.UNAUTHENTICATED,
+            "Some credentials problem"),
+        Arguments.of(
+            new OverloadedException("Some overloaded problem"),
+            Status.RESOURCE_EXHAUSTED,
+            "Some overloaded problem"),
+        Arguments.of(
+            new IsBootstrappingException(),
+            Status.UNAVAILABLE,
+            "Cannot read from a bootstrapping node"),
+        Arguments.of(
+            new ServerError("Some internal problem"), Status.INTERNAL, "Some internal problem"),
+        Arguments.of(
+            new UnauthorizedException("Some authorization problem"),
+            Status.PERMISSION_DENIED,
+            "Some authorization problem"),
+        Arguments.of(
+            new ConfigurationException("Some config problem"),
+            Status.FAILED_PRECONDITION,
+            "Some config problem"));
+  }
+
+  private void executeQueryWithException(PersistenceException pe) {
+    when(connection.prepare(anyString(), any(Parameters.class)))
+        .thenReturn(CompletableFuture.completedFuture(Utils.makePrepared()));
+
+    when(connection.execute(any(Statement.class), any(Parameters.class), anyLong()))
+        .then(
+            invocation -> {
+              throw pe;
+            });
+
+    when(persistence.newConnection()).thenReturn(connection);
+
+    startServer(persistence);
+
+    StargateBlockingStub stub = makeBlockingStub();
+
+    QueryOuterClass.Response response = executeQuery(stub, "DOESN'T MATTER");
+    assertThat(response).isNotNull();
+  }
+}


### PR DESCRIPTION
This PR resolves https://github.com/stargate/stargate/issues/923. 

My first attempt was to add a custom interceptor to like `TransmitStatusRuntimeExceptionInterceptor` (https://grpc.github.io/grpc-java/javadoc/io/grpc/util/TransmitStatusRuntimeExceptionInterceptor.html). However, I think this is more for debugging or trusted internal services. Also, the internal implementation has some complexity around threading and `Server.Listeners`.  Let me know if you think this is a better approach.

I think the preferred approach is to use `StreamObserver#onError(Throwable t)`. So this PR just handles all the unhandled and known exception types from the `Persistence` layer. Otherwise, code inside the service, where we control error handling, should use `StatusException` or `StatusRuntimeException`.