### PR TITLE
Add dependency to the legacy driver in OSS persistence modules

### DIFF
--- a/persistence-cassandra-3.11/pom.xml
+++ b/persistence-cassandra-3.11/pom.xml
@@ -9,7 +9,13 @@
   <groupId>io.stargate.db.cassandra</groupId>
   <artifactId>persistence-cassandra-3.11</artifactId>
   <properties>
+    <!-- If you update this, make sure to keep `cassandra.bundled-driver.version` in sync -->
     <cassandra.version>3.11.8</cassandra.version>
+    <!--
+      The driver used internally by cassandra-all for UDFs (must match the version declared in
+      cassandra-all's POM).
+    -->
+    <cassandra.bundled-driver.version>3.0.1</cassandra.bundled-driver.version>
   </properties>
   <dependencies>
     <dependency>
@@ -46,10 +52,14 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!--
+      Redeclare the driver dependency because it's optional in cassandra-all (this is required to
+      correctly handle UDFs).
+    -->
     <dependency>
       <groupId>com.datastax.cassandra</groupId>
       <artifactId>cassandra-driver-core</artifactId>
-      <version>3.0.1</version>
+      <version>${cassandra.bundled-driver.version}</version>
     </dependency>
     <dependency>
       <groupId>org.gridkit.jvmtool</groupId>

--- a/persistence-cassandra-3.11/pom.xml
+++ b/persistence-cassandra-3.11/pom.xml
@@ -47,6 +47,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>com.datastax.cassandra</groupId>
+      <artifactId>cassandra-driver-core</artifactId>
+      <version>3.0.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.gridkit.jvmtool</groupId>
       <artifactId>sjk-core</artifactId>
       <version>0.14</version>

--- a/persistence-cassandra-4.0/pom.xml
+++ b/persistence-cassandra-4.0/pom.xml
@@ -47,6 +47,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>com.datastax.cassandra</groupId>
+      <artifactId>cassandra-driver-core</artifactId>
+      <version>3.10.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.gridkit.jvmtool</groupId>
       <artifactId>sjk-core</artifactId>
       <version>0.14</version>

--- a/persistence-cassandra-4.0/pom.xml
+++ b/persistence-cassandra-4.0/pom.xml
@@ -9,7 +9,13 @@
   <groupId>io.stargate.db.cassandra</groupId>
   <artifactId>persistence-cassandra-4.0</artifactId>
   <properties>
+    <!-- If you update this, make sure to keep `cassandra.bundled-driver.version` in sync -->
     <cassandra.version>4.0-beta4</cassandra.version>
+    <!--
+      The driver used internally by cassandra-all for UDFs (must match the version declared in
+      cassandra-all's POM).
+    -->
+    <cassandra.bundled-driver.version>3.10.0</cassandra.bundled-driver.version>
   </properties>
   <dependencies>
     <dependency>
@@ -46,10 +52,14 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!--
+      Redeclare the driver dependency because it's optional in cassandra-all (this is required to
+      correctly handle UDFs).
+    -->
     <dependency>
       <groupId>com.datastax.cassandra</groupId>
       <artifactId>cassandra-driver-core</artifactId>
-      <version>3.10.0</version>
+      <version>${cassandra.bundled-driver.version}</version>
     </dependency>
     <dependency>
       <groupId>org.gridkit.jvmtool</groupId>


### PR DESCRIPTION
Cassandra uses the driver internally for UDFs. The dependency is
optional, but if the Stargate backend has UDFs, keyspaces can't be
parsed correctly if the driver is not present.

Fixes #645