### PR TITLE
Avoid proactively fetching empty pages when one result set row is expected

### DIFF
--- a/restapi/src/test/java/io/stargate/db/datastore/ValidatingDataStore.java
+++ b/restapi/src/test/java/io/stargate/db/datastore/ValidatingDataStore.java
@@ -317,11 +317,15 @@ public class ValidatingDataStore implements DataStore {
       executed = true;
 
       Optional<ByteBuffer> pagingState = parameters.pagingState();
+      int pageSize;
       if (expectation.pageSize < Integer.MAX_VALUE) {
-        assertThat(parameters.pageSize()).hasValue(expectation.pageSize);
+        pageSize = expectation.pageSize;
+        assertThat(parameters.pageSize()).hasValue(pageSize);
+      } else {
+        pageSize = parameters.pageSize().orElse(expectation.pageSize);
       }
 
-      ValidatingPaginator paginator = ValidatingPaginator.of(expectation.pageSize, pagingState);
+      ValidatingPaginator paginator = ValidatingPaginator.of(pageSize, pagingState);
 
       expectation.executed();
       return CompletableFuture.completedFuture(

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -519,10 +519,10 @@ public class DocumentServiceTest extends AbstractDataStoreTest {
         .returning(ImmutableList.of(leafRow(id1), leafRow(id2)));
 
     String checkDblValueQuery =
-        "SELECT key, leaf FROM test_docs.collection1 WHERE key = ? AND p0 = ? AND p1 = ? AND p2 = ? AND p3 = ? AND dbl_value = ? ALLOW FILTERING";
-    withQuery(table, checkDblValueQuery, id1, "d", "e", "f", "", 2.0)
+        "SELECT key, leaf FROM test_docs.collection1 WHERE key = ? AND p0 = ? AND p1 = ? AND p2 = ? AND p3 = ? AND dbl_value = ? LIMIT ? ALLOW FILTERING";
+    withQuery(table, checkDblValueQuery, id1, "d", "e", "f", "", 2.0, 1)
         .returning(ImmutableList.of(leafRow(id1)));
-    withQuery(table, checkDblValueQuery, id2, "d", "e", "f", "", 2.0)
+    withQuery(table, checkDblValueQuery, id2, "d", "e", "f", "", 2.0, 1)
         .returning(ImmutableList.of(leafRow(id2)));
 
     withQuery(table, selectAll("WHERE key = ?"), id1)
@@ -796,7 +796,7 @@ public class DocumentServiceTest extends AbstractDataStoreTest {
     private final String dblValueGtQuery =
         "SELECT key, leaf FROM test_docs.collection1 WHERE p0 = ? AND p1 = ? AND p2 = ? AND dbl_value > ? ALLOW FILTERING";
     private final String dblValueEqQuery =
-        "SELECT key, leaf FROM test_docs.collection1 WHERE key = ? AND p0 = ? AND p1 = ? AND p2 = ? AND p3 = ? AND dbl_value = ? ALLOW FILTERING";
+        "SELECT key, leaf FROM test_docs.collection1 WHERE key = ? AND p0 = ? AND p1 = ? AND p2 = ? AND p3 = ? AND dbl_value = ? LIMIT ? ALLOW FILTERING";
     private final String selectByKey = selectAll("WHERE key = ?");
     private final String selectAll = selectAll("");
     private final String insert =
@@ -811,11 +811,11 @@ public class DocumentServiceTest extends AbstractDataStoreTest {
       withQuery(table, dblValueGtQuery, params("a", "c", "", 1.0))
           .returning(ImmutableList.of(leafRow(id1), leafRow(id2), leafRow(id3)));
 
-      withQuery(table, dblValueEqQuery, id1, "d", "e", "f", "", 2.0)
+      withQuery(table, dblValueEqQuery, id1, "d", "e", "f", "", 2.0, 1)
           .returning(ImmutableList.of(leafRow(id1)));
-      withQuery(table, dblValueEqQuery, id2, "d", "e", "f", "", 2.0)
+      withQuery(table, dblValueEqQuery, id2, "d", "e", "f", "", 2.0, 1)
           .returning(ImmutableList.of(leafRow(id2)));
-      withQuery(table, dblValueEqQuery, id3, "d", "e", "f", "", 2.0).returningNothing();
+      withQuery(table, dblValueEqQuery, id3, "d", "e", "f", "", 2.0, 1).returningNothing();
 
       withQuery(table, selectByKey, id1)
           .returning(ImmutableList.of(row(id1, 3.0, "a", "b"), row(id1, 4.0, "a", "c")));

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/QueryExecutorTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/QueryExecutorTest.java
@@ -205,8 +205,10 @@ class QueryExecutorTest extends AbstractDataStoreTest {
   }
 
   @ParameterizedTest
-  @CsvSource({"1", "3", "5", "100"})
+  @CsvSource({"3", "5", "100"})
   void testFullScanFinalPagingState(int pageSize) {
+    // Note: page size must not be a divisor of the result set size for this test to work normally
+    // Otherwise, the last doc will have a non-null paging state
     withFiveTestDocs(pageSize);
 
     List<RawDocument> r1 =
@@ -217,8 +219,10 @@ class QueryExecutorTest extends AbstractDataStoreTest {
   }
 
   @ParameterizedTest
-  @CsvSource({"1", "3", "5", "100"})
+  @CsvSource({"3", "4", "6", "100"})
   void testPopulate(int pageSize) {
+    // Note: page size must not be a divisor of the result set size for this test to work normally.
+    // Otherwise, the last doc will have a non-null paging state
     withFiveTestDocIds(pageSize);
     withQuery(table, "SELECT * FROM %s WHERE key = ?", "2")
         .withPageSize(pageSize)
@@ -338,8 +342,10 @@ class QueryExecutorTest extends AbstractDataStoreTest {
   }
 
   @ParameterizedTest
-  @CsvSource({"1", "3", "5", "100"})
+  @CsvSource({"2", "4", "5", "100"})
   void testSubDocumentsPaged(int pageSize) {
+    // Note: page size must not be a divisor of the result set size for this test to work normally
+    // Otherwise, the last doc will have a non-null paging state
     withQuery(table, "SELECT * FROM %s WHERE key = ? AND p0 > ?", "a", "x")
         .withPageSize(pageSize)
         .returning(

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/QueryExecutorTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/QueryExecutorTest.java
@@ -205,24 +205,33 @@ class QueryExecutorTest extends AbstractDataStoreTest {
   }
 
   @ParameterizedTest
-  @CsvSource({"3", "5", "100"})
+  @CsvSource({"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "100"})
   void testFullScanFinalPagingState(int pageSize) {
-    // Note: page size must not be a divisor of the result set size for this test to work normally
-    // Otherwise, the last doc will have a non-null paging state
+    // Note: the test result set has 8 rows.
+    // If page size is a divisor of the result set size the test DataStore will return a non-null
+    // paging state in the page that contains the last row to emulate C* behaviour, which cannot
+    // say for sure that there are no more rows available in this case. Therefore, in that case
+    // the last doc will have a non-null paging state, but using it will yield no other docs.
+    boolean shouldHavePagingState = (8 % pageSize) == 0;
     withFiveTestDocs(pageSize);
 
     List<RawDocument> r1 =
         executor.queryDocs(allDocsQuery, pageSize, null, context).test().values();
     assertThat(r1).extracting(RawDocument::id).containsExactly("1", "2", "3", "4", "5");
-    assertThat(r1.get(4).makePagingState()).isNull();
-    assertThat(r1.get(4).hasPagingState()).isFalse();
+    assertThat(r1.get(4).hasPagingState()).isEqualTo(shouldHavePagingState);
+    ByteBuffer pagingState = r1.get(4).makePagingState();
+    assertThat(pagingState).matches(buf -> (buf == null) == !shouldHavePagingState);
+
+    if (pagingState != null) {
+      List<RawDocument> r2 =
+          executor.queryDocs(allDocsQuery, pageSize, pagingState, context).test().values();
+      assertThat(r2).isEmpty();
+    }
   }
 
   @ParameterizedTest
-  @CsvSource({"3", "4", "6", "100"})
+  @CsvSource({"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "100"})
   void testPopulate(int pageSize) {
-    // Note: page size must not be a divisor of the result set size for this test to work normally.
-    // Otherwise, the last doc will have a non-null paging state
     withFiveTestDocIds(pageSize);
     withQuery(table, "SELECT * FROM %s WHERE key = ?", "2")
         .withPageSize(pageSize)
@@ -256,8 +265,6 @@ class QueryExecutorTest extends AbstractDataStoreTest {
     RawDocument doc5a = r1.get(4);
     assertThat(doc5a.id()).isEqualTo("5");
     assertThat(doc5a.rows()).hasSize(1);
-    assertThat(doc5a.makePagingState()).isNull();
-    assertThat(doc5a.hasPagingState()).isFalse();
 
     RawDocument doc5b =
         doc5a
@@ -265,8 +272,8 @@ class QueryExecutorTest extends AbstractDataStoreTest {
             .blockingGet();
     assertThat(doc5b.id()).isEqualTo("5");
     assertThat(doc5b.rows()).hasSize(3);
-    assertThat(doc5b.makePagingState()).isNull();
-    assertThat(doc5b.hasPagingState()).isFalse();
+    assertThat(doc5b.hasPagingState()).isEqualTo(doc5a.hasPagingState());
+    assertThat(doc5b.makePagingState()).isEqualTo(doc5a.makePagingState());
   }
 
   @Test
@@ -342,10 +349,8 @@ class QueryExecutorTest extends AbstractDataStoreTest {
   }
 
   @ParameterizedTest
-  @CsvSource({"2", "4", "5", "100"})
+  @CsvSource({"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "100"})
   void testSubDocumentsPaged(int pageSize) {
-    // Note: page size must not be a divisor of the result set size for this test to work normally
-    // Otherwise, the last doc will have a non-null paging state
     withQuery(table, "SELECT * FROM %s WHERE key = ? AND p0 > ?", "a", "x")
         .withPageSize(pageSize)
         .returning(
@@ -397,7 +402,16 @@ class QueryExecutorTest extends AbstractDataStoreTest {
 
     assertThat(docs.get(0).hasPagingState()).isTrue();
     assertThat(docs.get(0).makePagingState()).isNotNull();
-    assertThat(docs.get(1).hasPagingState()).isFalse();
-    assertThat(docs.get(1).makePagingState()).isNull();
+
+    ByteBuffer lastPagingState = docs.get(1).makePagingState();
+    assertThat(docs.get(1).hasPagingState()).isEqualTo(lastPagingState != null);
+
+    // Depending on how pages align with the result set, the last doc may or may not have a paging
+    // state (see testFullScanFinalPagingState(...) for details). In any case, though, there
+    // should be no more documents in the pipeline.
+    if (lastPagingState != null) {
+      docs = executor.queryDocs(3, query, pageSize, lastPagingState, context).test().values();
+      assertThat(docs).isEmpty();
+    }
   }
 }


### PR DESCRIPTION
* Use LIMIT in nested filter queries

* Make QueryExecutor enforce non-zero page sizes

* Use non-zero page sizes in document populating queries.
  Note: previous usage of zero page size in these cases was
  incorrect and would lead to error if/when the whole doc does
  not fit into one page.