### PR TITLE
Add resource to attach a JSON schema to a collection

### DIFF
--- a/restapi/pom.xml
+++ b/restapi/pom.xml
@@ -63,6 +63,11 @@
       <version>1.1</version>
     </dependency>
     <dependency>
+      <groupId>com.github.java-json-tools</groupId>
+      <artifactId>json-schema-validator</artifactId>
+      <version>2.2.14</version>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>4.0.1</version>

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -167,6 +167,17 @@ public class DocumentDB {
     return dataStore.schema();
   }
 
+  public void writeJsonSchemaToCollection(String namespace, String collection, String schemaData) {
+    this.builder()
+        .alter()
+        .table(namespace, collection)
+        .withComment(schemaData)
+        .build()
+        .execute()
+        .join();
+    this.dataStore.waitForSchemaAgreement();
+  }
+
   /**
    * Creates the table described by @param tableName, in keyspace @keyspaceName, if it doesn't
    * already exist.

--- a/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
@@ -97,6 +97,10 @@ public enum ErrorCode {
   DOCS_API_JSON_SCHEMA_INVALID(
       Response.Status.BAD_REQUEST, "The provided JSON schema is invalid or malformed."),
 
+  DOCS_API_JSON_SCHEMA_INVALID_PARTIAL_UPDATE(
+      Response.Status.BAD_REQUEST,
+      "When a collection has a JSON schema, partial updates of documents are disallowed for performance reasons."),
+
   DOCS_API_INVALID_JSON_VALUE(
       Response.Status.BAD_REQUEST, "The provided JSON does not match the collection's schema.");
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
@@ -92,7 +92,13 @@ public enum ErrorCode {
 
   DOCS_API_SEARCH_RESULTS_NOT_FITTING(
       Response.Status.BAD_REQUEST,
-      "The results as requested must fit in one page, try increasing the `page-size` parameter.");
+      "The results as requested must fit in one page, try increasing the `page-size` parameter."),
+
+  DOCS_API_JSON_SCHEMA_INVALID(
+      Response.Status.BAD_REQUEST, "The provided JSON schema is invalid or malformed."),
+
+  DOCS_API_INVALID_JSON_VALUE(
+      Response.Status.BAD_REQUEST, "The provided JSON does not match the collection's schema.");
 
   /** Status of the response. */
   private final Response.Status responseStatus;

--- a/restapi/src/main/java/io/stargate/web/docsapi/models/JsonSchemaResponse.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/models/JsonSchemaResponse.java
@@ -1,0 +1,91 @@
+package io.stargate.web.docsapi.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.fge.jsonschema.core.report.LogLevel;
+import java.util.ArrayList;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class JsonSchemaResponse {
+  private JsonNode schema;
+
+  private List<String> debug;
+  private List<String> info;
+  private List<String> warn;
+  private List<String> error;
+  private List<String> fatal;
+
+  @JsonProperty("schema")
+  public JsonNode getSchema() {
+    return schema;
+  }
+
+  @JsonProperty("debug")
+  public List<String> getDebug() {
+    return debug;
+  }
+
+  @JsonProperty("info")
+  public List<String> getInfo() {
+    return info;
+  }
+
+  @JsonProperty("warn")
+  public List<String> getWarn() {
+    return warn;
+  }
+
+  @JsonProperty("error")
+  public List<String> getError() {
+    return error;
+  }
+
+  @JsonProperty("fatal")
+  public List<String> getFatal() {
+    return fatal;
+  }
+
+  @JsonCreator
+  public JsonSchemaResponse(@JsonProperty("schema") JsonNode schema) {
+    this.schema = schema;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "JsonSchemaResponse(schema=%s, debug=%s, info=%s, warn=%s, error=%s, fatal=%s)",
+        schema, debug, info, warn, error, fatal);
+  }
+
+  public void addMessage(LogLevel level, String message) {
+    if (level == LogLevel.DEBUG) {
+      if (debug == null) {
+        debug = new ArrayList<>();
+      }
+      debug.add(message);
+    } else if (level == LogLevel.INFO) {
+      if (info == null) {
+        info = new ArrayList<>();
+      }
+      info.add(message);
+    } else if (level == LogLevel.WARNING) {
+      if (warn == null) {
+        warn = new ArrayList<>();
+      }
+      warn.add(message);
+    } else if (level == LogLevel.ERROR) {
+      if (error == null) {
+        error = new ArrayList<>();
+      }
+      error.add(message);
+    } else if (level == LogLevel.FATAL) {
+      if (fatal == null) {
+        fatal = new ArrayList<>();
+      }
+      fatal.add(message);
+    }
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/JsonSchemaResource.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/JsonSchemaResource.java
@@ -1,0 +1,116 @@
+package io.stargate.web.docsapi.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.stargate.web.docsapi.dao.DocumentDB;
+import io.stargate.web.docsapi.models.JsonSchemaResponse;
+import io.stargate.web.docsapi.service.DocsSchemaChecker;
+import io.stargate.web.docsapi.service.JsonSchemaHandler;
+import io.stargate.web.models.Error;
+import io.stargate.web.resources.Db;
+import io.stargate.web.resources.RequestHandler;
+import io.swagger.annotations.*;
+import java.util.concurrent.CompletableFuture;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.glassfish.jersey.server.ManagedAsync;
+
+@Api(
+    produces = MediaType.APPLICATION_JSON,
+    consumes = MediaType.APPLICATION_JSON,
+    tags = {"documents"})
+@Path("/v2/namespaces/{namespace-id: [a-zA-Z_0-9]+}")
+@Produces(MediaType.APPLICATION_JSON)
+public class JsonSchemaResource {
+  @Inject private Db dbFactory;
+  @Inject private ObjectMapper mapper;
+  @Inject private JsonSchemaHandler jsonSchemaHandler;
+  @Inject private DocsSchemaChecker schemaChecker;
+
+  @PUT
+  @ManagedAsync
+  @ApiOperation(
+      value =
+          "Assign a JSON schema to a collection. This will erase any schema that already exists.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 200, message = "OK"),
+        @ApiResponse(code = 400, message = "Bad request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
+      })
+  @Path("collections/{collection-id}/json-schema")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response attachJsonSchema(
+      @ApiParam(
+              value =
+                  "The token returned from the authorization endpoint. Use this token in each request.",
+              required = true)
+          @HeaderParam("X-Cassandra-Token")
+          String token,
+      @ApiParam(value = "the namespace of the collection", required = true)
+          @PathParam("namespace-id")
+          String namespace,
+      @ApiParam(value = "the collection to add a JSON schema to", required = true)
+          @PathParam("collection-id")
+          String collection,
+      @ApiParam(value = "The JSON schema to attach") String payload,
+      @Context HttpServletRequest request) {
+    return RequestHandler.handle(
+        () -> {
+          DocumentDB db =
+              dbFactory.getDocDataStoreForToken(
+                  token, RequestToHeadersMapper.getAllHeaders(request));
+          JsonNode schemaRaw = mapper.readTree(payload);
+          schemaChecker.checkValidity(namespace, collection, db);
+          JsonSchemaResponse resp =
+              jsonSchemaHandler.attachSchemaToCollection(db, namespace, collection, schemaRaw);
+          return Response.ok(resp).build();
+        });
+  }
+
+  @GET
+  @ManagedAsync
+  @ApiOperation(value = "Get a JSON schema from a collection")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 200, message = "OK"),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
+        @ApiResponse(code = 404, message = "Not found", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
+      })
+  @Path("collections/{collection-id}/json-schema")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response getJsonSchema(
+      @ApiParam(
+              value =
+                  "The token returned from the authorization endpoint. Use this token in each request.",
+              required = true)
+          @HeaderParam("X-Cassandra-Token")
+          String token,
+      @ApiParam(value = "the namespace of the collection", required = true)
+          @PathParam("namespace-id")
+          String namespace,
+      @ApiParam(value = "the collection to add a JSON schema to", required = true)
+          @PathParam("collection-id")
+          String collection,
+      @Context HttpServletRequest request) {
+    return RequestHandler.handle(
+        () -> {
+          DocumentDB db =
+              dbFactory.getDocDataStoreForToken(
+                  token, RequestToHeadersMapper.getAllHeaders(request));
+          schemaChecker.checkValidity(namespace, collection, db);
+          CompletableFuture<JsonSchemaResponse> resp =
+              jsonSchemaHandler.getJsonSchemaForCollection(db, namespace, collection);
+          return Response.ok(resp.join()).build();
+        });
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/JsonSchemaResource.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/JsonSchemaResource.java
@@ -10,7 +10,6 @@ import io.stargate.web.models.Error;
 import io.stargate.web.resources.Db;
 import io.stargate.web.resources.RequestHandler;
 import io.swagger.annotations.*;
-import java.util.concurrent.CompletableFuture;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.*;
@@ -108,9 +107,9 @@ public class JsonSchemaResource {
               dbFactory.getDocDataStoreForToken(
                   token, RequestToHeadersMapper.getAllHeaders(request));
           schemaChecker.checkValidity(namespace, collection, db);
-          CompletableFuture<JsonSchemaResponse> resp =
+          JsonSchemaResponse resp =
               jsonSchemaHandler.getJsonSchemaForCollection(db, namespace, collection);
-          return Response.ok(resp.join()).build();
+          return Response.ok(resp).build();
         });
   }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocsApiComponentsBinder.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocsApiComponentsBinder.java
@@ -19,5 +19,6 @@ public class DocsApiComponentsBinder extends AbstractBinder {
     bindAsContract(DocsSchemaChecker.class);
     bindAsContract(DocumentService.class);
     bindAsContract(CollectionService.class);
+    bindAsContract(JsonSchemaHandler.class);
   }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -2,10 +2,12 @@ package io.stargate.web.docsapi.service;
 
 import static io.stargate.web.docsapi.dao.DocumentDB.MAX_DEPTH;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -59,6 +61,7 @@ public class DocumentService {
   private JsonConverter jsonConverterService;
   private ObjectMapper mapper;
   private DocsSchemaChecker schemaChecker;
+  private JsonSchemaHandler jsonSchemaHandler;
 
   @Inject
   public DocumentService(
@@ -66,12 +69,14 @@ public class DocumentService {
       ObjectMapper mapper,
       JsonConverter jsonConverterService,
       DocsApiConfiguration docsApiConfiguration,
-      DocsSchemaChecker schemaChecker) {
+      DocsSchemaChecker schemaChecker,
+      JsonSchemaHandler jsonSchemaHandler) {
     this.timeSource = timeSource;
     this.mapper = mapper;
     this.jsonConverterService = jsonConverterService;
     this.docsApiConfiguration = docsApiConfiguration;
     this.schemaChecker = schemaChecker;
+    this.jsonSchemaHandler = jsonSchemaHandler;
   }
 
   /*
@@ -401,8 +406,13 @@ public class DocumentService {
       boolean isJson,
       Map<String, String> headers,
       ExecutionContext context)
-      throws UnauthorizedException {
+      throws UnauthorizedException, JsonProcessingException, ProcessingException {
     DocumentDB db = dbFactory.getDocDataStoreForToken(authToken, headers);
+
+    JsonNode schema = jsonSchemaHandler.getCachedJsonSchema(db, keyspace, collection);
+    if (schema != null) {
+      jsonSchemaHandler.validate(schema, payload);
+    }
 
     JsonSurfer surfer = JsonSurferGson.INSTANCE;
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/JsonSchemaHandler.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/JsonSchemaHandler.java
@@ -1,0 +1,143 @@
+package io.stargate.web.docsapi.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+import com.github.fge.jsonschema.core.report.ProcessingReport;
+import com.github.fge.jsonschema.main.JsonSchemaFactory;
+import io.stargate.db.datastore.ResultSet;
+import io.stargate.db.datastore.Row;
+import io.stargate.db.query.Predicate;
+import io.stargate.db.query.builder.BuiltQuery;
+import io.stargate.web.docsapi.dao.DocumentDB;
+import io.stargate.web.docsapi.exception.ErrorCode;
+import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
+import io.stargate.web.docsapi.models.JsonSchemaResponse;
+import io.stargate.web.docsapi.service.util.ImmutableKeyspaceAndTable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.inject.Inject;
+
+/** Service that handles attaching and fetching JSON schemas to/from Documents API collections. */
+public class JsonSchemaHandler {
+  private ObjectMapper mapper;
+  private final JsonSchemaFactory schemaFactory = JsonSchemaFactory.byDefault();
+  private final ConcurrentHashMap<ImmutableKeyspaceAndTable, JsonNode> schemasPerCollection =
+      new ConcurrentHashMap<>();
+
+  @Inject
+  public JsonSchemaHandler(ObjectMapper mapper) {
+    if (mapper == null) {
+      throw new IllegalStateException("JsonSchemaHandler requires a non-null ObjectMapper");
+    }
+    this.mapper = mapper;
+  }
+
+  private JsonSchemaResponse reportToResponse(JsonNode schema, ProcessingReport report) {
+    JsonSchemaResponse resp = new JsonSchemaResponse(schema);
+    report.forEach(
+        msg -> {
+          resp.addMessage(msg.getLogLevel(), msg.getMessage());
+        });
+    return resp;
+  }
+
+  public JsonSchemaResponse attachSchemaToCollection(
+      DocumentDB db, String namespace, String collection, JsonNode schema) {
+    ProcessingReport report = schemaFactory.getSyntaxValidator().validateSchema(schema);
+    JsonSchemaResponse resp = reportToResponse(schema, report);
+    if (report.isSuccess()) {
+      writeSchemaToCollection(db, namespace, collection, schema.toString());
+      ImmutableKeyspaceAndTable info =
+          ImmutableKeyspaceAndTable.builder().keyspace(namespace).table(collection).build();
+      schemasPerCollection.put(info, schema);
+      return resp;
+    } else {
+      throw new ErrorCodeRuntimeException(ErrorCode.DOCS_API_JSON_SCHEMA_INVALID);
+    }
+  }
+
+  private CompletableFuture<String> getRawJsonSchemaForCollection(
+      DocumentDB db, String namespace, String collection) {
+    BuiltQuery q =
+        db.builder()
+            .select()
+            .column("comment")
+            .from("system_schema", "tables")
+            .where("keyspace_name", Predicate.EQ, namespace)
+            .where("table_name", Predicate.EQ, collection)
+            .build();
+    CompletableFuture<ResultSet> result = q.execute();
+    return result.thenApply(
+        rs -> {
+          List<Row> rows = rs.currentPageRows();
+          if (rows.size() > 0) {
+            String comment = rows.get(0).getString("comment");
+            return comment.isEmpty() ? null : comment;
+          } else {
+            return null;
+          }
+        });
+  }
+
+  public CompletableFuture<JsonSchemaResponse> getJsonSchemaForCollection(
+      DocumentDB db, String namespace, String collection) {
+    return getRawJsonSchemaForCollection(db, namespace, collection)
+        .thenApply(
+            schemaData -> {
+              try {
+                return new JsonSchemaResponse(mapper.readTree(schemaData));
+              } catch (JsonProcessingException e) {
+                return null;
+              }
+            });
+  }
+
+  /**
+   * Attaches a comment to the given C* table that represents a JSON schema.
+   *
+   * @param namespace
+   * @param collection
+   * @param schemaData
+   */
+  private void writeSchemaToCollection(
+      DocumentDB db, String namespace, String collection, String schemaData) {
+    db.builder().alter().table(namespace, collection).withComment(schemaData).build().execute();
+  }
+
+  public JsonNode getCachedJsonSchema(DocumentDB db, String namespace, String collection) {
+    ImmutableKeyspaceAndTable info =
+        ImmutableKeyspaceAndTable.builder().keyspace(namespace).table(collection).build();
+    return schemasPerCollection.computeIfAbsent(
+        info,
+        ksAndTable ->
+            getRawJsonSchemaForCollection(db, ksAndTable.getKeyspace(), ksAndTable.getTable())
+                .thenApply(
+                    schemaStr -> {
+                      if (schemaStr == null) {
+                        return null;
+                      }
+                      try {
+                        return mapper.readTree(schemaStr);
+                      } catch (JsonProcessingException e) {
+                        return null;
+                      }
+                    })
+                .join());
+  }
+
+  public void validate(JsonNode schema, String value)
+      throws ProcessingException, JsonProcessingException {
+    JsonNode jsonValue = mapper.readTree(value);
+    ProcessingReport result = schemaFactory.getValidator().validate(schema, jsonValue);
+    if (!result.isSuccess()) {
+      List<String> messages = new ArrayList<>();
+      result.forEach(msg -> messages.add(msg.getMessage()));
+      throw new ErrorCodeRuntimeException(
+          ErrorCode.DOCS_API_INVALID_JSON_VALUE, "Invalid JSON: " + messages.toString());
+    }
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/JsonSchemaHandler.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/JsonSchemaHandler.java
@@ -40,8 +40,8 @@ public class JsonSchemaHandler {
 
   private void clearCacheOnSchemaChange(DocumentDB db) {
     if (!db.schema().equals(lastCheckedSchema)) {
-        schemasPerCollection.clear();
-        this.lastCheckedSchema = db.schema();
+      schemasPerCollection.clear();
+      this.lastCheckedSchema = db.schema();
     }
   }
 
@@ -142,6 +142,16 @@ public class JsonSchemaHandler {
   public void validate(JsonNode schema, String value)
       throws ProcessingException, JsonProcessingException {
     JsonNode jsonValue = mapper.readTree(value);
+    ProcessingReport result = schemaFactory.getValidator().validate(schema, jsonValue);
+    if (!result.isSuccess()) {
+      List<String> messages = new ArrayList<>();
+      result.forEach(msg -> messages.add(msg.getMessage()));
+      throw new ErrorCodeRuntimeException(
+          ErrorCode.DOCS_API_INVALID_JSON_VALUE, "Invalid JSON: " + messages.toString());
+    }
+  }
+
+  public void validate(JsonNode schema, JsonNode jsonValue) throws ProcessingException {
     ProcessingReport result = schemaFactory.getValidator().validate(schema, jsonValue);
     if (!result.isSuccess()) {
       List<String> messages = new ArrayList<>();

--- a/restapi/src/main/java/io/stargate/web/impl/Server.java
+++ b/restapi/src/main/java/io/stargate/web/impl/Server.java
@@ -35,6 +35,7 @@ import io.stargate.web.RestApiActivator;
 import io.stargate.web.config.ApplicationConfiguration;
 import io.stargate.web.docsapi.resources.CollectionsResource;
 import io.stargate.web.docsapi.resources.DocumentResourceV2;
+import io.stargate.web.docsapi.resources.JsonSchemaResource;
 import io.stargate.web.docsapi.resources.NamespacesResource;
 import io.stargate.web.docsapi.service.DocsApiComponentsBinder;
 import io.stargate.web.resources.ColumnResource;
@@ -149,6 +150,7 @@ public class Server extends Application<ApplicationConfiguration> {
     // Documents API
     environment.jersey().register(new DocsApiComponentsBinder(environment));
     environment.jersey().register(DocumentResourceV2.class);
+    environment.jersey().register(JsonSchemaResource.class);
     environment.jersey().register(CollectionsResource.class);
     environment.jersey().register(NamespacesResource.class);
 

--- a/restapi/src/main/java/io/stargate/web/resources/RequestHandler.java
+++ b/restapi/src/main/java/io/stargate/web/resources/RequestHandler.java
@@ -16,6 +16,7 @@
 package io.stargate.web.resources;
 
 import io.stargate.auth.UnauthorizedException;
+import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
 import io.stargate.web.models.Error;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -34,6 +35,8 @@ public class RequestHandler {
   public static Response handle(Callable<Response> action) {
     try {
       return action.call();
+    } catch (ErrorCodeRuntimeException errorCodeException) {
+      return errorCodeException.getResponse();
     } catch (NotFoundException nfe) {
       logger.info("Resource not found", nfe);
       return Response.status(Response.Status.NOT_FOUND)

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/JsonSchemaHandlerTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/JsonSchemaHandlerTest.java
@@ -1,0 +1,76 @@
+package io.stargate.web.docsapi.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.ArgumentMatchers.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+import io.stargate.web.docsapi.dao.DocumentDB;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class JsonSchemaHandlerTest {
+  private JsonSchemaHandler schemaHandler;
+  private static final ObjectMapper mapper = new ObjectMapper();
+  private JsonNode schema;
+
+  @Mock(answer = RETURNS_DEEP_STUBS)
+  private DocumentDB dbMock;
+
+  @BeforeEach
+  void setup() throws JsonProcessingException {
+    schemaHandler = new JsonSchemaHandler(mapper);
+    schema =
+        mapper.readTree(
+            "{\n"
+                + "    \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n"
+                + "    \"title\": \"Product\",\n"
+                + "    \"description\": \"A product from the catalog\",\n"
+                + "    \"type\": \"object\",\n"
+                + "    \"properties\": {\n"
+                + "      \"id\": {\n"
+                + "        \"description\": \"The unique identifier for a product\",\n"
+                + "        \"type\": \"integer\"\n"
+                + "      },\n"
+                + "      \"name\": {\n"
+                + "        \"description\": \"Name of the product\",\n"
+                + "        \"type\": \"string\"\n"
+                + "      },\n"
+                + "      \"price\": {\n"
+                + "        \"type\": \"number\",\n"
+                + "        \"minimum\": 0,\n"
+                + "        \"exclusiveMinimum\": true\n"
+                + "      }\n"
+                + "    },\n"
+                + "    \"required\": [\"id\", \"name\", \"price\"]\n"
+                + "  }");
+  }
+
+  @Test
+  void testValidate() throws JsonProcessingException, ProcessingException {
+    schemaHandler.validate(schema, "{\"id\":1,\"name\":\"a\",\"price\":1}");
+
+    ThrowableAssert.ThrowingCallable action =
+        () -> schemaHandler.validate(schema, "{\"id\":1,\"price\":1}");
+    assertThatThrownBy(action)
+        .hasMessage("Invalid JSON: [object has missing required properties ([\"name\"])]");
+
+    action = () -> schemaHandler.validate(schema, "{\"id\":1,\"name\":\"a\",\"price\":-1}");
+    assertThatThrownBy(action)
+        .hasMessage(
+            "Invalid JSON: [numeric instance is lower than the required minimum (minimum: 0, found: -1)]");
+
+    action = () -> schemaHandler.validate(schema, "{}");
+    assertThatThrownBy(action)
+        .hasMessage(
+            "Invalid JSON: [object has missing required properties ([\"id\",\"name\",\"price\"])]");
+  }
+}

--- a/testing/src/main/java/io/stargate/it/http/docsapi/JsonSchemaResourceIntTest.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/JsonSchemaResourceIntTest.java
@@ -102,12 +102,17 @@ public class JsonSchemaResourceIntTest extends BaseOsgiIntegrationTest {
 
   @Test
   public void testIt() throws IOException {
+    RestUtils.post(
+        authToken,
+        hostWithPort + "/v2/namespaces/" + keyspace + "/collections",
+        "{\"name\":\"collection\"}",
+        201);
     JsonNode schema =
         OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("schema.json"));
     RestUtils.put(authToken, collectionPath + "/json-schema", schema.toString(), 200);
 
     String schemaResp = RestUtils.get(authToken, collectionPath + "/json-schema", 200);
-    assertThat(schema).isEqualTo(OBJECT_MAPPER.readTree(schemaResp));
+    assertThat(schema.toString()).isEqualTo(OBJECT_MAPPER.readTree(schemaResp).requiredAt("/schema").toString());
 
     JsonNode obj = OBJECT_MAPPER.readTree("{\"id\":1, \"name\":\"a\", \"price\":1}");
     RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);

--- a/testing/src/main/java/io/stargate/it/http/docsapi/JsonSchemaResourceIntTest.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/JsonSchemaResourceIntTest.java
@@ -1,0 +1,136 @@
+package io.stargate.it.http.docsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import io.stargate.auth.model.AuthTokenResponse;
+import io.stargate.it.BaseOsgiIntegrationTest;
+import io.stargate.it.driver.CqlSessionExtension;
+import io.stargate.it.driver.CqlSessionSpec;
+import io.stargate.it.driver.TestKeyspace;
+import io.stargate.it.http.RestUtils;
+import io.stargate.it.http.models.Credentials;
+import io.stargate.it.storage.StargateConnectionInfo;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import net.jcip.annotations.NotThreadSafe;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@NotThreadSafe
+@ExtendWith(CqlSessionExtension.class)
+@CqlSessionSpec()
+public class JsonSchemaResourceIntTest extends BaseOsgiIntegrationTest {
+  private static final String TARGET_COLLECTION = "collection";
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final OkHttpClient CLIENT =
+      new OkHttpClient().newBuilder().readTimeout(Duration.ofMinutes(3)).build();
+
+  private static String authToken;
+  private static String host;
+  private static String hostWithPort;
+  private static String keyspace;
+  public static String collectionPath;
+
+  @BeforeAll
+  public static void setup(
+      StargateConnectionInfo cluster, @TestKeyspace CqlIdentifier keyspaceIdentifier)
+      throws IOException {
+    host = "http://" + cluster.seedAddress();
+    hostWithPort = host + ":8082";
+    keyspace = keyspaceIdentifier.toString();
+    collectionPath =
+        hostWithPort + "/v2/namespaces/" + keyspace + "/collections/" + TARGET_COLLECTION;
+    initAuth();
+  }
+
+  @AfterEach
+  public void emptyTargetCollection(CqlSession session) {
+    ResultSet results = session.execute(String.format("SELECT key FROM %s", TARGET_COLLECTION));
+    List<String> ids = new ArrayList<>();
+    results.forEach(row -> ids.add(String.format("'%s'", row.getString("key"))));
+
+    // This resets the JSON schema on the table
+    session.execute(String.format("ALTER TABLE %s WITH COMMENT = ''", TARGET_COLLECTION));
+
+    if (!ids.isEmpty()) {
+      session.execute(
+          String.format(
+              "DELETE FROM %s WHERE key IN (%s)", TARGET_COLLECTION, String.join(", ", ids)));
+    }
+  }
+
+  private static void initAuth() throws IOException {
+    OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    RequestBody requestBody =
+        RequestBody.create(
+            MediaType.parse("application/json"),
+            OBJECT_MAPPER.writeValueAsString(new Credentials("cassandra", "cassandra")));
+
+    Request request =
+        new Request.Builder()
+            .url(String.format("%s:8081/v1/auth/token/generate", host))
+            .post(requestBody)
+            .addHeader("X-Cassandra-Request-Id", "foo")
+            .build();
+    Response response = CLIENT.newCall(request).execute();
+    ResponseBody body = response.body();
+
+    assertThat(body).isNotNull();
+    AuthTokenResponse authTokenResponse =
+        OBJECT_MAPPER.readValue(body.string(), AuthTokenResponse.class);
+    authToken = authTokenResponse.getAuthToken();
+    assertThat(authToken).isNotNull();
+  }
+
+  @Test
+  public void testIt() throws IOException {
+    JsonNode schema = OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("schema.json"));
+    RestUtils.put(authToken, collectionPath + "/json-schema", schema.toString(), 200);
+
+    JsonNode obj =
+        OBJECT_MAPPER.readTree("{\"id\":1, \"name\":\"a\", \"price\":1}");
+    RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);
+
+    obj =
+            OBJECT_MAPPER.readTree("{\"id\":1, \"price\":1}");
+    String resp = RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 400);
+    JsonNode data = OBJECT_MAPPER.readTree(resp);
+    assertThat(data.requiredAt("/description"))
+      .isEqualTo(TextNode.valueOf("Invalid JSON: [object has missing required properties ([\\\"name\\\"])]"));
+
+    obj =
+            OBJECT_MAPPER.readTree("{\"id\":1, \"name\":\"a\", \"price\":-1}");
+    resp = RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 400);
+    data = OBJECT_MAPPER.readTree(resp);
+    assertThat(data.requiredAt("/description"))
+            .isEqualTo(TextNode.valueOf("Invalid JSON: [numeric instance is lower than the required minimum (minimum: 0, found: -1)]"));
+  }
+
+  @Test
+  public void testInvalidSchema() throws IOException {
+    JsonNode schema = OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("invalid-schema.json"));
+    String resp = RestUtils.put(authToken, collectionPath + "/json-schema", schema.toString(), 400);
+    JsonNode data = OBJECT_MAPPER.readTree(resp);
+    assertThat(data.requiredAt("/description"))
+      .isEqualTo(TextNode.valueOf("The provided JSON schema is invalid or malformed."));
+  }
+}

--- a/testing/src/main/java/io/stargate/it/http/docsapi/JsonSchemaResourceIntTest.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/JsonSchemaResourceIntTest.java
@@ -112,7 +112,8 @@ public class JsonSchemaResourceIntTest extends BaseOsgiIntegrationTest {
     RestUtils.put(authToken, collectionPath + "/json-schema", schema.toString(), 200);
 
     String schemaResp = RestUtils.get(authToken, collectionPath + "/json-schema", 200);
-    assertThat(schema.toString()).isEqualTo(OBJECT_MAPPER.readTree(schemaResp).requiredAt("/schema").toString());
+    assertThat(schema.toString())
+        .isEqualTo(OBJECT_MAPPER.readTree(schemaResp).requiredAt("/schema").toString());
 
     JsonNode obj = OBJECT_MAPPER.readTree("{\"id\":1, \"name\":\"a\", \"price\":1}");
     RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);
@@ -120,18 +121,15 @@ public class JsonSchemaResourceIntTest extends BaseOsgiIntegrationTest {
     obj = OBJECT_MAPPER.readTree("{\"id\":1, \"price\":1}");
     String resp = RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 400);
     JsonNode data = OBJECT_MAPPER.readTree(resp);
-    assertThat(data.requiredAt("/description"))
-        .isEqualTo(
-            TextNode.valueOf(
-                "Invalid JSON: [object has missing required properties ([\\\"name\\\"])]"));
+    assertThat(data.requiredAt("/description").textValue())
+        .isEqualTo("Invalid JSON: [object has missing required properties ([\"name\"])]");
 
     obj = OBJECT_MAPPER.readTree("{\"id\":1, \"name\":\"a\", \"price\":-1}");
     resp = RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 400);
     data = OBJECT_MAPPER.readTree(resp);
-    assertThat(data.requiredAt("/description"))
+    assertThat(data.requiredAt("/description").textValue())
         .isEqualTo(
-            TextNode.valueOf(
-                "Invalid JSON: [numeric instance is lower than the required minimum (minimum: 0, found: -1)]"));
+            "Invalid JSON: [numeric instance is lower than the required minimum (minimum: 0, found: -1)]");
   }
 
   @Test

--- a/testing/src/main/resources/invalid-schema.json
+++ b/testing/src/main/resources/invalid-schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Product",
+  "description": "A product from the catalog",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "The unique identifier for a product",
+      "type": "integerz"
+    },
+    "name": {
+      "description": "Name of the product",
+      "type": "stringa"
+    },
+    "price": {
+      "type": "numbers",
+      "minimum": 0,
+      "exclusiveMinimum": true
+    }
+  },
+  "required": ["id", "name", "price"]
+}

--- a/testing/src/main/resources/schema.json
+++ b/testing/src/main/resources/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Product",
+  "description": "A product from the catalog",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "The unique identifier for a product",
+      "type": "integer"
+    },
+    "name": {
+      "description": "Name of the product",
+      "type": "string"
+    },
+    "price": {
+      "type": "number",
+      "minimum": 0,
+      "exclusiveMinimum": true
+    }
+  },
+  "required": ["id", "name", "price"]
+}


### PR DESCRIPTION
Adds an endpoint to attach a JSON schema to a given collection; When PUT/POST ing a document to that collection, if a schema is present, the document will be checked against the schema, and the request will be rejected if the document doesn't match the schema.

Note that with a schema defined, you can no longer do partial updates of your document (it is disallowed), because you need to be able to check the _entire_ document for correctness, all at once.

In order to ensure that the schema is always available, I hacked the comment on the table to have the schema saved there