### PR TITLE
Rename property to enable GraphQL-first API

### DIFF
--- a/graphqlapi/src/main/java/io/stargate/graphql/GraphqlActivator.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/GraphqlActivator.java
@@ -43,7 +43,7 @@ public class GraphqlActivator extends BaseActivator {
   private static final String AUTH_IDENTIFIER =
       System.getProperty("stargate.auth_id", "AuthTableBasedService");
   private static final boolean ENABLE_GRAPHQL_FIRST =
-      Boolean.getBoolean("stargate.enable_graphql_first");
+      Boolean.getBoolean("stargate.graphql_first.enabled");
 
   private ServicePointer<AuthenticationService> authentication =
       ServicePointer.create(AuthenticationService.class, "AuthIdentifier", AUTH_IDENTIFIER);

--- a/testing/src/main/java/io/stargate/it/http/graphql/graphqlfirst/GraphqlFirstTestBase.java
+++ b/testing/src/main/java/io/stargate/it/http/graphql/graphqlfirst/GraphqlFirstTestBase.java
@@ -25,7 +25,7 @@ public abstract class GraphqlFirstTestBase extends BaseOsgiIntegrationTest {
 
   @SuppressWarnings("ununsed") // invoked by StargateSpec
   public static void enableGraphqlFirst(StargateParameters.Builder builder) {
-    builder.putSystemProperties("stargate.enable_graphql_first", "true");
+    builder.putSystemProperties("stargate.graphql_first.enabled", "true");
   }
 
   protected static void deleteAllGraphqlSchemas(String keyspace, CqlSession session) {


### PR DESCRIPTION
Trivial change to align naming with `stargate.graphql_first.replication_options` (introduced in #989).