### PR TITLE
GraphQL: use a single DataStore per HTTP request

### DIFF
--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/CassandraFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/CassandraFetcher.java
@@ -2,10 +2,8 @@ package io.stargate.graphql.schema;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.auth.AuthenticationSubject;
 import io.stargate.db.Parameters;
 import io.stargate.db.datastore.DataStore;
-import io.stargate.db.datastore.DataStoreOptions;
 import io.stargate.graphql.web.StargateGraphqlContext;
 import org.apache.cassandra.stargate.db.ConsistencyLevel;
 
@@ -26,23 +24,7 @@ public abstract class CassandraFetcher<ResultT> implements DataFetcher<ResultT> 
   @Override
   public final ResultT get(DataFetchingEnvironment environment) throws Exception {
     StargateGraphqlContext context = environment.getContext();
-
-    AuthenticationSubject authenticationSubject = context.getSubject();
-
-    Parameters parameters = getDatastoreParameters(environment);
-    DataStoreOptions dataStoreOptions =
-        DataStoreOptions.builder()
-            .putAllCustomProperties(context.getAllHeaders())
-            .defaultParameters(parameters)
-            .alwaysPrepareQueries(true)
-            .build();
-    DataStore dataStore =
-        context.getDataStoreFactory().create(authenticationSubject.asUser(), dataStoreOptions);
-    return get(environment, dataStore, context);
-  }
-
-  protected Parameters getDatastoreParameters(DataFetchingEnvironment environment) {
-    return DEFAULT_PARAMETERS;
+    return get(environment, context.getDataStore(), context);
   }
 
   protected abstract ResultT get(

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/CassandraFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/CassandraFetcher.java
@@ -3,7 +3,6 @@ package io.stargate.graphql.schema;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import io.stargate.db.Parameters;
-import io.stargate.db.datastore.DataStore;
 import io.stargate.graphql.web.StargateGraphqlContext;
 import org.apache.cassandra.stargate.db.ConsistencyLevel;
 
@@ -23,11 +22,14 @@ public abstract class CassandraFetcher<ResultT> implements DataFetcher<ResultT> 
 
   @Override
   public final ResultT get(DataFetchingEnvironment environment) throws Exception {
+
+    // Small convenience: subclasses could just call environment.getContext() directly, but they'd
+    // have to cast every time
     StargateGraphqlContext context = environment.getContext();
-    return get(environment, context.getDataStore(), context);
+
+    return get(environment, context);
   }
 
   protected abstract ResultT get(
-      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
-      throws Exception;
+      DataFetchingEnvironment environment, StargateGraphqlContext context) throws Exception;
 }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/AllKeyspacesFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/AllKeyspacesFetcher.java
@@ -19,7 +19,6 @@ import graphql.schema.DataFetchingEnvironment;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.UnauthorizedException;
 import io.stargate.auth.entity.ResourceKind;
-import io.stargate.db.datastore.DataStore;
 import io.stargate.graphql.schema.CassandraFetcher;
 import io.stargate.graphql.web.StargateGraphqlContext;
 import java.util.Collections;
@@ -34,9 +33,9 @@ public class AllKeyspacesFetcher extends CassandraFetcher<List<KeyspaceDto>> {
 
   @Override
   protected List<KeyspaceDto> get(
-      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context) {
+      DataFetchingEnvironment environment, StargateGraphqlContext context) {
 
-    return dataStore.schema().keyspaces().stream()
+    return context.getDataStore().schema().keyspaces().stream()
         .filter(
             keyspace -> {
               try {

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DdlQueryFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/DdlQueryFetcher.java
@@ -17,7 +17,6 @@ package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
 import io.stargate.auth.UnauthorizedException;
-import io.stargate.db.datastore.DataStore;
 import io.stargate.db.query.Query;
 import io.stargate.db.query.builder.QueryBuilder;
 import io.stargate.db.schema.Column;
@@ -39,10 +38,12 @@ import java.util.Map;
 public abstract class DdlQueryFetcher extends CassandraFetcher<Boolean> {
 
   @Override
-  protected Boolean get(
-      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
+  protected Boolean get(DataFetchingEnvironment environment, StargateGraphqlContext context)
       throws Exception {
-    dataStore.execute(buildQuery(environment, dataStore.queryBuilder(), context).bind()).get();
+    context
+        .getDataStore()
+        .execute(buildQuery(environment, context.getDataStore().queryBuilder(), context).bind())
+        .get();
     return true;
   }
 

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/SingleKeyspaceFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/ddl/fetchers/SingleKeyspaceFetcher.java
@@ -18,7 +18,6 @@ package io.stargate.graphql.schema.cqlfirst.ddl.fetchers;
 import graphql.schema.DataFetchingEnvironment;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.entity.ResourceKind;
-import io.stargate.db.datastore.DataStore;
 import io.stargate.db.schema.Keyspace;
 import io.stargate.graphql.schema.CassandraFetcher;
 import io.stargate.graphql.web.StargateGraphqlContext;
@@ -27,12 +26,11 @@ import java.util.Collections;
 public class SingleKeyspaceFetcher extends CassandraFetcher<KeyspaceDto> {
 
   @Override
-  protected KeyspaceDto get(
-      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
+  protected KeyspaceDto get(DataFetchingEnvironment environment, StargateGraphqlContext context)
       throws Exception {
     String keyspaceName = environment.getArgument("name");
 
-    Keyspace keyspace = dataStore.schema().keyspace(keyspaceName);
+    Keyspace keyspace = context.getDataStore().schema().keyspace(keyspaceName);
     if (keyspace == null) {
       return null;
     }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/BulkInsertMutationFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/BulkInsertMutationFetcher.java
@@ -22,7 +22,6 @@ import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.TypedKeyValue;
 import io.stargate.auth.UnauthorizedException;
-import io.stargate.db.datastore.DataStore;
 import io.stargate.db.query.BoundDMLQuery;
 import io.stargate.db.query.BoundQuery;
 import io.stargate.db.query.builder.ValueModifier;
@@ -42,7 +41,7 @@ public class BulkInsertMutationFetcher extends BulkMutationFetcher {
 
   @Override
   protected List<BoundQuery> buildQueries(
-      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
+      DataFetchingEnvironment environment, StargateGraphqlContext context)
       throws UnauthorizedException {
     boolean ifNotExists =
         environment.containsArgument("ifNotExists")
@@ -53,7 +52,8 @@ public class BulkInsertMutationFetcher extends BulkMutationFetcher {
     List<BoundQuery> boundQueries = new ArrayList<>(valuesToInsert.size());
     for (Map<String, Object> value : valuesToInsert) {
       BoundQuery query =
-          dataStore
+          context
+              .getDataStore()
               .queryBuilder()
               .insertInto(table.keyspace(), table.name())
               .value(buildInsertValues(value))

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/BulkMutationFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/BulkMutationFetcher.java
@@ -23,7 +23,6 @@ import graphql.GraphQLException;
 import graphql.language.OperationDefinition;
 import graphql.schema.DataFetchingEnvironment;
 import io.stargate.db.Parameters;
-import io.stargate.db.datastore.DataStore;
 import io.stargate.db.query.BoundQuery;
 import io.stargate.db.schema.Table;
 import io.stargate.graphql.schema.cqlfirst.dml.NameMapping;
@@ -45,7 +44,7 @@ public abstract class BulkMutationFetcher
 
   @Override
   protected CompletableFuture<List<Map<String, Object>>> get(
-      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context) {
+      DataFetchingEnvironment environment, StargateGraphqlContext context) {
     List<BoundQuery> queries = new ArrayList<>();
     Exception buildException = null;
 
@@ -54,7 +53,7 @@ public abstract class BulkMutationFetcher
       // buildStatement() could throw an unchecked exception.
       // As the statement might be part of a batch, we need to make sure the
       // batched operation completes.
-      queries = buildQueries(environment, dataStore, context);
+      queries = buildQueries(environment, context);
     } catch (Exception e) {
       buildException = e;
     }
@@ -145,6 +144,5 @@ public abstract class BulkMutationFetcher
   }
 
   protected abstract List<BoundQuery> buildQueries(
-      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
-      throws Exception;
+      DataFetchingEnvironment environment, StargateGraphqlContext context) throws Exception;
 }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/DeleteMutationFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/DeleteMutationFetcher.java
@@ -5,7 +5,6 @@ import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.TypedKeyValue;
 import io.stargate.auth.UnauthorizedException;
-import io.stargate.db.datastore.DataStore;
 import io.stargate.db.query.BoundDelete;
 import io.stargate.db.query.BoundQuery;
 import io.stargate.db.schema.Table;
@@ -20,7 +19,7 @@ public class DeleteMutationFetcher extends MutationFetcher {
 
   @Override
   protected BoundQuery buildQuery(
-      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
+      DataFetchingEnvironment environment, StargateGraphqlContext context)
       throws UnauthorizedException {
 
     boolean ifExists =
@@ -29,7 +28,8 @@ public class DeleteMutationFetcher extends MutationFetcher {
             && (Boolean) environment.getArgument("ifExists");
 
     BoundQuery bound =
-        dataStore
+        context
+            .getDataStore()
             .queryBuilder()
             .delete()
             .from(table.keyspace(), table.name())

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/InsertMutationFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/InsertMutationFetcher.java
@@ -23,7 +23,6 @@ import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.TypedKeyValue;
 import io.stargate.auth.UnauthorizedException;
-import io.stargate.db.datastore.DataStore;
 import io.stargate.db.query.BoundDMLQuery;
 import io.stargate.db.query.BoundQuery;
 import io.stargate.db.query.builder.ValueModifier;
@@ -43,7 +42,7 @@ public class InsertMutationFetcher extends MutationFetcher {
 
   @Override
   protected BoundQuery buildQuery(
-      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
+      DataFetchingEnvironment environment, StargateGraphqlContext context)
       throws UnauthorizedException {
     boolean ifNotExists =
         environment.containsArgument("ifNotExists")
@@ -51,7 +50,8 @@ public class InsertMutationFetcher extends MutationFetcher {
             && (Boolean) environment.getArgument("ifNotExists");
 
     BoundQuery query =
-        dataStore
+        context
+            .getDataStore()
             .queryBuilder()
             .insertInto(table.keyspace(), table.name())
             .value(buildInsertValues(environment))

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/MutationFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/MutationFetcher.java
@@ -65,12 +65,14 @@ public abstract class MutationFetcher extends DmlFetcher<CompletableFuture<Map<S
     }
 
     if (containsDirective(operation, ASYNC_DIRECTIVE)) {
-      return executeAsyncAccepted(dataStore, query, environment.getArgument("value"));
+      return executeAsyncAccepted(
+          query, environment.getArgument("value"), buildParameters(environment), context);
     }
 
     // Execute as a single statement
-    return dataStore
-        .execute(query)
+    return context
+        .getDataStore()
+        .execute(query, buildParameters(environment))
         .thenApply(rs -> toMutationResult(rs, environment.getArgument("value")));
   }
 

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/MutationFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/MutationFetcher.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableMap;
 import graphql.GraphQLException;
 import graphql.language.OperationDefinition;
 import graphql.schema.DataFetchingEnvironment;
-import io.stargate.db.datastore.DataStore;
 import io.stargate.db.query.BoundQuery;
 import io.stargate.db.schema.Table;
 import io.stargate.graphql.schema.cqlfirst.dml.NameMapping;
@@ -37,7 +36,7 @@ public abstract class MutationFetcher extends DmlFetcher<CompletableFuture<Map<S
 
   @Override
   protected CompletableFuture<Map<String, Object>> get(
-      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context) {
+      DataFetchingEnvironment environment, StargateGraphqlContext context) {
     BoundQuery query = null;
     Exception buildException = null;
 
@@ -46,7 +45,7 @@ public abstract class MutationFetcher extends DmlFetcher<CompletableFuture<Map<S
       // buildStatement() could throw an unchecked exception.
       // As the statement might be part of a batch, we need to make sure the
       // batched operation completes.
-      query = buildQuery(environment, dataStore, context);
+      query = buildQuery(environment, context);
     } catch (Exception e) {
       buildException = e;
     }
@@ -55,7 +54,7 @@ public abstract class MutationFetcher extends DmlFetcher<CompletableFuture<Map<S
     if (containsDirective(operation, ATOMIC_DIRECTIVE)
         && operation.getSelectionSet().getSelections().size() > 1) {
       // There are more than one mutation in @atomic operation
-      return executeAsPartOfBatch(environment, dataStore, query, buildException, operation);
+      return executeAsPartOfBatch(environment, query, buildException, operation);
     }
 
     if (buildException != null) {
@@ -78,7 +77,6 @@ public abstract class MutationFetcher extends DmlFetcher<CompletableFuture<Map<S
 
   private CompletableFuture<Map<String, Object>> executeAsPartOfBatch(
       DataFetchingEnvironment environment,
-      DataStore dataStore,
       BoundQuery query,
       Exception buildException,
       OperationDefinition operation) {
@@ -120,6 +118,5 @@ public abstract class MutationFetcher extends DmlFetcher<CompletableFuture<Map<S
   }
 
   protected abstract BoundQuery buildQuery(
-      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
-      throws Exception;
+      DataFetchingEnvironment environment, StargateGraphqlContext context) throws Exception;
 }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/QueryFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/QueryFetcher.java
@@ -60,7 +60,7 @@ public class QueryFetcher extends DmlFetcher<Map<String, Object>> {
         context
             .getAuthorizationService()
             .authorizedDataRead(
-                () -> dataStore.execute(query).get(),
+                () -> context.getDataStore().execute(query, buildParameters(environment)).get(),
                 context.getSubject(),
                 table.keyspace(),
                 table.name(),

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/QueryFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/QueryFetcher.java
@@ -52,9 +52,8 @@ public class QueryFetcher extends DmlFetcher<Map<String, Object>> {
 
   @Override
   protected Map<String, Object> get(
-      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
-      throws Exception {
-    BoundQuery query = buildQuery(environment, dataStore);
+      DataFetchingEnvironment environment, StargateGraphqlContext context) throws Exception {
+    BoundQuery query = buildQuery(environment, context.getDataStore());
 
     ResultSet resultSet =
         context

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/UpdateMutationFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/UpdateMutationFetcher.java
@@ -7,7 +7,6 @@ import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.TypedKeyValue;
 import io.stargate.auth.UnauthorizedException;
-import io.stargate.db.datastore.DataStore;
 import io.stargate.db.query.BoundDMLQuery;
 import io.stargate.db.query.BoundQuery;
 import io.stargate.db.query.Modification;
@@ -31,7 +30,7 @@ public class UpdateMutationFetcher extends MutationFetcher {
 
   @Override
   protected BoundQuery buildQuery(
-      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
+      DataFetchingEnvironment environment, StargateGraphqlContext context)
       throws UnauthorizedException {
     boolean ifExists =
         environment.containsArgument("ifExists")
@@ -39,7 +38,8 @@ public class UpdateMutationFetcher extends MutationFetcher {
             && (Boolean) environment.getArgument("ifExists");
 
     BoundQuery query =
-        dataStore
+        context
+            .getDataStore()
             .queryBuilder()
             .update(table.keyspace(), table.name())
             .ttl(getTTL(environment))

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/AllSchemasFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/AllSchemasFetcher.java
@@ -38,12 +38,11 @@ public class AllSchemasFetcher extends SchemaFetcher<List<SchemaSource>> {
 
   @Override
   protected List<SchemaSource> get(
-      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
-      throws Exception {
-    String keyspace = getKeyspace(environment, dataStore);
+      DataFetchingEnvironment environment, StargateGraphqlContext context) throws Exception {
+    String keyspace = getKeyspace(environment, context.getDataStore());
 
     authorize(context, keyspace);
 
-    return schemaSourceDaoProvider.apply(dataStore).getAllVersions(keyspace);
+    return schemaSourceDaoProvider.apply(context.getDataStore()).getAllVersions(keyspace);
   }
 }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/SingleSchemaFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/SingleSchemaFetcher.java
@@ -38,15 +38,16 @@ public class SingleSchemaFetcher extends SchemaFetcher<SchemaSource> {
   }
 
   @Override
-  protected SchemaSource get(
-      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
+  protected SchemaSource get(DataFetchingEnvironment environment, StargateGraphqlContext context)
       throws Exception {
-    String keyspace = getKeyspace(environment, dataStore);
+    String keyspace = getKeyspace(environment, context.getDataStore());
     Optional<UUID> version =
         Optional.ofNullable((String) environment.getArgument("version")).map(UUID::fromString);
 
     authorize(context, keyspace);
 
-    return schemaSourceDaoProvider.apply(dataStore).getSingleVersion(keyspace, version);
+    return schemaSourceDaoProvider
+        .apply(context.getDataStore())
+        .getSingleVersion(keyspace, version);
   }
 }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/UndeploySchemaFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/UndeploySchemaFetcher.java
@@ -19,7 +19,6 @@ import graphql.schema.DataFetchingEnvironment;
 import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.entity.ResourceKind;
-import io.stargate.db.datastore.DataStore;
 import io.stargate.db.schema.Keyspace;
 import io.stargate.graphql.persistence.graphqlfirst.SchemaSourceDao;
 import io.stargate.graphql.schema.CassandraFetcher;
@@ -29,12 +28,11 @@ import java.util.UUID;
 public class UndeploySchemaFetcher extends CassandraFetcher<Boolean> {
 
   @Override
-  protected Boolean get(
-      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
+  protected Boolean get(DataFetchingEnvironment environment, StargateGraphqlContext context)
       throws Exception {
 
     String keyspaceName = environment.getArgument("keyspace");
-    Keyspace keyspace = dataStore.schema().keyspace(keyspaceName);
+    Keyspace keyspace = context.getDataStore().schema().keyspace(keyspaceName);
     if (keyspace == null) {
       throw new IllegalArgumentException(
           String.format("Keyspace '%s' does not exist.", keyspaceName));
@@ -53,7 +51,7 @@ public class UndeploySchemaFetcher extends CassandraFetcher<Boolean> {
     UUID expectedVersion = getExpectedVersion(environment);
     boolean force = environment.getArgument("force");
 
-    new SchemaSourceDao(dataStore).undeploy(keyspaceName, expectedVersion, force);
+    new SchemaSourceDao(context.getDataStore()).undeploy(keyspaceName, expectedVersion, force);
     return true;
   }
 

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/DeleteFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/DeleteFetcher.java
@@ -52,7 +52,7 @@ public class DeleteFetcher extends MutationFetcher<DeleteModel, Object> {
       throws UnauthorizedException {
 
     EntityModel entityModel = model.getEntity();
-    Keyspace keyspace = dataStore.schema().keyspace(entityModel.getKeyspaceName());
+    Keyspace keyspace = context.getDataStore().schema().keyspace(entityModel.getKeyspaceName());
 
     // We're either getting the values from a single entity argument, or individual PK field
     // arguments:
@@ -77,7 +77,8 @@ public class DeleteFetcher extends MutationFetcher<DeleteModel, Object> {
     List<BuiltCondition> ifConditions =
         bindIf(model.getIfConditions(), hasArgument, getArgument, keyspace);
     AbstractBound<?> query =
-        dataStore
+        context
+            .getDataStore()
             .queryBuilder()
             .delete()
             .from(entityModel.getKeyspaceName(), entityModel.getCqlName())
@@ -97,7 +98,7 @@ public class DeleteFetcher extends MutationFetcher<DeleteModel, Object> {
             Scope.DELETE,
             SourceAPI.GRAPHQL);
 
-    ResultSet resultSet = executeUnchecked(query, dataStore);
+    ResultSet resultSet = executeUnchecked(query, buildParameters(environment), context);
     boolean applied = !model.ifExists() || resultSet.one().getBoolean("[applied]");
 
     ReturnType returnType = model.getReturnType();

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/DeleteFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/DeleteFetcher.java
@@ -21,7 +21,6 @@ import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.TypedKeyValue;
 import io.stargate.auth.UnauthorizedException;
-import io.stargate.db.datastore.DataStore;
 import io.stargate.db.datastore.ResultSet;
 import io.stargate.db.query.BoundDelete;
 import io.stargate.db.query.builder.AbstractBound;
@@ -47,8 +46,7 @@ public class DeleteFetcher extends MutationFetcher<DeleteModel, Object> {
   }
 
   @Override
-  protected Object get(
-      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
+  protected Object get(DataFetchingEnvironment environment, StargateGraphqlContext context)
       throws UnauthorizedException {
 
     EntityModel entityModel = model.getEntity();

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/FederatedEntityFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/FederatedEntityFetcher.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
 
 /**
  * Executes the {@code _entities} query of GraphQL federation.
@@ -54,13 +55,13 @@ public class FederatedEntityFetcher extends DeployedFetcher<List<FederatedEntity
     List<FederatedEntity> result = new ArrayList<>();
     for (Map<String, Object> representation :
         environment.<List<Map<String, Object>>>getArgument(_Entity.argumentName)) {
-      result.add(getEntity(representation, dataStore, context));
+      result.add(getEntity(representation, context));
     }
     return result;
   }
 
   private FederatedEntity getEntity(
-      Map<String, Object> representation, DataStore dataStore, StargateGraphqlContext context)
+      Map<String, Object> representation, StargateGraphqlContext context)
       throws UnauthorizedException {
     Object rawTypeName = representation.get("__typename");
     if (!(rawTypeName instanceof String)) {
@@ -73,7 +74,7 @@ public class FederatedEntityFetcher extends DeployedFetcher<List<FederatedEntity
     if (entityModel == null) {
       throw new IllegalArgumentException(String.format("Unknown entity type %s", entityName));
     }
-    Keyspace keyspace = dataStore.schema().keyspace(entityModel.getKeyspaceName());
+    Keyspace keyspace = context.getDataStore().schema().keyspace(entityModel.getKeyspaceName());
     List<BuiltCondition> whereConditions =
         bindWhere(
             entityModel.getPrimaryKeyWhereConditions(),
@@ -81,7 +82,8 @@ public class FederatedEntityFetcher extends DeployedFetcher<List<FederatedEntity
             representation::get,
             entityModel::validateNoFiltering,
             keyspace);
-    ResultSet resultSet = query(entityModel, whereConditions, Optional.empty(), dataStore, context);
+    ResultSet resultSet =
+        query(entityModel, whereConditions, Optional.empty(), UnaryOperator.identity(), context);
     Map<String, Object> entity = toSingleEntity(resultSet, entityModel);
     return FederatedEntity.wrap(entityModel, entity);
   }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/FederatedEntityFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/FederatedEntityFetcher.java
@@ -18,7 +18,6 @@ package io.stargate.graphql.schema.graphqlfirst.fetchers.deployed;
 import com.apollographql.federation.graphqljava._Entity;
 import graphql.schema.DataFetchingEnvironment;
 import io.stargate.auth.UnauthorizedException;
-import io.stargate.db.datastore.DataStore;
 import io.stargate.db.datastore.ResultSet;
 import io.stargate.db.query.builder.BuiltCondition;
 import io.stargate.db.schema.Keyspace;
@@ -49,7 +48,7 @@ public class FederatedEntityFetcher extends DeployedFetcher<List<FederatedEntity
 
   @Override
   protected List<FederatedEntity> get(
-      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
+      DataFetchingEnvironment environment, StargateGraphqlContext context)
       throws UnauthorizedException {
 
     List<FederatedEntity> result = new ArrayList<>();

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/InsertFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/InsertFetcher.java
@@ -80,7 +80,8 @@ public class InsertFetcher extends MutationFetcher<InsertModel, Object> {
             .collect(Collectors.toList());
 
     AbstractBound<?> query =
-        dataStore
+        context
+            .getDataStore()
             .queryBuilder()
             .insertInto(entityModel.getKeyspaceName(), entityModel.getCqlName())
             .value(modifiers)
@@ -98,7 +99,7 @@ public class InsertFetcher extends MutationFetcher<InsertModel, Object> {
             Scope.MODIFY,
             SourceAPI.GRAPHQL);
 
-    ResultSet resultSet = executeUnchecked(query, dataStore);
+    ResultSet resultSet = executeUnchecked(query, buildParameters(environment), context);
 
     if (responseContainsEntity) {
       Map<String, Object> entityData;

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/InsertFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/InsertFetcher.java
@@ -53,8 +53,7 @@ public class InsertFetcher extends MutationFetcher<InsertModel, Object> {
   }
 
   @Override
-  protected Object get(
-      DataFetchingEnvironment environment, StargateGraphqlContext context)
+  protected Object get(DataFetchingEnvironment environment, StargateGraphqlContext context)
       throws UnauthorizedException {
     DataFetchingFieldSelectionSet selectionSet = environment.getSelectionSet();
 

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/InsertFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/InsertFetcher.java
@@ -21,7 +21,6 @@ import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.TypedKeyValue;
 import io.stargate.auth.UnauthorizedException;
-import io.stargate.db.datastore.DataStore;
 import io.stargate.db.datastore.ResultSet;
 import io.stargate.db.datastore.Row;
 import io.stargate.db.query.BoundDMLQuery;
@@ -55,7 +54,7 @@ public class InsertFetcher extends MutationFetcher<InsertModel, Object> {
 
   @Override
   protected Object get(
-      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
+      DataFetchingEnvironment environment, StargateGraphqlContext context)
       throws UnauthorizedException {
     DataFetchingFieldSelectionSet selectionSet = environment.getSelectionSet();
 
@@ -70,7 +69,7 @@ public class InsertFetcher extends MutationFetcher<InsertModel, Object> {
             .flatMap(ResponsePayloadModel::getEntityField)
             .map(EntityField::getName)
             .orElse(null);
-    Keyspace keyspace = dataStore.schema().keyspace(entityModel.getKeyspaceName());
+    Keyspace keyspace = context.getDataStore().schema().keyspace(entityModel.getKeyspaceName());
     Map<String, Object> input = environment.getArgument(model.getEntityArgumentName());
     Map<String, Object> response = new LinkedHashMap<>();
     Map<String, Object> cqlValues = buildCqlValues(entityModel, keyspace, input);

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/MutationFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/MutationFetcher.java
@@ -19,6 +19,7 @@ import graphql.schema.DataFetchingEnvironment;
 import io.stargate.db.Parameters;
 import io.stargate.graphql.schema.graphqlfirst.processor.MappingModel;
 import io.stargate.graphql.schema.graphqlfirst.processor.MutationModel;
+import java.util.function.UnaryOperator;
 import org.apache.cassandra.stargate.db.ConsistencyLevel;
 
 /** An INSERT, UPDATE or DELETE mutation. */
@@ -32,20 +33,20 @@ public abstract class MutationFetcher<MutationModelT extends MutationModel, Resu
     this.model = model;
   }
 
-  @Override
-  protected Parameters getDatastoreParameters(DataFetchingEnvironment environment) {
+  protected UnaryOperator<Parameters> buildParameters(DataFetchingEnvironment environment) {
     ConsistencyLevel consistencyLevel = model.getConsistencyLevel().orElse(DEFAULT_CONSISTENCY);
     ConsistencyLevel serialConsistencyLevel =
         model.getSerialConsistencyLevel().orElse(DEFAULT_SERIAL_CONSISTENCY);
     if (consistencyLevel == DEFAULT_CONSISTENCY
         && serialConsistencyLevel == DEFAULT_SERIAL_CONSISTENCY) {
-      return DEFAULT_PARAMETERS;
+      return UnaryOperator.identity();
     } else {
-      return DEFAULT_PARAMETERS
-          .toBuilder()
-          .consistencyLevel(consistencyLevel)
-          .serialConsistencyLevel(serialConsistencyLevel)
-          .build();
+      return parameters ->
+          parameters
+              .toBuilder()
+              .consistencyLevel(consistencyLevel)
+              .serialConsistencyLevel(serialConsistencyLevel)
+              .build();
     }
   }
 }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/QueryFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/QueryFetcher.java
@@ -19,7 +19,6 @@ import graphql.schema.Coercing;
 import graphql.schema.DataFetchingEnvironment;
 import io.stargate.auth.UnauthorizedException;
 import io.stargate.db.Parameters;
-import io.stargate.db.datastore.DataStore;
 import io.stargate.db.datastore.ResultSet;
 import io.stargate.db.query.builder.BuiltCondition;
 import io.stargate.db.schema.Keyspace;
@@ -76,8 +75,7 @@ public class QueryFetcher extends DeployedFetcher<Object> {
   }
 
   @Override
-  protected Object get(
-      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
+  protected Object get(DataFetchingEnvironment environment, StargateGraphqlContext context)
       throws UnauthorizedException {
     Keyspace keyspace =
         context.getDataStore().schema().keyspace(model.getEntity().getKeyspaceName());

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/UpdateFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/UpdateFetcher.java
@@ -21,7 +21,6 @@ import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.TypedKeyValue;
 import io.stargate.auth.UnauthorizedException;
-import io.stargate.db.datastore.DataStore;
 import io.stargate.db.datastore.ResultSet;
 import io.stargate.db.datastore.Row;
 import io.stargate.db.query.BoundDMLQuery;
@@ -46,13 +45,12 @@ public class UpdateFetcher extends MutationFetcher<UpdateModel, Object> {
   }
 
   @Override
-  protected Object get(
-      DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
+  protected Object get(DataFetchingEnvironment environment, StargateGraphqlContext context)
       throws UnauthorizedException {
     DataFetchingFieldSelectionSet selectionSet = environment.getSelectionSet();
 
     EntityModel entityModel = model.getEntity();
-    Keyspace keyspace = dataStore.schema().keyspace(entityModel.getKeyspaceName());
+    Keyspace keyspace = context.getDataStore().schema().keyspace(entityModel.getKeyspaceName());
 
     // We're either getting the values from a single entity argument, or individual PK field
     // arguments:

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/UpdateFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/UpdateFetcher.java
@@ -87,7 +87,8 @@ public class UpdateFetcher extends MutationFetcher<UpdateModel, Object> {
     }
 
     AbstractBound<?> query =
-        dataStore
+        context
+            .getDataStore()
             .queryBuilder()
             .update(entityModel.getKeyspaceName(), entityModel.getCqlName())
             .value(modifiers)
@@ -107,7 +108,7 @@ public class UpdateFetcher extends MutationFetcher<UpdateModel, Object> {
             Scope.MODIFY,
             SourceAPI.GRAPHQL);
 
-    ResultSet resultSet = executeUnchecked(query, dataStore);
+    ResultSet resultSet = executeUnchecked(query, buildParameters(environment), context);
 
     boolean responseContainsEntity =
         model.getResponsePayload().flatMap(ResponsePayloadModel::getEntityField).isPresent();

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/ProcessingContext.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/ProcessingContext.java
@@ -20,9 +20,7 @@ import com.google.errorprone.annotations.FormatString;
 import graphql.GraphQL;
 import graphql.language.SourceLocation;
 import graphql.schema.idl.TypeDefinitionRegistry;
-import io.stargate.auth.AuthorizationService;
 import io.stargate.db.Persistence;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.schema.Keyspace;
 import io.stargate.graphql.schema.scalars.CqlScalar;
 import java.util.ArrayList;
@@ -66,9 +64,7 @@ class ProcessingContext {
     return persistence;
   }
 
-  /**
-   * @see SchemaProcessor#SchemaProcessor(AuthorizationService, DataStoreFactory, boolean, boolean)
-   */
+  /** @see SchemaProcessor#SchemaProcessor(Persistence, boolean) */
   public boolean isPersisted() {
     return isPersisted;
   }

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/DropwizardServer.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/DropwizardServer.java
@@ -142,7 +142,9 @@ public class DropwizardServer extends Application<Configuration> {
                 bind(FrameworkUtil.getBundle(GraphqlActivator.class)).to(Bundle.class);
               }
             });
-    environment.jersey().register(new AuthenticationFilter(authenticationService));
+    environment
+        .jersey()
+        .register(new AuthenticationFilter(authenticationService, dataStoreFactory));
     environment
         .jersey()
         .register(

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/DropwizardServer.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/DropwizardServer.java
@@ -111,25 +111,7 @@ public class DropwizardServer extends Application<Configuration> {
             new AbstractBinder() {
               @Override
               protected void configure() {
-                bind(authenticationService).to(AuthenticationService.class);
-              }
-            });
-    environment
-        .jersey()
-        .register(
-            new AbstractBinder() {
-              @Override
-              protected void configure() {
                 bind(authorizationService).to(AuthorizationService.class);
-              }
-            });
-    environment
-        .jersey()
-        .register(
-            new AbstractBinder() {
-              @Override
-              protected void configure() {
-                bind(dataStoreFactory).to(DataStoreFactory.class);
               }
             });
 

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/StargateGraphqlContext.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/StargateGraphqlContext.java
@@ -20,14 +20,12 @@ import io.stargate.auth.AuthorizationService;
 import io.stargate.db.Parameters;
 import io.stargate.db.Persistence;
 import io.stargate.db.datastore.DataStore;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.datastore.ResultSet;
 import io.stargate.db.query.BoundQuery;
 import io.stargate.graphql.web.resources.AuthenticationFilter;
 import io.stargate.graphql.web.resources.GraphqlCache;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
@@ -35,11 +33,9 @@ import javax.servlet.http.HttpServletRequest;
 
 public class StargateGraphqlContext {
 
-  private final HttpServletRequest request;
   private final AuthenticationSubject subject;
   private final DataStore dataStore;
   private final AuthorizationService authorizationService;
-  private final DataStoreFactory dataStoreFactory;
   private final Persistence persistence;
   private final GraphqlCache graphqlCache;
 
@@ -54,14 +50,11 @@ public class StargateGraphqlContext {
   public StargateGraphqlContext(
       HttpServletRequest request,
       AuthorizationService authorizationService,
-      DataStoreFactory dataStoreFactory,
       Persistence persistence,
       GraphqlCache graphqlCache) {
-    this.request = request;
     this.subject = (AuthenticationSubject) request.getAttribute(AuthenticationFilter.SUBJECT_KEY);
     this.dataStore = (DataStore) request.getAttribute(AuthenticationFilter.DATA_STORE_KEY);
     this.authorizationService = authorizationService;
-    this.dataStoreFactory = dataStoreFactory;
     this.persistence = persistence;
     this.graphqlCache = graphqlCache;
     if (this.subject == null) {
@@ -74,20 +67,12 @@ public class StargateGraphqlContext {
     return subject;
   }
 
-  public Map<String, String> getAllHeaders() {
-    return RequestToHeadersMapper.getAllHeaders(request);
-  }
-
   public BatchContext getBatchContext() {
     return batchContext;
   }
 
   public AuthorizationService getAuthorizationService() {
     return authorizationService;
-  }
-
-  public DataStoreFactory getDataStoreFactory() {
-    return dataStoreFactory;
   }
 
   public DataStore getDataStore() {

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/StargateGraphqlContext.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/StargateGraphqlContext.java
@@ -36,6 +36,7 @@ public class StargateGraphqlContext {
 
   private final HttpServletRequest request;
   private final AuthenticationSubject subject;
+  private final DataStore dataStore;
   private final AuthorizationService authorizationService;
   private final DataStoreFactory dataStoreFactory;
   private final Persistence persistence;
@@ -57,6 +58,7 @@ public class StargateGraphqlContext {
       GraphqlCache graphqlCache) {
     this.request = request;
     this.subject = (AuthenticationSubject) request.getAttribute(AuthenticationFilter.SUBJECT_KEY);
+    this.dataStore = (DataStore) request.getAttribute(AuthenticationFilter.DATA_STORE_KEY);
     this.authorizationService = authorizationService;
     this.dataStoreFactory = dataStoreFactory;
     this.persistence = persistence;
@@ -85,6 +87,10 @@ public class StargateGraphqlContext {
 
   public DataStoreFactory getDataStoreFactory() {
     return dataStoreFactory;
+  }
+
+  public DataStore getDataStore() {
+    return dataStore;
   }
 
   public Persistence getPersistence() {

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/StargateGraphqlContext.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/StargateGraphqlContext.java
@@ -17,6 +17,7 @@ package io.stargate.graphql.web;
 
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
+import io.stargate.db.Parameters;
 import io.stargate.db.Persistence;
 import io.stargate.db.datastore.DataStore;
 import io.stargate.db.datastore.DataStoreFactory;
@@ -27,9 +28,9 @@ import io.stargate.graphql.web.resources.GraphqlCache;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
 import javax.servlet.http.HttpServletRequest;
 
 public class StargateGraphqlContext {
@@ -109,7 +110,8 @@ public class StargateGraphqlContext {
     private final List<BoundQuery> queries = new ArrayList<>();
     private int operationCount;
     private final CompletableFuture<ResultSet> executionFuture = new CompletableFuture<>();
-    private AtomicReference<DataStore> dataStore = new AtomicReference<>();
+    private final AtomicReference<UnaryOperator<Parameters>> parametersModifier =
+        new AtomicReference<>();
 
     public CompletableFuture<ResultSet> getExecutionFuture() {
       return executionFuture;
@@ -141,13 +143,14 @@ public class StargateGraphqlContext {
       return operationCount;
     }
 
-    /** Sets the data store and returns whether it was already set */
-    public boolean setDataStore(DataStore dataStore) {
-      return this.dataStore.getAndSet(dataStore) != null;
+    /** Sets the parameters to use for the batch and returns whether they were already set. */
+    public boolean setParametersModifier(UnaryOperator<Parameters> parametersModifier) {
+      return this.parametersModifier.getAndSet(parametersModifier) != null;
     }
 
-    public Optional<DataStore> getDataStore() {
-      return Optional.ofNullable(this.dataStore.get());
+    public UnaryOperator<Parameters> getParametersModifier() {
+      UnaryOperator<Parameters> savedParameters = this.parametersModifier.get();
+      return savedParameters == null ? UnaryOperator.identity() : savedParameters;
     }
   }
 }

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/resources/DmlResource.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/resources/DmlResource.java
@@ -17,7 +17,7 @@ package io.stargate.graphql.web.resources;
 
 import graphql.GraphQL;
 import graphql.GraphqlErrorException;
-import io.stargate.auth.AuthenticationSubject;
+import io.stargate.db.datastore.DataStore;
 import io.stargate.graphql.web.RequestToHeadersMapper;
 import io.stargate.graphql.web.models.GraphqlJsonBody;
 import java.util.regex.Pattern;
@@ -168,7 +168,7 @@ public class DmlResource extends GraphqlResourceBase {
       GraphQL graphql =
           graphqlCache.getDml(
               keyspaceName,
-              (AuthenticationSubject) httpRequest.getAttribute(AuthenticationFilter.SUBJECT_KEY),
+              (DataStore) httpRequest.getAttribute(AuthenticationFilter.DATA_STORE_KEY),
               RequestToHeadersMapper.getAllHeaders(httpRequest));
       if (graphql == null) {
         replyWithGraphqlError(

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/resources/GraphqlResourceBase.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/resources/GraphqlResourceBase.java
@@ -32,7 +32,6 @@ import io.stargate.auth.SourceAPI;
 import io.stargate.auth.UnauthorizedException;
 import io.stargate.auth.entity.ResourceKind;
 import io.stargate.db.Persistence;
-import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.graphql.web.StargateGraphqlContext;
 import io.stargate.graphql.web.models.GraphqlJsonBody;
 import java.io.IOException;
@@ -69,7 +68,6 @@ public class GraphqlResourceBase {
   private static final Splitter PATH_SPLITTER = Splitter.on(".");
 
   @Inject protected AuthorizationService authorizationService;
-  @Inject protected DataStoreFactory dataStoreFactory;
   @Inject protected Persistence persistence;
   @Inject protected GraphqlCache graphqlCache;
 
@@ -98,11 +96,7 @@ public class GraphqlResourceBase {
               .operationName(operationName)
               .context(
                   new StargateGraphqlContext(
-                      httpRequest,
-                      authorizationService,
-                      dataStoreFactory,
-                      persistence,
-                      graphqlCache));
+                      httpRequest, authorizationService, persistence, graphqlCache));
 
       if (!Strings.isNullOrEmpty(variables)) {
         @SuppressWarnings("unchecked")
@@ -160,11 +154,7 @@ public class GraphqlResourceBase {
             .operationName(operationName)
             .context(
                 new StargateGraphqlContext(
-                    httpRequest,
-                    authorizationService,
-                    dataStoreFactory,
-                    persistence,
-                    graphqlCache));
+                    httpRequest, authorizationService, persistence, graphqlCache));
     if (variables != null) {
       input = input.variables(variables);
     }
@@ -342,7 +332,7 @@ public class GraphqlResourceBase {
         ExecutionInput.newExecutionInput(query)
             .context(
                 new StargateGraphqlContext(
-                    httpRequest, authorizationService, dataStoreFactory, persistence, graphqlCache))
+                    httpRequest, authorizationService, persistence, graphqlCache))
             .build();
     executeAsync(input, graphql, asyncResponse);
   }

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/GraphQlTestBase.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/GraphQlTestBase.java
@@ -139,7 +139,9 @@ public abstract class GraphQlTestBase {
 
     when(context.getSubject()).thenReturn(authenticationSubject);
     when(context.getAuthorizationService()).thenReturn(authorizationService);
-    when(context.getDataStoreFactory()).thenReturn(dataStoreFactory);
+
+    // TODO adapt this:
+    //    when(context.getDataStoreFactory()).thenReturn(dataStoreFactory);
 
     return graphQl.execute(ExecutionInput.newExecutionInput(query).context(context).build());
   }

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/BulkMutationFetcherTest.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/BulkMutationFetcherTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import graphql.ExecutionResult;
 import graphql.GraphQLError;
+import io.stargate.db.Parameters;
 import io.stargate.db.schema.Schema;
 import io.stargate.graphql.schema.SampleKeyspaces;
 import io.stargate.graphql.schema.cqlfirst.dml.DmlTestBase;
@@ -84,11 +85,9 @@ public class BulkMutationFetcherTest extends DmlTestBase {
     };
 
     assertThat(getCapturedBatchQueriesString()).containsExactly(queries);
-    assertThat(batchParameters)
-        .extracting(p -> p.consistencyLevel())
+    assertThat(getCapturedParameters())
+        .extracting(Parameters::consistencyLevel)
         .isEqualTo(ConsistencyLevel.valueOf(cl));
-
-    batchParameters = null;
 
     // Test with options in second position
     result =
@@ -103,8 +102,8 @@ public class BulkMutationFetcherTest extends DmlTestBase {
                 cl));
     assertThat(result.getErrors()).isEmpty();
     assertThat(getCapturedBatchQueriesString()).containsExactly(queries);
-    assertThat(batchParameters)
-        .extracting(p -> p.consistencyLevel(), p -> p.serialConsistencyLevel().get())
+    assertThat(getCapturedParameters())
+        .extracting(Parameters::consistencyLevel, p -> p.serialConsistencyLevel().get())
         .containsExactly(ConsistencyLevel.valueOf(cl), ConsistencyLevel.LOCAL_SERIAL);
   }
 

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/MutationFetcherTest.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/MutationFetcherTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import graphql.ExecutionResult;
 import graphql.GraphQLError;
+import io.stargate.db.Parameters;
 import io.stargate.db.schema.Schema;
 import io.stargate.graphql.schema.SampleKeyspaces;
 import io.stargate.graphql.schema.cqlfirst.dml.DmlTestBase;
@@ -69,11 +70,9 @@ public class MutationFetcherTest extends DmlTestBase {
     };
 
     assertThat(getCapturedBatchQueriesString()).containsExactly(queries);
-    assertThat(batchParameters)
-        .extracting(p -> p.consistencyLevel())
+    assertThat(getCapturedParameters())
+        .extracting(Parameters::consistencyLevel)
         .isEqualTo(ConsistencyLevel.valueOf(cl));
-
-    batchParameters = null;
 
     // Test with options in second position
     result =
@@ -88,8 +87,8 @@ public class MutationFetcherTest extends DmlTestBase {
                 cl));
     assertThat(result.getErrors()).isEmpty();
     assertThat(getCapturedBatchQueriesString()).containsExactly(queries);
-    assertThat(batchParameters)
-        .extracting(p -> p.consistencyLevel(), p -> p.serialConsistencyLevel().get())
+    assertThat(getCapturedParameters())
+        .extracting(Parameters::consistencyLevel, p -> p.serialConsistencyLevel().get())
         .containsExactly(ConsistencyLevel.valueOf(cl), ConsistencyLevel.LOCAL_SERIAL);
   }
 

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/QueryFetcherTest.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/QueryFetcherTest.java
@@ -76,7 +76,7 @@ public class QueryFetcherTest extends DmlTestBase {
       String graphQlOperation, Parameters expectedParameters) {
     ExecutionResult result = executeGraphQl(graphQlOperation);
     assertThat(result.getErrors()).isEmpty();
-    assertThat(dataStoreOptionsCaptor.getValue().defaultParameters()).isEqualTo(expectedParameters);
+    assertThat(getCapturedParameters()).isEqualTo(expectedParameters);
   }
 
   @ParameterizedTest

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/AllSchemasFetcherTest.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/AllSchemasFetcherTest.java
@@ -54,7 +54,7 @@ class AllSchemasFetcherTest {
     when(context.getSubject()).thenReturn(subject);
 
     // when
-    List<SchemaSource> result = allSchemasFetcher.get(dataFetchingEnvironment, dataStore, context);
+    List<SchemaSource> result = allSchemasFetcher.get(dataFetchingEnvironment, context);
 
     // then
     assertThat(result).containsExactly(schemaSource1, schemaSource2);

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/AllSchemasFetcherTest.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/AllSchemasFetcherTest.java
@@ -45,13 +45,14 @@ class AllSchemasFetcherTest {
     AllSchemasFetcher allSchemasFetcher = new AllSchemasFetcher((ds) -> schemaSourceDao);
 
     DataFetchingEnvironment dataFetchingEnvironment = mockDataFetchingEnvironment(keyspace);
-    DataStore dataStore = mockDataStore(keyspace);
 
     StargateGraphqlContext context = mock(StargateGraphqlContext.class);
     AuthorizationService authorizationService = mock(AuthorizationService.class);
     AuthenticationSubject subject = mock(AuthenticationSubject.class);
+    DataStore dataStore = mockDataStore(keyspace);
     when(context.getAuthorizationService()).thenReturn(authorizationService);
     when(context.getSubject()).thenReturn(subject);
+    when(context.getDataStore()).thenReturn(dataStore);
 
     // when
     List<SchemaSource> result = allSchemasFetcher.get(dataFetchingEnvironment, context);

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/SingleSchemaFetcherTest.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/SingleSchemaFetcherTest.java
@@ -48,8 +48,7 @@ class SingleSchemaFetcherTest {
     DataStore dataStore = mockDataStore(keyspace);
 
     // when
-    SchemaSource result =
-        singleSchemaFetcher.get(dataFetchingEnvironment, dataStore, mockContext());
+    SchemaSource result = singleSchemaFetcher.get(dataFetchingEnvironment, mockContext());
 
     // then
     assertThat(result).isSameAs(schemaSource);
@@ -71,8 +70,7 @@ class SingleSchemaFetcherTest {
     DataStore dataStore = mockDataStore(keyspace);
 
     // when
-    SchemaSource result =
-        singleSchemaFetcher.get(dataFetchingEnvironment, dataStore, mockContext());
+    SchemaSource result = singleSchemaFetcher.get(dataFetchingEnvironment, mockContext());
 
     // then
     assertThat(result).isSameAs(schemaSource);

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/SingleSchemaFetcherTest.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/graphqlfirst/fetchers/admin/SingleSchemaFetcherTest.java
@@ -45,10 +45,9 @@ class SingleSchemaFetcherTest {
     SingleSchemaFetcher singleSchemaFetcher = new SingleSchemaFetcher((ds) -> schemaSourceDao);
 
     DataFetchingEnvironment dataFetchingEnvironment = mockDataFetchingEnvironment(keyspace);
-    DataStore dataStore = mockDataStore(keyspace);
 
     // when
-    SchemaSource result = singleSchemaFetcher.get(dataFetchingEnvironment, mockContext());
+    SchemaSource result = singleSchemaFetcher.get(dataFetchingEnvironment, mockContext(keyspace));
 
     // then
     assertThat(result).isSameAs(schemaSource);
@@ -67,10 +66,9 @@ class SingleSchemaFetcherTest {
 
     DataFetchingEnvironment dataFetchingEnvironment =
         mockDataFetchingEnvironment(keyspace, version.toString());
-    DataStore dataStore = mockDataStore(keyspace);
 
     // when
-    SchemaSource result = singleSchemaFetcher.get(dataFetchingEnvironment, mockContext());
+    SchemaSource result = singleSchemaFetcher.get(dataFetchingEnvironment, mockContext(keyspace));
 
     // then
     assertThat(result).isSameAs(schemaSource);
@@ -96,12 +94,14 @@ class SingleSchemaFetcherTest {
     return dataStore;
   }
 
-  private StargateGraphqlContext mockContext() {
+  private StargateGraphqlContext mockContext(String keyspace) {
     StargateGraphqlContext context = mock(StargateGraphqlContext.class);
     AuthorizationService authorizationService = mock(AuthorizationService.class);
     AuthenticationSubject subject = mock(AuthenticationSubject.class);
+    DataStore dataStore = mockDataStore(keyspace);
     when(context.getAuthorizationService()).thenReturn(authorizationService);
     when(context.getSubject()).thenReturn(subject);
+    when(context.getDataStore()).thenReturn(dataStore);
     return context;
   }
 }


### PR DESCRIPTION
As discussed on #1021. Kudos @tub for detecting the issue.

We now create a single DataStore in `AuthenticationFilter`, and store it as a request attribute. `GraphqlResourceBase` picks it up and stores it in `StargateGraphqlContext` for the fetchers. A few other components also access it directly (`GraphqlCache`, `FilesResource`).

The fetchers that need custom execution parameters now provide them to `DataStore.execute` or `DataStore.batch`.