### PR TITLE
relates to #944: property for collecting path params as tags in the h…

### DIFF
--- a/core/src/main/java/io/stargate/core/metrics/StargateMetricConstants.java
+++ b/core/src/main/java/io/stargate/core/metrics/StargateMetricConstants.java
@@ -27,6 +27,9 @@ public class StargateMetricConstants {
   // tag keys
   public static final String MODULE_KEY = "module";
 
+  // unknown value for any tag
+  public static final String UNKNOWN = "unknown";
+
   // unknown tag instances
   public static final Tag TAG_MODULE_UNKNOWN = Tag.of(MODULE_KEY, "unknown");
 }

--- a/metrics-jersey/src/main/java/io/stargate/metrics/jersey/PathParametersTagsProvider.java
+++ b/metrics-jersey/src/main/java/io/stargate/metrics/jersey/PathParametersTagsProvider.java
@@ -88,22 +88,21 @@ public class PathParametersTagsProvider implements JerseyTagsProvider {
     }
 
     public static Config fromSystemProps() {
+      String property = System.getProperty("stargate.metrics.http_server_requests_path_param_tags");
+      return fromPropertyValue(property);
+    }
+
+    public static Config fromPropertyValue(String value) {
       boolean matchAll = false;
       boolean matchNone = false;
       Collection<String> matchParams = Collections.emptyList();
 
-      try {
-        String property =
-            System.getProperty("stargate.metrics.http_server_requests_path_param_tags");
-        if (null == property || property.length() == 0) {
-          matchNone = true;
-        } else if (Objects.equals(property, "*")) {
-          matchAll = true;
-        } else {
-          matchParams = Arrays.asList(property.split(","));
-        }
-      } catch (Exception e) {
+      if (null == value || value.length() == 0) {
         matchNone = true;
+      } else if (Objects.equals(value, "*")) {
+        matchAll = true;
+      } else {
+        matchParams = Arrays.asList(value.split(","));
       }
 
       return new Config(matchAll, matchNone, matchParams);

--- a/metrics-jersey/src/main/java/io/stargate/metrics/jersey/PathParametersTagsProvider.java
+++ b/metrics-jersey/src/main/java/io/stargate/metrics/jersey/PathParametersTagsProvider.java
@@ -75,6 +75,18 @@ public class PathParametersTagsProvider implements JerseyTagsProvider {
   // stargate.metrics.http_server_requests_path_param_tags
   public static class Config {
 
+    private final boolean matchAll;
+
+    private final boolean matchNone;
+
+    private final Collection<String> matchParams;
+
+    public Config(boolean matchAll, boolean matchNone, Collection<String> matchParams) {
+      this.matchAll = matchAll;
+      this.matchNone = matchNone;
+      this.matchParams = matchParams;
+    }
+
     public static Config fromSystemProps() {
       boolean matchAll = false;
       boolean matchNone = false;
@@ -95,18 +107,6 @@ public class PathParametersTagsProvider implements JerseyTagsProvider {
       }
 
       return new Config(matchAll, matchNone, matchParams);
-    }
-
-    private final boolean matchAll;
-
-    private final boolean matchNone;
-
-    private final Collection<String> matchParams;
-
-    public Config(boolean matchAll, boolean matchNone, Collection<String> matchParams) {
-      this.matchAll = matchAll;
-      this.matchNone = matchNone;
-      this.matchParams = matchParams;
     }
   }
 }

--- a/metrics-jersey/src/main/java/io/stargate/metrics/jersey/ResourceMetricsEventListener.java
+++ b/metrics-jersey/src/main/java/io/stargate/metrics/jersey/ResourceMetricsEventListener.java
@@ -20,6 +20,7 @@ import io.micrometer.jersey2.server.MetricsApplicationEventListener;
 import io.stargate.core.metrics.StargateMetricConstants;
 import io.stargate.core.metrics.api.HttpMetricsTagProvider;
 import io.stargate.core.metrics.api.Metrics;
+import java.util.Collections;
 
 public class ResourceMetricsEventListener extends MetricsApplicationEventListener {
 
@@ -27,7 +28,10 @@ public class ResourceMetricsEventListener extends MetricsApplicationEventListene
       Metrics metrics, HttpMetricsTagProvider httpMetricsTagProvider, String module) {
     super(
         metrics.getMeterRegistry(),
-        new ResourceTagsProvider(httpMetricsTagProvider, metrics.tagsForModule(module)),
+        new ResourceTagsProvider(
+            httpMetricsTagProvider,
+            metrics.tagsForModule(module),
+            Collections.singleton(new PathParametersTagsProvider())),
         StargateMetricConstants.METRIC_HTTP_SERVER_REQUESTS,
         true);
   }

--- a/metrics-jersey/src/test/java/io/stargate/metrics/jersey/PathParametersTagsProviderTest.java
+++ b/metrics-jersey/src/test/java/io/stargate/metrics/jersey/PathParametersTagsProviderTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.metrics.jersey;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.Tag;
+import java.util.Arrays;
+import javax.ws.rs.core.MultivaluedHashMap;
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.glassfish.jersey.server.monitoring.RequestEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PathParametersTagsProviderTest {
+
+  @Mock RequestEvent requestEvent;
+
+  @Mock ExtendedUriInfo extendedUriInfo;
+
+  @BeforeEach
+  public void mockEvent() {
+    lenient().when(requestEvent.getUriInfo()).thenReturn(extendedUriInfo);
+    System.clearProperty("stargate.metrics.http_server_requests_path_param_tags");
+  }
+
+  @Nested
+  class HttpRequestTags {
+
+    @Test
+    public void matchSpecific() {
+      System.setProperty("stargate.metrics.http_server_requests_path_param_tags", "k2");
+      MultivaluedHashMap<String, String> paramMap = new MultivaluedHashMap<>();
+      paramMap.putSingle("k1", "v1");
+      paramMap.putSingle("k2", "v2");
+      when(extendedUriInfo.getPathParameters(true)).thenReturn(paramMap);
+
+      PathParametersTagsProvider provider = new PathParametersTagsProvider();
+      Iterable<Tag> result = provider.httpRequestTags(requestEvent);
+
+      assertThat(result).hasSize(1).contains(Tag.of("k2", "v2"));
+    }
+
+    @Test
+    public void matchSpecificMultiple() {
+      System.setProperty("stargate.metrics.http_server_requests_path_param_tags", "k1,k2");
+      MultivaluedHashMap<String, String> paramMap = new MultivaluedHashMap<>();
+      paramMap.putSingle("k1", "v1");
+      paramMap.putSingle("k2", "v2");
+      when(extendedUriInfo.getPathParameters(true)).thenReturn(paramMap);
+
+      PathParametersTagsProvider provider = new PathParametersTagsProvider();
+      Iterable<Tag> result = provider.httpRequestTags(requestEvent);
+
+      assertThat(result).hasSize(2).contains(Tag.of("k1", "v1")).contains(Tag.of("k2", "v2"));
+    }
+
+    @Test
+    public void matchAll() {
+      System.setProperty("stargate.metrics.http_server_requests_path_param_tags", "*");
+      MultivaluedHashMap<String, String> paramMap = new MultivaluedHashMap<>();
+      paramMap.putSingle("k1", "v1");
+      paramMap.put("k2", Arrays.asList("v2", "v3"));
+      when(extendedUriInfo.getPathParameters(true)).thenReturn(paramMap);
+
+      PathParametersTagsProvider provider = new PathParametersTagsProvider();
+      Iterable<Tag> result = provider.httpRequestTags(requestEvent);
+
+      assertThat(result).hasSize(2).contains(Tag.of("k1", "v1")).contains(Tag.of("k2", "v2,v3"));
+    }
+
+    @Test
+    public void matchAllButEmpty() {
+      System.setProperty("stargate.metrics.http_server_requests_path_param_tags", "*");
+      MultivaluedHashMap<String, String> paramMap = new MultivaluedHashMap<>();
+      when(extendedUriInfo.getPathParameters(true)).thenReturn(paramMap);
+
+      PathParametersTagsProvider provider = new PathParametersTagsProvider();
+      Iterable<Tag> result = provider.httpRequestTags(requestEvent);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void matchNothing() {
+      PathParametersTagsProvider provider = new PathParametersTagsProvider();
+      Iterable<Tag> result = provider.httpRequestTags(requestEvent);
+
+      assertThat(result).isEmpty();
+      verifyNoInteractions(requestEvent);
+    }
+  }
+}

--- a/metrics-jersey/src/test/java/io/stargate/metrics/jersey/ResourceTagsProviderTest.java
+++ b/metrics-jersey/src/test/java/io/stargate/metrics/jersey/ResourceTagsProviderTest.java
@@ -118,7 +118,7 @@ class ResourceTagsProviderTest {
           .contains(Tag.of("method", "GET"))
           .contains(Tag.of("status", "200"))
           .contains(Tag.of("uri", "/base/target/uri"));
-      verify(delegate).httpLongRequestTags(requestEvent);
+      verify(delegate).httpRequestTags(requestEvent);
       verifyNoMoreInteractions(delegate);
     }
 

--- a/metrics-jersey/src/test/java/io/stargate/metrics/jersey/ResourceTagsProviderTest.java
+++ b/metrics-jersey/src/test/java/io/stargate/metrics/jersey/ResourceTagsProviderTest.java
@@ -17,10 +17,13 @@
 package io.stargate.metrics.jersey;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
+import io.micrometer.jersey2.server.JerseyTagsProvider;
 import io.stargate.core.metrics.api.HttpMetricsTagProvider;
 import java.util.Collections;
 import javax.ws.rs.core.MultivaluedMap;
@@ -49,6 +52,8 @@ class ResourceTagsProviderTest {
   @Mock ContainerRequest containerRequest;
 
   @Mock ExtendedUriInfo extendedUriInfo;
+
+  @Mock JerseyTagsProvider delegate;
 
   @BeforeEach
   public void mockEvent() {
@@ -84,6 +89,37 @@ class ResourceTagsProviderTest {
           .contains(Tag.of("method", "GET"))
           .contains(Tag.of("status", "200"))
           .contains(Tag.of("uri", "/base/target/uri"));
+    }
+
+    @Test
+    public void happyPathWithDelegates() {
+      Tags defaultTags = Tags.of("default", "true");
+      MultivaluedMap<String, String> headers = new MultivaluedStringMap();
+      headers.putSingle("some", "header");
+
+      when(extendedUriInfo.getMatchedTemplates())
+          .thenReturn(Collections.singletonList(new UriTemplate("/target/uri")));
+      when(extendedUriInfo.getBaseUri()).thenReturn(UriTemplate.normalize("http://localhost/base"));
+      when(containerRequest.getMethod()).thenReturn("GET");
+      when(containerRequest.getHeaders()).thenReturn(headers);
+      when(containerResponse.getStatus()).thenReturn(200);
+      when(httpMetricsTagProvider.getRequestTags(headers)).thenReturn(Tags.of("extra", "true"));
+      when(delegate.httpRequestTags(requestEvent)).thenReturn(Tags.of("delegate", "present"));
+
+      ResourceTagsProvider resourceTagsProvider =
+          new ResourceTagsProvider(
+              httpMetricsTagProvider, defaultTags, Collections.singletonList(delegate));
+      Iterable<Tag> result = resourceTagsProvider.httpRequestTags(requestEvent);
+
+      assertThat(result)
+          .containsAll(defaultTags)
+          .contains(Tag.of("extra", "true"))
+          .contains(Tag.of("delegate", "present"))
+          .contains(Tag.of("method", "GET"))
+          .contains(Tag.of("status", "200"))
+          .contains(Tag.of("uri", "/base/target/uri"));
+      verify(delegate).httpLongRequestTags(requestEvent);
+      verifyNoMoreInteractions(delegate);
     }
 
     @Test
@@ -137,6 +173,38 @@ class ResourceTagsProviderTest {
           .contains(Tag.of("extra", "true"))
           .contains(Tag.of("method", "GET"))
           .contains(Tag.of("uri", "/base/target/uri"));
+    }
+
+    @Test
+    public void happyPathWithDelegate() {
+      Tags defaultTags = Tags.of("default", "true");
+      MultivaluedMap<String, String> headers = new MultivaluedStringMap();
+      headers.putSingle("some", "header");
+
+      when(extendedUriInfo.getMatchedTemplates())
+          .thenReturn(Collections.singletonList(new UriTemplate("/target/uri")));
+      when(extendedUriInfo.getBaseUri()).thenReturn(UriTemplate.normalize("http://localhost/base"));
+      when(containerRequest.getMethod()).thenReturn("GET");
+      when(containerRequest.getHeaders()).thenReturn(headers);
+      when(containerResponse.getStatus()).thenReturn(200);
+      when(httpMetricsTagProvider.getRequestTags(headers)).thenReturn(Tags.of("extra", "true"));
+      when(delegate.httpLongRequestTags(requestEvent))
+          .thenReturn(Tags.of("delegate1", "present", "delegate2", "present"));
+
+      ResourceTagsProvider resourceTagsProvider =
+          new ResourceTagsProvider(
+              httpMetricsTagProvider, defaultTags, Collections.singletonList(delegate));
+      Iterable<Tag> result = resourceTagsProvider.httpLongRequestTags(requestEvent);
+
+      assertThat(result)
+          .containsAll(defaultTags)
+          .contains(Tag.of("extra", "true"))
+          .contains(Tag.of("delegate1", "present"))
+          .contains(Tag.of("delegate2", "present"))
+          .contains(Tag.of("method", "GET"))
+          .contains(Tag.of("uri", "/base/target/uri"));
+      verify(delegate).httpLongRequestTags(requestEvent);
+      verifyNoMoreInteractions(delegate);
     }
   }
 }


### PR DESCRIPTION
Added the `stargate.metrics.http_server_requests_path_param_tags` property option to declare what path params should be taken into account and use them as the tags in the `http_server_resuests`. Examples:

- ~`stargate.metrics.http_server_requests_path_param_tags=*`~ - can not be supported, produces diff amount of tags every time
- `stargate.metrics.http_server_requests_path_param_tags=keyspaceName,collection` - only path params that are matching `keyspaceName` or `collection`.

**This is a global option and affects all endpoints.**