### PR TITLE
closes #944: default http tag provider to return selected headers

### DIFF
--- a/core/src/main/java/io/stargate/core/CoreActivator.java
+++ b/core/src/main/java/io/stargate/core/CoreActivator.java
@@ -2,6 +2,7 @@ package io.stargate.core;
 
 import com.codahale.metrics.health.HealthCheckRegistry;
 import io.stargate.core.activator.BaseActivator;
+import io.stargate.core.metrics.api.DefaultHttpMetricsTagProvider;
 import io.stargate.core.metrics.api.HttpMetricsTagProvider;
 import io.stargate.core.metrics.api.Metrics;
 import io.stargate.core.metrics.api.MetricsScraper;
@@ -28,16 +29,14 @@ public class CoreActivator extends BaseActivator {
     MetricsImpl metricsImpl = new MetricsImpl();
 
     List<ServiceAndProperties> services = new ArrayList<>();
-    services.add(new ServiceAndProperties(metricsImpl, Metrics.class, null));
-    services.add(new ServiceAndProperties(metricsImpl, MetricsScraper.class, null));
-    services.add(
-        new ServiceAndProperties(new HealthCheckRegistry(), HealthCheckRegistry.class, null));
+    services.add(new ServiceAndProperties(metricsImpl, Metrics.class));
+    services.add(new ServiceAndProperties(metricsImpl, MetricsScraper.class));
+    services.add(new ServiceAndProperties(new HealthCheckRegistry(), HealthCheckRegistry.class));
 
     // register default http tag provider if we are not using any special one
     if (null == HTTP_TAG_PROVIDER_ID) {
-      services.add(
-          new ServiceAndProperties(
-              HttpMetricsTagProvider.DEFAULT, HttpMetricsTagProvider.class, null));
+      DefaultHttpMetricsTagProvider provider = new DefaultHttpMetricsTagProvider();
+      services.add(new ServiceAndProperties(provider, HttpMetricsTagProvider.class));
     }
 
     return services;

--- a/core/src/main/java/io/stargate/core/metrics/StargateMetricConstants.java
+++ b/core/src/main/java/io/stargate/core/metrics/StargateMetricConstants.java
@@ -31,5 +31,5 @@ public class StargateMetricConstants {
   public static final String UNKNOWN = "unknown";
 
   // unknown tag instances
-  public static final Tag TAG_MODULE_UNKNOWN = Tag.of(MODULE_KEY, "unknown");
+  public static final Tag TAG_MODULE_UNKNOWN = Tag.of(MODULE_KEY, UNKNOWN);
 }

--- a/core/src/main/java/io/stargate/core/metrics/api/DefaultHttpMetricsTagProvider.java
+++ b/core/src/main/java/io/stargate/core/metrics/api/DefaultHttpMetricsTagProvider.java
@@ -52,7 +52,7 @@ public class DefaultHttpMetricsTagProvider implements HttpMetricsTagProvider {
       Tag[] collect =
           headers.entrySet().stream()
               .filter(e -> whitelist.contains(e.getKey().toLowerCase()))
-              .map(e -> Tag.of(e.getKey(), String.join(",", e.getValue())))
+              .map(e -> Tag.of(e.getKey().toLowerCase(), String.join(",", e.getValue())))
               .toArray(Tag[]::new);
       return Tags.of(collect);
     }
@@ -63,16 +63,24 @@ public class DefaultHttpMetricsTagProvider implements HttpMetricsTagProvider {
     private final Collection<String> whitelistedHeaderNames;
 
     public Config(Collection<String> whitelistedHeaderNames) {
-      this.whitelistedHeaderNames = whitelistedHeaderNames;
+      if (null == whitelistedHeaderNames) {
+        this.whitelistedHeaderNames = Collections.emptyList();
+      } else {
+        this.whitelistedHeaderNames = whitelistedHeaderNames;
+      }
     }
 
     public static Config fromSystemProps() {
-      try {
         String property = System.getProperty("stargate.metrics.http_server_requests_header_tags");
-        if (null != property) {
-          String[] headers = property.split(",");
+        return fromPropertyString(property);
+    }
+
+    public static Config fromPropertyString(String value) {
+      try {
+        if (null != value) {
+          String[] headers = value.split(",");
           List<String> lowercaseHeaders =
-              Arrays.stream(headers).map(String::toLowerCase).collect(Collectors.toList());
+                  Arrays.stream(headers).map(String::toLowerCase).collect(Collectors.toList());
           return new Config(lowercaseHeaders);
         } else {
           return new Config(Collections.emptyList());

--- a/core/src/main/java/io/stargate/core/metrics/api/DefaultHttpMetricsTagProvider.java
+++ b/core/src/main/java/io/stargate/core/metrics/api/DefaultHttpMetricsTagProvider.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.core.metrics.api;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Default {@link HttpMetricsTagProvider} that adds headers as tags based on the whitelisted header
+ * names from the system prop.
+ */
+public class DefaultHttpMetricsTagProvider implements HttpMetricsTagProvider {
+
+  private final Config config;
+
+  public DefaultHttpMetricsTagProvider() {
+    this(Config.fromSystemProps());
+  }
+
+  public DefaultHttpMetricsTagProvider(Config config) {
+    this.config = config;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Tags getRequestTags(Map<String, List<String>> headers) {
+    Collection<String> whitelist = config.whitelistedHeaderNames;
+    if (null == whitelist || whitelist.isEmpty()) {
+      return Tags.empty();
+    } else {
+      Tag[] collect =
+          headers.entrySet().stream()
+              .filter(e -> whitelist.contains(e.getKey().toLowerCase()))
+              .map(e -> Tag.of(e.getKey(), String.join(",", e.getValue())))
+              .toArray(Tag[]::new);
+      return Tags.of(collect);
+    }
+  }
+
+  public static class Config {
+
+    public static Config fromSystemProps() {
+      try {
+        String property = System.getProperty("stargate.metrics.http_server_requests_header_tags");
+        if (null != property) {
+          String[] headers = property.split(",");
+          List<String> lowercaseHeaders =
+              Arrays.stream(headers).map(String::toLowerCase).collect(Collectors.toList());
+          return new Config(lowercaseHeaders);
+        } else {
+          return new Config(Collections.emptyList());
+        }
+      } catch (Exception e) {
+        return new Config(Collections.emptyList());
+      }
+    }
+
+    private final Collection<String> whitelistedHeaderNames;
+
+    public Config(Collection<String> whitelistedHeaderNames) {
+      this.whitelistedHeaderNames = whitelistedHeaderNames;
+    }
+  }
+}

--- a/core/src/main/java/io/stargate/core/metrics/api/DefaultHttpMetricsTagProvider.java
+++ b/core/src/main/java/io/stargate/core/metrics/api/DefaultHttpMetricsTagProvider.java
@@ -60,6 +60,12 @@ public class DefaultHttpMetricsTagProvider implements HttpMetricsTagProvider {
 
   public static class Config {
 
+    private final Collection<String> whitelistedHeaderNames;
+
+    public Config(Collection<String> whitelistedHeaderNames) {
+      this.whitelistedHeaderNames = whitelistedHeaderNames;
+    }
+
     public static Config fromSystemProps() {
       try {
         String property = System.getProperty("stargate.metrics.http_server_requests_header_tags");
@@ -74,12 +80,6 @@ public class DefaultHttpMetricsTagProvider implements HttpMetricsTagProvider {
       } catch (Exception e) {
         return new Config(Collections.emptyList());
       }
-    }
-
-    private final Collection<String> whitelistedHeaderNames;
-
-    public Config(Collection<String> whitelistedHeaderNames) {
-      this.whitelistedHeaderNames = whitelistedHeaderNames;
     }
   }
 }

--- a/core/src/main/java/io/stargate/core/metrics/api/DefaultHttpMetricsTagProvider.java
+++ b/core/src/main/java/io/stargate/core/metrics/api/DefaultHttpMetricsTagProvider.java
@@ -87,7 +87,7 @@ public class DefaultHttpMetricsTagProvider implements HttpMetricsTagProvider {
 
     public static Config fromPropertyString(String value) {
       try {
-        if (null != value) {
+        if (null != value && value.length() > 0) {
           String[] headers = value.split(",");
           List<String> lowercaseHeaders =
               Arrays.stream(headers).map(String::toLowerCase).collect(Collectors.toList());

--- a/core/src/main/java/io/stargate/core/metrics/api/HttpMetricsTagProvider.java
+++ b/core/src/main/java/io/stargate/core/metrics/api/HttpMetricsTagProvider.java
@@ -20,26 +20,14 @@ import io.micrometer.core.instrument.Tags;
 import java.util.List;
 import java.util.Map;
 
-/**
- * Provides extra micrometer {@link Tags} for user requests coming from the HTTP.
- *
- * <p>Note that each method implementation must always return constant amount of tags regardless of
- * the input.
- */
+/** Provides extra micrometer {@link Tags} for user requests coming from the HTTP. */
 public interface HttpMetricsTagProvider {
-
-  /** Returns default interface implementation, which returns empty tags for all methods. */
-  HttpMetricsTagProvider DEFAULT = new HttpMetricsTagProvider() {};
 
   /**
    * Returns tags for a HTTP request, usually extracted from the given headers.
    *
-   * <p>Note that the implementation must return constant amount of tags for any input.
-   *
    * @param headers HTTP Headers
    * @return Tags
    */
-  default Tags getRequestTags(Map<String, List<String>> headers) {
-    return Tags.empty();
-  }
+  Tags getRequestTags(Map<String, List<String>> headers);
 }

--- a/core/src/main/java/io/stargate/core/metrics/api/HttpMetricsTagProvider.java
+++ b/core/src/main/java/io/stargate/core/metrics/api/HttpMetricsTagProvider.java
@@ -26,6 +26,9 @@ public interface HttpMetricsTagProvider {
   /**
    * Returns tags for a HTTP request, usually extracted from the given headers.
    *
+   * <p><b>IMPORTANT:</b> that the implementation must return constant amount of tags for any input.
+   * Prometheus does not allow different tags from the single process.
+   *
    * @param headers HTTP Headers
    * @return Tags
    */

--- a/core/src/test/java/io/stargate/core/metrics/api/DefaultHttpMetricsTagProviderTest.java
+++ b/core/src/test/java/io/stargate/core/metrics/api/DefaultHttpMetricsTagProviderTest.java
@@ -36,20 +36,14 @@ class DefaultHttpMetricsTagProviderTest {
   @Nested
   class GetRequestTags {
 
-    @BeforeEach
-    @AfterEach
-    public void clearProperty() {
-      System.clearProperty("stargate.metrics.http_server_requests_header_tags");
-    }
-
     @Test
     public void happyPath() {
-      System.setProperty("stargate.metrics.http_server_requests_header_tags", "header1");
       Map<String, List<String>> headers = new HashMap<>();
       headers.put("header1", Collections.singletonList("value1"));
       headers.put("header2", Arrays.asList("value1", "value2"));
 
-      DefaultHttpMetricsTagProvider provider = new DefaultHttpMetricsTagProvider();
+      DefaultHttpMetricsTagProvider.Config config = DefaultHttpMetricsTagProvider.Config.fromPropertyString("header1");
+      DefaultHttpMetricsTagProvider provider = new DefaultHttpMetricsTagProvider(config);
       Tags result = provider.getRequestTags(headers);
 
       assertThat(result).containsOnly(Tag.of("header1", "value1"));
@@ -57,16 +51,16 @@ class DefaultHttpMetricsTagProviderTest {
 
     @Test
     public void caseIrrelevant() {
-      System.setProperty("stargate.metrics.http_server_requests_header_tags", "HEADER1,header2");
       Map<String, List<String>> headers = new HashMap<>();
       headers.put("header1", Collections.singletonList("value1"));
       headers.put("Header2", Arrays.asList("value1", "value2"));
 
-      DefaultHttpMetricsTagProvider provider = new DefaultHttpMetricsTagProvider();
+      DefaultHttpMetricsTagProvider.Config config = DefaultHttpMetricsTagProvider.Config.fromPropertyString("HEADER1,header2");
+      DefaultHttpMetricsTagProvider provider = new DefaultHttpMetricsTagProvider(config);
       Tags result = provider.getRequestTags(headers);
 
       assertThat(result)
-          .containsOnly(Tag.of("header1", "value1"), Tag.of("Header2", "value1,value2"));
+          .containsOnly(Tag.of("header1", "value1"), Tag.of("header2", "value1,value2"));
     }
 
     @Test
@@ -75,7 +69,8 @@ class DefaultHttpMetricsTagProviderTest {
       headers.put("header1", Collections.singletonList("value1"));
       headers.put("header2", Arrays.asList("value1", "value2"));
 
-      DefaultHttpMetricsTagProvider provider = new DefaultHttpMetricsTagProvider();
+      DefaultHttpMetricsTagProvider.Config config = DefaultHttpMetricsTagProvider.Config.fromPropertyString(null);
+      DefaultHttpMetricsTagProvider provider = new DefaultHttpMetricsTagProvider(config);
       Tags result = provider.getRequestTags(headers);
 
       assertThat(result).isEmpty();

--- a/core/src/test/java/io/stargate/core/metrics/api/DefaultHttpMetricsTagProviderTest.java
+++ b/core/src/test/java/io/stargate/core/metrics/api/DefaultHttpMetricsTagProviderTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.core.metrics.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class DefaultHttpMetricsTagProviderTest {
+
+  @Nested
+  class GetRequestTags {
+
+    @BeforeEach
+    @AfterEach
+    public void clearProperty() {
+      System.clearProperty("stargate.metrics.http_server_requests_header_tags");
+    }
+
+    @Test
+    public void happyPath() {
+      System.setProperty("stargate.metrics.http_server_requests_header_tags", "header1");
+      Map<String, List<String>> headers = new HashMap<>();
+      headers.put("header1", Collections.singletonList("value1"));
+      headers.put("header2", Arrays.asList("value1", "value2"));
+
+      DefaultHttpMetricsTagProvider provider = new DefaultHttpMetricsTagProvider();
+      Tags result = provider.getRequestTags(headers);
+
+      assertThat(result).containsOnly(Tag.of("header1", "value1"));
+    }
+
+    @Test
+    public void caseIrrelevant() {
+      System.setProperty("stargate.metrics.http_server_requests_header_tags", "HEADER1,header2");
+      Map<String, List<String>> headers = new HashMap<>();
+      headers.put("header1", Collections.singletonList("value1"));
+      headers.put("Header2", Arrays.asList("value1", "value2"));
+
+      DefaultHttpMetricsTagProvider provider = new DefaultHttpMetricsTagProvider();
+      Tags result = provider.getRequestTags(headers);
+
+      assertThat(result)
+          .containsOnly(Tag.of("header1", "value1"), Tag.of("Header2", "value1,value2"));
+    }
+
+    @Test
+    public void collectNothing() {
+      Map<String, List<String>> headers = new HashMap<>();
+      headers.put("header1", Collections.singletonList("value1"));
+      headers.put("header2", Arrays.asList("value1", "value2"));
+
+      DefaultHttpMetricsTagProvider provider = new DefaultHttpMetricsTagProvider();
+      Tags result = provider.getRequestTags(headers);
+
+      assertThat(result).isEmpty();
+    }
+  }
+}

--- a/core/src/test/java/io/stargate/core/metrics/api/DefaultHttpMetricsTagProviderTest.java
+++ b/core/src/test/java/io/stargate/core/metrics/api/DefaultHttpMetricsTagProviderTest.java
@@ -90,5 +90,19 @@ class DefaultHttpMetricsTagProviderTest {
 
       assertThat(result).isEmpty();
     }
+
+    @Test
+    public void collectNothingEmptyConfigString() {
+      Map<String, List<String>> headers = new HashMap<>();
+      headers.put("header1", Collections.singletonList("value1"));
+      headers.put("header2", Arrays.asList("value1", "value2"));
+
+      DefaultHttpMetricsTagProvider.Config config =
+          DefaultHttpMetricsTagProvider.Config.fromPropertyString("");
+      DefaultHttpMetricsTagProvider provider = new DefaultHttpMetricsTagProvider(config);
+      Tags result = provider.getRequestTags(headers);
+
+      assertThat(result).isEmpty();
+    }
   }
 }

--- a/core/src/test/java/io/stargate/core/metrics/api/DefaultHttpMetricsTagProviderTest.java
+++ b/core/src/test/java/io/stargate/core/metrics/api/DefaultHttpMetricsTagProviderTest.java
@@ -26,8 +26,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -42,7 +40,8 @@ class DefaultHttpMetricsTagProviderTest {
       headers.put("header1", Collections.singletonList("value1"));
       headers.put("header2", Arrays.asList("value1", "value2"));
 
-      DefaultHttpMetricsTagProvider.Config config = DefaultHttpMetricsTagProvider.Config.fromPropertyString("header1");
+      DefaultHttpMetricsTagProvider.Config config =
+          DefaultHttpMetricsTagProvider.Config.fromPropertyString("header1");
       DefaultHttpMetricsTagProvider provider = new DefaultHttpMetricsTagProvider(config);
       Tags result = provider.getRequestTags(headers);
 
@@ -55,7 +54,8 @@ class DefaultHttpMetricsTagProviderTest {
       headers.put("header1", Collections.singletonList("value1"));
       headers.put("Header2", Arrays.asList("value1", "value2"));
 
-      DefaultHttpMetricsTagProvider.Config config = DefaultHttpMetricsTagProvider.Config.fromPropertyString("HEADER1,header2");
+      DefaultHttpMetricsTagProvider.Config config =
+          DefaultHttpMetricsTagProvider.Config.fromPropertyString("HEADER1,header2");
       DefaultHttpMetricsTagProvider provider = new DefaultHttpMetricsTagProvider(config);
       Tags result = provider.getRequestTags(headers);
 
@@ -64,12 +64,27 @@ class DefaultHttpMetricsTagProviderTest {
     }
 
     @Test
+    public void missingHeaderAsUnknown() {
+      Map<String, List<String>> headers = new HashMap<>();
+      headers.put("header1", Collections.singletonList("value1"));
+      headers.put("header2", Arrays.asList("value1", "value2"));
+
+      DefaultHttpMetricsTagProvider.Config config =
+          DefaultHttpMetricsTagProvider.Config.fromPropertyString("otherHeader");
+      DefaultHttpMetricsTagProvider provider = new DefaultHttpMetricsTagProvider(config);
+      Tags result = provider.getRequestTags(headers);
+
+      assertThat(result).containsOnly(Tag.of("otherheader", "unknown"));
+    }
+
+    @Test
     public void collectNothing() {
       Map<String, List<String>> headers = new HashMap<>();
       headers.put("header1", Collections.singletonList("value1"));
       headers.put("header2", Arrays.asList("value1", "value2"));
 
-      DefaultHttpMetricsTagProvider.Config config = DefaultHttpMetricsTagProvider.Config.fromPropertyString(null);
+      DefaultHttpMetricsTagProvider.Config config =
+          DefaultHttpMetricsTagProvider.Config.fromPropertyString(null);
       DefaultHttpMetricsTagProvider provider = new DefaultHttpMetricsTagProvider(config);
       Tags result = provider.getRequestTags(headers);
 


### PR DESCRIPTION
Added `stargate.metrics.http_server_requests_header_tags` to select what headers you want added as tags. This is now default impl for the `HttpMetricsTagProvider`.