### PR TITLE
allow insert to return Boolean to have the unified API between insert and update

### DIFF
--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/InsertFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/InsertFetcher.java
@@ -33,6 +33,7 @@ import io.stargate.graphql.schema.graphqlfirst.processor.EntityModel;
 import io.stargate.graphql.schema.graphqlfirst.processor.FieldModel;
 import io.stargate.graphql.schema.graphqlfirst.processor.InsertModel;
 import io.stargate.graphql.schema.graphqlfirst.processor.MappingModel;
+import io.stargate.graphql.schema.graphqlfirst.processor.OperationModel;
 import io.stargate.graphql.schema.graphqlfirst.processor.ResponsePayloadModel;
 import io.stargate.graphql.schema.graphqlfirst.processor.ResponsePayloadModel.EntityField;
 import io.stargate.graphql.schema.graphqlfirst.processor.ResponsePayloadModel.TechnicalField;
@@ -46,14 +47,14 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-public class InsertFetcher extends MutationFetcher<InsertModel, Map<String, Object>> {
+public class InsertFetcher extends MutationFetcher<InsertModel, Object> {
 
   public InsertFetcher(InsertModel model, MappingModel mappingModel) {
     super(model, mappingModel);
   }
 
   @Override
-  protected Map<String, Object> get(
+  protected Object get(
       DataFetchingEnvironment environment, DataStore dataStore, StargateGraphqlContext context)
       throws UnauthorizedException {
     DataFetchingFieldSelectionSet selectionSet = environment.getSelectionSet();
@@ -129,7 +130,11 @@ public class InsertFetcher extends MutationFetcher<InsertModel, Map<String, Obje
     if (selectionSet.contains(TechnicalField.APPLIED.getGraphqlName())) {
       response.put(TechnicalField.APPLIED.getGraphqlName(), applied);
     }
-    return response;
+    if (model.getReturnType() == OperationModel.SimpleReturnType.BOOLEAN) {
+      return applied;
+    } else {
+      return response;
+    }
   }
 
   private Map<String, Object> buildCqlValues(

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/InsertModel.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/InsertModel.java
@@ -27,6 +27,7 @@ public class InsertModel extends MutationModel {
   private final String entityArgumentName;
   private final Optional<ResponsePayloadModel> responsePayload;
   private final boolean ifNotExists;
+  private final ReturnType returnType;
 
   InsertModel(
       String parentTypeName,
@@ -36,12 +37,14 @@ public class InsertModel extends MutationModel {
       Optional<ResponsePayloadModel> responsePayload,
       boolean ifNotExists,
       Optional<ConsistencyLevel> consistencyLevel,
-      Optional<ConsistencyLevel> serialConsistencyLevel) {
+      Optional<ConsistencyLevel> serialConsistencyLevel,
+      ReturnType returnType) {
     super(parentTypeName, field, consistencyLevel, serialConsistencyLevel);
     this.entity = entity;
     this.entityArgumentName = entityArgumentName;
     this.responsePayload = responsePayload;
     this.ifNotExists = ifNotExists;
+    this.returnType = returnType;
   }
 
   public EntityModel getEntity() {
@@ -58,6 +61,10 @@ public class InsertModel extends MutationModel {
 
   public boolean ifNotExists() {
     return ifNotExists;
+  }
+
+  public ReturnType getReturnType() {
+    return returnType;
   }
 
   @Override

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/InsertModelBuilder.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/InsertModelBuilder.java
@@ -69,11 +69,12 @@ class InsertModelBuilder extends MutationModelBuilder {
 
     // Validate return type: must be the entity itself, or a wrapper payload
     ReturnType returnType = getReturnType("Mutation " + operationName);
-    if (returnType.isEntityList()
-        || !returnType.getEntity().filter(e -> e.equals(entity)).isPresent()) {
+    if (!returnType.isEntityList()
+        && !returnType.getEntity().filter(e -> e.equals(entity)).isPresent()
+        && returnType != OperationModel.SimpleReturnType.BOOLEAN) {
       invalidMapping(
           "Mutation %s: invalid return type. Expected %s, or a response payload that wraps a "
-              + "single instance of it.",
+              + "single instance of it or Boolean.",
           operationName, entity.getGraphqlName());
     }
 
@@ -90,7 +91,8 @@ class InsertModelBuilder extends MutationModelBuilder {
         responsePayload,
         ifNotExists,
         getConsistencyLevel(cqlInsertDirective),
-        getSerialConsistencyLevel(cqlInsertDirective));
+        getSerialConsistencyLevel(cqlInsertDirective),
+        returnType);
   }
 
   private boolean computeIfNotExists(Optional<Directive> cqlInsertDirective) {

--- a/testing/src/main/java/io/stargate/it/http/graphql/graphqlfirst/InsertTest.java
+++ b/testing/src/main/java/io/stargate/it/http/graphql/graphqlfirst/InsertTest.java
@@ -56,6 +56,7 @@ public class InsertTest extends GraphqlFirstTestBase {
             + "}\n"
             + "type Mutation {\n"
             + "  insertUser(user: UserInput!): User\n"
+            + "  insertUserReturnBoolean(user: UserInput!): Boolean\n"
             + "  persistUser(user: UserInput!): User @cql_insert\n"
             + "  insertUser2(user: UserInput!): InsertUserResponse\n"
             + "  insertUserIfNotExists(user: UserInput!): InsertUserResponse\n"
@@ -67,6 +68,21 @@ public class InsertTest extends GraphqlFirstTestBase {
   @DisplayName("Should map simple insert")
   public void testSimpleInsert() {
     testSimpleInsert("insertUser");
+  }
+
+  @Test
+  @DisplayName("Should map simple insert return boolean")
+  public void testSimpleInsertReturnBoolean() {
+    Object response =
+        CLIENT.executeKeyspaceQuery(
+            KEYSPACE,
+            "mutation {\n"
+                + "  result: insertUserReturnBoolean(user: {name: \"Ada Lovelace\", username: \"@ada\"})\n"
+                + "}");
+
+    // Should have generated an id
+    Boolean applied = JsonPath.<Boolean>read(response, "$.result");
+    assertThat(applied).isTrue();
   }
 
   @Test


### PR DESCRIPTION
After more investigation of the data retrieval code for Update and Insert fetchers, I think that the logic should stay separate. There are more differences between those code paths. However, I think that we should allow inserting to support return `Boolean` to have the unified API. I've implemented it in this PR.