### PR TITLE
relates to #1024: refactored doc search rows to node conversion

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
-import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -802,33 +801,6 @@ public class DocumentService {
     return docsResult;
   }
 
-  private boolean fieldMatchesRowPath(Row row, String field) {
-    String rowPath = getFieldPathFromRow(row, DocumentServiceUtils.maxFieldDepth(field));
-    return rowPath.startsWith(field)
-        && (rowPath.substring(field.length()).isEmpty()
-            || rowPath.substring(field.length()).startsWith("."));
-  }
-
-  // todo move to the json converter
-  public void addToJsonMap(
-      DocumentDB db, ObjectNode docsResult, List<RawDocument> docs, List<String> fields) {
-    for (RawDocument doc : docs) {
-      List<Row> rows;
-      if (fields.isEmpty()) {
-        rows = doc.rows();
-      } else {
-        rows =
-            doc.rows().stream()
-                .filter(row -> fields.stream().anyMatch(field -> fieldMatchesRowPath(row, field)))
-                .collect(Collectors.toList());
-      }
-
-      docsResult.set(
-          doc.id(),
-          jsonConverterService.convertToJsonDoc(rows, false, db.treatBooleansAsNumeric()));
-    }
-  }
-
   private ExecutionContext nestedInMemory(ExecutionContext context, FilterCondition filter) {
     return context.nested(
         "FILTER IN MEMORY: "
@@ -913,18 +885,6 @@ public class DocumentService {
       }
     }
     return s.toString();
-  }
-
-  private String getFieldPathFromRow(Row row, long maxDepth) {
-    List<String> path = new ArrayList<>();
-    for (int i = 0; i < maxDepth; i++) {
-      String value = row.getString("p" + i);
-      if (value.isEmpty()) {
-        break;
-      }
-      path.add(value);
-    }
-    return Joiner.on(".").join(path);
   }
 
   private boolean pathsMatch(String path1, String path2) {
@@ -1028,19 +988,10 @@ public class DocumentService {
                         }));
   }
 
-  private Boolean getBooleanFromRow(Row row, String colName, boolean numericBooleans) {
-    if (row.isNull("bool_value")) return null;
-    if (numericBooleans) {
-      byte value = row.getByte(colName);
-      return value != 0;
-    }
-    return row.getBoolean(colName);
-  }
-
   private boolean allFiltersMatch(Row row, List<FilterCondition> filters, boolean numericBooleans) {
-    String textValue = row.isNull("text_value") ? null : row.getString("text_value");
-    Boolean boolValue = getBooleanFromRow(row, "bool_value", numericBooleans);
-    Double dblValue = row.isNull("dbl_value") ? null : row.getDouble("dbl_value");
+    String textValue = DocumentServiceUtils.getStringFromRow(row);
+    Boolean boolValue = DocumentServiceUtils.getBooleanFromRow(row, numericBooleans);
+    Double dblValue = DocumentServiceUtils.getDoubleFromRow(row);
     for (FilterCondition fc : filters) {
       if (fc.getFilterOp() == FilterOp.EXISTS) {
         if (textValue == null && boolValue == null && dblValue == null) {

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -28,7 +28,7 @@ import io.stargate.web.docsapi.service.filter.FilterOp;
 import io.stargate.web.docsapi.service.filter.ListFilterCondition;
 import io.stargate.web.docsapi.service.filter.SingleFilterCondition;
 import io.stargate.web.docsapi.service.json.DeadLeafCollectorImpl;
-import io.stargate.web.docsapi.service.query.DocumentServiceUtils;
+import io.stargate.web.docsapi.service.util.DocsApiUtils;
 import io.stargate.web.resources.Db;
 import java.util.*;
 import java.util.regex.Pattern;
@@ -989,9 +989,9 @@ public class DocumentService {
   }
 
   private boolean allFiltersMatch(Row row, List<FilterCondition> filters, boolean numericBooleans) {
-    String textValue = DocumentServiceUtils.getStringFromRow(row);
-    Boolean boolValue = DocumentServiceUtils.getBooleanFromRow(row, numericBooleans);
-    Double dblValue = DocumentServiceUtils.getDoubleFromRow(row);
+    String textValue = DocsApiUtils.getStringFromRow(row);
+    Boolean boolValue = DocsApiUtils.getBooleanFromRow(row, numericBooleans);
+    Double dblValue = DocsApiUtils.getDoubleFromRow(row);
     for (FilterCondition fc : filters) {
       if (fc.getFilterOp() == FilterOp.EXISTS) {
         if (textValue == null && boolValue == null && dblValue == null) {

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/JsonConverter.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/JsonConverter.java
@@ -15,7 +15,7 @@ import io.stargate.web.docsapi.dao.DocumentDB;
 import io.stargate.web.docsapi.service.json.DeadLeafCollector;
 import io.stargate.web.docsapi.service.json.ImmutableDeadLeaf;
 import io.stargate.web.docsapi.service.json.ImmutableDeadLeafCollector;
-import io.stargate.web.docsapi.service.query.DocumentServiceUtils;
+import io.stargate.web.docsapi.service.util.DocsApiUtils;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -243,7 +243,7 @@ public class JsonConverter {
         n = new TextNode(value);
       }
     } else if (!row.isNull("bool_value")) {
-      Boolean booleanFromRow = DocumentServiceUtils.getBooleanFromRow(row, numericBooleans);
+      Boolean booleanFromRow = DocsApiUtils.getBooleanFromRow(row, numericBooleans);
       n = BooleanNode.valueOf(booleanFromRow);
     } else if (!row.isNull("dbl_value")) {
       // If not a fraction represent as a long to the user

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/JsonConverter.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/JsonConverter.java
@@ -2,14 +2,24 @@ package io.stargate.web.docsapi.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.*;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import io.stargate.db.datastore.Row;
 import io.stargate.db.schema.Column;
 import io.stargate.web.docsapi.dao.DocumentDB;
 import io.stargate.web.docsapi.service.json.DeadLeafCollector;
 import io.stargate.web.docsapi.service.json.ImmutableDeadLeaf;
 import io.stargate.web.docsapi.service.json.ImmutableDeadLeafCollector;
-import java.util.*;
+import io.stargate.web.docsapi.service.query.DocumentServiceUtils;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import javax.inject.Inject;
 
 public class JsonConverter {
@@ -25,16 +35,6 @@ public class JsonConverter {
     this.docsApiConfiguration = docsApiConfiguration;
   }
 
-  // TODO find a place to refactor this to, along with DocumentService#getBooleanFromRow
-  private static Boolean getBooleanFromRow(Row row, String colName, boolean numericBooleans) {
-    if (row.isNull("bool_value")) return null;
-    if (numericBooleans) {
-      byte value = row.getByte(colName);
-      return value != 0;
-    }
-    return row.getBoolean(colName);
-  }
-
   public JsonNode convertToJsonDoc(
       List<Row> rows, boolean writeAllPathsAsObjects, boolean numericBooleans) {
     return convertToJsonDoc(
@@ -46,6 +46,16 @@ public class JsonConverter {
       DeadLeafCollector collector,
       boolean writeAllPathsAsObjects,
       boolean numericBooleans) {
+    int maxDepth = docsApiConfiguration.getMaxDepth();
+    return convertToJsonDoc(rows, collector, writeAllPathsAsObjects, numericBooleans, maxDepth);
+  }
+
+  private JsonNode convertToJsonDoc(
+      List<Row> rows,
+      DeadLeafCollector collector,
+      boolean writeAllPathsAsObjects,
+      boolean numericBooleans,
+      int maxDepth) {
     JsonNode doc = mapper.createObjectNode();
     Map<String, Long> pathWriteTimes = new HashMap<>();
     if (rows.isEmpty()) {
@@ -66,10 +76,9 @@ public class JsonConverter {
 
       String parentPath = "$";
 
-      for (int i = 0; i < docsApiConfiguration.getMaxDepth(); i++) {
+      for (int i = 0; i < maxDepth; i++) {
         String p = row.getString("p" + i);
-        String nextP =
-            i < docsApiConfiguration.getMaxDepth() - 1 ? row.getString("p" + (i + 1)) : "";
+        String nextP = i < maxDepth - 1 ? row.getString("p" + (i + 1)) : "";
         boolean endOfPath = nextP.equals("");
         boolean isArray = p.startsWith("[");
         boolean nextIsArray = nextP.startsWith("[");
@@ -234,7 +243,8 @@ public class JsonConverter {
         n = new TextNode(value);
       }
     } else if (!row.isNull("bool_value")) {
-      n = BooleanNode.valueOf(getBooleanFromRow(row, "bool_value", numericBooleans));
+      Boolean booleanFromRow = DocumentServiceUtils.getBooleanFromRow(row, numericBooleans);
+      n = BooleanNode.valueOf(booleanFromRow);
     } else if (!row.isNull("dbl_value")) {
       // If not a fraction represent as a long to the user
       // This lets us handle queries of doubles and longs without

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
@@ -113,13 +113,7 @@ public class ReactiveDocumentService {
           // call the search service
           return searchService
               .searchDocuments(
-                  db.getQueryExecutor(),
-                  namespace,
-                  collection,
-                  expression,
-                  fieldsResolved,
-                  paginator,
-                  context)
+                  db.getQueryExecutor(), namespace, collection, expression, paginator, context)
 
               // collect and make sure it's not empty
               .toList()

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
@@ -34,9 +34,9 @@ import io.stargate.web.docsapi.exception.ErrorCode;
 import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
 import io.stargate.web.docsapi.models.DocumentResponseWrapper;
 import io.stargate.web.docsapi.service.query.DocumentSearchService;
-import io.stargate.web.docsapi.service.query.DocumentServiceUtils;
 import io.stargate.web.docsapi.service.query.ExpressionParser;
 import io.stargate.web.docsapi.service.query.FilterExpression;
+import io.stargate.web.docsapi.service.util.DocsApiUtils;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -92,7 +92,7 @@ public class ReactiveDocumentService {
           if (null != fields) {
             try {
               JsonNode fieldsNode = objectMapper.readTree(fields);
-              fieldPaths = DocumentServiceUtils.convertFieldsToPaths(fieldsNode);
+              fieldPaths = DocsApiUtils.convertFieldsToPaths(fieldsNode);
             } catch (JsonProcessingException ex) {
               throw new ErrorCodeRuntimeException(ErrorCode.DOCS_API_SEARCH_FIELDS_JSON_INVALID);
             }
@@ -148,8 +148,7 @@ public class ReactiveDocumentService {
                 .filter(
                     row ->
                         fieldPaths.stream()
-                            .anyMatch(
-                                fieldPath -> DocumentServiceUtils.isRowOnPath(row, fieldPath)))
+                            .anyMatch(fieldPath -> DocsApiUtils.isRowOnPath(row, fieldPath)))
                 .collect(Collectors.toList());
       }
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/DocumentSearchService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/DocumentSearchService.java
@@ -35,7 +35,6 @@ import io.stargate.web.docsapi.service.query.search.db.impl.PopulateSearchQueryB
 import io.stargate.web.docsapi.service.query.search.resolver.BaseResolver;
 import io.stargate.web.docsapi.service.query.search.resolver.DocumentsResolver;
 import io.stargate.web.rx.RxUtils;
-import java.util.Collection;
 import javax.inject.Inject;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -48,7 +47,6 @@ public class DocumentSearchService {
       String keyspace,
       String collection,
       Expression<FilterExpression> expression,
-      Collection<String> fields,
       Paginator paginator,
       ExecutionContext context) {
 
@@ -97,14 +95,11 @@ public class DocumentSearchService {
       Paginator paginator,
       ExecutionContext context) {
 
-    // TODO use fields when having them to limit scope of fetched columns
-    //  plus add the p(depth+1) = "" to not fetch rows we don't need
-
     // prepare first (this could be cached for the max depth)
     return RxUtils.singleFromFuture(
             () -> {
-              String[] columns =
-                  QueryConstants.ALL_COLUMNS_NAMES.apply(configuration.getMaxDepth());
+              int maxDepth = configuration.getMaxDepth();
+              String[] columns = QueryConstants.ALL_COLUMNS_NAMES.apply(maxDepth);
 
               DataStore dataStore = queryExecutor.getDataStore();
 
@@ -138,18 +133,9 @@ public class DocumentSearchService {
     Single<? extends Query<? extends BoundQuery>> preparedSingle =
         RxUtils.singleFromFuture(
                 () -> {
-                  // TODO make sure that if we have fields, we only fetch max amount of P columns
-                  // needed
-                  //  plus add the p(depth+1) = "" to not fetch rows we don't need
-                  //  fallback to max depth if no fields
-                  //  not possible at the moment, as JsonConverter is not supporting it
-                  // long depth =
-                  // DocumentServiceUtils.maxFieldsDepth(fields).orElse(configuration.getMaxDepth());
-
                   // columns from depth
-                  String[] columns =
-                      QueryConstants.ALL_COLUMNS_NAMES.apply(
-                          Long.valueOf(configuration.getMaxDepth()).intValue());
+                  int maxDepth = configuration.getMaxDepth();
+                  String[] columns = QueryConstants.ALL_COLUMNS_NAMES.apply(maxDepth);
 
                   // data store need for build and prepare
                   DataStore dataStore = queryExecutor.getDataStore();

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/ExpressionParser.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/ExpressionParser.java
@@ -23,6 +23,7 @@ import com.bpodgursky.jbool_expressions.rules.RuleSet;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.stargate.web.docsapi.service.query.condition.BaseCondition;
 import io.stargate.web.docsapi.service.query.condition.ConditionParser;
+import io.stargate.web.docsapi.service.util.DocsApiUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -117,7 +118,7 @@ public class ExpressionParser {
     String[] fieldNamePath = PERIOD_PATTERN.split(fieldPath);
     List<String> convertedFieldNamePath =
         Arrays.stream(fieldNamePath)
-            .map(DocumentServiceUtils::convertArrayPath)
+            .map(DocsApiUtils::convertArrayPath)
             .collect(Collectors.toList());
 
     if (!prependedPath.isEmpty()) {
@@ -126,7 +127,7 @@ public class ExpressionParser {
               .map(
                   pathSeg -> {
                     String path = pathSeg.getPath();
-                    return DocumentServiceUtils.convertArrayPath(path);
+                    return DocsApiUtils.convertArrayPath(path);
                   })
               .collect(Collectors.toList());
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/FilterExpression.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/FilterExpression.java
@@ -23,6 +23,7 @@ import com.bpodgursky.jbool_expressions.util.ExprFactory;
 import io.stargate.db.datastore.Row;
 import io.stargate.web.docsapi.service.RawDocument;
 import io.stargate.web.docsapi.service.query.condition.BaseCondition;
+import io.stargate.web.docsapi.service.util.DocsApiUtils;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -143,7 +144,7 @@ public abstract class FilterExpression extends Expression<FilterExpression>
     }
 
     // then as last resort confirm the path is matching
-    return DocumentServiceUtils.isRowOnPath(row, targetPath);
+    return DocsApiUtils.isRowOnPath(row, targetPath);
   }
 
   // below is Expression relevant implementation that targets this

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/FilterExpression.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/FilterExpression.java
@@ -21,10 +21,8 @@ import com.bpodgursky.jbool_expressions.options.ExprOptions;
 import com.bpodgursky.jbool_expressions.rules.RuleList;
 import com.bpodgursky.jbool_expressions.util.ExprFactory;
 import io.stargate.db.datastore.Row;
-import io.stargate.web.docsapi.dao.DocumentDB;
 import io.stargate.web.docsapi.service.RawDocument;
 import io.stargate.web.docsapi.service.query.condition.BaseCondition;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -145,38 +143,7 @@ public abstract class FilterExpression extends Expression<FilterExpression>
     }
 
     // then as last resort confirm the path is matching
-    int p = 0;
-    while (p < targetPathSize) {
-      int index = p++;
-      String target = targetPath.get(index);
-
-      // skip any target path that is wildcard
-      if (Objects.equals(target, DocumentDB.GLOB_VALUE)
-          || Objects.equals(target, DocumentDB.GLOB_ARRAY_VALUE)) {
-        continue;
-      }
-
-      // check that row has the request path depth
-      String path = row.getString(QueryConstants.P_COLUMN_NAME.apply(index));
-      if (null != path && path.length() == 0) {
-        return false;
-      }
-
-      boolean pathSegment = target.contains(",");
-      // if we have the path segment, we need to check if any matches
-      if (pathSegment) {
-        boolean noneMatch =
-            Arrays.stream(target.split(",")).noneMatch(t -> Objects.equals(t, path));
-        if (noneMatch) {
-          return false;
-        }
-      } else if (!Objects.equals(path, target)) {
-        // if not equal, fail
-        return false;
-      }
-    }
-
-    return true;
+    return DocumentServiceUtils.isRowOnPath(row, targetPath);
   }
 
   // below is Expression relevant implementation that targets this

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/BaseCondition.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/BaseCondition.java
@@ -18,8 +18,8 @@ package io.stargate.web.docsapi.service.query.condition;
 
 import io.stargate.db.datastore.Row;
 import io.stargate.db.query.builder.BuiltCondition;
-import io.stargate.web.docsapi.service.query.DocumentServiceUtils;
 import io.stargate.web.docsapi.service.query.filter.operation.FilterOperationCode;
+import io.stargate.web.docsapi.service.util.DocsApiUtils;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -53,7 +53,7 @@ public interface BaseCondition extends Predicate<Row> {
    * @return Returns resolved value or <code>null</code>
    */
   default String getString(Row row) {
-    return DocumentServiceUtils.getStringFromRow(row);
+    return DocsApiUtils.getStringFromRow(row);
   }
 
   /**
@@ -63,7 +63,7 @@ public interface BaseCondition extends Predicate<Row> {
    * @return Returns resolved value or <code>null</code>
    */
   default Double getDouble(Row row) {
-    return DocumentServiceUtils.getDoubleFromRow(row);
+    return DocsApiUtils.getDoubleFromRow(row);
   }
 
   /**
@@ -74,6 +74,6 @@ public interface BaseCondition extends Predicate<Row> {
    * @return Returns resolved value or <code>null</code>
    */
   default Boolean getBoolean(Row row, boolean numericBooleans) {
-    return DocumentServiceUtils.getBooleanFromRow(row, numericBooleans);
+    return DocsApiUtils.getBooleanFromRow(row, numericBooleans);
   }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/BaseCondition.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/BaseCondition.java
@@ -18,7 +18,7 @@ package io.stargate.web.docsapi.service.query.condition;
 
 import io.stargate.db.datastore.Row;
 import io.stargate.db.query.builder.BuiltCondition;
-import io.stargate.web.docsapi.service.query.QueryConstants;
+import io.stargate.web.docsapi.service.query.DocumentServiceUtils;
 import io.stargate.web.docsapi.service.query.filter.operation.FilterOperationCode;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -53,9 +53,7 @@ public interface BaseCondition extends Predicate<Row> {
    * @return Returns resolved value or <code>null</code>
    */
   default String getString(Row row) {
-    return row.isNull(QueryConstants.STRING_VALUE_COLUMN_NAME)
-        ? null
-        : row.getString(QueryConstants.STRING_VALUE_COLUMN_NAME);
+    return DocumentServiceUtils.getStringFromRow(row);
   }
 
   /**
@@ -65,9 +63,7 @@ public interface BaseCondition extends Predicate<Row> {
    * @return Returns resolved value or <code>null</code>
    */
   default Double getDouble(Row row) {
-    return row.isNull(QueryConstants.DOUBLE_VALUE_COLUMN_NAME)
-        ? null
-        : row.getDouble(QueryConstants.DOUBLE_VALUE_COLUMN_NAME);
+    return DocumentServiceUtils.getDoubleFromRow(row);
   }
 
   /**
@@ -78,16 +74,6 @@ public interface BaseCondition extends Predicate<Row> {
    * @return Returns resolved value or <code>null</code>
    */
   default Boolean getBoolean(Row row, boolean numericBooleans) {
-    boolean nullValue = row.isNull(QueryConstants.BOOLEAN_VALUE_COLUMN_NAME);
-    if (nullValue) {
-      return null;
-    } else {
-      if (numericBooleans) {
-        byte value = row.getByte(QueryConstants.BOOLEAN_VALUE_COLUMN_NAME);
-        return value != 0;
-      } else {
-        return row.getBoolean(QueryConstants.BOOLEAN_VALUE_COLUMN_NAME);
-      }
-    }
+    return DocumentServiceUtils.getBooleanFromRow(row, numericBooleans);
   }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/ReactiveDocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/ReactiveDocumentServiceTest.java
@@ -50,7 +50,6 @@ import io.stargate.web.docsapi.service.query.FilterExpression;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,8 +70,6 @@ class ReactiveDocumentServiceTest {
 
   @Mock DocumentSearchService searchService;
 
-  @Mock DocumentService documentService;
-
   @Mock JsonConverter jsonConverter;
 
   @Mock DocumentDB documentDB;
@@ -92,8 +89,7 @@ class ReactiveDocumentServiceTest {
   @BeforeEach
   public void init() {
     reactiveDocumentService =
-        new ReactiveDocumentService(
-            expressionParser, searchService, documentService, jsonConverter, objectMapper);
+        new ReactiveDocumentService(expressionParser, searchService, jsonConverter, objectMapper);
     lenient().when(documentDB.getAuthorizationService()).thenReturn(authService);
     lenient().when(documentDB.getAuthenticationSubject()).thenReturn(authSubject);
   }
@@ -111,7 +107,6 @@ class ReactiveDocumentServiceTest {
       String collection = RandomStringUtils.randomAlphanumeric(16);
       String where = "{}";
       String fields = "[\"myField\"]";
-      List<String> fieldList = Collections.singletonList("myField");
       byte[] pageState = RandomUtils.nextBytes(64);
       Flowable<RawDocument> docs = Flowable.just(rawDocument);
       when(documentDB.treatBooleansAsNumeric()).thenReturn(true);
@@ -119,8 +114,6 @@ class ReactiveDocumentServiceTest {
       when(expressionParser.constructFilterExpression(
               Collections.emptyList(), objectMapper.readTree(where), true))
           .thenReturn(expression);
-      when(documentService.convertToSelectionList(objectMapper.readTree(fields)))
-          .thenReturn(fieldList);
       when(searchService.searchDocuments(
               queryExecutor, namespace, collection, expression, paginator, context))
           .thenReturn(docs);
@@ -163,7 +156,6 @@ class ReactiveDocumentServiceTest {
       String collection = RandomStringUtils.randomAlphanumeric(16);
       String where = "{}";
       String fields = "[\"myField\"]";
-      List<String> fieldList = Collections.singletonList("myField");
       byte[] pageState = RandomUtils.nextBytes(64);
       Flowable<RawDocument> docs = Flowable.just(rawDocument);
       when(documentDB.treatBooleansAsNumeric()).thenReturn(true);
@@ -171,8 +163,6 @@ class ReactiveDocumentServiceTest {
       when(expressionParser.constructFilterExpression(
               Collections.emptyList(), objectMapper.readTree(where), true))
           .thenReturn(expression);
-      when(documentService.convertToSelectionList(objectMapper.readTree(fields)))
-          .thenReturn(fieldList);
       when(searchService.searchDocuments(
               queryExecutor, namespace, collection, expression, paginator, context))
           .thenReturn(docs);
@@ -215,7 +205,6 @@ class ReactiveDocumentServiceTest {
       String collection = RandomStringUtils.randomAlphanumeric(16);
       String where = "{}";
       String fields = "[]";
-      List<String> fieldList = Collections.emptyList();
       byte[] pageState = RandomUtils.nextBytes(64);
       Flowable<RawDocument> docs = Flowable.just(rawDocument);
       when(documentDB.treatBooleansAsNumeric()).thenReturn(true);
@@ -223,8 +212,6 @@ class ReactiveDocumentServiceTest {
       when(expressionParser.constructFilterExpression(
               Collections.emptyList(), objectMapper.readTree(where), true))
           .thenReturn(expression);
-      when(documentService.convertToSelectionList(objectMapper.readTree(fields)))
-          .thenReturn(fieldList);
       when(searchService.searchDocuments(
               queryExecutor, namespace, collection, expression, paginator, context))
           .thenReturn(docs);
@@ -264,14 +251,11 @@ class ReactiveDocumentServiceTest {
       String collection = RandomStringUtils.randomAlphanumeric(16);
       String where = "{}";
       String fields = "[\"myField\"]";
-      List<String> fieldList = Collections.singletonList("muField");
       when(documentDB.treatBooleansAsNumeric()).thenReturn(true);
       when(documentDB.getQueryExecutor()).thenReturn(queryExecutor);
       when(expressionParser.constructFilterExpression(
               Collections.emptyList(), objectMapper.readTree(where), true))
           .thenReturn(expression);
-      when(documentService.convertToSelectionList(objectMapper.readTree(fields)))
-          .thenReturn(fieldList);
       when(searchService.searchDocuments(
               queryExecutor, namespace, collection, expression, paginator, context))
           .thenReturn(Flowable.empty());

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/ReactiveDocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/ReactiveDocumentServiceTest.java
@@ -122,7 +122,7 @@ class ReactiveDocumentServiceTest {
       when(documentService.convertToSelectionList(objectMapper.readTree(fields)))
           .thenReturn(fieldList);
       when(searchService.searchDocuments(
-              queryExecutor, namespace, collection, expression, fieldList, paginator, context))
+              queryExecutor, namespace, collection, expression, paginator, context))
           .thenReturn(docs);
       doReturn(documentNode)
           .when(jsonConverter)
@@ -174,7 +174,7 @@ class ReactiveDocumentServiceTest {
       when(documentService.convertToSelectionList(objectMapper.readTree(fields)))
           .thenReturn(fieldList);
       when(searchService.searchDocuments(
-              queryExecutor, namespace, collection, expression, fieldList, paginator, context))
+              queryExecutor, namespace, collection, expression, paginator, context))
           .thenReturn(docs);
       doReturn(documentNode)
           .when(jsonConverter)
@@ -226,7 +226,7 @@ class ReactiveDocumentServiceTest {
       when(documentService.convertToSelectionList(objectMapper.readTree(fields)))
           .thenReturn(fieldList);
       when(searchService.searchDocuments(
-              queryExecutor, namespace, collection, expression, fieldList, paginator, context))
+              queryExecutor, namespace, collection, expression, paginator, context))
           .thenReturn(docs);
       doReturn(documentNode)
           .when(jsonConverter)
@@ -273,7 +273,7 @@ class ReactiveDocumentServiceTest {
       when(documentService.convertToSelectionList(objectMapper.readTree(fields)))
           .thenReturn(fieldList);
       when(searchService.searchDocuments(
-              queryExecutor, namespace, collection, expression, fieldList, paginator, context))
+              queryExecutor, namespace, collection, expression, paginator, context))
           .thenReturn(Flowable.empty());
 
       Single<DocumentResponseWrapper<? extends JsonNode>> result =
@@ -305,13 +305,7 @@ class ReactiveDocumentServiceTest {
       byte[] pageState = RandomUtils.nextBytes(64);
       when(documentDB.getQueryExecutor()).thenReturn(queryExecutor);
       when(searchService.searchDocuments(
-              queryExecutor,
-              namespace,
-              collection,
-              Literal.getTrue(),
-              Collections.emptyList(),
-              paginator,
-              context))
+              queryExecutor, namespace, collection, Literal.getTrue(), paginator, context))
           .thenReturn(docs);
       when(rawDocument.makePagingState()).thenReturn(ByteBuffer.wrap(pageState));
 

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/DocumentSearchServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/DocumentSearchServiceTest.java
@@ -38,7 +38,6 @@ import io.stargate.web.docsapi.service.query.condition.BaseCondition;
 import io.stargate.web.docsapi.service.query.condition.impl.ImmutableStringCondition;
 import io.stargate.web.docsapi.service.query.filter.operation.impl.EqFilterOperation;
 import java.util.Arrays;
-import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -117,7 +116,6 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
               KEYSPACE_NAME,
               COLLECTION_NAME,
               expression,
-              Collections.emptyList(),
               paginator,
               context);
 
@@ -243,7 +241,6 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
               KEYSPACE_NAME,
               COLLECTION_NAME,
               expression,
-              Collections.emptyList(),
               paginator,
               context);
 
@@ -342,7 +339,6 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
               KEYSPACE_NAME,
               COLLECTION_NAME,
               expression,
-              Collections.emptyList(),
               paginator,
               context);
 
@@ -407,7 +403,6 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
               KEYSPACE_NAME,
               COLLECTION_NAME,
               Literal.getTrue(),
-              Collections.emptyList(),
               paginator,
               context);
 

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/FilterExpressionTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/FilterExpressionTest.java
@@ -302,7 +302,7 @@ public class FilterExpressionTest {
                   QueryConstants.LEAF_COLUMN_NAME,
                   "field",
                   QueryConstants.P_COLUMN_NAME.apply(0),
-                  "parent",
+                  "[000001]",
                   QueryConstants.P_COLUMN_NAME.apply(1),
                   "field",
                   QueryConstants.P_COLUMN_NAME.apply(2),

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/util/DocsApiUtilsTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/util/DocsApiUtilsTest.java
@@ -1,0 +1,429 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.web.docsapi.service.util;
+
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.stargate.db.datastore.MapBackedRow;
+import io.stargate.db.datastore.Row;
+import io.stargate.db.schema.Table;
+import io.stargate.web.docsapi.DocsApiTestSchemaProvider;
+import io.stargate.web.docsapi.exception.ErrorCode;
+import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
+import io.stargate.web.docsapi.service.query.QueryConstants;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DocsApiUtilsTest {
+
+  @Nested
+  class ConvertArrayPath {
+
+    @Test
+    public void happyPath() {
+      int index = RandomUtils.nextInt(100, 999);
+
+      String result = DocsApiUtils.convertArrayPath(String.format("[%d]", index));
+
+      assertThat(result).isEqualTo(String.format("[000%d]", index));
+    }
+
+    @Test
+    public void happyPathWithSegments() {
+      String result = DocsApiUtils.convertArrayPath("[1],[44],[555]");
+
+      assertThat(result).isEqualTo("[000001],[000044],[000555]");
+    }
+
+    @Test
+    public void globIgnored() {
+      String result = DocsApiUtils.convertArrayPath("[*]");
+
+      assertThat(result).isEqualTo("[*]");
+    }
+
+    @Test
+    public void notArrayIgnored() {
+      String result = DocsApiUtils.convertArrayPath("somePath");
+
+      assertThat(result).isEqualTo("somePath");
+    }
+
+    @Test
+    public void notArrayWithSegmentsIgnored() {
+      String result = DocsApiUtils.convertArrayPath("somePath,otherPath");
+
+      assertThat(result).isEqualTo("somePath,otherPath");
+    }
+
+    @Test
+    public void maxArrayExceeded() {
+      Throwable t = catchThrowable(() -> DocsApiUtils.convertArrayPath("[1234567]"));
+
+      assertThat(t)
+          .isInstanceOf(ErrorCodeRuntimeException.class)
+          .hasFieldOrPropertyWithValue(
+              "errorCode", ErrorCode.DOCS_API_GENERAL_ARRAY_LENGTH_EXCEEDED);
+    }
+
+    @Test
+    public void numberFormatException() {
+      Throwable t = catchThrowable(() -> DocsApiUtils.convertArrayPath("[not_allowed]"));
+
+      assertThat(t)
+          .isInstanceOf(ErrorCodeRuntimeException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_SEARCH_ARRAY_PATH_INVALID);
+    }
+  }
+
+  @Nested
+  class ConvertFieldsToPaths {
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void happyPath() {
+      ArrayNode input =
+          objectMapper.createArrayNode().add("path.to.the.field").add("path.to.different");
+
+      Collection<List<String>> result = DocsApiUtils.convertFieldsToPaths(input);
+      assertThat(result)
+          .hasSize(2)
+          .anySatisfy(l -> assertThat(l).containsExactly("path", "to", "the", "field"))
+          .anySatisfy(l -> assertThat(l).containsExactly("path", "to", "different"));
+    }
+
+    @Test
+    public void arrays() {
+      ArrayNode input = objectMapper.createArrayNode().add("path.[*].any.[1].field");
+
+      Collection<List<String>> result = DocsApiUtils.convertFieldsToPaths(input);
+      assertThat(result)
+          .singleElement()
+          .satisfies(l -> assertThat(l).containsExactly("path", "[*]", "any", "[000001]", "field"));
+    }
+
+    @Test
+    public void segments() {
+      ArrayNode input = objectMapper.createArrayNode().add("path.one,two.[0],[1].field");
+
+      Collection<List<String>> result = DocsApiUtils.convertFieldsToPaths(input);
+      assertThat(result)
+          .singleElement()
+          .satisfies(
+              l -> assertThat(l).containsExactly("path", "one,two", "[000000],[000001]", "field"));
+    }
+
+    @Test
+    public void notArrayInput() {
+      ObjectNode input = objectMapper.createObjectNode();
+
+      Throwable t = catchThrowable(() -> DocsApiUtils.convertFieldsToPaths(input));
+
+      assertThat(t)
+          .isInstanceOf(ErrorCodeRuntimeException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_GENERAL_FIELDS_INVALID);
+    }
+
+    @Test
+    public void containsNotStringInInput() {
+      ArrayNode input = objectMapper.createArrayNode().add("path.one,two.[0],[1].field").add(15L);
+
+      Throwable t = catchThrowable(() -> DocsApiUtils.convertFieldsToPaths(input));
+
+      assertThat(t)
+          .isInstanceOf(ErrorCodeRuntimeException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_GENERAL_FIELDS_INVALID);
+    }
+  }
+
+  @Nested
+  class GetStringFromRow {
+
+    @Mock Row row;
+
+    @Test
+    public void happyPath() {
+      String value = RandomStringUtils.randomAlphanumeric(16);
+      when(row.isNull("text_value")).thenReturn(false);
+      when(row.getString("text_value")).thenReturn(value);
+
+      String result = DocsApiUtils.getStringFromRow(row);
+
+      assertThat(result).isEqualTo(value);
+    }
+
+    @Test
+    public void noValue() {
+      when(row.isNull("text_value")).thenReturn(true);
+
+      String result = DocsApiUtils.getStringFromRow(row);
+
+      assertThat(result).isNull();
+    }
+  }
+
+  @Nested
+  class GetDoubleFromRow {
+
+    @Mock Row row;
+
+    @Test
+    public void happyPath() {
+      Double value = RandomUtils.nextDouble();
+      when(row.isNull("dbl_value")).thenReturn(false);
+      when(row.getDouble("dbl_value")).thenReturn(value);
+
+      Double result = DocsApiUtils.getDoubleFromRow(row);
+
+      assertThat(result).isEqualTo(value);
+    }
+
+    @Test
+    public void noValue() {
+      when(row.isNull("dbl_value")).thenReturn(true);
+
+      Double result = DocsApiUtils.getDoubleFromRow(row);
+
+      assertThat(result).isNull();
+    }
+  }
+
+  @Nested
+  class GetBooleanFromRow {
+
+    @Mock Row row;
+
+    @Test
+    public void happyPath() {
+      boolean value = RandomUtils.nextBoolean();
+      when(row.isNull("bool_value")).thenReturn(false);
+      when(row.getBoolean("bool_value")).thenReturn(value);
+
+      Boolean result = DocsApiUtils.getBooleanFromRow(row, false);
+
+      assertThat(result).isEqualTo(value);
+    }
+
+    @Test
+    public void numericBooleansZero() {
+      when(row.isNull("bool_value")).thenReturn(false);
+      when(row.getByte("bool_value")).thenReturn((byte) 0);
+
+      Boolean result = DocsApiUtils.getBooleanFromRow(row, true);
+
+      assertThat(result).isFalse();
+    }
+
+    @Test
+    public void numericBooleansOne() {
+      when(row.isNull("bool_value")).thenReturn(false);
+      when(row.getByte("bool_value")).thenReturn((byte) 1);
+
+      Boolean result = DocsApiUtils.getBooleanFromRow(row, true);
+
+      assertThat(result).isTrue();
+    }
+
+    @Test
+    public void noValue() {
+      when(row.isNull("bool_value")).thenReturn(true);
+
+      Boolean result = DocsApiUtils.getBooleanFromRow(row, false);
+
+      assertThat(result).isNull();
+    }
+  }
+
+  @Nested
+  class IsRowOnPath {
+
+    private final DocsApiTestSchemaProvider SCHEMA_PROVIDER = new DocsApiTestSchemaProvider(4);
+    private final Table TABLE = SCHEMA_PROVIDER.getTable();
+
+    @Test
+    public void matchingExact() {
+      List<String> path = Arrays.asList("field", "value");
+      Row row =
+          MapBackedRow.of(
+              TABLE,
+              ImmutableMap.of(
+                  QueryConstants.P_COLUMN_NAME.apply(0),
+                  "field",
+                  QueryConstants.P_COLUMN_NAME.apply(1),
+                  "value"));
+
+      boolean result = DocsApiUtils.isRowOnPath(row, path);
+
+      Assertions.assertThat(result).isTrue();
+    }
+
+    @Test
+    public void matchingSubPath() {
+      List<String> path = Collections.singletonList("field");
+      Row row =
+          MapBackedRow.of(
+              TABLE,
+              ImmutableMap.of(
+                  QueryConstants.P_COLUMN_NAME.apply(0),
+                  "field",
+                  QueryConstants.P_COLUMN_NAME.apply(1),
+                  "more"));
+
+      boolean result = DocsApiUtils.isRowOnPath(row, path);
+
+      Assertions.assertThat(result).isTrue();
+    }
+
+    @Test
+    public void matchingSegment() {
+      List<String> path = Arrays.asList("field", "value1,value2");
+      Row row =
+          MapBackedRow.of(
+              TABLE,
+              ImmutableMap.of(
+                  QueryConstants.P_COLUMN_NAME.apply(0),
+                  "field",
+                  QueryConstants.P_COLUMN_NAME.apply(1),
+                  "value2"));
+
+      boolean result = DocsApiUtils.isRowOnPath(row, path);
+
+      Assertions.assertThat(result).isTrue();
+    }
+
+    @Test
+    public void matchingGlob() {
+      List<String> path = Arrays.asList("*", "[*]");
+      Row row =
+          MapBackedRow.of(
+              TABLE,
+              ImmutableMap.of(
+                  QueryConstants.P_COLUMN_NAME.apply(0),
+                  "field",
+                  QueryConstants.P_COLUMN_NAME.apply(1),
+                  "[000001]"));
+
+      boolean result = DocsApiUtils.isRowOnPath(row, path);
+
+      Assertions.assertThat(result).isTrue();
+    }
+
+    @Test
+    public void pathNotMatchingDifferent() {
+      List<String> path = Arrays.asList("parent", "field");
+      Row row =
+          MapBackedRow.of(
+              TABLE,
+              ImmutableMap.of(
+                  QueryConstants.P_COLUMN_NAME.apply(0),
+                  "field",
+                  QueryConstants.P_COLUMN_NAME.apply(1),
+                  "parent"));
+
+      boolean result = DocsApiUtils.isRowOnPath(row, path);
+
+      Assertions.assertThat(result).isFalse();
+    }
+
+    @Test
+    public void pathNotMatchingTooShort() {
+      List<String> path = Arrays.asList("parent", "field");
+      Row row =
+          MapBackedRow.of(
+              TABLE,
+              ImmutableMap.of(
+                  QueryConstants.P_COLUMN_NAME.apply(0),
+                  "parent",
+                  QueryConstants.P_COLUMN_NAME.apply(1),
+                  ""));
+
+      boolean result = DocsApiUtils.isRowOnPath(row, path);
+
+      Assertions.assertThat(result).isFalse();
+    }
+
+    @Test
+    public void notMatchingSegment() {
+      List<String> path = Arrays.asList("field", "value1,value2");
+      Row row =
+          MapBackedRow.of(
+              TABLE,
+              ImmutableMap.of(
+                  QueryConstants.P_COLUMN_NAME.apply(0),
+                  "field",
+                  QueryConstants.P_COLUMN_NAME.apply(1),
+                  "noValue"));
+
+      boolean result = DocsApiUtils.isRowOnPath(row, path);
+
+      Assertions.assertThat(result).isFalse();
+    }
+
+    @Test
+    public void matchingMatchingGlobArray() {
+      List<String> path = Arrays.asList("field", "*");
+      Row row =
+          MapBackedRow.of(
+              TABLE,
+              ImmutableMap.of(
+                  QueryConstants.P_COLUMN_NAME.apply(0),
+                  "field",
+                  QueryConstants.P_COLUMN_NAME.apply(1),
+                  "[000001]"));
+
+      boolean result = DocsApiUtils.isRowOnPath(row, path);
+
+      Assertions.assertThat(result).isFalse();
+    }
+
+    @Test
+    public void matchingMatchingGlob() {
+      List<String> path = Arrays.asList("field", "[*]");
+      Row row =
+          MapBackedRow.of(
+              TABLE,
+              ImmutableMap.of(
+                  QueryConstants.P_COLUMN_NAME.apply(0),
+                  "field",
+                  QueryConstants.P_COLUMN_NAME.apply(1),
+                  "value"));
+
+      boolean result = DocsApiUtils.isRowOnPath(row, path);
+
+      Assertions.assertThat(result).isFalse();
+    }
+  }
+}

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -2174,6 +2174,72 @@ public class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   }
 
   @Test
+  public void searchWithFieldsArrayPath() throws Exception {
+    JsonNode doc =
+        OBJECT_MAPPER.readTree(
+            "{\"first\": 5, \"value\": [{ \"n\": { \"value\": 5} }, { \"m\": { \"value\": 8} }]}");
+    RestUtils.put(authToken, collectionPath + "/doc", doc.toString(), 200);
+
+    // Any filter on full collection search should only match the level of nesting of the where
+    // clause
+    String r =
+        RestUtils.get(
+            authToken,
+            hostWithPort
+                + "/v2/namespaces/"
+                + keyspace
+                + "/collections/collection?page-size=2&fields=[\"value.[1].m\"]&raw=true",
+            200);
+
+    String expected = "{\"doc\":{\"value\":[null,{\"m\":{\"value\":8}}]}}";
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(expected));
+  }
+
+  @Test
+  public void searchWithFieldsArrayGlobSegmentedPath() throws Exception {
+    JsonNode doc =
+        OBJECT_MAPPER.readTree(
+            "{\"first\": 5, \"value\": [{ \"n\": { \"value\": 5} }, { \"m\": { \"value\": 8} }]}");
+    RestUtils.put(authToken, collectionPath + "/doc", doc.toString(), 200);
+
+    // Any filter on full collection search should only match the level of nesting of the where
+    // clause
+    String r =
+        RestUtils.get(
+            authToken,
+            hostWithPort
+                + "/v2/namespaces/"
+                + keyspace
+                + "/collections/collection?page-size=2&fields=[\"value.[*].m,n\"]&raw=true",
+            200);
+
+    String expected = "{\"doc\":{\"value\":[{\"n\":{\"value\":5}},{\"m\":{\"value\":8}}]}}";
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(expected));
+  }
+
+  @Test
+  public void searchWithFieldsDoubleGlob() throws Exception {
+    JsonNode doc =
+        OBJECT_MAPPER.readTree(
+            "{\"first\": 5, \"value\": [{ \"n\": { \"value\": 5} }, { \"m\": { \"value\": 8} }]}");
+    RestUtils.put(authToken, collectionPath + "/doc", doc.toString(), 200);
+
+    // Any filter on full collection search should only match the level of nesting of the where
+    // clause
+    String r =
+        RestUtils.get(
+            authToken,
+            hostWithPort
+                + "/v2/namespaces/"
+                + keyspace
+                + "/collections/collection?page-size=2&fields=[\"*.[*].n\"]&raw=true",
+            200);
+
+    String expected = "{\"doc\":{\"value\":[{\"n\":{\"value\":5}}]}}";
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(expected));
+  }
+
+  @Test
   public void searchInvalidPageSize() throws IOException {
     RestUtils.put(authToken, collectionPath + "/dummy", "{\"k\":\"v\"}", 200);
 


### PR DESCRIPTION
Before being able to optimize on the query level, we had to do small refactoring and bug fixing:

**New features:**
* supports globs and paths segments in fields in the same way as in the where - no difference now. This all works -> `fields=["field.*.value","field.one,two,three.value","field.[*].value","field.[2].value","field.[0],[1],[2].value"]`

**Fixed bugs:**
* fail on wrong array index was not working - `[not_allowed]` would pass :disappointed: 
* improved matching on globs
   * `{ field: value}` would pass a condition and selection on `[*].value`
   * `[{ field: value}]` would pass a condition and selection on `*.value`

**Tasks done:**
* [x] moved code related to the search to `ReactiveDocumentService`
* [x] extracted loading values from rows to a utils class 
* [x] improved tests
* [x] break connection from  `ReactiveDocumentService` to `DocumentService`, move `convertToSelectionList` to utils
* [x] move `DocumentServiceUtils` to proper package and add tests for every method
* [x] check where `DocumentServiceUtils` can be used more to decrease code in `DocumentService`
* [x] blocked by #1050 