### PR TITLE
Support paginating over nested doc elements

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
@@ -748,7 +748,9 @@ public class DocumentResourceV2 {
           ExecutionContext context = ExecutionContext.create(profile);
 
           JsonNode node;
-          if (filters.isEmpty()) {
+          // Fetch the whole doc at the specified path only if the request does not have an explicit
+          // page size. Otherwise, produce paginated results for child data at the specified path.
+          if (filters.isEmpty() && pageSizeParam == null) {
             node = documentService.getJsonAtPath(db, namespace, collection, id, path, context);
             if (node == null) {
               return Response.status(Response.Status.NOT_FOUND).build();
@@ -769,7 +771,15 @@ public class DocumentResourceV2 {
             final Paginator paginator = new Paginator(pageStateParam, pageSize);
             JsonNode result =
                 documentService.searchDocumentsV2(
-                    db, namespace, collection, filters, selectionList, id, paginator, context);
+                    db,
+                    namespace,
+                    collection,
+                    path,
+                    filters,
+                    selectionList,
+                    id,
+                    paginator,
+                    context);
 
             if (result == null) {
               return Response.noContent().build();

--- a/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
@@ -216,7 +216,6 @@ public class DocumentResourceV2Test {
     String id = "id";
     String where = null;
     String fields = null;
-    int pageSizeParam = 0;
     String pageStateParam = null;
 
     ObjectNode mockedReturn = mapper.createObjectNode();
@@ -237,7 +236,7 @@ public class DocumentResourceV2Test {
             id,
             where,
             fields,
-            pageSizeParam,
+            null,
             pageStateParam,
             false,
             true,
@@ -257,7 +256,6 @@ public class DocumentResourceV2Test {
     String id = "id";
     String where = null;
     String fields = null;
-    int pageSizeParam = 0;
     String pageStateParam = null;
     List<PathSegment> path = new ArrayList<>();
 
@@ -280,7 +278,7 @@ public class DocumentResourceV2Test {
             path,
             where,
             fields,
-            pageSizeParam,
+            null,
             pageStateParam,
             false,
             true,
@@ -311,6 +309,7 @@ public class DocumentResourceV2Test {
                 anyObject(),
                 anyString(),
                 anyString(),
+                anyList(),
                 anyList(),
                 anyList(),
                 anyString(),
@@ -354,7 +353,6 @@ public class DocumentResourceV2Test {
     String id = "id";
     String where = null;
     String fields = null;
-    int pageSizeParam = 0;
     String pageStateParam = null;
     List<PathSegment> path = new ArrayList<>();
 
@@ -377,7 +375,7 @@ public class DocumentResourceV2Test {
             path,
             where,
             fields,
-            pageSizeParam,
+            null,
             pageStateParam,
             false,
             false,
@@ -400,7 +398,6 @@ public class DocumentResourceV2Test {
     String id = "id";
     String where = null;
     String fields = null;
-    int pageSizeParam = 0;
     String pageStateParam = null;
     List<PathSegment> path = new ArrayList<>();
 
@@ -420,7 +417,7 @@ public class DocumentResourceV2Test {
             path,
             where,
             fields,
-            pageSizeParam,
+            null,
             pageStateParam,
             false,
             false,
@@ -437,7 +434,7 @@ public class DocumentResourceV2Test {
             path,
             where,
             fields,
-            pageSizeParam,
+            null,
             pageStateParam,
             false,
             true,


### PR DESCRIPTION
This is now enabled when the page-size parameter is used even without a where clause.

Note: this is a slight change in API behaviour as previously
the page-size parameter was ignored in this case. However, there
was no reason for specifying the page size in this case before,
so hopefully end-user use cases are not broken by this change.

Fixes #1040

----

Example usage:

```
~ $ curl -L -H "X-Cassandra-Token: $AUTH_TOKEN" -g '127.0.2.1:8082/v2/namespaces/demo1/collections/test2/1f7af925-3dd2-4dd3-8cda-74a1814f4155'|jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   102  100   102    0     0   7285      0 --:--:-- --:--:-- --:--:--  7285
{
  "documentId": "1f7af925-3dd2-4dd3-8cda-74a1814f4155",
  "data": {
    "b": 1,
    "o": {
      "1": {
        "x": "1"
      },
      "2": {
        "x": "2"
      }
    }
  }
}
```

Paginate over top-level elements:
```
~ $ curl -L -H "X-Cassandra-Token: $AUTH_TOKEN" -g '127.0.2.1:8082/v2/namespaces/demo1/collections/test2/1f7af925-3dd2-4dd3-8cda-74a1814f4155/*?page-size=1'|jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   177  100   177    0     0  11062      0 --:--:-- --:--:-- --:--:-- 11062
{
  "documentId": "1f7af925-3dd2-4dd3-8cda-74a1814f4155",
  "pageState": "JDFmN2FmOTI1LTNkZDItNGRkMy04Y2RhLTc0YTE4MTRmNDE1NRT_VVVVVVVVVVQBYv9VVVVVVVVVVfB_____8H____8=",
  "data": [
    {
      "b": 1
    }
  ]
}

~ $ curl -L -H "X-Cassandra-Token: $AUTH_TOKEN" -g '127.0.2.1:8082/v2/namespaces/demo1/collections/test2/1f7af925-3dd2-4dd3-8cda-74a1814f4155/*?page-size=1&page-state=JDFmN2FmOTI1LTNkZDItNGRkMy04Y2RhLTc0YTE4MTRmNDE1NRT_VVVVVVVVVVQBYv9VVVVVVVVVVfB_____8H____8='|jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    98  100    98    0     0   8909      0 --:--:-- --:--:-- --:--:--  9800
{
  "documentId": "1f7af925-3dd2-4dd3-8cda-74a1814f4155",
  "data": [
    {
      "o": {
        "1": {
          "x": "1"
        },
        "2": {
          "x": "2"
        }
      }
    }
  ]
}
```

Paginate over second-level elements:
```
~ $ curl -L -H "X-Cassandra-Token: $AUTH_TOKEN" -g '127.0.2.1:8082/v2/namespaces/demo1/collections/test2/1f7af925-3dd2-4dd3-8cda-74a1814f4155/*/*?page-size=1'|jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   195  100   195    0     0  16250      0 --:--:-- --:--:-- --:--:-- 16250
{
  "documentId": "1f7af925-3dd2-4dd3-8cda-74a1814f4155",
  "pageState": "JDFmN2FmOTI1LTNkZDItNGRkMy04Y2RhLTc0YTE4MTRmNDE1NRj_VVVVVVVVVUABbwExAXj_VVVVVVVVVVXwf_____B_____",
  "data": [
    {
      "o": {
        "1": {
          "x": "1"
        }
      }
    }
  ]
}

~ $ curl -L -H "X-Cassandra-Token: $AUTH_TOKEN" -g '127.0.2.1:8082/v2/namespaces/demo1/collections/test2/1f7af925-3dd2-4dd3-8cda-74a1814f4155/*/*?page-size=1&page-state=JDFmN2FmOTI1LTNkZDItNGRkMy04Y2RhLTc0YTE4MTRmNDE1NRj_VVVVVVVVVUABbwExAXj_VVVVVVVVVVXwf_____B_____'|jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    84  100    84    0     0   7000      0 --:--:-- --:--:-- --:--:--  7636
{
  "documentId": "1f7af925-3dd2-4dd3-8cda-74a1814f4155",
  "data": [
    {
      "o": {
        "2": {
          "x": "2"
        }
      }
    }
  ]
}
```

Get all nested elements (same as before this change):
```
~ $ curl -L -H "X-Cassandra-Token: $AUTH_TOKEN" -g '127.0.2.1:8082/v2/namespaces/demo1/collections/test2/1f7af925-3dd2-4dd3-8cda-74a1814f4155/o'|jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    90  100    90    0     0  15000      0 --:--:-- --:--:-- --:--:-- 15000
{
  "documentId": "1f7af925-3dd2-4dd3-8cda-74a1814f4155",
  "data": {
    "1": {
      "x": "1"
    },
    "2": {
      "x": "2"
    }
  }
}
```