### PR TITLE
fixes #1049: path segment search with in-memory filter fixed

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/DocumentServiceUtils.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/DocumentServiceUtils.java
@@ -20,10 +20,12 @@ package io.stargate.web.docsapi.service.query;
 import io.stargate.web.docsapi.dao.DocumentDB;
 import io.stargate.web.docsapi.exception.ErrorCode;
 import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.OptionalLong;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 public final class DocumentServiceUtils {
@@ -32,7 +34,30 @@ public final class DocumentServiceUtils {
 
   private DocumentServiceUtils() {}
 
+  /**
+   * Converts given path to an array one if needed:
+   *
+   * <ol>
+   *   <li>[1] - converted to [000001]
+   *   <li>[0],[1] - converted to [000000],[000001]
+   *   <li>[*] - not converted
+   *   <li>anyPath - not converted
+   * </ol>
+   *
+   * @param path filter or filed path
+   * @return Converted to represent expected path in DB, keeping the segmentation.
+   */
   public static String convertArrayPath(String path) {
+    if (path.contains(",")) {
+      return Arrays.stream(path.split(","))
+          .map(DocumentServiceUtils::convertSingleArrayPath)
+          .collect(Collectors.joining(","));
+    } else {
+      return convertSingleArrayPath(path);
+    }
+  }
+
+  private static String convertSingleArrayPath(String path) {
     // check if we have array path
     if (ARRAY_PATH_PATTERN.matcher(path).matches()) {
       String innerPath = path.substring(1, path.length() - 1);

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/DocumentServiceUtils.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/DocumentServiceUtils.java
@@ -44,7 +44,7 @@ public final class DocumentServiceUtils {
    *   <li>anyPath - not converted
    * </ol>
    *
-   * @param path filter or filed path
+   * @param path single filter or field path
    * @return Converted to represent expected path in DB, keeping the segmentation.
    */
   public static String convertArrayPath(String path) {

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/FilterExpression.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/FilterExpression.java
@@ -24,6 +24,7 @@ import io.stargate.db.datastore.Row;
 import io.stargate.web.docsapi.dao.DocumentDB;
 import io.stargate.web.docsapi.service.RawDocument;
 import io.stargate.web.docsapi.service.query.condition.BaseCondition;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -161,8 +162,16 @@ public abstract class FilterExpression extends Expression<FilterExpression>
         return false;
       }
 
-      // if not equal, fail
-      if (!Objects.equals(path, target)) {
+      boolean pathSegment = target.contains(",");
+      // if we have the path segment, we need to check if any matches
+      if (pathSegment) {
+        boolean noneMatch =
+            Arrays.stream(target.split(",")).noneMatch(t -> Objects.equals(t, path));
+        if (noneMatch) {
+          return false;
+        }
+      } else if (!Objects.equals(path, target)) {
+        // if not equal, fail
         return false;
       }
     }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/db/impl/FilterPathSearchQueryBuilder.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/db/impl/FilterPathSearchQueryBuilder.java
@@ -22,7 +22,6 @@ import io.stargate.db.query.builder.BuiltCondition;
 import io.stargate.web.docsapi.dao.DocumentDB;
 import io.stargate.web.docsapi.exception.ErrorCode;
 import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
-import io.stargate.web.docsapi.service.query.DocumentServiceUtils;
 import io.stargate.web.docsapi.service.query.FilterPath;
 import io.stargate.web.docsapi.service.query.QueryConstants;
 import io.stargate.web.docsapi.service.query.search.db.AbstractSearchQueryBuilder;
@@ -32,7 +31,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /** The search query builder that creates all needed predicates for a {@link FilterPath}. */
 public class FilterPathSearchQueryBuilder extends AbstractSearchQueryBuilder {
@@ -87,20 +85,15 @@ public class FilterPathSearchQueryBuilder extends AbstractSearchQueryBuilder {
           predicates.add(
               BuiltCondition.of(QueryConstants.P_COLUMN_NAME.apply(i), Predicate.GT, ""));
         } else {
-          String convertedPath = DocumentServiceUtils.convertArrayPath(pathSegment);
           predicates.add(
-              BuiltCondition.of(
-                  QueryConstants.P_COLUMN_NAME.apply(i), Predicate.EQ, convertedPath));
+              BuiltCondition.of(QueryConstants.P_COLUMN_NAME.apply(i), Predicate.EQ, pathSegment));
         }
       } else {
-        // left pad any array segments to 6 places
-        List<String> segmentsList =
-            Arrays.stream(pathSegmentSplit)
-                .map(DocumentServiceUtils::convertArrayPath)
-                .collect(Collectors.toList());
-
         predicates.add(
-            BuiltCondition.of(QueryConstants.P_COLUMN_NAME.apply(i), Predicate.IN, segmentsList));
+            BuiltCondition.of(
+                QueryConstants.P_COLUMN_NAME.apply(i),
+                Predicate.IN,
+                Arrays.asList(pathSegmentSplit)));
       }
     }
 

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/ExpressionParserIntTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/ExpressionParserIntTest.java
@@ -325,7 +325,7 @@ class ExpressionParserIntTest {
                 assertThat(c.getOrderIndex()).isZero();
                 assertThat(c.getFilterPath().getField()).isEqualTo("field");
                 assertThat(c.getFilterPath().getParentPath())
-                    .containsExactly("my", "filters", "[1],[2]");
+                    .containsExactly("my", "filters", "[000001],[000002]");
                 assertThat(c.getCondition())
                     .isInstanceOfSatisfying(
                         StringCondition.class,

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/FilterExpressionTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/FilterExpressionTest.java
@@ -343,6 +343,32 @@ public class FilterExpressionTest {
     }
 
     @Test
+    public void conditionFalsePathSegment() {
+      ImmutableFilterPath filterPath =
+          ImmutableFilterPath.of(Arrays.asList("parent,other", "field"));
+      Row row =
+          MapBackedRow.of(
+              TABLE,
+              ImmutableMap.of(
+                  QueryConstants.LEAF_COLUMN_NAME,
+                  "field",
+                  QueryConstants.P_COLUMN_NAME.apply(0),
+                  "parent",
+                  QueryConstants.P_COLUMN_NAME.apply(1),
+                  "field",
+                  QueryConstants.P_COLUMN_NAME.apply(2),
+                  ""));
+      when(condition.test(row)).thenReturn(false);
+
+      FilterExpression expression = ImmutableFilterExpression.of(filterPath, condition, 0);
+      boolean result = expression.test(row);
+
+      assertThat(result).isFalse();
+      verify(condition).test(row);
+      verifyNoMoreInteractions(condition);
+    }
+
+    @Test
     public void pathNotMatchingLeafDoesNotMatchField() {
       ImmutableFilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("parent", "field"));
       Row row =

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/db/impl/FilterPathSearchQueryBuilderTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/db/impl/FilterPathSearchQueryBuilderTest.java
@@ -174,7 +174,7 @@ class FilterPathSearchQueryBuilderTest extends AbstractDataStoreTest {
 
     @Test
     public void fieldAndParentArrayPathSplit() {
-      List<String> path = Arrays.asList("path", "[0],[1],[2]", "field");
+      List<String> path = Arrays.asList("path", "[000000],[000001],[000002]", "field");
       FilterPath filterPath = ImmutableFilterPath.of(path);
 
       FilterPathSearchQueryBuilder builder = new FilterPathSearchQueryBuilder(filterPath, true);


### PR DESCRIPTION
See #1049 for details. Two fixes:

- `convertArrayPath` to transform also the path segments and convert directly to expected path
   - this enables complete removal of calls to the `convertArrayPath` outside the expression parsing
- filter expression to consider path segments when evaluating

Not sure if this was working before, there were no tests.