### PR TITLE
Get the user from the original clientState when cloning

### DIFF
--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
@@ -489,7 +489,7 @@ public class CassandraPersistence
           original.isInternal
               ? ClientState.forInternalCalls()
               : ClientState.forExternalCalls(original.getRemoteAddress());
-      clone.login(clone.getUser());
+      clone.login(original.getUser());
       if (original.isNoCompactMode()) {
         clone.setNoCompactMode();
       }


### PR DESCRIPTION
Only applies to 3.11. Neither 4.0 or DSE implement the same cloning functionality.