### PR TITLE
closes #1031: support parsing of the $or and $and expressions

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
@@ -101,6 +101,10 @@ public enum ErrorCode {
   DOCS_API_SEARCH_OBJECT_REQUIRED(
       Response.Status.BAD_REQUEST, "Search was expecting a JSON object as input."),
 
+  DOCS_API_SEARCH_OR_NOT_SUPPORTED(
+      Response.Status.BAD_REQUEST,
+      "Searching documents with the $or condition is not yet supported."),
+
   DOCS_API_SEARCH_RESULTS_NOT_FITTING(
       Response.Status.BAD_REQUEST,
       "The results as requested must fit in one page, try increasing the `page-size` parameter."),

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/ExpressionParser.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/ExpressionParser.java
@@ -49,11 +49,11 @@ public class ExpressionParser {
 
   private static final Pattern PERIOD_PATTERN = Pattern.compile("\\.");
 
-  private final ConditionParser conditionProvider;
+  private final ConditionParser conditionParser;
 
   @Inject
   public ExpressionParser(ConditionParser predicateProvider) {
-    this.conditionProvider = predicateProvider;
+    this.conditionParser = predicateProvider;
   }
 
   /**
@@ -143,7 +143,7 @@ public class ExpressionParser {
         } else {
           FilterPath filterPath = getFilterPath(prependedPath, fieldOrOp);
           Collection<BaseCondition> fieldConditions =
-              conditionProvider.getConditions(next.getValue(), numericBooleans);
+              conditionParser.getConditions(next.getValue(), numericBooleans);
           for (BaseCondition fieldCondition : fieldConditions) {
             ImmutableFilterExpression expression =
                 ImmutableFilterExpression.of(

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/ExpressionParser.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/ExpressionParser.java
@@ -94,7 +94,7 @@ public class ExpressionParser {
    * @param numericBooleans If number booleans should be used when creating conditions.
    * @return List of all expressions
    */
-  public List<Expression<FilterExpression>> parse(
+  private List<Expression<FilterExpression>> parse(
       List<PathSegment> prependedPath, JsonNode filterJson, boolean numericBooleans) {
     return parse(
         prependedPath, Collections.singletonList(filterJson), numericBooleans, new MutableInt(0));

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/CnfResolver.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/CnfResolver.java
@@ -26,6 +26,8 @@ import com.bpodgursky.jbool_expressions.rules.RuleList;
 import com.bpodgursky.jbool_expressions.rules.RulesHelper;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
+import io.stargate.web.docsapi.exception.ErrorCode;
+import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
 import io.stargate.web.docsapi.service.ExecutionContext;
 import io.stargate.web.docsapi.service.query.FilterExpression;
 import io.stargate.web.docsapi.service.query.FilterPath;
@@ -87,9 +89,9 @@ public final class CnfResolver {
                 nextInMemoryResolver(expression, children, weightResolver, context, parent)
                     .orElseThrow(
                         () ->
-                            // this should never happen before we have ors
-                            new RuntimeException(
-                                "Unresolvable expression in the expression tree.")));
+                            // this should happen only if we have ors
+                            new ErrorCodeRuntimeException(
+                                ErrorCode.DOCS_API_SEARCH_OR_NOT_SUPPORTED)));
   }
 
   private static Optional<DocumentsResolver> nextPersistenceResolver(

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/BaseResolverTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/BaseResolverTest.java
@@ -18,9 +18,13 @@
 package io.stargate.web.docsapi.service.query.search.resolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.bpodgursky.jbool_expressions.And;
 import com.bpodgursky.jbool_expressions.Literal;
+import com.bpodgursky.jbool_expressions.Or;
+import io.stargate.web.docsapi.exception.ErrorCode;
+import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
 import io.stargate.web.docsapi.service.ExecutionContext;
 import io.stargate.web.docsapi.service.query.FilterExpression;
 import io.stargate.web.docsapi.service.query.FilterPath;
@@ -155,6 +159,23 @@ class BaseResolverTest {
       DocumentsResolver result = BaseResolver.resolve(And.of(expression1), context);
 
       assertThat(result).isInstanceOf(PersistenceDocumentsResolver.class);
+    }
+
+    @Test
+    public void orOnSamePath() {
+      ExecutionContext context = ExecutionContext.create(true);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition1 = ImmutableStringCondition.of(GtFilterOperation.of(), "find-me");
+      BaseCondition condition2 = ImmutableStringCondition.of(LtFilterOperation.of(), "find-me");
+      FilterExpression expression1 = ImmutableFilterExpression.of(filterPath, condition1, 0);
+      FilterExpression expression2 = ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      Throwable t =
+          catchThrowable(() -> BaseResolver.resolve(Or.of(expression1, expression2), context));
+
+      assertThat(t)
+          .isInstanceOf(ErrorCodeRuntimeException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_SEARCH_OR_NOT_SUPPORTED);
     }
   }
 }


### PR DESCRIPTION
This supports parsing (only!) of the `$or` and `$and` conditions. The requests still fail if the `$or` is found with a `404: Searching documents with the $or condition is not yet supported.` 

Minimal changes in the parser, mostly tests.