### PR TITLE
closes #1076: not using withLatestFrom that can swallow rows

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/DocumentSearchService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/DocumentSearchService.java
@@ -153,7 +153,7 @@ public class DocumentSearchService {
 
     // combine
     return candidates
-        .withLatestFrom(preparedSingle.toFlowable(), Pair::of)
+        .concatMapSingle(doc -> preparedSingle.map(prepared -> Pair.of(doc, prepared)))
         .concatMap(
             p -> {
               // bind for this doc id

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/impl/AllFiltersResolver.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/impl/AllFiltersResolver.java
@@ -87,10 +87,11 @@ public class AllFiltersResolver implements DocumentsResolver {
 
                       return pairSingle.toFlowable();
                     })
-                .toList();
+                .toList()
+                .cache();
 
     return candidates
-        .withLatestFrom(queriesToCandidates.toFlowable(), Pair::of)
+        .concatMapSingle(doc -> queriesToCandidates.map(prepared -> Pair.of(doc, prepared)))
         .concatMap(
             pair -> {
               RawDocument doc = pair.getLeft();

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/AllFiltersResolverTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/AllFiltersResolverTest.java
@@ -258,13 +258,6 @@ class AllFiltersResolverTest extends AbstractDataStoreTest {
     public void noCandidates() {
       withAnySelectFrom(TABLE).returningNothing();
 
-      DataStore datastore = datastore();
-      doAnswer(i -> query1)
-          .when(candidatesFilter)
-          .prepareQuery(datastore, configuration, KEYSPACE_NAME, COLLECTION_NAME);
-      doAnswer(i -> query2)
-          .when(candidatesFilter2)
-          .prepareQuery(datastore, configuration, KEYSPACE_NAME, COLLECTION_NAME);
       DocumentsResolver candidatesResolver =
           (queryExecutor1, configuration1, keyspace, collection, paginator) -> Flowable.empty();
 
@@ -280,11 +273,6 @@ class AllFiltersResolverTest extends AbstractDataStoreTest {
       results.test().assertValueCount(0).assertComplete();
 
       ignorePreparedExecutions();
-
-      verify(candidatesFilter)
-          .prepareQuery(datastore, configuration, KEYSPACE_NAME, COLLECTION_NAME);
-      verify(candidatesFilter2)
-          .prepareQuery(datastore, configuration, KEYSPACE_NAME, COLLECTION_NAME);
       verifyNoMoreInteractions(candidatesFilter, candidatesFilter2);
     }
   }


### PR DESCRIPTION
This is a very simple fix to solve #1076.. I removed the `withLatestFrom` and applied solution from described in the issue. 

This is fixing a bug that can occur if the query preparation takes longer than fetching 2 or more rows, then rows are swallowed. Full analysis is available in the issue itself.

We have seen this bug only on C* 4. Also reproducing the bug is hard and in majority of cases race condition does not favor the bug (time to prepare is shorter than getting rows). This influences only full collection search. In order to reproduce I used test updates from the branch https://github.com/stargate/stargate/tree/ise-1076-withLatestFrom.