### PR TITLE
closes #1085: cassandra-4 move driver to 4.0-rc2

### DIFF
--- a/persistence-cassandra-4.0/pom.xml
+++ b/persistence-cassandra-4.0/pom.xml
@@ -10,12 +10,12 @@
   <artifactId>persistence-cassandra-4.0</artifactId>
   <properties>
     <!-- If you update this, make sure to keep `cassandra.bundled-driver.version` in sync -->
-    <cassandra.version>4.0-beta4</cassandra.version>
+    <cassandra.version>4.0-rc2</cassandra.version>
     <!--
       The driver used internally by cassandra-all for UDFs (must match the version declared in
       cassandra-all's POM).
     -->
-    <cassandra.bundled-driver.version>3.10.0</cassandra.bundled-driver.version>
+    <cassandra.bundled-driver.version>3.11.0</cassandra.bundled-driver.version>
   </properties>
   <dependencies>
     <dependency>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -391,7 +391,7 @@
                 </goals>
                 <configuration>
                   <systemPropertyVariables>
-                    <ccm.version>trunk</ccm.version>
+                    <ccm.version>4.0-rc2</ccm.version>
                     <stargate.test.nodes>1</stargate.test.nodes>
                   </systemPropertyVariables>
                   <failIfNoTests>true</failIfNoTests>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -391,7 +391,7 @@
                 </goals>
                 <configuration>
                   <systemPropertyVariables>
-                    <ccm.version>4.0-beta4</ccm.version>
+                    <ccm.version>trunk</ccm.version>
                     <stargate.test.nodes>1</stargate.test.nodes>
                   </systemPropertyVariables>
                   <failIfNoTests>true</failIfNoTests>


### PR DESCRIPTION
The driver version `rc2` uses `com.datastax.cassandra » cassandra-driver-core (optional) ` in version `3.11.0`. Everything else should be clear.