### PR TITLE
Support merging multiple result sets in QueryExecutor

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/Paginator.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/Paginator.java
@@ -39,7 +39,7 @@ public class Paginator {
     docPageSize = pageSize;
 
     if (pageState != null) {
-      this.currentPageState = ByteBufferUtils.fromBase64UrlParam(pageState).asReadOnlyBuffer();
+      this.currentPageState = ByteBufferUtils.fromBase64UrlParam(pageState);
     }
   }
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/Paginator.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/Paginator.java
@@ -39,7 +39,7 @@ public class Paginator {
     docPageSize = pageSize;
 
     if (pageState != null) {
-      this.currentPageState = ByteBufferUtils.fromBase64UrlParam(pageState);
+      this.currentPageState = ByteBufferUtils.fromBase64UrlParam(pageState).asReadOnlyBuffer();
     }
   }
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/CombinedPagingState.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/CombinedPagingState.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.web.docsapi.service;
+
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class CombinedPagingState {
+
+  private final List<ByteBuffer> nestedStates;
+
+  private CombinedPagingState(List<ByteBuffer> nestedStates) {
+    this.nestedStates = nestedStates;
+  }
+
+  public static CombinedPagingState of(List<ByteBuffer> nestedStates) {
+    return new CombinedPagingState(nestedStates);
+  }
+
+  public ByteBuffer serialize() {
+    if (nestedStates.stream().allMatch(Objects::isNull)) {
+      return null;
+    }
+
+    if (nestedStates.size() == 1) {
+      return nestedStates.get(0);
+    }
+
+    int toAllocate = 4; // size of int for element count
+    for (ByteBuffer state : nestedStates) {
+      toAllocate += 4; // size of int for element size
+      toAllocate += state == null ? 0 : state.remaining();
+    }
+
+    ByteBuffer result = ByteBuffer.allocate(toAllocate);
+
+    result.putInt(nestedStates.size());
+    for (ByteBuffer state : nestedStates) {
+      if (state != null) {
+        ByteBuffer nested = state.slice();
+
+        result.putInt(nested.remaining());
+        result.put(nested);
+      } else {
+        result.putInt(-1); // no state
+      }
+    }
+
+    result.flip();
+    return result;
+  }
+
+  public static CombinedPagingState deserialize(int expectedSize, ByteBuffer data) {
+    if (expectedSize <= 0) {
+      throw new IllegalArgumentException("Invalid paging state size: " + expectedSize);
+    }
+
+    if (data == null) {
+      ArrayList<ByteBuffer> buffers = new ArrayList<>(expectedSize);
+      for (int i = 0; i < expectedSize; i++) {
+        buffers.add(null);
+      }
+
+      return of(buffers);
+    }
+
+    if (expectedSize == 1) {
+      return of(ImmutableList.of(data));
+    }
+
+    if (data.remaining() < 4) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Invalid paging state: unable to read size, available bytes: %d", data.remaining()));
+    }
+
+    int count = data.getInt();
+    if (expectedSize != count) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Invalid paging state: expected element count: %d, actual: %d", expectedSize, count));
+    }
+
+    ArrayList<ByteBuffer> nested = new ArrayList<>(count);
+    while (count-- > 0) {
+      int size = data.getInt();
+
+      ByteBuffer element;
+      if (size >= 0) {
+        element = data.slice();
+        element.limit(size);
+        data.position(data.position() + size);
+      } else {
+        element = null;
+      }
+
+      nested.add(element);
+    }
+
+    return of(nested);
+  }
+
+  public List<ByteBuffer> nested() {
+    return nestedStates;
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/CombinedPagingState.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/CombinedPagingState.java
@@ -130,7 +130,7 @@ public class CombinedPagingState implements PagingStateSupplier {
       return ImmutableList.of(data);
     }
 
-    if (data.remaining() < 4) {
+    if (data.remaining() < Integer.BYTES) {
       throw new IllegalArgumentException(
           String.format(
               "Invalid paging state: unable to read size, available bytes: %d", data.remaining()));

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/PagingStateSupplier.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/PagingStateSupplier.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.web.docsapi.service;
+
+import io.stargate.db.PagingPosition.ResumeMode;
+import java.nio.ByteBuffer;
+
+public abstract class PagingStateSupplier {
+
+  public abstract boolean hasPagingState();
+
+  public abstract ByteBuffer makePagingState(ResumeMode resumeMode);
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/PagingStateSupplier.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/PagingStateSupplier.java
@@ -18,9 +18,22 @@ package io.stargate.web.docsapi.service;
 import io.stargate.db.PagingPosition.ResumeMode;
 import java.nio.ByteBuffer;
 
-public abstract class PagingStateSupplier {
+/**
+ * An abstraction layer for sources of a query paging state.
+ *
+ * <p>In general a paging state may come from:
+ * <li>a byte buffer, which in turn is a paging state returned from the previous query execution
+ *     that was not utilized during the current processing round and hence can be reused "as is"
+ *     regardless of {@link ResumeMode ResumeMode}.
+ * <li>a row that was received from the current (fresh) result set page.
+ */
+public interface PagingStateSupplier {
 
-  public abstract boolean hasPagingState();
+  /** Constructs paging state for the specified {@link ResumeMode ResumeMode}. */
+  ByteBuffer makePagingState(ResumeMode resumeMode);
 
-  public abstract ByteBuffer makePagingState(ResumeMode resumeMode);
+  /** Creates a {@link PagingStateSupplier} for a pre-built, fixed paging state buffer. */
+  static PagingStateSupplier fixed(ByteBuffer pagingState) {
+    return resumeMode -> pagingState;
+  }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
@@ -19,9 +19,14 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 import hu.akarnokd.rxjava3.operators.ExpandStrategy;
 import hu.akarnokd.rxjava3.operators.FlowableTransformers;
+import hu.akarnokd.rxjava3.operators.Flowables;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
+import io.stargate.db.ComparableKey;
 import io.stargate.db.ImmutableParameters;
+import io.stargate.db.PagingPosition;
+import io.stargate.db.PagingPosition.ResumeMode;
+import io.stargate.db.RowDecorator;
 import io.stargate.db.datastore.DataStore;
 import io.stargate.db.datastore.ResultSet;
 import io.stargate.db.datastore.Row;
@@ -31,13 +36,20 @@ import io.stargate.db.schema.Column;
 import io.stargate.web.rx.RxUtils;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.immutables.value.Value;
 
 /** Executes pre-built document queries, groups document rows and manages document pagination. */
 public class QueryExecutor {
+
+  private static final ByteBuffer EXHAUSTED_PAGE_STATE = ByteBuffer.allocate(0);
   private final Accumulator TERM = new Accumulator();
 
   private final DataStore dataStore;
@@ -47,13 +59,27 @@ public class QueryExecutor {
   }
 
   public Flowable<RawDocument> queryDocs(
+      List<BoundQuery> queries, int pageSize, ByteBuffer pagingState, ExecutionContext context) {
+    return queryDocs(1, queries, pageSize, pagingState, context);
+  }
+
+  public Flowable<RawDocument> queryDocs(
       BoundQuery query, int pageSize, ByteBuffer pagingState, ExecutionContext context) {
-    return queryDocs(1, query, pageSize, pagingState, context);
+    return queryDocs(1, ImmutableList.of(query), pageSize, pagingState, context);
   }
 
   public Flowable<RawDocument> queryDocs(
       int keyDepth,
       BoundQuery query,
+      int pageSize,
+      ByteBuffer pagingState,
+      ExecutionContext context) {
+    return queryDocs(keyDepth, ImmutableList.of(query), pageSize, pagingState, context);
+  }
+
+  public Flowable<RawDocument> queryDocs(
+      int keyDepth,
+      List<BoundQuery> queries,
       int pageSize,
       ByteBuffer pagingState,
       ExecutionContext context) {
@@ -63,24 +89,94 @@ public class QueryExecutor {
       throw new IllegalArgumentException("Unsupported page size: " + pageSize);
     }
 
-    BuiltSelect select = (BuiltSelect) query.source().query();
-    if (keyDepth < 1 || keyDepth > select.table().primaryKeyColumns().size()) {
-      throw new IllegalArgumentException("Invalid document identity depth: " + keyDepth);
-    }
+    List<Column> idColumns = idColumns(keyDepth, queries);
+    Comparator<DocProperty> comparator = rowComparator(queries);
 
-    List<Column> idColumns = select.table().primaryKeyColumns().subList(0, keyDepth);
+    CombinedPagingState pagingStates = CombinedPagingState.deserialize(queries.size(), pagingState);
 
-    return execute(query, pageSize, pagingState)
-        .flatMap(
-            rs -> Flowable.fromIterable(seeds(query, rs, idColumns, context)),
-            1) // concurrency factor 1
+    PagingStateTracker tracker = new PagingStateTracker(pagingStates);
+
+    return execute(queries, comparator, pageSize, pagingStates, context)
+        .map(p -> toSeed(p, comparator, idColumns))
         .concatWith(Single.just(TERM))
-        .scan(Accumulator::combine)
+        .scan(tracker::combine)
         .filter(Accumulator::isComplete)
         .map(Accumulator::toDoc);
   }
 
+  private Comparator<DocProperty> rowComparator(List<BoundQuery> queries) {
+    List<Column> pathColumns = null;
+    for (BoundQuery query : queries) {
+      BuiltSelect select = (BuiltSelect) query.source().query();
+
+      if (pathColumns == null) {
+        pathColumns = select.table().clusteringKeyColumns();
+      }
+    }
+
+    if (pathColumns == null) {
+      throw new IllegalArgumentException("No query provided");
+    }
+
+    Comparator<DocProperty> comparator = Comparator.comparing(DocProperty::comparableKey);
+    for (Column column : pathColumns) {
+      comparator = comparator.thenComparing(p -> p.keyValue(column));
+    }
+
+    return comparator;
+  }
+
+  private List<Column> idColumns(int keyDepth, List<BoundQuery> queries) {
+    List<Column> idColumns = null;
+    for (BoundQuery query : queries) {
+      BuiltSelect select = (BuiltSelect) query.source().query();
+      if (keyDepth < 1 || keyDepth > select.table().primaryKeyColumns().size()) {
+        throw new IllegalArgumentException("Invalid document identity depth: " + keyDepth);
+      }
+
+      if (idColumns == null) {
+        idColumns = select.table().primaryKeyColumns().subList(0, keyDepth);
+      }
+    }
+
+    if (idColumns == null) {
+      throw new IllegalArgumentException("No query provided");
+    }
+
+    return idColumns;
+  }
+
+  private Flowable<DocProperty> execute(
+      List<BoundQuery> queries,
+      Comparator<DocProperty> comparator,
+      int pageSize,
+      CombinedPagingState pagingState,
+      ExecutionContext context) {
+    List<Flowable<DocProperty>> flows = new ArrayList<>(queries.size());
+    int idx = 0;
+    for (BoundQuery query : queries) {
+      final int finalIdx = idx++;
+      ByteBuffer queryPagingState = pagingState.nested().get(finalIdx);
+      if (queryPagingState != null) {
+        queryPagingState = queryPagingState.slice();
+      }
+
+      flows.add(
+          execute(query, pageSize, queryPagingState)
+              .flatMap(
+                  rs -> Flowable.fromIterable(properties(finalIdx, query, rs, context)),
+                  1)); // max concurrency 1
+    }
+
+    return Flowables.orderedMerge(flows, comparator, false, 1); // prefetch 1
+  }
+
   public Flowable<ResultSet> execute(BoundQuery query, int pageSize, ByteBuffer pagingState) {
+    // An empty paging state means the query was exhaused during previous execution
+    if (pagingState != null && pagingState.remaining() == 0) {
+      return Flowable.empty();
+    }
+
     return fetchPage(query, pageSize, pagingState)
         .compose( // Expand BREADTH_FIRST to reduce the number of "proactive" page requests
             FlowableTransformers.expand(
@@ -116,20 +212,37 @@ public class QueryExecutor {
     }
   }
 
-  private Iterable<Accumulator> seeds(
-      BoundQuery query, ResultSet rs, List<Column> keyColumns, ExecutionContext context) {
+  private Accumulator toSeed(
+      DocProperty property, Comparator<DocProperty> comparator, List<Column> keyColumns) {
+    Row row = property.row();
+    String id = row.getString("key");
+    Builder<String> docKey = ImmutableList.builder();
+    for (Column c : keyColumns) {
+      docKey.add(Objects.requireNonNull(row.getString(c.name())));
+    }
+
+    return new Accumulator(id, comparator, docKey.build(), property);
+  }
+
+  private Iterable<DocProperty> properties(
+      int queryIndex, BoundQuery query, ResultSet rs, ExecutionContext context) {
     List<Row> rows = rs.currentPageRows();
     context.traceCqlResult(query, rows.size());
-    List<Accumulator> seeds = new ArrayList<>(rows.size());
+
+    Page page = ImmutablePage.builder().resultSet(rs).build();
+    List<DocProperty> properties = new ArrayList<>(rows.size());
+    int count = rows.size();
     for (Row row : rows) {
-      String id = row.getString("key");
-      Builder<String> docKey = ImmutableList.builder();
-      for (Column c : keyColumns) {
-        docKey.add(Objects.requireNonNull(row.getString(c.name())));
-      }
-      seeds.add(new Accumulator(id, docKey.build(), rs, row));
+      boolean last = --count <= 0;
+      properties.add(
+          ImmutableDocProperty.builder()
+              .queryIndex(queryIndex)
+              .page(page)
+              .row(row)
+              .lastInPage(last)
+              .build());
     }
-    return seeds;
+    return properties;
   }
 
   public DataStore getDataStore() {
@@ -139,39 +252,51 @@ public class QueryExecutor {
   private class Accumulator {
 
     private final String id;
+    private final Comparator<DocProperty> rowComparator;
     private final List<String> docKey;
-    private final List<Row> rows;
+    private final List<DocProperty> rows;
+    private final List<PagingStateSupplier> pagingState;
     private final boolean complete;
     private final Accumulator next;
-    private ResultSet lastResultSet;
+    private DocProperty lastRow;
 
     private Accumulator() {
       id = null;
-      docKey = null;
-      rows = null;
+      rowComparator = null;
+      docKey = Collections.emptyList();
+      rows = Collections.emptyList();
+      pagingState = Collections.emptyList();
       next = null;
       complete = false;
     }
 
-    private Accumulator(String id, List<String> docKey, ResultSet resultSet, Row seedRow) {
+    private Accumulator(
+        String id,
+        Comparator<DocProperty> rowComparator,
+        List<String> docKey,
+        DocProperty seedRow) {
       this.id = id;
+      this.rowComparator = rowComparator;
       this.docKey = docKey;
+      this.lastRow = seedRow;
       this.rows = new ArrayList<>();
+      this.pagingState = Collections.emptyList();
       this.next = null;
       this.complete = false;
-      this.lastResultSet = resultSet;
 
       rows.add(seedRow);
     }
 
     private Accumulator(
-        String id, List<String> docKey, ResultSet resultSet, List<Row> rows, Accumulator next) {
-      this.id = id;
-      this.docKey = docKey;
-      this.rows = rows;
+        Accumulator complete, List<PagingStateSupplier> pagingState, Accumulator next) {
+      this.id = complete.id;
+      this.rowComparator = complete.rowComparator;
+      this.docKey = complete.docKey;
+      this.rows = complete.rows;
+      this.pagingState = pagingState;
+      this.lastRow = complete.lastRow;
       this.next = next;
       this.complete = true;
-      this.lastResultSet = resultSet;
     }
 
     boolean isComplete() {
@@ -183,34 +308,59 @@ public class QueryExecutor {
         throw new IllegalStateException("Incomplete document.");
       }
 
-      boolean hasNext = next != null || lastResultSet.getPagingState() != null;
-      return new RawDocument(id, docKey, lastResultSet, hasNext, rows);
+      List<Row> docRows = this.rows.stream().map(DocProperty::row).collect(Collectors.toList());
+
+      PagingStateBuilder pagingStateBuilder = new PagingStateBuilder(pagingState);
+
+      return new RawDocument(id, docKey, pagingStateBuilder, docRows);
     }
 
-    private Accumulator end() {
+    private Accumulator complete(PagingStateTracker tracker, Accumulator next) {
+      rows.forEach(tracker::track);
+      List<PagingStateSupplier> currentPagingState = tracker.slice();
+
+      if (next == null) {
+        if (currentPagingState.stream().noneMatch(PagingStateSupplier::hasPagingState)) {
+          // Force a null paging state on the associated document
+          currentPagingState = NoPagingState.INSTANCE;
+        }
+      }
+
+      return new Accumulator(this, currentPagingState, next);
+    }
+
+    private Accumulator end(PagingStateTracker tracker) {
       if (next != null) {
         if (!complete) {
           throw new IllegalStateException("Ending an incomplete document");
         }
 
-        return next.end();
+        return next.end(tracker);
       }
 
       if (complete) {
         throw new IllegalStateException("Already complete");
       }
 
-      return new Accumulator(id, docKey, lastResultSet, rows, null);
+      return complete(tracker, null);
     }
 
     private void append(Accumulator other) {
-      rows.addAll(other.rows);
-      lastResultSet = other.lastResultSet;
+      if (rowComparator == null || lastRow == null) {
+        throw new IllegalStateException("Cannot compare");
+      }
+
+      DocProperty otherRow = other.lastRow;
+
+      if (rowComparator.compare(this.lastRow, otherRow) != 0) {
+        rows.add(otherRow);
+        this.lastRow = otherRow;
+      }
     }
 
-    private Accumulator combine(Accumulator buffer) {
+    private Accumulator combine(PagingStateTracker tracker, Accumulator buffer) {
       if (buffer == TERM) {
-        return end();
+        return end(tracker);
       }
 
       if (complete) {
@@ -219,15 +369,149 @@ public class QueryExecutor {
               "Unexpected continuation after a terminal document element.");
         }
 
-        return next.combine(buffer);
+        return next.combine(tracker, buffer);
       }
 
       if (docKey.equals(buffer.docKey)) {
         append(buffer);
         return this; // still not complete
       } else {
-        return new Accumulator(id, docKey, lastResultSet, rows, buffer);
+        return complete(tracker, buffer);
       }
+    }
+  }
+
+  private static class PagingStateTracker {
+    private final ArrayList<PagingStateSupplier> states;
+
+    private PagingStateTracker(CombinedPagingState pagingStates) {
+      states = new ArrayList<>(pagingStates.nested().size());
+      pagingStates.nested().stream().map(PreBuiltPagingState::new).forEach(states::add);
+    }
+
+    private Accumulator combine(Accumulator prev, Accumulator next) {
+      return prev.combine(this, next);
+    }
+
+    public void track(DocProperty row) {
+      states.set(row.queryIndex(), new RowPagingState(row));
+    }
+
+    public List<PagingStateSupplier> slice() {
+      return new ArrayList<>(states);
+    }
+  }
+
+  @Value.Immutable(lazyhash = true)
+  public abstract static class DocProperty {
+
+    abstract Page page();
+
+    abstract Row row();
+
+    abstract boolean lastInPage();
+
+    abstract int queryIndex();
+
+    @Value.Lazy
+    ComparableKey<?> comparableKey() {
+      return page().decorator().decoratePartitionKey(row());
+    }
+
+    String keyValue(Column column) {
+      return row().getString(column.name());
+    }
+
+    @Value.Lazy
+    @Override
+    public String toString() {
+      return row().toString();
+    }
+  }
+
+  @Value.Immutable(lazyhash = true)
+  public abstract static class Page {
+
+    abstract ResultSet resultSet();
+
+    @Value.Lazy
+    RowDecorator decorator() {
+      return resultSet().makeRowDecorator();
+    }
+  }
+
+  private static class PreBuiltPagingState extends PagingStateSupplier {
+    private final ByteBuffer pagingState;
+
+    private PreBuiltPagingState(ByteBuffer pagingState) {
+      this.pagingState = pagingState;
+    }
+
+    @Override
+    public boolean hasPagingState() {
+      // An empty paging state means the query was exhausted during previous execution.
+      // A null paging state mean the query was not executed yet.
+      return pagingState == null || pagingState.remaining() > 0;
+    }
+
+    @Override
+    public ByteBuffer makePagingState(ResumeMode resumeMode) {
+      return pagingState;
+    }
+  }
+
+  private static class RowPagingState extends PagingStateSupplier {
+    private final DocProperty row;
+
+    private RowPagingState(DocProperty row) {
+      this.row = row;
+    }
+
+    @Override
+    public boolean hasPagingState() {
+      return row.page().resultSet().getPagingState() != null;
+    }
+
+    @Override
+    public ByteBuffer makePagingState(ResumeMode resumeMode) {
+      if (row.lastInPage() && !hasPagingState()) {
+        return EXHAUSTED_PAGE_STATE;
+      }
+
+      return row.page()
+          .resultSet()
+          .makePagingState(PagingPosition.ofCurrentRow(row.row()).resumeFrom(resumeMode).build());
+    }
+  }
+
+  private static class NoPagingState extends PagingStateSupplier {
+    private static final List<PagingStateSupplier> INSTANCE =
+        Collections.singletonList(new NoPagingState());
+
+    @Override
+    public boolean hasPagingState() {
+      return false;
+    }
+
+    @Override
+    public ByteBuffer makePagingState(ResumeMode resumeMode) {
+      return null;
+    }
+  }
+
+  private static class PagingStateBuilder implements Function<ResumeMode, ByteBuffer> {
+    private final List<PagingStateSupplier> pagingState;
+
+    private PagingStateBuilder(List<PagingStateSupplier> pagingState) {
+      this.pagingState = pagingState;
+    }
+
+    @Override
+    public ByteBuffer apply(ResumeMode resumeMode) {
+      List<ByteBuffer> pagingStateBuffers =
+          pagingState.stream().map(s -> s.makePagingState(resumeMode)).collect(Collectors.toList());
+
+      return CombinedPagingState.of(pagingStateBuffers).serialize();
     }
   }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
@@ -522,7 +522,7 @@ public class QueryExecutor {
 
       if (sets.size() != 1) {
         throw new IllegalArgumentException(
-            "Invalid sets of columns are selected by the provided queries: "
+            "Incompatible sets of columns are selected by the provided queries: "
                 + sets.stream()
                     .map(
                         s ->

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
@@ -237,6 +237,11 @@ public class QueryExecutor {
     return new Accumulator(id, comparator, docKey.build(), property);
   }
 
+  /**
+   * Converts a single page of results into {@link DocProperty} objects to maintain an association
+   * of rows to their respective {@link ResultSet} objects and queries (the latter is needed for
+   * tracking the combined paging state).
+   */
   private Iterable<DocProperty> properties(
       int queryIndex, BoundQuery query, ResultSet rs, ExecutionContext context) {
     List<Row> rows = rs.currentPageRows();

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
@@ -36,6 +36,7 @@ import io.stargate.db.query.BoundQuery;
 import io.stargate.db.query.builder.BuiltSelect;
 import io.stargate.db.schema.Column;
 import io.stargate.db.schema.Table;
+import io.stargate.web.docsapi.service.query.QueryConstants;
 import io.stargate.web.rx.RxUtils;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -228,7 +229,7 @@ public class QueryExecutor {
   private Accumulator toSeed(
       DocProperty property, Comparator<DocProperty> comparator, List<Column> keyColumns) {
     Row row = property.row();
-    String id = row.getString("key");
+    String id = row.getString(QueryConstants.KEY_COLUMN_NAME);
     Builder<String> docKey = ImmutableList.builder();
     for (Column c : keyColumns) {
       docKey.add(Objects.requireNonNull(row.getString(c.name())));

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/RawDocument.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/RawDocument.java
@@ -22,20 +22,16 @@ import io.stargate.db.datastore.Row;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Function;
 
 public class RawDocument {
 
   private final String id;
   private final List<String> docKey;
-  private final Function<ResumeMode, ByteBuffer> pagingState;
+  private final PagingStateSupplier pagingState;
   private final List<Row> rows;
 
   public RawDocument(
-      String id,
-      List<String> docKey,
-      Function<ResumeMode, ByteBuffer> pagingState,
-      List<Row> rows) {
+      String id, List<String> docKey, PagingStateSupplier pagingState, List<Row> rows) {
     this.id = id;
     this.docKey = docKey;
     this.pagingState = pagingState;
@@ -87,6 +83,6 @@ public class RawDocument {
       resumeMode = ResumeMode.NEXT_PARTITION;
     }
 
-    return pagingState.apply(resumeMode);
+    return pagingState.makePagingState(resumeMode);
   }
 }

--- a/restapi/src/test/java/io/stargate/db/datastore/AbstractDataStoreTest.java
+++ b/restapi/src/test/java/io/stargate/db/datastore/AbstractDataStoreTest.java
@@ -15,9 +15,12 @@
  */
 package io.stargate.db.datastore;
 
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.stargate.db.datastore.ValidatingDataStore.QueryExpectation;
 import io.stargate.db.schema.Schema;
 import io.stargate.db.schema.Table;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -40,6 +43,12 @@ public abstract class AbstractDataStoreTest {
   @AfterEach
   public void checkExpectedExecutions() {
     dataStore.validate();
+  }
+
+  protected <T> List<T> values(Flowable<T> flowable) {
+    TestSubscriber<T> test = flowable.test();
+    test.assertNoErrors();
+    return test.values();
   }
 
   protected void ignorePreparedExecutions() {

--- a/restapi/src/test/java/io/stargate/db/datastore/AlphabeticalOrderPartitionKeyDecorator.java
+++ b/restapi/src/test/java/io/stargate/db/datastore/AlphabeticalOrderPartitionKeyDecorator.java
@@ -21,6 +21,10 @@ import io.stargate.db.schema.Column;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * A test implementation of {@link RowDecorator} that assumes partition keys to be {@link String}
+ * values and sorts them alphabetically using the natural order.
+ */
 public class AlphabeticalOrderPartitionKeyDecorator implements RowDecorator {
 
   private final List<Column> partitionKeyColumns;
@@ -32,13 +36,11 @@ public class AlphabeticalOrderPartitionKeyDecorator implements RowDecorator {
 
   @Override
   public <T extends Comparable<T>> ComparableKey<T> decoratePartitionKey(Row row) {
-    StringBuilder decorated = new StringBuilder();
-    for (Column column : partitionKeyColumns) {
-      String value = row.getString(column.name());
-      decorated.append(value);
-      decorated.append("|");
-    }
+    String decorated =
+        partitionKeyColumns.stream()
+            .map(column -> row.getString(column.name()))
+            .collect(Collectors.joining("|"));
     //noinspection unchecked
-    return (ComparableKey<T>) new ComparableKey<>(String.class, decorated.toString());
+    return (ComparableKey<T>) new ComparableKey<>(String.class, decorated);
   }
 }

--- a/restapi/src/test/java/io/stargate/db/datastore/AlphabeticalOrderPartitionKeyDecorator.java
+++ b/restapi/src/test/java/io/stargate/db/datastore/AlphabeticalOrderPartitionKeyDecorator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.db.datastore;
+
+import io.stargate.db.ComparableKey;
+import io.stargate.db.RowDecorator;
+import io.stargate.db.schema.Column;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AlphabeticalOrderPartitionKeyDecorator implements RowDecorator {
+
+  private final List<Column> partitionKeyColumns;
+
+  public AlphabeticalOrderPartitionKeyDecorator(List<Column> allColumns) {
+    this.partitionKeyColumns =
+        allColumns.stream().filter(Column::isPartitionKey).collect(Collectors.toList());
+  }
+
+  @Override
+  public <T extends Comparable<T>> ComparableKey<T> decoratePartitionKey(Row row) {
+    StringBuilder decorated = new StringBuilder();
+    for (Column column : partitionKeyColumns) {
+      String value = row.getString(column.name());
+      decorated.append(value);
+      decorated.append("|");
+    }
+    //noinspection unchecked
+    return (ComparableKey<T>) new ComparableKey<>(String.class, decorated.toString());
+  }
+}

--- a/restapi/src/test/java/io/stargate/db/datastore/ListBackedResultSet.java
+++ b/restapi/src/test/java/io/stargate/db/datastore/ListBackedResultSet.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -49,7 +50,11 @@ public class ListBackedResultSet implements ResultSet {
     data = paginator.filter(data);
     Set<String> columnNames =
         data.stream().flatMap(m -> m.keySet().stream()).collect(Collectors.toSet());
-    List<Column> columns = columnNames.stream().map(table::column).collect(Collectors.toList());
+    List<Column> columns =
+        columnNames.stream()
+            .map(table::column)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
 
     if (columnNames.isEmpty()) { // empty `data`
       columns = table.columns(); // use all columns as a fallback for tests
@@ -107,6 +112,6 @@ public class ListBackedResultSet implements ResultSet {
 
   @Override
   public RowDecorator makeRowDecorator() {
-    throw new UnsupportedOperationException();
+    return new AlphabeticalOrderPartitionKeyDecorator(columns);
   }
 }

--- a/restapi/src/test/java/io/stargate/db/datastore/MapBackedRow.java
+++ b/restapi/src/test/java/io/stargate/db/datastore/MapBackedRow.java
@@ -138,4 +138,9 @@ public class MapBackedRow implements Row {
   public ProtocolVersion protocolVersion() {
     throw new UnsupportedOperationException();
   }
+
+  @Override
+  public String toString() {
+    return dataMap.toString();
+  }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/DocsApiTestSchemaProvider.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/DocsApiTestSchemaProvider.java
@@ -17,6 +17,7 @@
 
 package io.stargate.web.docsapi;
 
+import static io.stargate.db.schema.Column.Kind.Clustering;
 import static io.stargate.db.schema.Column.Kind.PartitionKey;
 import static io.stargate.db.schema.Column.Kind.Regular;
 
@@ -83,7 +84,7 @@ public class DocsApiTestSchemaProvider {
           ImmutableColumn.builder()
               .name(QueryConstants.P_COLUMN_NAME.apply(i))
               .type(Column.Type.Text)
-              .kind(PartitionKey)
+              .kind(Clustering)
               .build();
       tableBuilder = tableBuilder.addColumns(column);
     }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/CombinedPagingStateTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/CombinedPagingStateTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.web.docsapi.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import io.stargate.core.util.ByteBufferUtils;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Objects;
+import org.junit.jupiter.api.Test;
+
+class CombinedPagingStateTest {
+
+  @Test
+  void testSingleNestedRoundTrip() {
+    ByteBuffer state = ByteBuffer.wrap(new byte[] {1, 2});
+    CombinedPagingState c0 = CombinedPagingState.of(ImmutableList.of(state));
+    CombinedPagingState c1 = CombinedPagingState.deserialize(1, c0.serialize());
+    assertThat(c1.nested()).hasSize(1);
+    assertThat(c1.nested().get(0).array()).isEqualTo(state.array());
+  }
+
+  @Test
+  void testSingleNestedShortcut() {
+    ByteBuffer state = ByteBuffer.wrap(new byte[] {1, 2});
+    CombinedPagingState c0 = CombinedPagingState.of(ImmutableList.of(state));
+    assertThat(c0.serialize().array()).isEqualTo(state.array());
+  }
+
+  @Test
+  void testSingleNestedShortcutEmpty() {
+    ByteBuffer state = ByteBuffer.wrap(new byte[] {});
+    CombinedPagingState c0 = CombinedPagingState.of(ImmutableList.of(state));
+    assertThat(c0.serialize().array()).isEqualTo(state.array());
+  }
+
+  @Test
+  void testSingleNestedShortcutNull() {
+    CombinedPagingState c0 = CombinedPagingState.of(Collections.singletonList(null));
+    assertThat(c0.serialize()).isNull();
+  }
+
+  @Test
+  void testMultipleNestedRoundTrip() {
+    ByteBuffer s0 = ByteBuffer.wrap(new byte[] {1, 2});
+    ByteBuffer s1 = ByteBuffer.wrap(new byte[0]);
+    ByteBuffer s2 = ByteBuffer.wrap(new byte[] {-1, -3});
+    CombinedPagingState orig = CombinedPagingState.of(ImmutableList.of(s0, s1, s2));
+    CombinedPagingState state = CombinedPagingState.deserialize(3, orig.serialize());
+    assertThat(state.nested()).hasSize(3);
+    assertThat(ByteBufferUtils.getArray(state.nested().get(0))).isEqualTo(s0.array());
+    assertThat(ByteBufferUtils.getArray(state.nested().get(1))).isEqualTo(s1.array());
+    assertThat(ByteBufferUtils.getArray(state.nested().get(2))).isEqualTo(s2.array());
+  }
+
+  @Test
+  void testMultipleNestedRoundTripWithNull() {
+    ByteBuffer s0 = ByteBuffer.wrap(new byte[] {1, 2});
+    ByteBuffer s1 = ByteBuffer.wrap(new byte[] {-1, -3});
+
+    CombinedPagingState orig = CombinedPagingState.of(Arrays.asList(s0, null, s1));
+    CombinedPagingState state = CombinedPagingState.deserialize(3, orig.serialize());
+    assertThat(state.nested()).hasSize(3);
+    assertThat(ByteBufferUtils.getArray(state.nested().get(0))).isEqualTo(s0.array());
+    assertThat(state.nested().get(1)).isNull();
+    assertThat(ByteBufferUtils.getArray(state.nested().get(2))).isEqualTo(s1.array());
+
+    orig = CombinedPagingState.of(Arrays.asList(null, s0, null));
+    state = CombinedPagingState.deserialize(3, orig.serialize());
+    assertThat(state.nested()).hasSize(3);
+    assertThat(state.nested().get(0)).isNull();
+    assertThat(ByteBufferUtils.getArray(state.nested().get(1))).isEqualTo(s0.array());
+    assertThat(state.nested().get(2)).isNull();
+  }
+
+  @Test
+  void testMultipleNestedRoundTripAllNull() {
+    CombinedPagingState orig = CombinedPagingState.of(Arrays.asList(null, null));
+    assertThat(orig.serialize()).isNull();
+  }
+
+  @Test
+  void testNullState() {
+    CombinedPagingState c = CombinedPagingState.deserialize(5, null);
+    assertThat(c.nested()).hasSize(5);
+    assertThat(c.nested()).allMatch(Objects::isNull);
+  }
+
+  @Test
+  void testExpectedSize() {
+    ByteBuffer s = ByteBuffer.wrap(new byte[] {1, 2});
+    CombinedPagingState c1 = CombinedPagingState.of(ImmutableList.of(s, s));
+
+    assertThatThrownBy(() -> CombinedPagingState.deserialize(-111, c1.serialize()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("-111");
+
+    assertThatThrownBy(() -> CombinedPagingState.deserialize(245, ByteBuffer.wrap(new byte[3])))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("available bytes: 3");
+
+    assertThatThrownBy(() -> CombinedPagingState.deserialize(1345, c1.serialize()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("2") // actual number of sub-states
+        .hasMessageContaining("1345"); // expected number of sub-states
+  }
+}

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/CombinedPagingStateTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/CombinedPagingStateTest.java
@@ -15,6 +15,7 @@
  */
 package io.stargate.web.docsapi.service;
 
+import static io.stargate.web.docsapi.service.CombinedPagingState.EXHAUSTED_PAGE_STATE;
 import static io.stargate.web.docsapi.service.CombinedPagingState.deserialize;
 import static io.stargate.web.docsapi.service.CombinedPagingState.serialize;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,103 +23,161 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import io.stargate.core.util.ByteBufferUtils;
+import io.stargate.db.PagingPosition.ResumeMode;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class CombinedPagingStateTest {
 
-  @Test
-  void testSingleNestedRoundTrip() {
-    ByteBuffer state = ByteBuffer.wrap(new byte[] {1, 2});
-    List<ByteBuffer> combined = deserialize(1, serialize(ImmutableList.of(state)));
-    assertThat(combined).hasSize(1);
-    assertThat(combined.get(0).array()).isEqualTo(state.array());
+  @Nested
+  class IsExhausted {
+
+    @Test
+    void constant() {
+      assertThat(CombinedPagingState.isExhausted(EXHAUSTED_PAGE_STATE)).isTrue();
+    }
+
+    @Test
+    void custom() {
+      assertThat(CombinedPagingState.isExhausted(ByteBuffer.allocate(0))).isTrue();
+      assertThat(CombinedPagingState.isExhausted(ByteBuffer.allocate(1))).isFalse();
+    }
+
+    @Test
+    void nullState() {
+      assertThat(CombinedPagingState.isExhausted(null)).isFalse();
+    }
   }
 
-  @Test
-  void testSingleNestedShortcut() {
-    ByteBuffer state = ByteBuffer.wrap(new byte[] {1, 2});
-    assertThat(serialize(ImmutableList.of(state)))
-        .isNotNull()
-        .extracting(ByteBuffer::array)
-        .isEqualTo(state.array());
+  @Nested
+  class MakePagingState {
+
+    @Test
+    void oneNull() {
+      CombinedPagingState combined = new CombinedPagingState(ImmutableList.of(resumeMode -> null));
+      assertThat(combined.makePagingState(ResumeMode.NEXT_PARTITION)).isNull();
+    }
+
+    @Test
+    void allNull() {
+      CombinedPagingState combined =
+          new CombinedPagingState(ImmutableList.of(resumeMode -> null, resumeMode -> null));
+      assertThat(combined.makePagingState(ResumeMode.NEXT_PARTITION)).isNull();
+    }
+
+    @Test
+    void mixed() {
+      CombinedPagingState combined =
+          new CombinedPagingState(
+              ImmutableList.of(resumeMode -> null, resumeMode -> EXHAUSTED_PAGE_STATE));
+      assertThat(combined.makePagingState(ResumeMode.NEXT_PARTITION)).isNotNull();
+    }
+
+    @Test
+    void exhausted() {
+      CombinedPagingState combined =
+          new CombinedPagingState(ImmutableList.of(resumeMode -> EXHAUSTED_PAGE_STATE));
+      assertThat(combined.makePagingState(ResumeMode.NEXT_PARTITION)).isNull();
+    }
   }
 
-  @Test
-  void testSingleNestedShortcutEmpty() {
-    ByteBuffer state = ByteBuffer.wrap(new byte[] {});
-    assertThat(serialize(ImmutableList.of(state)))
-        .isNotNull()
-        .extracting(ByteBuffer::array)
-        .isEqualTo(state.array());
-  }
+  @Nested
+  class Serialization {
 
-  @Test
-  void testSingleNestedShortcutNull() {
-    assertThat(serialize(Collections.singletonList(null))).isNull();
-  }
+    @Test
+    void singleNestedRoundTrip() {
+      ByteBuffer state = ByteBuffer.wrap(new byte[] {1, 2});
+      List<ByteBuffer> combined = deserialize(1, serialize(ImmutableList.of(state)));
+      assertThat(combined).hasSize(1);
+      assertThat(combined.get(0).array()).isEqualTo(state.array());
+    }
 
-  @Test
-  void testMultipleNestedRoundTrip() {
-    ByteBuffer s0 = ByteBuffer.wrap(new byte[] {1, 2});
-    ByteBuffer s1 = ByteBuffer.wrap(new byte[0]);
-    ByteBuffer s2 = ByteBuffer.wrap(new byte[] {-1, -3});
-    List<ByteBuffer> combined = deserialize(3, serialize(ImmutableList.of(s0, s1, s2)));
-    assertThat(combined).hasSize(3);
-    assertThat(ByteBufferUtils.getArray(combined.get(0))).isEqualTo(s0.array());
-    assertThat(ByteBufferUtils.getArray(combined.get(1))).isEqualTo(s1.array());
-    assertThat(ByteBufferUtils.getArray(combined.get(2))).isEqualTo(s2.array());
-  }
+    @Test
+    void singleNestedShortcut() {
+      ByteBuffer state = ByteBuffer.wrap(new byte[] {1, 2});
+      assertThat(serialize(ImmutableList.of(state)))
+          .isNotNull()
+          .extracting(ByteBuffer::array)
+          .isEqualTo(state.array());
+    }
 
-  @Test
-  void testMultipleNestedRoundTripWithNull() {
-    ByteBuffer s0 = ByteBuffer.wrap(new byte[] {1, 2});
-    ByteBuffer s1 = ByteBuffer.wrap(new byte[] {-1, -3});
+    @Test
+    void singleNestedShortcutEmpty() {
+      ByteBuffer state = ByteBuffer.wrap(new byte[] {});
+      assertThat(serialize(ImmutableList.of(state)))
+          .isNotNull()
+          .extracting(ByteBuffer::array)
+          .isEqualTo(state.array());
+    }
 
-    List<ByteBuffer> combined = deserialize(3, serialize(Arrays.asList(s0, null, s1)));
-    assertThat(combined).hasSize(3);
-    assertThat(ByteBufferUtils.getArray(combined.get(0))).isEqualTo(s0.array());
-    assertThat(combined.get(1)).isNull();
-    assertThat(ByteBufferUtils.getArray(combined.get(2))).isEqualTo(s1.array());
+    @Test
+    void singleNestedShortcutNull() {
+      assertThat(serialize(Collections.singletonList(null))).isNull();
+    }
 
-    combined = deserialize(3, serialize(Arrays.asList(null, s0, null)));
-    assertThat(combined).hasSize(3);
-    assertThat(combined.get(0)).isNull();
-    assertThat(ByteBufferUtils.getArray(combined.get(1))).isEqualTo(s0.array());
-    assertThat(combined.get(2)).isNull();
-  }
+    @Test
+    void multipleNestedRoundTrip() {
+      ByteBuffer s0 = ByteBuffer.wrap(new byte[] {1, 2});
+      ByteBuffer s1 = ByteBuffer.wrap(new byte[0]);
+      ByteBuffer s2 = ByteBuffer.wrap(new byte[] {-1, -3});
+      List<ByteBuffer> combined = deserialize(3, serialize(ImmutableList.of(s0, s1, s2)));
+      assertThat(combined).hasSize(3);
+      assertThat(ByteBufferUtils.getArray(combined.get(0))).isEqualTo(s0.array());
+      assertThat(ByteBufferUtils.getArray(combined.get(1))).isEqualTo(s1.array());
+      assertThat(ByteBufferUtils.getArray(combined.get(2))).isEqualTo(s2.array());
+    }
 
-  @Test
-  void testMultipleNestedRoundTripAllNull() {
-    assertThat(serialize(Arrays.asList(null, null))).isNull();
-  }
+    @Test
+    void multipleNestedRoundTripWithNull() {
+      ByteBuffer s0 = ByteBuffer.wrap(new byte[] {1, 2});
+      ByteBuffer s1 = ByteBuffer.wrap(new byte[] {-1, -3});
 
-  @Test
-  void testNullState() {
-    List<ByteBuffer> combined = deserialize(5, null);
-    assertThat(combined).hasSize(5);
-    assertThat(combined).allMatch(Objects::isNull);
-  }
+      List<ByteBuffer> combined = deserialize(3, serialize(Arrays.asList(s0, null, s1)));
+      assertThat(combined).hasSize(3);
+      assertThat(ByteBufferUtils.getArray(combined.get(0))).isEqualTo(s0.array());
+      assertThat(combined.get(1)).isNull();
+      assertThat(ByteBufferUtils.getArray(combined.get(2))).isEqualTo(s1.array());
 
-  @Test
-  void testExpectedSize() {
-    ByteBuffer s = ByteBuffer.wrap(new byte[] {1, 2});
+      combined = deserialize(3, serialize(Arrays.asList(null, s0, null)));
+      assertThat(combined).hasSize(3);
+      assertThat(combined.get(0)).isNull();
+      assertThat(ByteBufferUtils.getArray(combined.get(1))).isEqualTo(s0.array());
+      assertThat(combined.get(2)).isNull();
+    }
 
-    assertThatThrownBy(() -> deserialize(-111, serialize(ImmutableList.of(s, s))))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("-111"); // invalid expected size
+    @Test
+    void multipleNestedRoundTripAllNull() {
+      assertThat(serialize(Arrays.asList(null, null))).isNull();
+    }
 
-    assertThatThrownBy(() -> deserialize(245, ByteBuffer.wrap(new byte[3])))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("available bytes: 3");
+    @Test
+    void nullState() {
+      List<ByteBuffer> combined = deserialize(5, null);
+      assertThat(combined).hasSize(5);
+      assertThat(combined).allMatch(Objects::isNull);
+    }
 
-    assertThatThrownBy(() -> deserialize(1345, serialize(ImmutableList.of(s, s))))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("2") // actual number of sub-states
-        .hasMessageContaining("1345"); // expected number of sub-states
+    @Test
+    void expectedSize() {
+      ByteBuffer s = ByteBuffer.wrap(new byte[] {1, 2});
+
+      assertThatThrownBy(() -> deserialize(-111, serialize(ImmutableList.of(s, s))))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("-111"); // invalid expected size
+
+      assertThatThrownBy(() -> deserialize(245, ByteBuffer.wrap(new byte[3])))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("available bytes: 3");
+
+      assertThatThrownBy(() -> deserialize(1345, serialize(ImmutableList.of(s, s))))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("2") // actual number of sub-states
+          .hasMessageContaining("1345"); // expected number of sub-states
+    }
   }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/QueryExecutorTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/QueryExecutorTest.java
@@ -767,7 +767,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
                     1,
                     null,
                     context))
-        .hasMessageContaining("Invalid sets of columns are selected by the provided queries")
+        .hasMessageContaining("Incompatible sets of columns are selected by the provided queries")
         .hasMessageContaining("key")
         .hasMessageContaining("p0");
   }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/QueryExecutorTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/QueryExecutorTest.java
@@ -19,6 +19,7 @@ import static io.stargate.db.schema.Column.Kind.Clustering;
 import static io.stargate.db.schema.Column.Kind.PartitionKey;
 import static io.stargate.db.schema.Column.Kind.Regular;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList.Builder;
@@ -64,8 +65,16 @@ class QueryExecutorTest extends AbstractDataStoreTest {
               ImmutableColumn.builder().name("test_value").type(Type.Double).kind(Regular).build())
           .build();
 
+  protected static final Table table2 =
+      ImmutableTable.builder()
+          .keyspace("test_docs")
+          .name("collection2")
+          .addColumns(
+              ImmutableColumn.builder().name("key").type(Type.Text).kind(PartitionKey).build())
+          .build();
+
   private static final Keyspace keyspace =
-      ImmutableKeyspace.builder().name("test_docs").addTables(table).build();
+      ImmutableKeyspace.builder().name("test_docs").addTables(table, table2).build();
 
   private static final Schema schema = ImmutableSchema.builder().addKeyspaces(keyspace).build();
 
@@ -107,7 +116,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
     withQuery(table, "SELECT * FROM %s")
         .returning(ImmutableList.of(row("1", "x", 1.0d), row("1", "y", 2.0d), row("2", "x", 3.0d)));
 
-    List<RawDocument> r1 = executor.queryDocs(allDocsQuery, 100, null, context).test().values();
+    List<RawDocument> r1 = values(executor.queryDocs(allDocsQuery, 100, null, context));
     assertThat(r1).extracting(RawDocument::id).containsExactly("1", "2");
   }
 
@@ -143,8 +152,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
   void testFullScanPaged(int pageSize) {
     withFiveTestDocs(pageSize);
 
-    List<RawDocument> r1 =
-        executor.queryDocs(allDocsQuery, pageSize, null, context).test().values();
+    List<RawDocument> r1 = values(executor.queryDocs(allDocsQuery, pageSize, null, context));
     assertThat(r1).extracting(RawDocument::id).containsExactly("1", "2", "3", "4", "5");
     assertThat(r1.get(0).hasPagingState()).isTrue();
     assertThat(r1.get(1).hasPagingState()).isTrue();
@@ -152,15 +160,15 @@ class QueryExecutorTest extends AbstractDataStoreTest {
     assertThat(r1.get(3).hasPagingState()).isTrue();
 
     ByteBuffer ps1 = r1.get(0).makePagingState();
-    List<RawDocument> r2 = executor.queryDocs(allDocsQuery, pageSize, ps1, context).test().values();
+    List<RawDocument> r2 = values(executor.queryDocs(allDocsQuery, pageSize, ps1, context));
     assertThat(r2).extracting(RawDocument::id).containsExactly("2", "3", "4", "5");
 
     ByteBuffer ps2 = r1.get(1).makePagingState();
-    List<RawDocument> r3 = executor.queryDocs(allDocsQuery, pageSize, ps2, context).test().values();
+    List<RawDocument> r3 = values(executor.queryDocs(allDocsQuery, pageSize, ps2, context));
     assertThat(r3).extracting(RawDocument::id).containsExactly("3", "4", "5");
 
     ByteBuffer ps4 = r1.get(3).makePagingState();
-    List<RawDocument> r4 = executor.queryDocs(allDocsQuery, pageSize, ps4, context).test().values();
+    List<RawDocument> r4 = values(executor.queryDocs(allDocsQuery, pageSize, ps4, context));
     assertThat(r4).extracting(RawDocument::id).containsExactly("5");
   }
 
@@ -176,8 +184,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
     withQuery(table, "SELECT * FROM %s").withPageSize(pageSize).returning(rows.build());
 
     // Testing potential stack overflow in Rx pipelines
-    assertThat(executor.queryDocs(allDocsQuery, pageSize, null, context).test().values())
-        .hasSize(N);
+    assertThat(values(executor.queryDocs(allDocsQuery, pageSize, null, context))).hasSize(N);
   }
 
   @ParameterizedTest
@@ -223,8 +230,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
     boolean shouldHavePagingState = (8 % pageSize) == 0;
     withFiveTestDocs(pageSize);
 
-    List<RawDocument> r1 =
-        executor.queryDocs(allDocsQuery, pageSize, null, context).test().values();
+    List<RawDocument> r1 = values(executor.queryDocs(allDocsQuery, pageSize, null, context));
     assertThat(r1).extracting(RawDocument::id).containsExactly("1", "2", "3", "4", "5");
     assertThat(r1.get(4).hasPagingState()).isEqualTo(shouldHavePagingState);
     ByteBuffer pagingState = r1.get(4).makePagingState();
@@ -232,7 +238,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
 
     if (pagingState != null) {
       List<RawDocument> r2 =
-          executor.queryDocs(allDocsQuery, pageSize, pagingState, context).test().values();
+          values(executor.queryDocs(allDocsQuery, pageSize, pagingState, context));
       assertThat(r2).isEmpty();
     }
   }
@@ -253,8 +259,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
                 row("5", "y", 1.0d),
                 row("6", "x", 1.0d))); // the last row should be ignored
 
-    List<RawDocument> r1 =
-        executor.queryDocs(allDocsQuery, pageSize, null, context).test().values();
+    List<RawDocument> r1 = values(executor.queryDocs(allDocsQuery, pageSize, null, context));
     assertThat(r1).extracting(RawDocument::id).containsExactly("1", "2", "3", "4", "5");
 
     RawDocument doc2a = r1.get(1);
@@ -324,8 +329,8 @@ class QueryExecutorTest extends AbstractDataStoreTest {
                 row("b", "y", "3", "f2", 7.0d)));
 
     List<RawDocument> docs =
-        executor
-            .queryDocs(
+        values(
+            executor.queryDocs(
                 3,
                 datastore()
                     .queryBuilder()
@@ -338,9 +343,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
                     .bind(),
                 3,
                 null,
-                context)
-            .test()
-            .values();
+                context));
 
     assertThat(docs.get(0).rows())
         .extracting(r -> r.getDouble("test_value"))
@@ -384,8 +387,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
             .build()
             .bind();
 
-    List<RawDocument> docs =
-        executor.queryDocs(3, query, pageSize, null, context).take(2).test().values();
+    List<RawDocument> docs = values(executor.queryDocs(3, query, pageSize, null, context).take(2));
 
     assertThat(docs).hasSize(2);
     assertThat(docs.get(0).key()).containsExactly("a", "x", "2");
@@ -396,7 +398,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
     ByteBuffer ps2 = docs.get(1).makePagingState();
     assertThat(ps2).isNotNull();
 
-    docs = executor.queryDocs(3, query, pageSize, ps2, context).test().values();
+    docs = values(executor.queryDocs(3, query, pageSize, ps2, context));
 
     assertThat(docs).hasSize(2);
     assertThat(docs.get(0).key()).containsExactly("a", "y", "3");
@@ -418,7 +420,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
     // state (see testFullScanFinalPagingState(...) for details). In any case, though, there
     // should be no more documents in the pipeline.
     if (lastPagingState != null) {
-      docs = executor.queryDocs(3, query, pageSize, lastPagingState, context).test().values();
+      docs = values(executor.queryDocs(3, query, pageSize, lastPagingState, context));
       assertThat(docs).isEmpty();
     }
   }
@@ -450,17 +452,113 @@ class QueryExecutorTest extends AbstractDataStoreTest {
     AbstractBound<?> q1 = query.bind("x");
     AbstractBound<?> q2 = query.bind("y");
 
-    TestSubscriber<RawDocument> test =
-        executor.queryDocs(ImmutableList.of(q1, q2), pageSize, null, context).test();
-    test.assertNoErrors();
-
-    List<RawDocument> docs = test.values();
+    List<RawDocument> docs =
+        values(executor.queryDocs(ImmutableList.of(q1, q2), pageSize, null, context));
 
     assertThat(docs).extracting(RawDocument::id).containsExactly("a", "b", "c", "d");
     assertThat(docs.get(0).rows()).extracting(r -> r.getString("p0")).contains("x1", "x2");
     assertThat(docs.get(1).rows()).extracting(r -> r.getString("p0")).contains("y2");
     assertThat(docs.get(2).rows()).extracting(r -> r.getString("p0")).contains("x2", "x3");
     assertThat(docs.get(3).rows()).extracting(r -> r.getString("p0")).contains("z1", "z2");
+  }
+
+  @ParameterizedTest
+  @CsvSource({"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "100"})
+  void testMergeSubDocuments(int pageSize) {
+    withQuery(table, "SELECT * FROM %s WHERE p0 > ?", "x")
+        .withPageSize(pageSize)
+        .returning(
+            ImmutableList.of(
+                row("a", "x1", "y1", "", 1.0d),
+                row("a", "x1", "y1", "z1", 2.0d),
+                row("a", "x2", "y1", "z1", 3.0d),
+                row("b", "x1", "y1", "z1", 4.0d),
+                row("c", "x1", "y1", "", 5.0d)));
+    withQuery(table, "SELECT * FROM %s WHERE p0 > ?", "y")
+        .withPageSize(pageSize)
+        .returning(
+            ImmutableList.of(
+                row("a", "x1", "y1", "z1", 2.0d),
+                row("a", "x2", "y1", "z2", 6.0d),
+                row("b", "x1", "y1", "", 7.0d)));
+
+    BuiltQuery<?> query =
+        datastore().queryBuilder().select().star().from(table).where("p0", Predicate.GT).build();
+
+    AbstractBound<?> q1 = query.bind("x");
+    AbstractBound<?> q2 = query.bind("y");
+
+    List<RawDocument> docs =
+        values(executor.queryDocs(2, ImmutableList.of(q1, q2), pageSize, null, context));
+
+    assertThat(docs).extracting(RawDocument::id).containsExactly("a", "a", "b", "c");
+
+    assertThat(docs.get(0).key()).containsExactly("a", "x1");
+    assertThat(docs.get(0).rows())
+        .extracting(r -> r.getDouble("test_value"))
+        .containsExactly(1.0d, 2.0d);
+    assertThat(docs.get(1).key()).containsExactly("a", "x2");
+    assertThat(docs.get(1).rows())
+        .extracting(r -> r.getDouble("test_value"))
+        .containsExactly(3.0d, 6.0d);
+    assertThat(docs.get(2).key()).containsExactly("b", "x1");
+    assertThat(docs.get(2).rows())
+        .extracting(r -> r.getDouble("test_value"))
+        .containsExactly(7.0d, 4.0d);
+    assertThat(docs.get(3).key()).containsExactly("c", "x1");
+    assertThat(docs.get(3).rows()).extracting(r -> r.getDouble("test_value")).containsExactly(5.0d);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "100"})
+  void testMergeWithPartialPath(int pageSize) {
+    String cql = "SELECT key, p0, test_value FROM %s WHERE p0 > ?";
+    withQuery(table, cql, "x")
+        .withPageSize(pageSize)
+        .returning(
+            ImmutableList.of(
+                row("a", "x1", "y1", "", 1.0d),
+                row("a", "x1", "y1", "z1", 2.0d),
+                row("a", "x2", "y1", "z1", 3.0d),
+                row("b", "x1", "y1", "z1", 4.0d),
+                row("c", "x1", "y1", "", 5.0d)));
+    withQuery(table, cql, "y")
+        .withPageSize(pageSize)
+        .returning(
+            ImmutableList.of(
+                row("a", "x1", "y1", "z1", 2.0d),
+                row("a", "x2", "y1", "z2", 6.0d),
+                row("b", "x1", "y1", "", 7.0d)));
+
+    BuiltQuery<?> query =
+        datastore()
+            .queryBuilder()
+            .select()
+            .column("key")
+            .column("p0")
+            .column("test_value")
+            .from(table)
+            .where("p0", Predicate.GT)
+            .build();
+
+    AbstractBound<?> q1 = query.bind("x");
+    AbstractBound<?> q2 = query.bind("y");
+
+    List<RawDocument> docs =
+        values(executor.queryDocs(2, ImmutableList.of(q1, q2), pageSize, null, context));
+
+    assertThat(docs).extracting(RawDocument::id).containsExactly("a", "a", "b", "c");
+
+    // Note: clustering key columns that were not explicitly selected are not used to distinguish
+    // document property rows.
+    assertThat(docs.get(0).key()).containsExactly("a", "x1");
+    assertThat(docs.get(0).rows()).hasSize(1);
+    assertThat(docs.get(1).key()).containsExactly("a", "x2");
+    assertThat(docs.get(1).rows()).hasSize(1);
+    assertThat(docs.get(2).key()).containsExactly("b", "x1");
+    assertThat(docs.get(2).rows()).hasSize(1);
+    assertThat(docs.get(3).key()).containsExactly("c", "x1");
+    assertThat(docs.get(3).rows()).hasSize(1);
   }
 
   @ParameterizedTest
@@ -499,17 +597,13 @@ class QueryExecutorTest extends AbstractDataStoreTest {
             .add(query.bind("z"))
             .build();
 
-    TestSubscriber<RawDocument> test = executor.queryDocs(queries, pageSize, null, context).test();
-    test.assertNoErrors();
-    List<RawDocument> docs = test.values();
+    List<RawDocument> docs = values(executor.queryDocs(queries, pageSize, null, context));
 
     assertThat(docs).extracting(RawDocument::id).containsExactly("a", "b", "c", "d");
     assertThat(docs.get(0).rows()).extracting(r -> r.getString("p0")).contains("x1", "x2", "x3");
     assertThat(docs.get(0).makePagingState()).isNotNull();
 
-    test = executor.queryDocs(queries, pageSize, docs.get(0).makePagingState(), context).test();
-    test.assertNoErrors();
-    docs = test.values();
+    docs = values(executor.queryDocs(queries, pageSize, docs.get(0).makePagingState(), context));
 
     assertThat(docs).extracting(RawDocument::id).containsExactly("b", "c", "d");
     assertThat(docs.get(0).rows())
@@ -517,17 +611,13 @@ class QueryExecutorTest extends AbstractDataStoreTest {
         .contains("x1", "x2", "x3", "x4");
     assertThat(docs.get(0).makePagingState()).isNotNull();
 
-    test = executor.queryDocs(queries, pageSize, docs.get(0).makePagingState(), context).test();
-    test.assertNoErrors();
-    docs = test.values();
+    docs = values(executor.queryDocs(queries, pageSize, docs.get(0).makePagingState(), context));
 
     assertThat(docs).extracting(RawDocument::id).containsExactly("c", "d");
     assertThat(docs.get(0).rows()).extracting(r -> r.getString("p0")).contains("x1");
     assertThat(docs.get(0).makePagingState()).isNotNull();
 
-    test = executor.queryDocs(queries, pageSize, docs.get(0).makePagingState(), context).test();
-    test.assertNoErrors();
-    docs = test.values();
+    docs = values(executor.queryDocs(queries, pageSize, docs.get(0).makePagingState(), context));
 
     assertThat(docs).extracting(RawDocument::id).containsExactly("d");
     assertThat(docs.get(0).rows()).extracting(r -> r.getString("p0")).contains("x1");
@@ -538,9 +628,8 @@ class QueryExecutorTest extends AbstractDataStoreTest {
     if (!shouldHasPagingState) {
       assertThat(docs.get(0).makePagingState()).isNull();
     } else {
-      test = executor.queryDocs(queries, pageSize, docs.get(0).makePagingState(), context).test();
-      test.assertNoErrors();
-      assertThat(test.values()).isEmpty();
+      docs = values(executor.queryDocs(queries, pageSize, docs.get(0).makePagingState(), context));
+      assertThat(docs).isEmpty();
     }
   }
 
@@ -577,5 +666,94 @@ class QueryExecutorTest extends AbstractDataStoreTest {
     // Note: we exhausted the first query, so there was no need to re-execute it
     q1.assertExecuteCount().isEqualTo(1);
     q2.assertExecuteCount().isEqualTo(2);
+  }
+
+  @Test
+  void testIdentityDepthValidation() {
+    assertThatThrownBy(() -> executor.queryDocs(-123, allDocsQuery, 1, null, context))
+        .hasMessageContaining("Invalid document identity depth: -123");
+    assertThatThrownBy(() -> executor.queryDocs(123, allDocsQuery, 1, null, context))
+        .hasMessageContaining("Invalid document identity depth: 123");
+  }
+
+  @Test
+  void testIdentityColumnValidation() {
+    assertThatThrownBy(
+            () ->
+                executor.queryDocs(
+                    1,
+                    datastore().queryBuilder().select().column("p0").from(table).build().bind(),
+                    1,
+                    null,
+                    context))
+        .hasMessageContaining("Required identity column is not selected")
+        .hasMessageContaining("key");
+
+    assertThatThrownBy(
+            () ->
+                executor.queryDocs(
+                    3,
+                    datastore()
+                        .queryBuilder()
+                        .select()
+                        .column("key")
+                        .column("p1")
+                        .from(table)
+                        .build()
+                        .bind(),
+                    1,
+                    null,
+                    context))
+        .hasMessageContaining("Required identity column is not selected")
+        .hasMessageContaining("p0");
+  }
+
+  @Test
+  void testSelectionSetValidation() {
+    assertThatThrownBy(
+            () ->
+                executor.queryDocs(
+                    1,
+                    ImmutableList.of(
+                        datastore()
+                            .queryBuilder()
+                            .select()
+                            .column("key")
+                            .from(table)
+                            .build()
+                            .bind(),
+                        datastore()
+                            .queryBuilder()
+                            .select()
+                            .column("p0")
+                            .from(table)
+                            .build()
+                            .bind()),
+                    1,
+                    null,
+                    context))
+        .hasMessageContaining("Invalid sets of columns are selected by the provided queries")
+        .hasMessageContaining("key")
+        .hasMessageContaining("p0");
+  }
+
+  @Test
+  void testTableValidation() {
+    assertThatThrownBy(() -> executor.queryDocs(1, ImmutableList.of(), 1, null, context))
+        .hasMessageContaining("No tables are referenced by the provided queries");
+
+    assertThatThrownBy(
+            () ->
+                executor.queryDocs(
+                    1,
+                    ImmutableList.of(
+                        datastore().queryBuilder().select().star().from(table).build().bind(),
+                        datastore().queryBuilder().select().star().from(table2).build().bind()),
+                    1,
+                    null,
+                    context))
+        .hasMessageContaining("Too many tables are referenced by the provided queries")
+        .hasMessageContaining(table.name())
+        .hasMessageContaining(table2.name());
   }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/RawDocumentTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/RawDocumentTest.java
@@ -19,11 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import io.reactivex.rxjava3.core.Flowable;
-import io.stargate.db.PagingPosition.ResumeMode;
 import io.stargate.db.datastore.Row;
 import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -37,9 +35,8 @@ class RawDocumentTest {
   private final String id = "testId";
   private final List<String> key = ImmutableList.of("1", "2");
 
-  private final Function<ResumeMode, ByteBuffer> somePagingState =
-      resumeMode -> ByteBuffer.allocate(1);
-  @Mock private Function<ResumeMode, ByteBuffer> nullPagingState;
+  private final PagingStateSupplier somePagingState = resumeMode -> ByteBuffer.allocate(1);
+  @Mock private PagingStateSupplier nullPagingState;
   @Mock private Row row1;
   @Mock private Row row2;
   private List<Row> rows;


### PR DESCRIPTION
Contributes to #828 

-----

This PR adds support to `QueryExecutor` for running more than one query (against the same table) while merging the result sets on Document identity columns (C* primary key).

Paging state is extended to allow advancing pages in each of the underlying queries independently, as the iteration over the merged result set progresses.

This include minor changes to the handling of document pagination at the `RawDocument` level. In particular the `hasNext` flag is no longer necessary.

No functional changes are expected in the single query case.