### PR TITLE
Update openapi spec annotations for specific return types rather than generic responsewrapper

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/CollectionsResource.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/CollectionsResource.java
@@ -64,11 +64,11 @@ public class CollectionsResource {
   @GET
   @ApiOperation(
       value = "List collections in namespace",
-      response = ResponseWrapper.class,
+      response = DocCollection.class,
       responseContainer = "List")
   @ApiResponses(
       value = {
-        @ApiResponse(code = 200, message = "OK", response = ResponseWrapper.class),
+        @ApiResponse(code = 200, message = "OK", response = DocCollection.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
         @ApiResponse(code = 500, message = "Internal server error", response = Error.class)
       })
@@ -233,11 +233,12 @@ public class CollectionsResource {
   @POST
   @ApiOperation(
       value = "Upgrade a collection in a namespace",
+      response = DocCollection.class,
       notes =
           "WARNING: This endpoint is expected to cause some down-time for the collection you choose.")
   @ApiResponses(
       value = {
-        @ApiResponse(code = 200, message = "OK", response = ResponseWrapper.class),
+        @ApiResponse(code = 200, message = "OK", response = DocCollection.class),
         @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
         @ApiResponse(code = 404, message = "Collection not found", response = Error.class),

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/JsonSchemaResource.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/JsonSchemaResource.java
@@ -37,10 +37,11 @@ public class JsonSchemaResource {
   @ManagedAsync
   @ApiOperation(
       value =
-          "Assign a JSON schema to a collection. This will erase any schema that already exists.")
+          "Assign a JSON schema to a collection. This will erase any schema that already exists.",
+      response = JsonSchemaResponse.class)
   @ApiResponses(
       value = {
-        @ApiResponse(code = 200, message = "OK"),
+        @ApiResponse(code = 200, message = "OK", response = JsonSchemaResponse.class),
         @ApiResponse(code = 400, message = "Bad request", response = Error.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
         @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
@@ -85,10 +86,10 @@ public class JsonSchemaResource {
 
   @GET
   @ManagedAsync
-  @ApiOperation(value = "Get a JSON schema from a collection")
+  @ApiOperation(value = "Get a JSON schema from a collection", response = JsonSchemaResponse.class)
   @ApiResponses(
       value = {
-        @ApiResponse(code = 200, message = "OK"),
+        @ApiResponse(code = 200, message = "OK", response = JsonSchemaResponse.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
         @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
         @ApiResponse(code = 404, message = "Not found", response = Error.class),

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/NamespacesResource.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/NamespacesResource.java
@@ -72,11 +72,11 @@ public class NamespacesResource {
   @ApiOperation(
       value = "Get all namespaces",
       notes = "Retrieve all available namespaces.",
-      response = ResponseWrapper.class,
+      response = Keyspace.class,
       responseContainer = "List")
   @ApiResponses(
       value = {
-        @ApiResponse(code = 200, message = "OK", response = ResponseWrapper.class),
+        @ApiResponse(code = 200, message = "OK", response = Keyspace.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
         @ApiResponse(code = 500, message = "Internal server error", response = Error.class)
       })

--- a/restapi/src/main/java/io/stargate/web/resources/ColumnResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/ColumnResource.java
@@ -218,10 +218,11 @@ public class ColumnResource {
   @GET
   @ApiOperation(
       value = "Retrieve a column",
-      notes = "Return a single column specification in a specific table.")
+      notes = "Return a single column specification in a specific table.",
+      response = ColumnDefinition.class)
   @ApiResponses(
       value = {
-        @ApiResponse(code = 200, message = "OK"),
+        @ApiResponse(code = 200, message = "OK", response = ColumnDefinition.class),
         @ApiResponse(code = 400, message = "Bad request", response = Error.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
         @ApiResponse(code = 403, message = "Forbidden", response = Error.class),

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/ColumnsResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/ColumnsResource.java
@@ -73,11 +73,11 @@ public class ColumnsResource {
   @ApiOperation(
       value = "Get all columns",
       notes = "Return all columns for a specified table.",
-      response = ResponseWrapper.class,
+      response = ColumnDefinition.class,
       responseContainer = "List")
   @ApiResponses(
       value = {
-        @ApiResponse(code = 200, message = "OK", response = ResponseWrapper.class),
+        @ApiResponse(code = 200, message = "OK", response = ColumnDefinition.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
         @ApiResponse(code = 404, message = "Not Found", response = Error.class),
         @ApiResponse(code = 500, message = "Internal server error", response = Error.class)

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/KeyspacesResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/KeyspacesResource.java
@@ -72,11 +72,11 @@ public class KeyspacesResource {
   @ApiOperation(
       value = "Get all keyspaces",
       notes = "Retrieve all available keyspaces.",
-      response = ResponseWrapper.class,
+      response = Keyspace.class,
       responseContainer = "List")
   @ApiResponses(
       value = {
-        @ApiResponse(code = 200, message = "OK", response = ResponseWrapper.class),
+        @ApiResponse(code = 200, message = "OK", response = Keyspace.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
         @ApiResponse(code = 500, message = "Internal server error", response = Error.class)
       })

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/TablesResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/TablesResource.java
@@ -83,11 +83,11 @@ public class TablesResource {
   @ApiOperation(
       value = "Get all tables",
       notes = "Retrieve all tables in a specific keyspace.",
-      response = ResponseWrapper.class,
+      response = TableResponse.class,
       responseContainer = "List")
   @ApiResponses(
       value = {
-        @ApiResponse(code = 200, message = "OK", response = ResponseWrapper.class),
+        @ApiResponse(code = 200, message = "OK", response = TableResponse.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
         @ApiResponse(code = 404, message = "Not Found", response = Error.class),
         @ApiResponse(code = 500, message = "Internal server error", response = Error.class)

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/UserDefinedTypesResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/UserDefinedTypesResource.java
@@ -96,11 +96,11 @@ public class UserDefinedTypesResource {
   @ApiOperation(
       value = "Get all user defined types (UDT). ",
       notes = "Retrieve all user defined types (UDT) in a specific keyspace.",
-      response = ResponseWrapper.class,
+      response = UserDefinedTypeResponse.class,
       responseContainer = "List")
   @ApiResponses(
       value = {
-        @ApiResponse(code = 200, message = "OK", response = ResponseWrapper.class),
+        @ApiResponse(code = 200, message = "OK", response = UserDefinedTypeResponse.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
         @ApiResponse(code = 404, message = "Keyspace has not been found", response = Error.class),
         @ApiResponse(code = 500, message = "Internal server error", response = Error.class)


### PR DESCRIPTION

Wherever a response entity was set to use a specific class, namely when raw=true, modify the annotations to include that class rather than ResponseWrapper so that clients can generate the same types.

Fixes #1101