### PR TITLE
Encode special characters and decode them on read

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -34,7 +34,6 @@ import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.cassandra.stargate.db.ConsistencyLevel;
 import org.slf4j.Logger;
@@ -45,7 +44,6 @@ public class DocumentDB {
   private static final List<Column> allColumns;
   private static final List<String> allColumnNames;
   private static final List<Column.ColumnType> allColumnTypes;
-  private static final Pattern UNICODE_ESCAPE_PATTERN = Pattern.compile("\\\\u");
   private static final List<String> allPathColumnNames;
   private static final List<Column.ColumnType> allPathColumnTypes;
   public static final int MAX_PAGE_SIZE = 20;
@@ -145,7 +143,7 @@ public class DocumentDB {
   }
 
   public static boolean containsIllegalSequences(String x) {
-    return x.contains("[") || UNICODE_ESCAPE_PATTERN.matcher(x).find();
+    return x.contains("[") || x.contains(".");
   }
 
   public static List<Column> allColumns() {

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -144,8 +144,11 @@ public class DocumentDB {
   }
 
   public static boolean containsIllegalSequences(String x) {
-    String replaced = x.replaceAll(DocsApiUtils.ESCAPED_FORBIDDEN_CHAR_PATTERN.pattern(), "");
-    return replaced.contains("[") || replaced.contains(".") || replaced.contains("'");
+    String replaced = x.replaceAll(DocsApiUtils.ESCAPED_PATTERN.pattern(), "");
+    return replaced.contains("[")
+        || replaced.contains(".")
+        || replaced.contains("'")
+        || replaced.contains("\\");
   }
 
   public static List<Column> allColumns() {

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -30,7 +30,6 @@ import io.stargate.web.docsapi.service.ExecutionContext;
 import io.stargate.web.docsapi.service.QueryExecutor;
 import io.stargate.web.docsapi.service.RawDocument;
 import io.stargate.web.docsapi.service.json.DeadLeaf;
-import io.stargate.web.docsapi.service.util.DocsApiUtils;
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -141,14 +140,6 @@ public class DocumentDB {
 
   public boolean treatBooleansAsNumeric() {
     return !dataStore.supportsSecondaryIndex();
-  }
-
-  public static boolean containsIllegalSequences(String x) {
-    String replaced = x.replaceAll(DocsApiUtils.ESCAPED_PATTERN.pattern(), "");
-    return replaced.contains("[")
-        || replaced.contains(".")
-        || replaced.contains("'")
-        || replaced.contains("\\");
   }
 
   public static List<Column> allColumns() {

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -30,6 +30,7 @@ import io.stargate.web.docsapi.service.ExecutionContext;
 import io.stargate.web.docsapi.service.QueryExecutor;
 import io.stargate.web.docsapi.service.RawDocument;
 import io.stargate.web.docsapi.service.json.DeadLeaf;
+import io.stargate.web.docsapi.service.util.DocsApiUtils;
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -143,7 +144,8 @@ public class DocumentDB {
   }
 
   public static boolean containsIllegalSequences(String x) {
-    return x.contains("[") || x.contains(".") || x.contains("'");
+    String replaced = x.replaceAll(DocsApiUtils.ESCAPED_FORBIDDEN_CHAR_PATTERN.pattern(), "");
+    return replaced.contains("[") || replaced.contains(".") || replaced.contains("'");
   }
 
   public static List<Column> allColumns() {

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -2,7 +2,6 @@ package io.stargate.web.docsapi.dao;
 
 import com.datastax.oss.driver.api.core.servererrors.AlreadyExistsException;
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 import io.stargate.auth.AuthenticationSubject;
@@ -35,6 +34,7 @@ import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.cassandra.stargate.db.ConsistencyLevel;
 import org.slf4j.Logger;
@@ -42,10 +42,11 @@ import org.slf4j.LoggerFactory;
 
 public class DocumentDB {
   private static final Logger logger = LoggerFactory.getLogger(DocumentDB.class);
-  private static final List<Character> forbiddenCharacters;
   private static final List<Column> allColumns;
   private static final List<String> allColumnNames;
   private static final List<Column.ColumnType> allColumnTypes;
+  private static final Pattern ARRAY_INDEX_PATTERN = Pattern.compile("\\[[0-9]+\\]");
+  private static final Pattern UNICODE_ESCAPE_PATTERN = Pattern.compile("\\\\u");
   private static final List<String> allPathColumnNames;
   private static final List<Column.ColumnType> allPathColumnTypes;
   public static final int MAX_PAGE_SIZE = 20;
@@ -103,8 +104,6 @@ public class DocumentDB {
     allColumnTypes.add(Type.Boolean);
     allColumns.add(Column.create("bool_value", Type.Boolean));
 
-    forbiddenCharacters = ImmutableList.of('[', ']', ',', '.', '\'', '*');
-
     if (MAX_ARRAY_LENGTH > 1000000) {
       throw new IllegalStateException(
           "stargate.document_max_array_len cannot be greater than 1000000.");
@@ -146,20 +145,8 @@ public class DocumentDB {
     return !dataStore.supportsSecondaryIndex();
   }
 
-  public static List<String> getForbiddenCharactersMessage() {
-    return forbiddenCharacters.stream().map(ch -> "`" + ch + "`").collect(Collectors.toList());
-  }
-
-  public static boolean containsIllegalChars(String x) {
-    return forbiddenCharacters.stream().anyMatch(ch -> x.indexOf(ch) >= 0);
-  }
-
-  public static String replaceIllegalChars(String x) {
-    String newStr = x;
-    for (Character y : forbiddenCharacters) {
-      newStr = newStr.replace(y, '_');
-    }
-    return newStr;
+  public static boolean containsIllegalSequences(String x) {
+    return ARRAY_INDEX_PATTERN.matcher(x).matches() || UNICODE_ESCAPE_PATTERN.matcher(x).matches();
   }
 
   public static List<Column> allColumns() {

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -45,7 +45,6 @@ public class DocumentDB {
   private static final List<Column> allColumns;
   private static final List<String> allColumnNames;
   private static final List<Column.ColumnType> allColumnTypes;
-  private static final Pattern ARRAY_INDEX_PATTERN = Pattern.compile("\\[[0-9]+\\]");
   private static final Pattern UNICODE_ESCAPE_PATTERN = Pattern.compile("\\\\u");
   private static final List<String> allPathColumnNames;
   private static final List<Column.ColumnType> allPathColumnTypes;
@@ -146,7 +145,7 @@ public class DocumentDB {
   }
 
   public static boolean containsIllegalSequences(String x) {
-    return ARRAY_INDEX_PATTERN.matcher(x).matches() || UNICODE_ESCAPE_PATTERN.matcher(x).matches();
+    return x.contains("[") || UNICODE_ESCAPE_PATTERN.matcher(x).find();
   }
 
   public static List<Column> allColumns() {

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -143,7 +143,7 @@ public class DocumentDB {
   }
 
   public static boolean containsIllegalSequences(String x) {
-    return x.contains("[") || x.contains(".");
+    return x.contains("[") || x.contains(".") || x.contains("'");
   }
 
   public static List<Column> allColumns() {

--- a/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
@@ -49,7 +49,7 @@ public enum ErrorCode {
 
   DOCS_API_GENERAL_INVALID_FIELD_NAME(
       Response.Status.BAD_REQUEST,
-      String.format("Array paths with brackets are not permitted in JSON field names.")),
+      "Array paths with brackets are not permitted in JSON field names."),
 
   DOCS_API_GENERAL_PAGE_SIZE_EXCEEDED(
       Response.Status.BAD_REQUEST,

--- a/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
@@ -16,7 +16,6 @@
 
 package io.stargate.web.docsapi.exception;
 
-import io.stargate.web.docsapi.dao.DocumentDB;
 import io.stargate.web.docsapi.service.DocsApiConfiguration;
 import io.stargate.web.models.Error;
 import javax.ws.rs.core.MediaType;
@@ -50,9 +49,7 @@ public enum ErrorCode {
 
   DOCS_API_GENERAL_INVALID_FIELD_NAME(
       Response.Status.BAD_REQUEST,
-      String.format(
-          "The characters %s are not permitted in JSON field names.",
-          DocumentDB.getForbiddenCharactersMessage())),
+      String.format("Array paths with brackets are not permitted in JSON field names.")),
 
   DOCS_API_GENERAL_PAGE_SIZE_EXCEEDED(
       Response.Status.BAD_REQUEST,

--- a/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
@@ -49,7 +49,7 @@ public enum ErrorCode {
 
   DOCS_API_GENERAL_INVALID_FIELD_NAME(
       Response.Status.BAD_REQUEST,
-      "Array paths with brackets are not permitted in JSON field names."),
+      "Array paths contained in square brackets, periods, single quotes, and backslash are not allowed in field names."),
 
   DOCS_API_GENERAL_PAGE_SIZE_EXCEEDED(
       Response.Status.BAD_REQUEST,

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
@@ -91,7 +91,8 @@ public class DocumentResourceV2 {
   @ManagedAsync
   @ApiOperation(
       value = "Create a new document",
-      notes = "Auto-generates an ID for the newly created document",
+      notes =
+          "Auto-generates an ID for the newly created document. Use \\ to escape periods, commas, and asterisks.",
       code = 201)
   @ApiResponses(
       value = {

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/ReactiveDocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/ReactiveDocumentResourceV2.java
@@ -206,7 +206,7 @@ public class ReactiveDocumentResourceV2 {
       @Suspended AsyncResponse asyncResponse) {
 
     // we do search if we have conditions, or the page size is defined and we need to page through
-    // the resulsts
+    // the results
     boolean isSearch = where != null || pageSizeParam != null;
 
     // init sequence

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/ReactiveDocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/ReactiveDocumentResourceV2.java
@@ -257,8 +257,7 @@ public class ReactiveDocumentResourceV2 {
   @ManagedAsync
   @ApiOperation(
       value = "Search documents in a collection",
-      notes =
-          "Page over documents in a collection, with optional search parameters. Does not perform well for large documents.")
+      notes = "Page over documents in a collection, with optional search parameters.")
   @ApiResponses(
       value = {
         @ApiResponse(code = 200, message = "OK", response = DocumentResponseWrapper.class),

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/ReactiveDocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/ReactiveDocumentResourceV2.java
@@ -57,7 +57,8 @@ public class ReactiveDocumentResourceV2 {
       "a JSON blob with search filters;"
           + " allowed predicates: $eq, $ne, $in, $nin, $gt, $lt, $gte, $lte, $exists;"
           + " allowed boolean operators: $and, $or, $not;"
-          + " allowed hints: $selectivity (a number between 0.0 and 1.0, less is better)";
+          + " allowed hints: $selectivity (a number between 0.0 and 1.0, less is better);"
+          + " Use \\ to escape periods, commas, and asterisks.";
 
   @Inject private Db dbFactory;
   @Inject private ReactiveDocumentService reactiveDocumentService;
@@ -176,7 +177,10 @@ public class ReactiveDocumentResourceV2 {
           String collection,
       @ApiParam(value = "the name of the document", required = true) @PathParam("document-id")
           String id,
-      @ApiParam(value = "the path in the JSON that you want to retrieve", required = true)
+      @ApiParam(
+              value =
+                  "the path in the JSON that you want to retrieve. Use \\ to escape periods, commas, and asterisks.",
+              required = true)
           @PathParam("document-path")
           List<PathSegment> path,
       @ApiParam(value = WHERE_DESCRIPTION) @QueryParam("where") String where,

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
 
 public class DocumentService {
   private static final Logger logger = LoggerFactory.getLogger(DocumentService.class);
-  private static final Pattern PERIOD_PATTERN = Pattern.compile("\\.");
+  private static final Pattern PERIOD_PATTERN = Pattern.compile("(?<!\\\\)\\.");
   private static final Splitter FORM_SPLITTER = Splitter.on('&');
   private static final Splitter PAIR_SPLITTER = Splitter.on('=');
 
@@ -164,7 +164,7 @@ public class DocumentService {
 
                     // pv always starts with a square brace because of the above conversion
                     String innerPath =
-                        DocsApiUtils.convertUnicodeCodePoints(pv.substring(1, pv.length() - 1));
+                        DocsApiUtils.convertEscapedCharacters(pv.substring(1, pv.length() - 1));
                     boolean isArrayElement = op.getType() == PathOperator.Type.ARRAY;
                     if (isArrayElement) {
                       if (i == path.size() && patching) {

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -128,11 +128,11 @@ public class DocumentService {
               "$..*",
               (v, parsingContext) -> {
                 String fieldName = parsingContext.getCurrentFieldName();
-                if (fieldName != null && DocumentDB.containsIllegalChars(fieldName)) {
+                if (fieldName != null && DocumentDB.containsIllegalSequences(fieldName)) {
                   String msg =
                       String.format(
-                          "The characters %s are not permitted in JSON field names, invalid field %s.",
-                          DocumentDB.getForbiddenCharactersMessage(), fieldName);
+                          "Array paths contained in square brackets and literal unicode escape sequences are not allowed in field names, invalid field %s.",
+                          fieldName);
                   throw new ErrorCodeRuntimeException(
                       ErrorCode.DOCS_API_GENERAL_INVALID_FIELD_NAME, msg);
                 }
@@ -279,20 +279,12 @@ public class DocumentService {
       for (int i = 0; i < fieldNames.length; i++) {
         String fieldName = fieldNames[i];
         boolean isArrayElement = fieldName.startsWith("[") && fieldName.endsWith("]");
-        if (!isArrayElement) {
-          // Unlike using JSON, try to allow any input by replacing illegal characters with _.
-          // Form shredding is only supposed to be used for benchmarking tests.
-          fieldName = DocumentDB.replaceIllegalChars(fieldName);
-        }
         if (isArrayElement) {
           if (i == 0 && patching) {
             throw new ErrorCodeRuntimeException(ErrorCode.DOCS_API_PATCH_ARRAY_NOT_ACCEPTED);
           }
 
           String innerPath = fieldName.substring(1, fieldName.length() - 1);
-          // Unlike using JSON, try to allow any input by replacing illegal characters with _.
-          // Form shredding is only supposed to be used for benchmarking tests.
-          innerPath = DocumentDB.replaceIllegalChars(innerPath);
 
           int idx = 0;
           try {

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -131,7 +131,7 @@ public class DocumentService {
                 if (fieldName != null && DocumentDB.containsIllegalSequences(fieldName)) {
                   String msg =
                       String.format(
-                          "Array paths contained in square brackets and periods are not allowed in field names, invalid field %s.",
+                          "Array paths contained in square brackets, periods, and single quotes are not allowed in field names, invalid field %s. Hint: Use unicode escape sequences to encode these characters.",
                           fieldName);
                   throw new ErrorCodeRuntimeException(
                       ErrorCode.DOCS_API_GENERAL_INVALID_FIELD_NAME, msg);
@@ -163,7 +163,8 @@ public class DocumentService {
                     if (pv.equals("$")) continue;
 
                     // pv always starts with a square brace because of the above conversion
-                    String innerPath = pv.substring(1, pv.length() - 1);
+                    String innerPath =
+                        DocsApiUtils.convertUnicodeCodePoints(pv.substring(1, pv.length() - 1));
                     boolean isArrayElement = op.getType() == PathOperator.Type.ARRAY;
                     if (isArrayElement) {
                       if (i == path.size() && patching) {

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -131,7 +131,7 @@ public class DocumentService {
                 if (fieldName != null && DocumentDB.containsIllegalSequences(fieldName)) {
                   String msg =
                       String.format(
-                          "Array paths contained in square brackets and literal unicode escape sequences are not allowed in field names, invalid field %s.",
+                          "Array paths contained in square brackets and periods are not allowed in field names, invalid field %s.",
                           fieldName);
                   throw new ErrorCodeRuntimeException(
                       ErrorCode.DOCS_API_GENERAL_INVALID_FIELD_NAME, msg);

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -236,6 +236,7 @@ public class DocumentService {
       if (e instanceof ErrorCodeRuntimeException) {
         throw e;
       }
+      logger.error("Error occurred during JSON read", e);
       throw new ErrorCodeRuntimeException(
           ErrorCode.DOCS_API_INVALID_JSON_VALUE, "Malformed JSON object found during read.", e);
     }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -126,7 +126,7 @@ public class DocumentService {
               "$..*",
               (v, parsingContext) -> {
                 String fieldName = parsingContext.getCurrentFieldName();
-                if (fieldName != null && DocumentDB.containsIllegalSequences(fieldName)) {
+                if (fieldName != null && DocsApiUtils.containsIllegalSequences(fieldName)) {
                   String msg =
                       String.format(
                           "Array paths contained in square brackets, periods, single quotes, and backslash are not allowed in field names, invalid field %s",

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
@@ -491,7 +491,7 @@ public class ReactiveDocumentService {
   // we need to transform the stuff to support array elements
   private List<String> processSubDocumentPath(List<String> subDocumentPath) {
     return subDocumentPath.stream()
-        .map(path -> DocsApiUtils.convertEscapedCharacters(DocsApiUtils.convertArrayPath(path)))
+        .map(path -> DocsApiUtils.convertArrayPath(path))
         .collect(Collectors.toList());
   }
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
@@ -298,7 +298,7 @@ public class ReactiveDocumentService {
                                   p ->
                                       DocsApiUtils.extractArrayPathIndex(p)
                                           .map(Object::toString)
-                                          .orElse(p))
+                                          .orElse(DocsApiUtils.convertEscapedCharacters(p)))
                               .collect(Collectors.joining("/", "/", ""));
 
                       // find and return empty if missing

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
@@ -491,7 +491,7 @@ public class ReactiveDocumentService {
   // we need to transform the stuff to support array elements
   private List<String> processSubDocumentPath(List<String> subDocumentPath) {
     return subDocumentPath.stream()
-        .map(path -> DocsApiUtils.convertUnicodeCodePoints(DocsApiUtils.convertArrayPath(path)))
+        .map(path -> DocsApiUtils.convertEscapedCharacters(DocsApiUtils.convertArrayPath(path)))
         .collect(Collectors.toList());
   }
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
@@ -490,9 +490,8 @@ public class ReactiveDocumentService {
 
   // we need to transform the stuff to support array elements
   private List<String> processSubDocumentPath(List<String> subDocumentPath) {
-    // TODO after https://github.com/stargate/stargate/pull/1105 encode chars as well
     return subDocumentPath.stream()
-        .map(path -> DocsApiUtils.convertArrayPath(path))
+        .map(path -> DocsApiUtils.convertUnicodeCodePoints(DocsApiUtils.convertArrayPath(path)))
         .collect(Collectors.toList());
   }
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/ExpressionParser.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/ExpressionParser.java
@@ -294,11 +294,11 @@ public class ExpressionParser {
   }
 
   /**
-   * Resolves the collection/document prepended path and the filed path as specified in the filter
+   * Resolves the collection/document prepended path and the field path as specified in the filter
    * query.
    *
    * @param prependedPath Given collection or document path segments
-   * @param fieldPath filed path given in the filter query, expects dot notation, f.e. <code>
+   * @param fieldPath field path given in the filter query, expects dot notation, f.e. <code>
    *     car.name</code>
    * @return FilterPath
    */
@@ -307,11 +307,18 @@ public class ExpressionParser {
     List<String> convertedFieldNamePath =
         Arrays.stream(fieldNamePath)
             .map(DocsApiUtils::convertArrayPath)
+            .map(DocsApiUtils::convertUnicodeCodePoints)
             .collect(Collectors.toList());
 
     if (!prependedPath.isEmpty()) {
       List<String> prependedConverted =
-          prependedPath.stream().map(DocsApiUtils::convertArrayPath).collect(Collectors.toList());
+          prependedPath.stream()
+              .map(
+                  pathSeg -> {
+                    return DocsApiUtils.convertUnicodeCodePoints(
+                        DocsApiUtils.convertArrayPath(path));
+                  })
+              .collect(Collectors.toList());
 
       convertedFieldNamePath.addAll(0, prependedConverted);
     }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/ExpressionParser.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/ExpressionParser.java
@@ -41,7 +41,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -53,8 +52,6 @@ public class ExpressionParser {
   private static final String OR_OPERATOR = "$or";
 
   private static final String AND_OPERATOR = "$and";
-
-  private static final Pattern PERIOD_PATTERN = Pattern.compile("\\.");
 
   private final ConditionParser conditionParser;
 
@@ -303,7 +300,7 @@ public class ExpressionParser {
    * @return FilterPath
    */
   private FilterPath getFilterPath(List<String> prependedPath, String fieldPath) {
-    String[] fieldNamePath = PERIOD_PATTERN.split(fieldPath);
+    String[] fieldNamePath = DocsApiUtils.PERIOD_PATTERN.split(fieldPath);
     List<String> convertedFieldNamePath =
         Arrays.stream(fieldNamePath)
             .map(DocsApiUtils::convertArrayPath)

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/ExpressionParser.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/ExpressionParser.java
@@ -314,10 +314,8 @@ public class ExpressionParser {
       List<String> prependedConverted =
           prependedPath.stream()
               .map(
-                  pathSeg -> {
-                    return DocsApiUtils.convertUnicodeCodePoints(
-                        DocsApiUtils.convertArrayPath(path));
-                  })
+                  path ->
+                      DocsApiUtils.convertUnicodeCodePoints(DocsApiUtils.convertArrayPath(path)))
               .collect(Collectors.toList());
 
       convertedFieldNamePath.addAll(0, prependedConverted);

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/ExpressionParser.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/ExpressionParser.java
@@ -307,7 +307,7 @@ public class ExpressionParser {
     List<String> convertedFieldNamePath =
         Arrays.stream(fieldNamePath)
             .map(DocsApiUtils::convertArrayPath)
-            .map(DocsApiUtils::convertUnicodeCodePoints)
+            .map(DocsApiUtils::convertEscapedCharacters)
             .collect(Collectors.toList());
 
     if (!prependedPath.isEmpty()) {
@@ -315,7 +315,7 @@ public class ExpressionParser {
           prependedPath.stream()
               .map(
                   path ->
-                      DocsApiUtils.convertUnicodeCodePoints(DocsApiUtils.convertArrayPath(path)))
+                      DocsApiUtils.convertEscapedCharacters(DocsApiUtils.convertArrayPath(path)))
               .collect(Collectors.toList());
 
       convertedFieldNamePath.addAll(0, prependedConverted);

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/ExpressionParser.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/ExpressionParser.java
@@ -177,7 +177,6 @@ public class ExpressionParser {
         }
       }
     }
-
     return expressions;
   }
 
@@ -304,15 +303,12 @@ public class ExpressionParser {
     List<String> convertedFieldNamePath =
         Arrays.stream(fieldNamePath)
             .map(DocsApiUtils::convertArrayPath)
-            .map(DocsApiUtils::convertEscapedCharacters)
             .collect(Collectors.toList());
 
     if (!prependedPath.isEmpty()) {
       List<String> prependedConverted =
           prependedPath.stream()
-              .map(
-                  path ->
-                      DocsApiUtils.convertEscapedCharacters(DocsApiUtils.convertArrayPath(path)))
+              .map(path -> DocsApiUtils.convertArrayPath(path))
               .collect(Collectors.toList());
 
       convertedFieldNamePath.addAll(0, prependedConverted);

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/db/impl/FilterPathSearchQueryBuilder.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/db/impl/FilterPathSearchQueryBuilder.java
@@ -24,6 +24,7 @@ import io.stargate.web.docsapi.exception.ErrorCode;
 import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
 import io.stargate.web.docsapi.service.query.FilterPath;
 import io.stargate.web.docsapi.service.query.QueryConstants;
+import io.stargate.web.docsapi.service.util.DocsApiUtils;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -76,7 +77,7 @@ public class FilterPathSearchQueryBuilder extends PathSearchQueryBuilder {
     if (parentSize >= DocumentDB.MAX_DEPTH) {
       throw new ErrorCodeRuntimeException(ErrorCode.DOCS_API_GENERAL_DEPTH_EXCEEDED);
     } else {
-      String field = filterPath.getField();
+      String field = DocsApiUtils.convertEscapedCharacters(filterPath.getField());
       if (matchField) {
         // apply to both p and leaf, as index is on leaf and we want it kicking in
         return Arrays.asList(

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/db/impl/PathSearchQueryBuilder.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/db/impl/PathSearchQueryBuilder.java
@@ -29,7 +29,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * The search query builder that creates all needed predicates for a path represented as a list of
@@ -42,12 +41,6 @@ public class PathSearchQueryBuilder extends AbstractSearchQueryBuilder {
   /** @param path Path to match. */
   public PathSearchQueryBuilder(List<String> path) {
     this.path = path;
-  }
-
-  private List<String> unescape(List<String> escaped) {
-    return escaped.stream()
-        .map(DocsApiUtils::convertEscapedCharacters)
-        .collect(Collectors.toList());
   }
 
   @Override
@@ -91,7 +84,7 @@ public class PathSearchQueryBuilder extends AbstractSearchQueryBuilder {
             BuiltCondition.of(
                 QueryConstants.P_COLUMN_NAME.apply(i),
                 Predicate.IN,
-                unescape(Arrays.asList(pathSegmentSplit))));
+                DocsApiUtils.convertEscapedCharacters(Arrays.asList(pathSegmentSplit))));
       }
     }
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/db/impl/PathSearchQueryBuilder.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/db/impl/PathSearchQueryBuilder.java
@@ -81,7 +81,10 @@ public class PathSearchQueryBuilder extends AbstractSearchQueryBuilder {
               BuiltCondition.of(QueryConstants.P_COLUMN_NAME.apply(i), Predicate.GT, ""));
         } else {
           predicates.add(
-              BuiltCondition.of(QueryConstants.P_COLUMN_NAME.apply(i), Predicate.EQ, pathSegment));
+              BuiltCondition.of(
+                  QueryConstants.P_COLUMN_NAME.apply(i),
+                  Predicate.EQ,
+                  DocsApiUtils.convertEscapedCharacters(pathSegment)));
         }
       } else {
         predicates.add(

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/BaseResolver.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/BaseResolver.java
@@ -52,7 +52,6 @@ public final class BaseResolver {
    */
   public static DocumentsResolver resolve(
       Expression<FilterExpression> expression, ExecutionContext context, DocumentsResolver parent) {
-
     // if we are hitting the literal TRUE, then return parent
     if (Literal.EXPR_TYPE.equals(expression.getExprType())) {
       return parent;

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/util/DocsApiUtils.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/util/DocsApiUtils.java
@@ -35,12 +35,10 @@ import org.apache.commons.lang3.StringUtils;
 
 public final class DocsApiUtils {
 
-  private static final Pattern PERIOD_PATTERN = Pattern.compile("(?<!\\\\)\\.");
+  public static final Pattern PERIOD_PATTERN = Pattern.compile("(?<!\\\\)\\.");
   private static final Pattern ARRAY_PATH_PATTERN = Pattern.compile("\\[.*\\]");
-  public static final Pattern ESCAPED_FORBIDDEN_CHAR_PATTERN =
-      Pattern.compile("(\\\\'|\\\\\\.|\\\\\\[|\\\\\\]|\\\\\\\\)");
-  public static final Pattern ESCAPED_FORBIDDEN_CHAR_PATTERN_INTERNAL_CAPTURE =
-      Pattern.compile("\\\\(\\.|'|\\]|\\[|\\\\)");
+  public static final Pattern ESCAPED_PATTERN = Pattern.compile("(\\\\,|\\\\\\.|\\\\\\*)");
+  public static final Pattern ESCAPED_PATTERN_INTERNAL_CAPTURE = Pattern.compile("\\\\(\\.|\\*|,)");
 
   private DocsApiUtils() {}
 
@@ -68,16 +66,16 @@ public final class DocsApiUtils {
   }
 
   /**
-   * Converts any of the valid escape sequences (for periods, square braces, and single quotes) into
-   * their actual character. E.g. if the input string is literally abc\.123, this function returns
-   * abc.123 This allows a user to use escape sequences in where filters and when writing documents
-   * when it would otherwise be ambiguous to use the corresponding character.
+   * Converts any of the valid escape sequences (for periods, commas, and asterisks) into their
+   * actual character. E.g. if the input string is literally abc\.123, this function returns abc.123
+   * This allows a user to use escape sequences in where filters and when writing documents when it
+   * would otherwise be ambiguous to use the corresponding character.
    *
    * @param path single filter or field path
    * @return Converted to a string with no literal unicode code points.
    */
   public static String convertEscapedCharacters(String path) {
-    return path.replaceAll(ESCAPED_FORBIDDEN_CHAR_PATTERN_INTERNAL_CAPTURE.pattern(), "$1");
+    return path.replaceAll(ESCAPED_PATTERN_INTERNAL_CAPTURE.pattern(), "$1");
   }
 
   private static String convertSingleArrayPath(String path) {

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/util/DocsApiUtils.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/util/DocsApiUtils.java
@@ -38,6 +38,7 @@ public final class DocsApiUtils {
   private static final Pattern PERIOD_PATTERN = Pattern.compile("\\.");
 
   private static final Pattern ARRAY_PATH_PATTERN = Pattern.compile("\\[.*\\]");
+  private static final Pattern UNICODE_POINT_PATTERN = Pattern.compile("[0-9a-fA-F]{4}");
 
   private DocsApiUtils() {}
 
@@ -62,6 +63,37 @@ public final class DocsApiUtils {
     } else {
       return convertSingleArrayPath(path);
     }
+  }
+
+  /**
+   * Converts any literal unicode points into their actual character. E.g. if the input string is
+   * literally abc\u002E123, this function returns abc.123 This allows a user to use unicode escape
+   * sequence in where filters when it would otherwise be ambiguous to use the corresponding
+   * character. Any path that already has square brackets in it will be left alone.
+   *
+   * @param path single filter or field path
+   * @return Converted to a string with no literal unicode code points.
+   */
+  public static String convertUnicodeCodePoints(String path) {
+    if (ARRAY_PATH_PATTERN.matcher(path).matches()) {
+      return path;
+    }
+
+    String[] segments = path.split("\\\\u");
+    for (int i = 1; i < segments.length; i++) {
+      String segment = segments[i];
+      if (segment.length() >= 4
+          && UNICODE_POINT_PATTERN.matcher(segment.substring(0, 4)).matches()) {
+        String unicodePoint = segment.substring(0, 4);
+        String rest = segment.substring(4);
+        int value = Integer.parseInt(unicodePoint, 16);
+        char[] ch = Character.toChars(value);
+        segments[i] = String.valueOf(ch) + rest;
+      } else {
+        segments[i] = "\\u" + segments[i];
+      }
+    }
+    return String.join("", segments);
   }
 
   private static String convertSingleArrayPath(String path) {
@@ -132,6 +164,7 @@ public final class DocsApiUtils {
       List<String> fieldPath =
           Arrays.stream(fieldValue.split("\\."))
               .map(DocsApiUtils::convertArrayPath)
+              .map(DocsApiUtils::convertUnicodeCodePoints)
               .collect(Collectors.toList());
 
       results.add(fieldPath);

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/util/DocsApiUtils.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/util/DocsApiUtils.java
@@ -312,6 +312,7 @@ public final class DocsApiUtils {
 
       boolean pathSegment = target.contains(",");
       // if we have the path segment, we need to check if any matches
+
       if (pathSegment) {
         boolean noneMatch =
             Arrays.stream(target.split(COMMA_PATTERN.pattern()))

--- a/restapi/src/test/java/io/stargate/web/docsapi/dao/DocumentDBTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/dao/DocumentDBTest.java
@@ -84,6 +84,10 @@ public class DocumentDBTest {
     assertThat(DocumentDB.containsIllegalSequences("[aaa")).isTrue();
     assertThat(DocumentDB.containsIllegalSequences("aaa]")).isFalse();
     assertThat(DocumentDB.containsIllegalSequences("a.2000")).isTrue();
+    assertThat(DocumentDB.containsIllegalSequences("a\\.2000")).isFalse();
+    assertThat(DocumentDB.containsIllegalSequences("a\\[2000")).isFalse();
+    assertThat(DocumentDB.containsIllegalSequences("a\\'2000")).isFalse();
+    assertThat(DocumentDB.containsIllegalSequences("a\\'2000.")).isTrue();
   }
 
   @Test

--- a/restapi/src/test/java/io/stargate/web/docsapi/dao/DocumentDBTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/dao/DocumentDBTest.java
@@ -76,21 +76,10 @@ public class DocumentDBTest {
   }
 
   @Test
-  public void getForbiddenCharactersMessage() {
-    List<String> res = DocumentDB.getForbiddenCharactersMessage();
-    assertThat(res).isEqualTo(ImmutableList.of("`[`", "`]`", "`,`", "`.`", "`\'`", "`*`"));
-  }
-
-  @Test
-  public void containsIllegalChars() {
-    assertThat(DocumentDB.containsIllegalChars("[")).isTrue();
-    assertThat(DocumentDB.containsIllegalChars("]")).isTrue();
-    assertThat(DocumentDB.containsIllegalChars(",")).isTrue();
-    assertThat(DocumentDB.containsIllegalChars(".")).isTrue();
-    assertThat(DocumentDB.containsIllegalChars("\'")).isTrue();
-    assertThat(DocumentDB.containsIllegalChars("*")).isTrue();
-    assertThat(DocumentDB.containsIllegalChars("a[b")).isTrue();
-    assertThat(DocumentDB.containsIllegalChars("\"")).isFalse();
+  public void containsIllegalSequences() {
+    assertThat(DocumentDB.containsIllegalSequences("[012]")).isTrue();
+    assertThat(DocumentDB.containsIllegalSequences("]012[")).isFalse();
+    assertThat(DocumentDB.containsIllegalSequences("[aaa]")).isFalse();
   }
 
   @Test

--- a/restapi/src/test/java/io/stargate/web/docsapi/dao/DocumentDBTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/dao/DocumentDBTest.java
@@ -85,9 +85,7 @@ public class DocumentDBTest {
     assertThat(DocumentDB.containsIllegalSequences("aaa]")).isFalse();
     assertThat(DocumentDB.containsIllegalSequences("a.2000")).isTrue();
     assertThat(DocumentDB.containsIllegalSequences("a\\.2000")).isFalse();
-    assertThat(DocumentDB.containsIllegalSequences("a\\[2000")).isFalse();
-    assertThat(DocumentDB.containsIllegalSequences("a\\'2000")).isFalse();
-    assertThat(DocumentDB.containsIllegalSequences("a\\'2000.")).isTrue();
+    assertThat(DocumentDB.containsIllegalSequences("a'2000")).isTrue();
   }
 
   @Test

--- a/restapi/src/test/java/io/stargate/web/docsapi/dao/DocumentDBTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/dao/DocumentDBTest.java
@@ -83,7 +83,7 @@ public class DocumentDBTest {
     assertThat(DocumentDB.containsIllegalSequences("[aaa]")).isTrue();
     assertThat(DocumentDB.containsIllegalSequences("[aaa")).isTrue();
     assertThat(DocumentDB.containsIllegalSequences("aaa]")).isFalse();
-    assertThat(DocumentDB.containsIllegalSequences("a\\u2000")).isTrue();
+    assertThat(DocumentDB.containsIllegalSequences("a.2000")).isTrue();
   }
 
   @Test

--- a/restapi/src/test/java/io/stargate/web/docsapi/dao/DocumentDBTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/dao/DocumentDBTest.java
@@ -78,8 +78,12 @@ public class DocumentDBTest {
   @Test
   public void containsIllegalSequences() {
     assertThat(DocumentDB.containsIllegalSequences("[012]")).isTrue();
-    assertThat(DocumentDB.containsIllegalSequences("]012[")).isFalse();
-    assertThat(DocumentDB.containsIllegalSequences("[aaa]")).isFalse();
+    assertThat(DocumentDB.containsIllegalSequences("aaa[012]")).isTrue();
+    assertThat(DocumentDB.containsIllegalSequences("]012[")).isTrue();
+    assertThat(DocumentDB.containsIllegalSequences("[aaa]")).isTrue();
+    assertThat(DocumentDB.containsIllegalSequences("[aaa")).isTrue();
+    assertThat(DocumentDB.containsIllegalSequences("aaa]")).isFalse();
+    assertThat(DocumentDB.containsIllegalSequences("a\\u2000")).isTrue();
   }
 
   @Test

--- a/restapi/src/test/java/io/stargate/web/docsapi/dao/DocumentDBTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/dao/DocumentDBTest.java
@@ -76,19 +76,6 @@ public class DocumentDBTest {
   }
 
   @Test
-  public void containsIllegalSequences() {
-    assertThat(DocumentDB.containsIllegalSequences("[012]")).isTrue();
-    assertThat(DocumentDB.containsIllegalSequences("aaa[012]")).isTrue();
-    assertThat(DocumentDB.containsIllegalSequences("]012[")).isTrue();
-    assertThat(DocumentDB.containsIllegalSequences("[aaa]")).isTrue();
-    assertThat(DocumentDB.containsIllegalSequences("[aaa")).isTrue();
-    assertThat(DocumentDB.containsIllegalSequences("aaa]")).isFalse();
-    assertThat(DocumentDB.containsIllegalSequences("a.2000")).isTrue();
-    assertThat(DocumentDB.containsIllegalSequences("a\\.2000")).isFalse();
-    assertThat(DocumentDB.containsIllegalSequences("a'2000")).isTrue();
-  }
-
-  @Test
   public void getInsertStatement() {
     Object[] values = new Object[DocumentDB.allColumns().size()];
     int idx = 0;

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/util/DocsApiUtilsTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/util/DocsApiUtilsTest.java
@@ -130,6 +130,40 @@ class DocsApiUtilsTest {
   }
 
   @Nested
+  class ConvertUnicodeCodePoints {
+
+    @Test
+    public void happyPath() {
+      String result = DocsApiUtils.convertUnicodeCodePoints("\\u002E is a period");
+
+      assertThat(result).isEqualTo(". is a period");
+
+      result =
+          DocsApiUtils.convertUnicodeCodePoints("I can represent braces too: \\u005b000\\u005d");
+      assertThat(result).isEqualTo("I can represent braces too: [000]");
+
+      result =
+          DocsApiUtils.convertUnicodeCodePoints(
+              "\\u but without valid code points after are ignored: \\ufg00");
+      assertThat(result).isEqualTo("\\u but without valid code points after are ignored: \\ufg00");
+    }
+
+    @Test
+    public void arraySegmentsIgnored() {
+      String result = DocsApiUtils.convertUnicodeCodePoints("[1],[44],[555]");
+
+      assertThat(result).isEqualTo("[1],[44],[555]");
+    }
+
+    @Test
+    public void globIgnored() {
+      String result = DocsApiUtils.convertUnicodeCodePoints("[*]");
+
+      assertThat(result).isEqualTo("[*]");
+    }
+  }
+
+  @Nested
   class ConvertFieldsToPaths {
 
     ObjectMapper objectMapper = new ObjectMapper();

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/util/DocsApiUtilsTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/util/DocsApiUtilsTest.java
@@ -147,20 +147,6 @@ class DocsApiUtilsTest {
               "\\u but without valid code points after are ignored: \\ufg00");
       assertThat(result).isEqualTo("\\u but without valid code points after are ignored: \\ufg00");
     }
-
-    @Test
-    public void arraySegmentsIgnored() {
-      String result = DocsApiUtils.convertUnicodeCodePoints("[1],[44],[555]");
-
-      assertThat(result).isEqualTo("[1],[44],[555]");
-    }
-
-    @Test
-    public void globIgnored() {
-      String result = DocsApiUtils.convertUnicodeCodePoints("[*]");
-
-      assertThat(result).isEqualTo("[*]");
-    }
   }
 
   @Nested

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/util/DocsApiUtilsTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/util/DocsApiUtilsTest.java
@@ -134,18 +134,20 @@ class DocsApiUtilsTest {
 
     @Test
     public void happyPath() {
-      String result = DocsApiUtils.convertUnicodeCodePoints("\\u002E is a period");
+      String result = DocsApiUtils.convertEscapedCharacters("\\. is a period");
 
       assertThat(result).isEqualTo(". is a period");
 
-      result =
-          DocsApiUtils.convertUnicodeCodePoints("I can represent braces too: \\u005b000\\u005d");
+      result = DocsApiUtils.convertEscapedCharacters("I can represent braces too: \\[000\\]");
       assertThat(result).isEqualTo("I can represent braces too: [000]");
 
+      result = DocsApiUtils.convertEscapedCharacters("I can represent backslashes too: \\\\");
+      assertThat(result).isEqualTo("I can represent backslashes too: \\");
+
       result =
-          DocsApiUtils.convertUnicodeCodePoints(
-              "\\u but without valid code points after are ignored: \\ufg00");
-      assertThat(result).isEqualTo("\\u but without valid code points after are ignored: \\ufg00");
+          DocsApiUtils.convertEscapedCharacters(
+              "\\ but without valid chars after are ignored: \\a");
+      assertThat(result).isEqualTo("\\ but without valid chars after are ignored: \\a");
     }
   }
 

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/util/DocsApiUtilsTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/util/DocsApiUtilsTest.java
@@ -130,7 +130,7 @@ class DocsApiUtilsTest {
   }
 
   @Nested
-  class ConvertUnicodeCodePoints {
+  class ConvertEscapedCharacters {
 
     @Test
     public void happyPath() {
@@ -138,11 +138,11 @@ class DocsApiUtilsTest {
 
       assertThat(result).isEqualTo(". is a period");
 
-      result = DocsApiUtils.convertEscapedCharacters("I can represent braces too: \\[000\\]");
-      assertThat(result).isEqualTo("I can represent braces too: [000]");
+      result = DocsApiUtils.convertEscapedCharacters("I can represent asterisks too: \\*");
+      assertThat(result).isEqualTo("I can represent asterisks too: *");
 
-      result = DocsApiUtils.convertEscapedCharacters("I can represent backslashes too: \\\\");
-      assertThat(result).isEqualTo("I can represent backslashes too: \\");
+      result = DocsApiUtils.convertEscapedCharacters("I can represent commas too: \\,");
+      assertThat(result).isEqualTo("I can represent commas too: ,");
 
       result =
           DocsApiUtils.convertEscapedCharacters(

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/util/DocsApiUtilsTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/util/DocsApiUtilsTest.java
@@ -360,6 +360,27 @@ class DocsApiUtilsTest {
     }
 
     @Test
+    public void matchingSpecialCharacters() {
+      List<String> path = Arrays.asList("field\\,with", "commas\\.");
+      Row row =
+          MapBackedRow.of(
+              TABLE,
+              ImmutableMap.of(
+                  QueryConstants.LEAF_COLUMN_NAME,
+                  "commas.",
+                  QueryConstants.P_COLUMN_NAME.apply(0),
+                  "field,with",
+                  QueryConstants.P_COLUMN_NAME.apply(1),
+                  "commas.",
+                  QueryConstants.P_COLUMN_NAME.apply(2),
+                  ""));
+
+      boolean result = DocsApiUtils.isRowMatchingPath(row, path);
+
+      Assertions.assertThat(result).isTrue();
+    }
+
+    @Test
     public void notMatchingExtraDepth() {
       List<String> path = Arrays.asList("field", "value");
       Row row =
@@ -421,6 +442,23 @@ class DocsApiUtilsTest {
                   "field",
                   QueryConstants.P_COLUMN_NAME.apply(1),
                   "value"));
+
+      boolean result = DocsApiUtils.isRowOnPath(row, path);
+
+      Assertions.assertThat(result).isTrue();
+    }
+
+    @Test
+    public void matchingSpecialCharacters() {
+      List<String> path = Arrays.asList("field\\,with", "commas\\.");
+      Row row =
+          MapBackedRow.of(
+              TABLE,
+              ImmutableMap.of(
+                  QueryConstants.P_COLUMN_NAME.apply(0),
+                  "field,with",
+                  QueryConstants.P_COLUMN_NAME.apply(1),
+                  "commas."));
 
       boolean result = DocsApiUtils.isRowOnPath(row, path);
 

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -307,36 +307,36 @@ public abstract class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
 
   @Test
   public void testInvalidKeyPut() throws IOException {
-    JsonNode obj = OBJECT_MAPPER.readTree("{ \"square[]braces\": \"are not allowed\" }");
+    JsonNode obj = OBJECT_MAPPER.readTree("{ \"bracketedarraypaths[100]\": \"are not allowed\" }");
 
     String resp = RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 400);
     assertThat(resp)
         .isEqualTo(
-            "{\"description\":\"The characters [`[`, `]`, `,`, `.`, `'`, `*`] are not permitted in JSON field names, invalid field square[]braces.\",\"code\":400}");
+            "{\"description\":\"Array paths contained in square brackets and literal unicode escape sequences are not allowed in field names, invalid field bracketedarraypaths[100].\",\"code\":400}");
+  }
 
-    obj = OBJECT_MAPPER.readTree("{ \"commas,\": \"are not allowed\" }");
-    resp = RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 400);
-    assertThat(resp)
-        .isEqualTo(
-            "{\"description\":\"The characters [`[`, `]`, `,`, `.`, `'`, `*`] are not permitted in JSON field names, invalid field commas,.\",\"code\":400}");
+  @Test
+  public void testEscapableKeyPut() throws IOException {
+    JsonNode obj = OBJECT_MAPPER.readTree("{ \"square[]braces\": \"are allowed\" }");
 
-    obj = OBJECT_MAPPER.readTree("{ \"periods.\": \"are not allowed\" }");
-    resp = RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 400);
-    assertThat(resp)
-        .isEqualTo(
-            "{\"description\":\"The characters [`[`, `]`, `,`, `.`, `'`, `*`] are not permitted in JSON field names, invalid field periods..\",\"code\":400}");
+    RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);
+    String resp = RestUtils.get(authToken, collectionPath + "/1", 200);
+    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(obj);
 
-    obj = OBJECT_MAPPER.readTree("{ \"'quotes'\": \"are not allowed\" }");
-    resp = RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 400);
-    assertThat(resp)
-        .isEqualTo(
-            "{\"description\":\"The characters [`[`, `]`, `,`, `.`, `'`, `*`] are not permitted in JSON field names, invalid field 'quotes'.\",\"code\":400}");
+    obj = OBJECT_MAPPER.readTree("{ \"periods.\": \"are allowed\" }");
+    RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);
+    resp = RestUtils.get(authToken, collectionPath + "/1", 200);
+    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(obj);
 
-    obj = OBJECT_MAPPER.readTree("{ \"*asterisks*\": \"are not allowed\" }");
-    resp = RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 400);
-    assertThat(resp)
-        .isEqualTo(
-            "{\"description\":\"The characters [`[`, `]`, `,`, `.`, `'`, `*`] are not permitted in JSON field names, invalid field *asterisks*.\",\"code\":400}");
+    obj = OBJECT_MAPPER.readTree("{ \"'quotes'\": \"are allowed\" }");
+    RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);
+    resp = RestUtils.get(authToken, collectionPath + "/1", 200);
+    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(obj);
+
+    obj = OBJECT_MAPPER.readTree("{ \"*asterisks*\": \"are allowed\" }");
+    RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);
+    resp = RestUtils.get(authToken, collectionPath + "/1", 200);
+    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(obj);
 
     resp = RestUtils.put(authToken, collectionPath + "/1", "", 422);
     assertThat(resp)

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -324,26 +324,29 @@ public abstract class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
 
   @Test
   public void testEscapableKeyPut() throws IOException {
-    JsonNode obj = OBJECT_MAPPER.readTree("{ \"square[]braces\": \"are allowed\" }");
+    JsonNode obj =
+        OBJECT_MAPPER.readTree(
+            "{ \"square\\\\u005b\\\\u005dbraces\": \"are allowed if escaped\" }");
 
     RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);
-    String resp = RestUtils.get(authToken, collectionPath + "/1", 200);
-    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(obj);
+    String resp = RestUtils.get(authToken, collectionPath + "/1?raw=true", 200);
+    assertThat(OBJECT_MAPPER.readTree(resp))
+        .isEqualTo(OBJECT_MAPPER.readTree("{ \"square[]braces\": \"are allowed if escaped\" }"));
 
-    obj = OBJECT_MAPPER.readTree("{ \"periods\\u002e\": \"are allowed if escaped\" }");
+    obj = OBJECT_MAPPER.readTree("{ \"periods\\\\u002e\": \"are allowed if escaped\" }");
     RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);
-    resp = RestUtils.get(authToken, collectionPath + "/1", 200);
+    resp = RestUtils.get(authToken, collectionPath + "/1?raw=true", 200);
     assertThat(OBJECT_MAPPER.readTree(resp))
         .isEqualTo(OBJECT_MAPPER.readTree("{\"periods.\": \"are allowed if escaped\" }"));
 
-    obj = OBJECT_MAPPER.readTree("{ \"'qu''otes'\": \"are allowed\" }");
+    obj = OBJECT_MAPPER.readTree("{ \"'qu''otes'\": { \"are'\": \"allowed\" }}");
     RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);
-    resp = RestUtils.get(authToken, collectionPath + "/1", 200);
+    resp = RestUtils.get(authToken, collectionPath + "/1?raw=true", 200);
     assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(obj);
 
     obj = OBJECT_MAPPER.readTree("{ \"*aste*risks*\": \"are allowed\" }");
     RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);
-    resp = RestUtils.get(authToken, collectionPath + "/1", 200);
+    resp = RestUtils.get(authToken, collectionPath + "/1?raw=true", 200);
     assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(obj);
 
     resp = RestUtils.put(authToken, collectionPath + "/1", "", 422);
@@ -1158,14 +1161,14 @@ public abstract class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   @Test
   public void testBasicSearchUnicodeAndBrackets() throws IOException {
     JsonNode fullObj =
-        OBJECT_MAPPER.readTree("{\"a\\u002eb\":\"somedata\",\"some]data\":\"something\"}");
+        OBJECT_MAPPER.readTree("{\"a\\\\u002eb\":\"somedata\",\"some]data\":\"something\"}");
     RestUtils.put(authToken, collectionPath + "/cool-search-id", fullObj.toString(), 200);
 
     // With Unicode code point
     String r =
         RestUtils.get(
             authToken,
-            collectionPath + "/cool-search-id?where={\"a\\u002eb\": {\"$eq\": \"somedata\"}}",
+            collectionPath + "/cool-search-id?where={\"a\\\\u002eb\": {\"$eq\": \"somedata\"}}",
             200);
 
     String searchResultStr = "[{\"a.b\":\"somedata\"}]";

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -332,15 +332,14 @@ public abstract class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   @Test
   public void testEscapableKeyPut() throws IOException {
     JsonNode obj =
-        OBJECT_MAPPER.readTree(
-            "{ \"square\\\\u005b\\\\u005dbraces\": \"are allowed if escaped\" }");
+        OBJECT_MAPPER.readTree("{ \"square\\\\[\\\\]braces\": \"are allowed if escaped\" }");
 
     RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);
     String resp = RestUtils.get(authToken, collectionPath + "/1?raw=true", 200);
     assertThat(OBJECT_MAPPER.readTree(resp))
         .isEqualTo(OBJECT_MAPPER.readTree("{ \"square[]braces\": \"are allowed if escaped\" }"));
 
-    obj = OBJECT_MAPPER.readTree("{ \"periods\\\\u002e\": \"are allowed if escaped\" }");
+    obj = OBJECT_MAPPER.readTree("{ \"periods\\\\.\": \"are allowed if escaped\" }");
     RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);
     resp = RestUtils.get(authToken, collectionPath + "/1?raw=true", 200);
     assertThat(OBJECT_MAPPER.readTree(resp))
@@ -348,12 +347,19 @@ public abstract class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     obj =
         OBJECT_MAPPER.readTree(
-            "{ \"\\\\u0027qu\\\\u0027\\\\u0027otes\\\\u0027\": { \"are\\\\u0027\": \"allowed if escaped\" }}");
+            "{ \"\\\\'qu\\\\'\\\\'otes\\\\'\": { \"are\\\\'\": \"allowed if escaped\" }}");
     RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);
     resp = RestUtils.get(authToken, collectionPath + "/1?raw=true", 200);
     assertThat(OBJECT_MAPPER.readTree(resp))
         .isEqualTo(
             OBJECT_MAPPER.readTree("{\"'qu''otes'\": { \"are'\": \"allowed if escaped\" }}"));
+
+    obj = OBJECT_MAPPER.readTree("{ \"slashes\\\\\": { \"are\\\\\": \"allowed if escaped\" }}");
+    RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);
+    resp = RestUtils.get(authToken, collectionPath + "/1?raw=true", 200);
+    assertThat(OBJECT_MAPPER.readTree(resp))
+        .isEqualTo(
+            OBJECT_MAPPER.readTree("{\"slashes\\\": { \"are\\\": \"allowed if escaped\" }}"));
 
     obj = OBJECT_MAPPER.readTree("{ \"*aste*risks*\": \"are allowed\" }");
     RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);
@@ -1172,14 +1178,14 @@ public abstract class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   @Test
   public void testBasicSearchUnicodeAndBrackets() throws IOException {
     JsonNode fullObj =
-        OBJECT_MAPPER.readTree("{\"a\\\\u002eb\":\"somedata\",\"some]data\":\"something\"}");
+        OBJECT_MAPPER.readTree("{\"a\\\\.b\":\"somedata\",\"some]data\":\"something\"}");
     RestUtils.put(authToken, collectionPath + "/cool-search-id", fullObj.toString(), 200);
 
     // With Unicode code point
     String r =
         RestUtils.get(
             authToken,
-            collectionPath + "/cool-search-id?where={\"a\\\\u002eb\": {\"$eq\": \"somedata\"}}",
+            collectionPath + "/cool-search-id?where={\"a\\\\.b\": {\"$eq\": \"somedata\"}}",
             200);
 
     String searchResultStr = "[{\"a.b\":\"somedata\"}]";

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -328,11 +328,11 @@ public abstract class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
         .isEqualTo(
             "{\"description\":\"Array paths contained in square brackets, periods, single quotes, and backslash are not allowed in field names, invalid field single'quotes\",\"code\":400}");
 
-    obj = OBJECT_MAPPER.readTree("{ \"back\\slashes\": \"are not allowed\" }");
+    obj = OBJECT_MAPPER.readTree("{ \"back\\\\\\\\slashes\": \"are not allowed\" }");
     resp = RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 400);
     assertThat(resp)
         .isEqualTo(
-            "{\"description\":\"Array paths contained in square brackets, periods, single quotes, and backslash are not allowed in field names, invalid field back\\slashes\",\"code\":400}");
+            "{\"description\":\"Array paths contained in square brackets, periods, single quotes, and backslash are not allowed in field names, invalid field back\\\\\\\\slashes\",\"code\":400}");
   }
 
   @Test
@@ -1185,22 +1185,17 @@ public abstract class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
         RestUtils.get(
             authToken,
             collectionPath
-                + "/cool-search-id?where={\"some\\,data\": {\"$eq\": \"something\"}}&raw=true",
+                + "/cool-search-id?where={\"some\\\\,data\": {\"$eq\": \"something\"}}&raw=true",
             200);
 
     searchResultStr = "[{\"some,data\":\"something\"}]";
     assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(searchResultStr));
 
-    RestUtils.get(
-        authToken,
-        collectionPath + "/cool-search-id?where={\"some,data\": {\"$eq\": \"something\"}}&raw=true",
-        204);
-
     // With asterisk
     r =
         RestUtils.get(
             authToken,
-            collectionPath + "/cool-search-id?where={\"\\*\": {\"$eq\": \"star\"}}&raw=true",
+            collectionPath + "/cool-search-id?where={\"\\\\*\": {\"$eq\": \"star\"}}&raw=true",
             200);
 
     searchResultStr = "[{\"*\":\"star\"}]";

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -312,14 +312,14 @@ public abstract class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     String resp = RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 400);
     assertThat(resp)
         .isEqualTo(
-            "{\"description\":\"Array paths contained in square brackets and literal unicode escape sequences are not allowed in field names, invalid field bracketedarraypaths[100].\",\"code\":400}");
+            "{\"description\":\"Array paths contained in square brackets and periods are not allowed in field names, invalid field bracketedarraypaths[100].\",\"code\":400}");
 
-    obj = OBJECT_MAPPER.readTree("{ \"unicodeescaping\\uanything\": \"are not allowed\" }");
+    obj = OBJECT_MAPPER.readTree("{ \"periods.something\": \"are not allowed\" }");
 
     resp = RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 400);
     assertThat(resp)
         .isEqualTo(
-            "{\"description\":\"Array paths contained in square brackets and literal unicode escape sequences are not allowed in field names, invalid field bracketedarraypaths[100].\",\"code\":400}");
+            "{\"description\":\"Array paths contained in square brackets and periods are not allowed in field names, invalid field periods.something.\",\"code\":400}");
   }
 
   @Test
@@ -330,17 +330,18 @@ public abstract class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     String resp = RestUtils.get(authToken, collectionPath + "/1", 200);
     assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(obj);
 
-    obj = OBJECT_MAPPER.readTree("{ \"periods.\": \"are allowed\" }");
+    obj = OBJECT_MAPPER.readTree("{ \"periods\\u002e\": \"are allowed if escaped\" }");
+    RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);
+    resp = RestUtils.get(authToken, collectionPath + "/1", 200);
+    assertThat(OBJECT_MAPPER.readTree(resp))
+        .isEqualTo(OBJECT_MAPPER.readTree("{\"periods.\": \"are allowed if escaped\" }"));
+
+    obj = OBJECT_MAPPER.readTree("{ \"'qu''otes'\": \"are allowed\" }");
     RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);
     resp = RestUtils.get(authToken, collectionPath + "/1", 200);
     assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(obj);
 
-    obj = OBJECT_MAPPER.readTree("{ \"'quotes'\": \"are allowed\" }");
-    RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);
-    resp = RestUtils.get(authToken, collectionPath + "/1", 200);
-    assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(obj);
-
-    obj = OBJECT_MAPPER.readTree("{ \"*asterisks*\": \"are allowed\" }");
+    obj = OBJECT_MAPPER.readTree("{ \"*aste*risks*\": \"are allowed\" }");
     RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);
     resp = RestUtils.get(authToken, collectionPath + "/1", 200);
     assertThat(OBJECT_MAPPER.readTree(resp)).isEqualTo(obj);
@@ -1156,7 +1157,8 @@ public abstract class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
 
   @Test
   public void testBasicSearchUnicodeAndBrackets() throws IOException {
-    JsonNode fullObj = OBJECT_MAPPER.readTree("{\"a.b\":\"somedata\",\"some]data\":\"something\"}");
+    JsonNode fullObj =
+        OBJECT_MAPPER.readTree("{\"a\\u002eb\":\"somedata\",\"some]data\":\"something\"}");
     RestUtils.put(authToken, collectionPath + "/cool-search-id", fullObj.toString(), 200);
 
     // With Unicode code point

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -477,6 +477,24 @@ public abstract class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   }
 
   @Test
+  public void testEscapedCharGet() throws IOException {
+    JsonNode obj =
+        OBJECT_MAPPER.readTree(
+            "{\"a\\\\.b\":\"somedata\",\"some,data\":\"something\",\"*\":\"star\"}");
+    String resp = RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);
+    assertThat(resp).isEqualTo("{\"documentId\":\"1\"}");
+
+    String result = RestUtils.get(authToken, collectionPath + "/1/a%5C.b?raw=true", 200);
+    assertThat(result).isEqualTo("\"somedata\"");
+
+    result = RestUtils.get(authToken, collectionPath + "/1/some%5C,data?raw=true", 200);
+    assertThat(result).isEqualTo("\"something\"");
+
+    result = RestUtils.get(authToken, collectionPath + "/1/%5C*?raw=true", 200);
+    assertThat(result).isEqualTo("\"star\"");
+  }
+
+  @Test
   public void testPutNullsAndEmpties() throws IOException {
     JsonNode obj = OBJECT_MAPPER.readTree("{\"abc\": null}");
     RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 200);


### PR DESCRIPTION
This PR removes restrictions on characters in field names.  Because certain characters have a special meaning in the search/path syntax, the characters `, . *` were previously disallowed; however now they are allowed if they are escaped on ingestion. This is the case for both writing documents and searching with a path.