### PR TITLE
Fix invalid (e.g `0.0.0.0`) `rpc_address` in `system.local`

### DIFF
--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/StargateSystemKeyspace.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/StargateSystemKeyspace.java
@@ -148,7 +148,7 @@ public class StargateSystemKeyspace {
         snitch.getDatacenter(FBUtilities.getBroadcastAddress()),
         snitch.getRack(FBUtilities.getBroadcastAddress()),
         DatabaseDescriptor.getPartitioner().getClass().getName(),
-        DatabaseDescriptor.getRpcAddress(),
+        FBUtilities.getBroadcastRpcAddress(),
         FBUtilities.getBroadcastAddress(),
         FBUtilities.getLocalAddress(),
         SystemKeyspace.BootstrapState.COMPLETED.name(),

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/StargateSystemKeyspace.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/StargateSystemKeyspace.java
@@ -184,7 +184,7 @@ public class StargateSystemKeyspace {
         snitch.getLocalDatacenter(),
         snitch.getLocalRack(),
         DatabaseDescriptor.getPartitioner().getClass().getName(),
-        DatabaseDescriptor.getRpcAddress(),
+        FBUtilities.getJustBroadcastNativeAddress(),
         DatabaseDescriptor.getNativeTransportPort(),
         FBUtilities.getJustBroadcastAddress(),
         DatabaseDescriptor.getStoragePort(),

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/StargateSystemKeyspace.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/StargateSystemKeyspace.java
@@ -55,7 +55,7 @@ public class StargateSystemKeyspace {
     local.setPartitioner(DatabaseDescriptor.getPartitioner().getClass().getName());
     local.setBroadcastAddress(FBUtilities.getBroadcastAddress());
     local.setListenAddress(FBUtilities.getLocalAddress());
-    local.setNativeAddress(DatabaseDescriptor.getNativeTransportAddress());
+    local.setNativeAddress(FBUtilities.getNativeTransportBroadcastAddress());
     local.setNativePort(DatabaseDescriptor.getNativeTransportPort());
     local.setNativePortSsl(DatabaseDescriptor.getNativeTransportPortSSL());
     local.setStoragePort(DatabaseDescriptor.getStoragePort());

--- a/testing/src/main/java/io/stargate/it/cql/SystemTablesTest.java
+++ b/testing/src/main/java/io/stargate/it/cql/SystemTablesTest.java
@@ -15,6 +15,7 @@ import io.stargate.it.storage.StargateConnectionInfo;
 import io.stargate.it.storage.StargateEnvironmentInfo;
 import io.stargate.it.storage.StargateSpec;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -39,6 +40,9 @@ class SystemTablesTest extends BaseOsgiIntegrationTest {
                 SimpleStatement.builder("SELECT * FROM system.local").setNode(localNode).build())
             .one();
     assertThat(localRow).isNotNull();
+    assertThat(localRow.getInetAddress("rpc_address"))
+        .isEqualTo(
+            localNode.getBroadcastRpcAddress().map(InetSocketAddress::getAddress).orElse(null));
     assertThat(localRow.getInetAddress("listen_address")).isEqualTo(getNodeAddress(localNode));
     assertThat(localRow.getSet("tokens", String.class)).hasSizeGreaterThan(1);
 


### PR DESCRIPTION
Use the broadcast RPC address as the `rpc_address` in `system.local`. It
was populated with the bound RPC address which was often `0.0.0.0` when
deployed.