### PR TITLE
Allow CQL to be bound to more than one port

### DIFF
--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Server.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Server.java
@@ -107,9 +107,6 @@ public class Server implements CassandraDaemon.Server {
       else workerGroup = new NioEventLoopGroup();
     }
     this.persistence.registerEventListener(new EventNotifier(this));
-
-    // Please see the comment on setUnsetValue().
-    CBUtil.setUnsetValue(persistence.unsetValue());
   }
 
   @Override
@@ -173,7 +170,13 @@ public class Server implements CassandraDaemon.Server {
 
   private Connection newConnection(Channel channel, ProxyInfo proxyInfo, ProtocolVersion version) {
     return new ServerConnection(
-        channel, proxyInfo, version, connectionTracker, persistence, authentication);
+        channel,
+        socket.getPort(),
+        proxyInfo,
+        version,
+        connectionTracker,
+        persistence,
+        authentication);
   }
 
   public int countConnectedClients() {

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/ServerConnection.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/ServerConnection.java
@@ -46,6 +46,7 @@ public class ServerConnection extends Connection {
 
   ServerConnection(
       Channel channel,
+      int boundPort,
       ProxyInfo proxyInfo,
       ProtocolVersion version,
       Connection.Tracker tracker,
@@ -58,7 +59,7 @@ public class ServerConnection extends Connection {
         tracker,
         persistence,
         authentication,
-        getClientInfo(channel, proxyInfo));
+        getClientInfo(channel, boundPort, proxyInfo));
   }
 
   private ServerConnection(
@@ -80,9 +81,10 @@ public class ServerConnection extends Connection {
   }
 
   @NotNull
-  private static ClientInfo getClientInfo(Channel channel, ProxyInfo proxyInfo) {
+  private static ClientInfo getClientInfo(Channel channel, int boundPort, ProxyInfo proxyInfo) {
     return new ClientInfo(
         proxyInfo != null ? proxyInfo.sourceAddress : (InetSocketAddress) channel.remoteAddress(),
+        boundPort,
         proxyInfo != null ? proxyInfo.publicAddress : null);
   }
 

--- a/persistence-api/src/main/java/io/stargate/db/ClientInfo.java
+++ b/persistence-api/src/main/java/io/stargate/db/ClientInfo.java
@@ -15,6 +15,7 @@ public class ClientInfo {
   public static final String PROXY_PUBLIC_ADDRESS_HEADER = "proxy_public_address_header";
 
   private final InetSocketAddress remoteAddress;
+  private final int boundPort;
   private final @Nullable InetSocketAddress publicAddress;
 
   private volatile DriverInfo driverInfo;
@@ -22,13 +23,25 @@ public class ClientInfo {
   private AuthenticatedUser authenticatedUser;
   private Map<String, ByteBuffer> serializedAuthData;
 
+  public ClientInfo(
+      InetSocketAddress remoteAddress, int boundPort, @Nullable InetSocketAddress publicAddress) {
+    this.remoteAddress = remoteAddress;
+    this.boundPort = boundPort;
+    this.publicAddress = publicAddress;
+  }
+
   public ClientInfo(InetSocketAddress remoteAddress, @Nullable InetSocketAddress publicAddress) {
     this.remoteAddress = remoteAddress;
+    this.boundPort = 0;
     this.publicAddress = publicAddress;
   }
 
   public InetSocketAddress remoteAddress() {
     return remoteAddress;
+  }
+
+  public int boundPort() {
+    return boundPort;
   }
 
   public Optional<InetSocketAddress> publicAddress() {

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/ClientStateWithBoundPort.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/ClientStateWithBoundPort.java
@@ -1,0 +1,18 @@
+package io.stargate.db.dse;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import org.apache.cassandra.service.ClientState;
+
+public class ClientStateWithBoundPort extends ClientState {
+  private final int boundPort;
+
+  public ClientStateWithBoundPort(SocketAddress remoteAddress, int boundPort) {
+    super((InetSocketAddress) remoteAddress, null);
+    this.boundPort = boundPort;
+  }
+
+  public int boundPort() {
+    return boundPort;
+  }
+}

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -24,6 +24,7 @@ import io.stargate.db.RowDecorator;
 import io.stargate.db.SimpleStatement;
 import io.stargate.db.Statement;
 import io.stargate.db.datastore.common.AbstractCassandraPersistence;
+import io.stargate.db.dse.ClientStateWithBoundPort;
 import io.stargate.db.dse.impl.interceptors.DefaultQueryInterceptor;
 import io.stargate.db.dse.impl.interceptors.ProxyProtocolQueryInterceptor;
 import io.stargate.db.dse.impl.interceptors.QueryInterceptor;
@@ -416,7 +417,7 @@ public class DsePersistence
       return new ClientStateWithPublicAddress(
           clientInfo.remoteAddress(), clientInfo.publicAddress().get());
     }
-    return ClientState.forExternalCalls(clientInfo.remoteAddress(), null);
+    return new ClientStateWithBoundPort(clientInfo.remoteAddress(), clientInfo.boundPort());
   }
 
   public void setAuthorizationService(AtomicReference<AuthorizationService> authorizationService) {

--- a/testing/src/main/java/io/stargate/it/cql/AdditionalPortsTest.java
+++ b/testing/src/main/java/io/stargate/it/cql/AdditionalPortsTest.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -38,6 +39,8 @@ public class AdditionalPortsTest extends BaseOsgiIntegrationTest {
 
   public static final List<Integer> ADDITIONAL_PORTS = ImmutableList.of(29042, 39042);
 
+  public static int MAIN_PORT = 9043;
+
   // The tests are going to set the contact points explicitly
   public static class EmptyContactPointResolver implements ContactPointResolver {
 
@@ -45,6 +48,12 @@ public class AdditionalPortsTest extends BaseOsgiIntegrationTest {
     public List<InetSocketAddress> resolve(ExtensionContext context) {
       return Collections.emptyList();
     }
+  }
+
+  @BeforeAll
+  public static void beforeAll(StargateEnvironmentInfo stargate) {
+    assertThat(stargate.nodes()).hasSizeGreaterThan(0);
+    MAIN_PORT = stargate.nodes().get(0).cqlPort();
   }
 
   @ParameterizedTest
@@ -93,7 +102,7 @@ public class AdditionalPortsTest extends BaseOsgiIntegrationTest {
   }
 
   public static List<Integer> allPorts() {
-    return ImmutableList.<Integer>builder().addAll(ADDITIONAL_PORTS).add(9043).build();
+    return ImmutableList.<Integer>builder().add(MAIN_PORT).addAll(ADDITIONAL_PORTS).build();
   }
 
   @SuppressWarnings("unused") // referenced in @StargateSpec

--- a/testing/src/main/java/io/stargate/it/cql/AdditionalPortsTest.java
+++ b/testing/src/main/java/io/stargate/it/cql/AdditionalPortsTest.java
@@ -1,0 +1,105 @@
+package io.stargate.it.cql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.CqlSessionBuilder;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
+import io.stargate.it.BaseOsgiIntegrationTest;
+import io.stargate.it.cql.AdditionalPortsTest.EmptyContactPointResolver;
+import io.stargate.it.driver.ContactPointResolver;
+import io.stargate.it.driver.CqlSessionExtension;
+import io.stargate.it.driver.CqlSessionSpec;
+import io.stargate.it.storage.StargateEnvironmentInfo;
+import io.stargate.it.storage.StargateParameters;
+import io.stargate.it.storage.StargateSpec;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@ExtendWith(CqlSessionExtension.class)
+@StargateSpec(nodes = 2, parametersCustomizer = "buildParameters")
+@CqlSessionSpec(contactPointResolver = EmptyContactPointResolver.class, createSession = false)
+public class AdditionalPortsTest extends BaseOsgiIntegrationTest {
+
+  public static final List<Integer> ADDITIONAL_PORTS = ImmutableList.of(29042, 39042);
+
+  // The tests are going to set the contact points explicitly
+  public static class EmptyContactPointResolver implements ContactPointResolver {
+
+    @Override
+    public List<InetSocketAddress> resolve(ExtensionContext context) {
+      return Collections.emptyList();
+    }
+  }
+
+  @ParameterizedTest
+  @DisplayName("Connects to stargate using the main and additional port values")
+  @MethodSource("allPorts")
+  public void connectToMainAndAdditionalPorts(
+      int port, CqlSessionBuilder builder, StargateEnvironmentInfo stargate) {
+    builder.addContactPoint(new InetSocketAddress(stargate.nodes().get(0).seedAddress(), port));
+    CqlSession session = builder.build();
+
+    Iterator<Node> nodes = session.getMetadata().getNodes().values().iterator();
+
+    Node localNode = nodes.next();
+    Row localRow =
+        session
+            .execute(
+                SimpleStatement.builder("SELECT * FROM system.local").setNode(localNode).build())
+            .one();
+    assertThat(localRow).isNotNull();
+    assertThat(localRow.getInetAddress("rpc_address"))
+        .isEqualTo(
+            localNode.getBroadcastRpcAddress().map(InetSocketAddress::getAddress).orElse(null));
+    if (backend.isDse()) {
+      assertThat(localRow.getInt("native_transport_port")).isEqualTo(port);
+    }
+
+    ResultSet rs =
+        session.execute(
+            SimpleStatement.builder("SELECT * FROM system.peers").setNode(localNode).build());
+    List<Row> rows = rs.all();
+
+    assertThat(rows).hasSizeGreaterThan(0);
+    List<InetAddress> rpcAddresses = new ArrayList<>();
+    rows.forEach(
+        row -> {
+          rpcAddresses.add(row.getInetAddress("rpc_address"));
+          if (backend.isDse()) {
+            assertThat(row.getInt("native_transport_port")).isEqualTo(port);
+          }
+        });
+    List<InetAddress> expectedRpcAddresses =
+        Streams.stream(nodes)
+            .map(n -> n.getBroadcastRpcAddress().map(InetSocketAddress::getAddress).orElse(null))
+            .collect(Collectors.toList());
+    assertThat(rpcAddresses).containsExactlyInAnyOrderElementsOf(expectedRpcAddresses);
+  }
+
+  public static List<Integer> allPorts() {
+    return ImmutableList.<Integer>builder().addAll(ADDITIONAL_PORTS).add(9043).build();
+  }
+
+  @SuppressWarnings("unused") // referenced in @StargateSpec
+  public static void buildParameters(StargateParameters.Builder builder) {
+    builder.putSystemProperties(
+        "stargate.cql.additional_ports",
+        ADDITIONAL_PORTS.stream().map(p -> Integer.toString(p)).collect(Collectors.joining(",")));
+  }
+}


### PR DESCRIPTION
This also returns the correct `native_transport_port` for DSE's version
of `system.local` and `system.peers` based on the client connection's
destination port (the server's bound port).