### PR TITLE
relates to #1028: glob wildcard to match both field and array item

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/service/util/DocsApiUtils.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/util/DocsApiUtils.java
@@ -232,15 +232,12 @@ public final class DocsApiUtils {
         return false;
       }
 
-      // skip any target path that is wildcard
+      // skip any target path that is a wildcard
       if (Objects.equals(target, DocumentDB.GLOB_VALUE)) {
-        // but make sure this is not an array
-        if (ARRAY_PATH_PATTERN.matcher(path).matches()) {
-          return false;
-        }
         continue;
       }
 
+      // skip any target path that is an array wildcard
       if (Objects.equals(target, DocumentDB.GLOB_ARRAY_VALUE)) {
         // but make sure this is not an normal field
         if (!ARRAY_PATH_PATTERN.matcher(path).matches()) {

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/util/DocsApiUtilsTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/util/DocsApiUtilsTest.java
@@ -478,7 +478,7 @@ class DocsApiUtilsTest {
 
       boolean result = DocsApiUtils.isRowOnPath(row, path);
 
-      Assertions.assertThat(result).isFalse();
+      Assertions.assertThat(result).isTrue();
     }
 
     @Test


### PR DESCRIPTION
In #1080 we agreed that glob `*` should match both field and array item, while `[*]` should explicitly target only array items.