### PR TITLE
closes #1117: never return html code as the API response

### DIFF
--- a/auth-api/src/main/java/io/stargate/auth/api/impl/Server.java
+++ b/auth-api/src/main/java/io/stargate/auth/api/impl/Server.java
@@ -39,6 +39,7 @@ import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.server.ServerProperties;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
@@ -114,6 +115,9 @@ public class Server extends Application<ApplicationConfiguration> {
         new ResourceMetricsEventListener(
             metrics, httpMetricsTagProvider, AuthApiActivator.MODULE_NAME);
     environment.jersey().register(metricsListener);
+
+    // no html content
+    environment.jersey().property(ServerProperties.RESPONSE_SET_STATUS_OVER_SEND_ERROR, true);
   }
 
   @Override

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/DropwizardServer.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/DropwizardServer.java
@@ -44,6 +44,7 @@ import javax.servlet.FilterRegistration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.server.ServerProperties;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
@@ -161,6 +162,9 @@ public class DropwizardServer extends Application<Configuration> {
     environment
         .lifecycle()
         .addServerLifecycleListener(server -> DropwizardServer.this.jettyServer = server);
+
+    // no html content
+    environment.jersey().property(ServerProperties.RESPONSE_SET_STATUS_OVER_SEND_ERROR, true);
   }
 
   @Override

--- a/health-checker/src/main/java/io/stargate/health/Server.java
+++ b/health-checker/src/main/java/io/stargate/health/Server.java
@@ -17,6 +17,7 @@ import io.stargate.core.metrics.api.MetricsScraper;
 import io.stargate.metrics.jersey.ResourceMetricsEventListener;
 import java.lang.management.ManagementFactory;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.server.ServerProperties;
 
 public class Server extends Application<ApplicationConfiguration> {
 
@@ -80,6 +81,9 @@ public class Server extends Application<ApplicationConfiguration> {
         new ResourceMetricsEventListener(
             metrics, httpMetricsTagProvider, HealthCheckerActivator.MODULE_NAME);
     environment.jersey().register(component);
+
+    // no html content
+    environment.jersey().property(ServerProperties.RESPONSE_SET_STATUS_OVER_SEND_ERROR, true);
   }
 
   @Override

--- a/restapi/src/main/java/io/stargate/web/impl/Server.java
+++ b/restapi/src/main/java/io/stargate/web/impl/Server.java
@@ -64,6 +64,7 @@ import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.server.ServerProperties;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
@@ -176,6 +177,9 @@ public class Server extends Application<ApplicationConfiguration> {
         new ResourceMetricsEventListener(
             metrics, httpMetricsTagProvider, RestApiActivator.MODULE_NAME);
     environment.jersey().register(metricListener);
+
+    // no html content
+    environment.jersey().property(ServerProperties.RESPONSE_SET_STATUS_OVER_SEND_ERROR, true);
   }
 
   @VisibleForTesting


### PR DESCRIPTION
:heavy_check_mark: Confirmed with a request like:

```
curl -H "x-cassandra-token: ..." http://127.0.0.4:8082/v2/namespaces/namespace/collections/payu/1/quiz/maths/q1/options/[0] -v 
*   Trying 127.0.0.4:8082...
* TCP_NODELAY set
* Connected to 127.0.0.4 (127.0.0.4) port 8082 (#0)
> GET /v2/namespaces/namespace/collections/payu/1/quiz/maths/q1/options/[0] HTTP/1.1
> Host: 127.0.0.4:8082
> User-Agent: curl/7.68.0
> Accept: */*
> x-cassandra-token: ...
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 404 Not Found
< Date: Tue, 20 Jul 2021 11:30:06 GMT
< Content-Length: 0
< 
* Connection #0 to host 127.0.0.4 left intact
```

which used to return the HTML.

:heavy_check_mark:  Checked the GraphQL playground, works fine.
:heavy_check_mark: INT tests should be fine as well.