### PR TITLE
Add selectivity hints to Docs API query filters

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -30,6 +30,7 @@ import io.stargate.web.docsapi.service.filter.FilterOp;
 import io.stargate.web.docsapi.service.filter.ListFilterCondition;
 import io.stargate.web.docsapi.service.filter.SingleFilterCondition;
 import io.stargate.web.docsapi.service.json.DeadLeafCollectorImpl;
+import io.stargate.web.docsapi.service.query.filter.operation.FilterHintCode;
 import io.stargate.web.docsapi.service.util.DocsApiUtils;
 import io.stargate.web.resources.Db;
 import java.io.IOException;
@@ -793,6 +794,12 @@ public class DocumentService {
       Iterator<String> ops = fieldConditions.fieldNames();
       while (ops.hasNext()) {
         String op = ops.next();
+
+        // Ignore hints, DocumentService does not support them
+        if (FilterHintCode.getByRawValue(op).isPresent()) {
+          continue;
+        }
+
         JsonNode value = fieldConditions.get(op);
         validateOpAndValue(op, value, fieldName);
         if (value.isNumber()) {

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/ExpressionParser.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/ExpressionParser.java
@@ -227,6 +227,13 @@ public class ExpressionParser {
               filterPath.getField());
       throw new ErrorCodeRuntimeException(ErrorCode.DOCS_API_SEARCH_FILTER_INVALID, msg);
     }
+
+    if (selectivity.isPresent() && conditions.isEmpty()) {
+      String msg =
+          String.format(
+              "Field '%s' has a selectivity hint but no condition", filterPath.getField());
+      throw new ErrorCodeRuntimeException(ErrorCode.DOCS_API_SEARCH_FILTER_INVALID, msg);
+    }
   }
 
   private Or<FilterExpression> resolveOr(

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/FilterExpression.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/FilterExpression.java
@@ -23,6 +23,7 @@ import com.bpodgursky.jbool_expressions.util.ExprFactory;
 import io.stargate.db.datastore.Row;
 import io.stargate.web.docsapi.service.RawDocument;
 import io.stargate.web.docsapi.service.query.condition.BaseCondition;
+import io.stargate.web.docsapi.service.query.filter.operation.FilterHintCode;
 import io.stargate.web.docsapi.service.util.DocsApiUtils;
 import java.util.Collections;
 import java.util.Comparator;
@@ -52,6 +53,21 @@ public abstract class FilterExpression extends Expression<FilterExpression>
   /** @return Returns the order index of this filter expression given by the user. */
   @Value.Parameter
   public abstract int getOrderIndex();
+
+  /**
+   * The best known selectivity of this filter expression.
+   *
+   * <p>Selectivity is a value between 0 and 1 (inclusive) that represents the percentage of rows
+   * that are expected to be matched by this filter.
+   *
+   * <p>By default, filters that do not have an explicit selectivity {@link
+   * FilterHintCode#SELECTIVITY hint} provided by the query get the selectivity value of {@code 1.0}
+   * (the worst possible selectivity).
+   */
+  @Value.Default
+  public double getSelectivity() {
+    return 1.0;
+  }
 
   /** @return Returns human-readable description of this expression. */
   public String getDescription() {

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/FilterExpression.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/FilterExpression.java
@@ -69,6 +69,16 @@ public abstract class FilterExpression extends Expression<FilterExpression>
     return 1.0;
   }
 
+  public static FilterExpression of(
+      FilterPath filterPath, BaseCondition condition, int orderIndex, double selectivity) {
+    return ImmutableFilterExpression.builder()
+        .filterPath(filterPath)
+        .condition(condition)
+        .orderIndex(orderIndex)
+        .selectivity(selectivity)
+        .build();
+  }
+
   /** @return Returns human-readable description of this expression. */
   public String getDescription() {
     BaseCondition condition = getCondition();

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/ConditionParser.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/ConditionParser.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.stargate.web.docsapi.exception.ErrorCode;
 import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
 import io.stargate.web.docsapi.service.query.condition.provider.ConditionProvider;
+import io.stargate.web.docsapi.service.query.filter.operation.FilterHintCode;
 import io.stargate.web.docsapi.service.query.filter.operation.FilterOperationCode;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -41,8 +42,8 @@ public class ConditionParser {
    * @param conditionsNode Node containing the filter ops as keys
    * @param numericBooleans If number booleans should be used when creating conditions.
    * @return Collection of created conditions.
-   * @throws io.stargate.web.docsapi.exception.DocumentAPIRequestException If filter op is not
-   *     found, condition constructions fails or filter value is not supported by the filter op.
+   * @throws io.stargate.web.docsapi.exception.ErrorCodeRuntimeException If filter op is not found,
+   *     condition constructions fails or filter value is not supported by the filter op.
    */
   public Collection<BaseCondition> getConditions(JsonNode conditionsNode, boolean numericBooleans) {
     List<BaseCondition> results = new ArrayList<>();
@@ -50,6 +51,12 @@ public class ConditionParser {
     fields.forEachRemaining(
         field -> {
           String filterOp = field.getKey();
+
+          // skip hints (processed elsewhere)
+          if (FilterHintCode.getByRawValue(filterOp).isPresent()) {
+            return;
+          }
+
           Optional<FilterOperationCode> operationCode = FilterOperationCode.getByRawValue(filterOp);
           if (operationCode.isPresent()) {
             JsonNode valueNode = field.getValue();

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/FilterHintCode.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/FilterHintCode.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.stargate.web.docsapi.service.query.filter.operation;
+
+import io.stargate.web.docsapi.service.query.FilterExpression;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+
+/** Enumerates tags for query hints. */
+public enum FilterHintCode {
+
+  /**
+   * Filter selectivity.
+   *
+   * @see FilterExpression#getSelectivity()
+   */
+  SELECTIVITY("$selectivity");
+
+  private final String rawValue;
+
+  FilterHintCode(String rawValue) {
+    this.rawValue = rawValue;
+  }
+
+  public static Optional<FilterHintCode> getByRawValue(String rawValue) {
+    return Arrays.stream(FilterHintCode.values())
+        .filter(code -> Objects.equals(code.rawValue, rawValue))
+        .findFirst();
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/FilterOperationCode.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/FilterOperationCode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package io.stargate.web.docsapi.service.query.filter.operation;
 
 import io.stargate.web.docsapi.service.query.condition.provider.ConditionProvider;

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/weigth/impl/UserOrderWeightResolver.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/weigth/impl/UserOrderWeightResolver.java
@@ -33,23 +33,33 @@ public class UserOrderWeightResolver implements ExpressionWeightResolver<FilterE
   /** {@inheritDoc} */
   @Override
   public int compare(FilterExpression o1, FilterExpression o2) {
-    int defaultCompare = ExpressionWeightResolver.super.compare(o1, o2);
-    if (defaultCompare != 0) {
-      return defaultCompare;
-    } else {
-      return Integer.compare(o1.getOrderIndex(), o2.getOrderIndex());
+    int result = ExpressionWeightResolver.super.compare(o1, o2);
+    if (result != 0) {
+      return result;
     }
+
+    result = Double.compare(o1.getSelectivity(), o2.getSelectivity());
+    if (result != 0) {
+      return result;
+    }
+
+    return Integer.compare(o1.getOrderIndex(), o2.getOrderIndex());
   }
 
   /** {@inheritDoc} */
   @Override
   public int compare(Collection<FilterExpression> c1, Collection<FilterExpression> c2) {
-    int defaultCompare = ExpressionWeightResolver.super.compare(c1, c2);
-    if (defaultCompare != 0) {
-      return defaultCompare;
-    } else {
-      return Integer.compare(lowestIndex(c1), lowestIndex(c2));
+    int result = ExpressionWeightResolver.super.compare(c1, c2);
+    if (result != 0) {
+      return result;
     }
+
+    result = Double.compare(lowestSelectivity(c1), lowestSelectivity(c2));
+    if (result != 0) {
+      return result;
+    }
+
+    return Integer.compare(lowestIndex(c1), lowestIndex(c2));
   }
 
   private int lowestIndex(Collection<FilterExpression> collection) {
@@ -57,5 +67,12 @@ public class UserOrderWeightResolver implements ExpressionWeightResolver<FilterE
         .mapToInt(FilterExpression::getOrderIndex)
         .min()
         .orElse(Integer.MAX_VALUE);
+  }
+
+  private double lowestSelectivity(Collection<FilterExpression> collection) {
+    return collection.stream()
+        .mapToDouble(FilterExpression::getSelectivity)
+        .min()
+        .orElse(Double.MAX_VALUE);
   }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/ExpressionParserIntTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/ExpressionParserIntTest.java
@@ -81,6 +81,7 @@ class ExpressionParserIntTest {
               FilterExpression.class,
               c -> {
                 assertThat(c.getOrderIndex()).isZero();
+                assertThat(c.getSelectivity()).isEqualTo(1.0); // default selectivity
                 assertThat(c.getFilterPath().getField()).isEqualTo("myField");
                 assertThat(c.getFilterPath().getParentPath()).isEmpty();
                 assertThat(c.getCondition())
@@ -541,8 +542,8 @@ class ExpressionParserIntTest {
 
       Expression<FilterExpression> result =
           service.constructFilterExpression(Collections.emptyList(), root, false);
-
       assertThat(result).isInstanceOf(And.class);
+
       List<? extends Expression<?>> children = ((And<?>) result).getChildren();
       assertThat(children)
           .hasSize(2)
@@ -777,6 +778,110 @@ class ExpressionParserIntTest {
       assertThat(t)
           .isInstanceOf(ErrorCodeRuntimeException.class)
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_SEARCH_FILTER_INVALID);
+    }
+  }
+
+  @Nested
+  class ConstructFilterWithSelectivity {
+    @Test
+    public void singleField() throws Exception {
+      String json = "{\"my.*.field\": {\"$eq\": \"some-value\", \"$selectivity\": 0.123}}";
+      JsonNode root = mapper.readTree(json);
+
+      Expression<FilterExpression> result =
+          service.constructFilterExpression(Collections.emptyList(), root, false);
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              FilterExpression.class,
+              c -> {
+                assertThat(c.getOrderIndex()).isZero();
+                assertThat(c.getSelectivity()).isEqualTo(0.123);
+                assertThat(c.getFilterPath().getField()).isEqualTo("field");
+                assertThat(c.getCondition()).isInstanceOf(StringCondition.class);
+              });
+    }
+
+    @Test
+    public void multipleFields() throws Exception {
+      String json =
+          "{\"field1\": {\"$eq\": \"some-value\", \"$selectivity\": 0.111},"
+              + "\"field2\": {\"$selectivity\": 0.222, \"$ne\": \"some-small-value\"},"
+              + "\"field3\": {\"$ne\": \"some-small-value\"}}";
+      JsonNode root = mapper.readTree(json);
+
+      Expression<FilterExpression> result =
+          service.constructFilterExpression(Collections.emptyList(), root, false);
+      assertThat(result).isInstanceOf(And.class);
+      List<? extends Expression<?>> children = ((And<?>) result).getChildren();
+
+      assertThat(children)
+          .hasSize(3)
+          .anySatisfy(
+              e ->
+                  assertThat(e)
+                      .isInstanceOfSatisfying(
+                          FilterExpression.class,
+                          c -> {
+                            assertThat(c.getFilterPath().getField()).isEqualTo("field1");
+                            assertThat(c.getOrderIndex()).isEqualTo(0);
+                            assertThat(c.getSelectivity()).isEqualTo(0.111);
+                          }))
+          .anySatisfy(
+              e ->
+                  assertThat(e)
+                      .isInstanceOfSatisfying(
+                          FilterExpression.class,
+                          c -> {
+                            assertThat(c.getFilterPath().getField()).isEqualTo("field2");
+                            assertThat(c.getOrderIndex()).isEqualTo(1);
+                            assertThat(c.getSelectivity()).isEqualTo(0.222);
+                          }))
+          .anySatisfy(
+              e ->
+                  assertThat(e)
+                      .isInstanceOfSatisfying(
+                          FilterExpression.class,
+                          c -> {
+                            assertThat(c.getFilterPath().getField()).isEqualTo("field3");
+                            assertThat(c.getOrderIndex()).isEqualTo(2);
+                            assertThat(c.getSelectivity()).isEqualTo(1.0); // default selectivity
+                          }));
+    }
+
+    @Test
+    public void singleFieldMultipleConditions() throws Exception {
+      String json = "{\"my.*.field\": {\"$eq\": \"some-value\", \"$selectivity\": 0.123}}";
+      JsonNode root = mapper.readTree(json);
+
+      Expression<FilterExpression> result =
+          service.constructFilterExpression(Collections.emptyList(), root, false);
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              FilterExpression.class,
+              c -> {
+                assertThat(c.getOrderIndex()).isZero();
+                assertThat(c.getSelectivity()).isEqualTo(0.123);
+                assertThat(c.getFilterPath().getField()).isEqualTo("field");
+                assertThat(c.getCondition()).isInstanceOf(StringCondition.class);
+              });
+    }
+
+    @Test
+    public void invalidSelectivityValueType() throws Exception {
+      String json = "{\"field1\": {\"$gt\": \"a\", \"$lt\": \"z\", \"$selectivity\": 0.123}}";
+      JsonNode root = mapper.readTree(json);
+
+      assertThatThrownBy(
+              () -> service.constructFilterExpression(Collections.emptyList(), root, false))
+          .isInstanceOfSatisfying(
+              ErrorCodeRuntimeException.class,
+              e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.DOCS_API_SEARCH_FILTER_INVALID))
+          .hasMessageContaining(
+              "Specifying multiple filter conditions in the same JSON block with a selectivity "
+                  + "hint is not supported. Combine them using \"$and\" to disambiguate. "
+                  + "Related field: 'field1')");
     }
   }
 


### PR DESCRIPTION
* Allow "$selectivity" to be used as a key in JSON objects
  defining a single filter. The expected value is a number.

* Selectivity hints in JSON objects defining multiple filters
  are not supported to avoid ambiguity in case the filters
  later get separated during transformations of the boolean
  expression that contains them.

Fixes #1072

Contributes to #828