### PR TITLE
closes #1063: full support for $or queries in the docs api

### DIFF
--- a/persistence-api/src/main/java/io/stargate/db/datastore/Row.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/Row.java
@@ -19,10 +19,20 @@ import com.datastax.oss.driver.api.core.data.GettableByIndex;
 import com.datastax.oss.driver.api.core.data.GettableByName;
 import io.stargate.db.schema.Column;
 import java.util.List;
+import java.util.Objects;
 
 public interface Row extends GettableByIndex, GettableByName {
 
   List<Column> columns();
+
+  default boolean columnExists(String columnName) {
+    List<Column> columns = columns();
+    if (null == columns) {
+      return false;
+    }
+
+    return columns.stream().anyMatch(c -> Objects.equals(c.name(), columnName));
+  }
 
   @Override
   String toString();

--- a/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
@@ -102,8 +102,7 @@ public enum ErrorCode {
       Response.Status.BAD_REQUEST, "Search was expecting a JSON object as input."),
 
   DOCS_API_SEARCH_EXPRESSION_NOT_RESOLVED(
-      Response.Status.INTERNAL_SERVER_ERROR,
-      "Can not find the document resolver for the given expression."),
+      Response.Status.INTERNAL_SERVER_ERROR, "Unable to resolve the given expression."),
 
   DOCS_API_SEARCH_RESULTS_NOT_FITTING(
       Response.Status.BAD_REQUEST,

--- a/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
@@ -101,9 +101,9 @@ public enum ErrorCode {
   DOCS_API_SEARCH_OBJECT_REQUIRED(
       Response.Status.BAD_REQUEST, "Search was expecting a JSON object as input."),
 
-  DOCS_API_SEARCH_OR_NOT_SUPPORTED(
-      Response.Status.BAD_REQUEST,
-      "Searching documents with the $or condition is not yet supported."),
+  DOCS_API_SEARCH_EXPRESSION_NOT_RESOLVED(
+      Response.Status.INTERNAL_SERVER_ERROR,
+      "Can not find the document resolver for the given expression."),
 
   DOCS_API_SEARCH_RESULTS_NOT_FITTING(
       Response.Status.BAD_REQUEST,

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/rules/TrueFilterExpressions.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/rules/TrueFilterExpressions.java
@@ -39,7 +39,6 @@ public class TrueFilterExpressions extends Rule<Expression<FilterExpression>, Fi
   @Override
   public Expression<FilterExpression> applyInternal(
       Expression<FilterExpression> input, ExprOptions<FilterExpression> options) {
-    // cast OK because of the isApply
     boolean test = truePredicate.test(input);
     if (test) {
       return Literal.getTrue();

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/rules/TrueFilterExpressions.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/rules/TrueFilterExpressions.java
@@ -25,14 +25,14 @@ import io.stargate.web.docsapi.service.query.FilterExpression;
 import java.util.function.Predicate;
 
 /**
- * A {@link Rule} that coverts any {@link FilterExpression} matching the given predicate to {@link
- * Literal#getTrue()}.
+ * A {@link Rule} that coverts any {@link Expression<FilterExpression>} matching the given predicate
+ * to {@link Literal#getTrue()}.
  */
 public class TrueFilterExpressions extends Rule<Expression<FilterExpression>, FilterExpression> {
 
-  private final Predicate<FilterExpression> truePredicate;
+  private final Predicate<Expression<FilterExpression>> truePredicate;
 
-  public TrueFilterExpressions(Predicate<FilterExpression> truePredicate) {
+  public TrueFilterExpressions(Predicate<Expression<FilterExpression>> truePredicate) {
     this.truePredicate = truePredicate;
   }
 
@@ -40,7 +40,7 @@ public class TrueFilterExpressions extends Rule<Expression<FilterExpression>, Fi
   public Expression<FilterExpression> applyInternal(
       Expression<FilterExpression> input, ExprOptions<FilterExpression> options) {
     // cast OK because of the isApply
-    boolean test = truePredicate.test((FilterExpression) input);
+    boolean test = truePredicate.test(input);
     if (test) {
       return Literal.getTrue();
     } else {
@@ -51,6 +51,6 @@ public class TrueFilterExpressions extends Rule<Expression<FilterExpression>, Fi
   // only instance of FilterExpression
   @Override
   protected boolean isApply(Expression<FilterExpression> input) {
-    return input instanceof FilterExpression;
+    return true;
   }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/impl/AbstractFiltersResolver.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/impl/AbstractFiltersResolver.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in comHpliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.web.docsapi.service.query.search.resolver.impl;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import io.stargate.db.query.BoundQuery;
+import io.stargate.db.query.Query;
+import io.stargate.web.docsapi.dao.Paginator;
+import io.stargate.web.docsapi.service.DocsApiConfiguration;
+import io.stargate.web.docsapi.service.QueryExecutor;
+import io.stargate.web.docsapi.service.RawDocument;
+import io.stargate.web.docsapi.service.query.search.resolver.DocumentsResolver;
+import io.stargate.web.docsapi.service.query.search.resolver.filter.CandidatesFilter;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
+
+public abstract class AbstractFiltersResolver implements DocumentsResolver {
+
+  protected abstract DocumentsResolver getCandidatesResolver();
+
+  protected abstract Collection<CandidatesFilter> getCandidatesFilters();
+
+  protected abstract Flowable<RawDocument> resolveSources(
+      RawDocument rawDocument, List<Maybe<?>> sources);
+
+  @Override
+  public Flowable<RawDocument> getDocuments(
+      QueryExecutor queryExecutor,
+      DocsApiConfiguration configuration,
+      String keyspace,
+      String collection,
+      Paginator paginator) {
+    Flowable<RawDocument> candidates =
+        getCandidatesResolver()
+            .getDocuments(queryExecutor, configuration, keyspace, collection, paginator);
+
+    Single<List<Pair<? extends Query<? extends BoundQuery>, CandidatesFilter>>>
+        queriesToCandidates =
+            Flowable.fromIterable(getCandidatesFilters())
+                .flatMap(
+                    filter -> {
+                      Single<Pair<? extends Query<? extends BoundQuery>, CandidatesFilter>>
+                          pairSingle =
+                              filter
+                                  .prepareQuery(
+                                      queryExecutor.getDataStore(),
+                                      configuration,
+                                      keyspace,
+                                      collection)
+                                  .zipWith(Single.just(filter), Pair::of);
+
+                      return pairSingle.toFlowable();
+                    })
+                .toList()
+                .cache();
+
+    return candidates
+        .concatMapSingle(doc -> queriesToCandidates.map(prepared -> Pair.of(doc, prepared)))
+        .concatMap(
+            pair -> {
+              RawDocument doc = pair.getLeft();
+              List<Maybe<?>> sources =
+                  pair.getRight().stream()
+                      .map(
+                          queryToFilter -> {
+                            CandidatesFilter filter = queryToFilter.getRight();
+                            Query<? extends BoundQuery> query = queryToFilter.getLeft();
+                            return filter.bindAndFilter(queryExecutor, configuration, query, doc);
+                          })
+                      .collect(Collectors.toList());
+
+              // only if all filters emit the item, return the doc
+              // this means all filters are passed
+              return resolveSources(doc, sources);
+            });
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/impl/AnyFiltersResolver.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/impl/AnyFiltersResolver.java
@@ -68,7 +68,8 @@ public class AnyFiltersResolver extends AbstractFiltersResolver {
   @Override
   protected Flowable<RawDocument> resolveSources(RawDocument rawDocument, List<Maybe<?>> sources) {
     // only one signal is needed here, we can dispose the rest immediately
-    // when one emits, map to the document
-    return Maybe.amb(sources).map(any -> rawDocument).toFlowable();
+    // when one emits, map to the document because we need to return the document that passes
+    // it's important to keep with the concatMap approach in the abstract class
+    return Maybe.concat(sources).take(1).map(any -> rawDocument);
   }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/impl/AnyFiltersResolver.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/impl/AnyFiltersResolver.java
@@ -70,6 +70,6 @@ public class AnyFiltersResolver extends AbstractFiltersResolver {
     // only one signal is needed here, we can dispose the rest immediately
     // when one emits, map to the document because we need to return the document that passes
     // it's important to keep with the concatMap approach in the abstract class
-    return Maybe.concat(sources).take(1).map(any -> rawDocument);
+    return Maybe.merge(sources).take(1).map(any -> rawDocument);
   }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolver.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolver.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.web.docsapi.service.query.search.resolver.impl;
+
+import com.bpodgursky.jbool_expressions.Or;
+import com.bpodgursky.jbool_expressions.eval.EvalEngine;
+import com.bpodgursky.jbool_expressions.eval.EvalRule;
+import io.reactivex.rxjava3.core.Flowable;
+import io.stargate.db.datastore.DataStore;
+import io.stargate.db.query.BoundQuery;
+import io.stargate.db.query.Query;
+import io.stargate.db.query.builder.BuiltQuery;
+import io.stargate.web.docsapi.dao.Paginator;
+import io.stargate.web.docsapi.service.DocsApiConfiguration;
+import io.stargate.web.docsapi.service.ExecutionContext;
+import io.stargate.web.docsapi.service.QueryExecutor;
+import io.stargate.web.docsapi.service.RawDocument;
+import io.stargate.web.docsapi.service.query.FilterExpression;
+import io.stargate.web.docsapi.service.query.QueryConstants;
+import io.stargate.web.docsapi.service.query.eval.RawDocumentEvalRule;
+import io.stargate.web.docsapi.service.query.search.db.AbstractSearchQueryBuilder;
+import io.stargate.web.docsapi.service.query.search.db.impl.FilterExpressionSearchQueryBuilder;
+import io.stargate.web.docsapi.service.query.search.db.impl.FilterPathSearchQueryBuilder;
+import io.stargate.web.docsapi.service.query.search.db.impl.FullSearchQueryBuilder;
+import io.stargate.web.docsapi.service.query.search.resolver.DocumentsResolver;
+import io.stargate.web.rx.RxUtils;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class OrExpressionDocumentsResolver implements DocumentsResolver {
+
+  private final Or<FilterExpression> expression;
+
+  private final Set<FilterExpression> children;
+
+  private final List<AbstractSearchQueryBuilder> queryBuilders;
+
+  private final ExecutionContext context;
+
+  public OrExpressionDocumentsResolver(Or<FilterExpression> expression, ExecutionContext context) {
+    this.expression = expression;
+    this.children = getChildren(expression);
+    this.queryBuilders = buildQueries(this.children);
+    this.context = createContext(context, expression);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Flowable<RawDocument> getDocuments(
+      QueryExecutor queryExecutor,
+      DocsApiConfiguration configuration,
+      String keyspace,
+      String collection,
+      Paginator paginator) {
+    DataStore dataStore = queryExecutor.getDataStore();
+
+    // find the max size of columns in all queries and use that for now
+    String[] columns =
+        queryBuilders.stream()
+            .map(qb -> columnsForQuery(qb, configuration.getMaxDepth()))
+            .max(Comparator.comparingInt(o -> o.length))
+            .orElseGet(() -> QueryConstants.ALL_COLUMNS_NAMES.apply(configuration.getMaxDepth()));
+
+    return Flowable.fromIterable(queryBuilders)
+        .flatMap(
+            queryBuilder ->
+                RxUtils.singleFromFuture(
+                        () -> {
+                          // TODO column per query if possible
+                          // String[] columns = columnsForQuery(queryBuilder,
+                          // configuration.getMaxDepth());
+                          BuiltQuery<? extends BoundQuery> query =
+                              queryBuilder.buildQuery(
+                                  dataStore::queryBuilder, keyspace, collection, columns);
+                          return dataStore.prepare(query);
+                        })
+                    .toFlowable())
+        .toList()
+        .cache()
+        .flatMapPublisher(
+            preparedQueries -> {
+              // find all with empty bind values
+              List<BoundQuery> boundQueries =
+                  preparedQueries.stream().map(Query::bind).collect(Collectors.toList());
+
+              // execute them all by respecting the paging state
+              return queryExecutor.queryDocs(
+                  boundQueries,
+                  configuration.getSearchPageSize(),
+                  paginator.getCurrentDbPageState(),
+                  context);
+            })
+        .filter(
+            doc -> {
+              // now we can get doc as a result of the persistence or in memory query
+              // if we can locate that it was a result of the persistence ones, then nothing is
+              // needed anymore
+              // we can do this by finding any row that does not have any path related column
+              // TODO enable if solved in the query executor
+              // boolean noPaths = doc.rows().stream().anyMatch(r ->
+              // !r.columnExists(QueryConstants.P_COLUMN_NAME.apply(0)));
+              // if (noPaths) {
+              // return true;
+              // }
+
+              // otherwise evaluate using the EvalEngine
+              // this is gonna test the persistence expressions as well, but they must respond to
+              // false
+              Map<String, EvalRule<FilterExpression>> rules = EvalEngine.booleanRules();
+              rules.put(FilterExpression.EXPR_TYPE, new RawDocumentEvalRule(doc));
+              return EvalEngine.evaluate(expression, rules);
+            });
+  }
+
+  private String[] columnsForQuery(AbstractSearchQueryBuilder queryBuilder, int maxDepth) {
+    String[] columns;
+    // we need to figure columns for each query
+    // TODO re-enable if possible key/leaf only
+    // if (queryBuilder instanceof FilterExpressionSearchQueryBuilder) {
+    // columns = new String[] {QueryConstants.KEY_COLUMN_NAME, QueryConstants.LEAF_COLUMN_NAME};
+    if (queryBuilder instanceof FilterPathSearchQueryBuilder) {
+      FilterPathSearchQueryBuilder fpqb = (FilterPathSearchQueryBuilder) queryBuilder;
+      columns = QueryConstants.ALL_COLUMNS_NAMES.apply(fpqb.getFilterPath().getPath().size() + 1);
+    } else {
+      columns = QueryConstants.ALL_COLUMNS_NAMES.apply(maxDepth);
+    }
+    return columns;
+  }
+
+  private List<AbstractSearchQueryBuilder> buildQueries(Set<FilterExpression> children) {
+    // if any condition is evaluate on missing, then we can do a full search only
+    boolean evaluateOnMissing =
+        children.stream().anyMatch(e -> e.getCondition().isEvaluateOnMissingFields());
+    if (evaluateOnMissing) {
+      return Collections.singletonList(new FullSearchQueryBuilder());
+    }
+
+    // otherwise, for each persistence condition an own builder
+    List<AbstractSearchQueryBuilder> persistenceQueries =
+        children.stream()
+            .filter(e -> e.getCondition().isPersistenceCondition())
+            .map(FilterExpressionSearchQueryBuilder::new)
+            .collect(Collectors.toList());
+
+    // for the memory ones, we can collect only distinct filter paths
+    List<AbstractSearchQueryBuilder> inMemoryQueries =
+        children.stream()
+            .filter(e -> !e.getCondition().isPersistenceCondition())
+            .map(FilterExpression::getFilterPath)
+            .distinct()
+            .map(fp -> new FilterPathSearchQueryBuilder(fp, true))
+            .collect(Collectors.toList());
+
+    // merge and return
+    persistenceQueries.addAll(inMemoryQueries);
+    return persistenceQueries;
+  }
+
+  private Set<FilterExpression> getChildren(Or<FilterExpression> expression) {
+    Set<FilterExpression> set = new HashSet<>();
+    expression.collectK(set, Integer.MAX_VALUE);
+    return set;
+  }
+
+  private ExecutionContext createContext(
+      ExecutionContext context, Or<FilterExpression> expression) {
+    return context.nested("MERGING OR: expression '" + expression + "'");
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolver.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolver.java
@@ -83,7 +83,7 @@ public class OrExpressionDocumentsResolver implements DocumentsResolver {
     // resolve if no path are there, used in the filtering
     boolean noPaths =
         Arrays.stream(columns)
-            .anyMatch(c -> Objects.equals(c, QueryConstants.P_COLUMN_NAME.apply(0)));
+            .allMatch(c -> !Objects.equals(c, QueryConstants.P_COLUMN_NAME.apply(0)));
 
     return Flowable.fromIterable(queryBuilders)
         .flatMap(

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolver.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolver.java
@@ -51,16 +51,13 @@ public class OrExpressionDocumentsResolver implements DocumentsResolver {
 
   private final Or<FilterExpression> expression;
 
-  private final Set<FilterExpression> children;
-
   private final List<AbstractSearchQueryBuilder> queryBuilders;
 
   private final ExecutionContext context;
 
   public OrExpressionDocumentsResolver(Or<FilterExpression> expression, ExecutionContext context) {
     this.expression = expression;
-    this.children = getChildren(expression);
-    this.queryBuilders = buildQueries(this.children);
+    this.queryBuilders = buildQueries(getChildren(expression));
     this.context = createContext(context, expression);
   }
 

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/ReactiveDocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/ReactiveDocumentServiceTest.java
@@ -136,6 +136,7 @@ class ReactiveDocumentServiceTest {
             })
         .when(expression)
         .collectK(any(), anyInt());
+    lenient().when(row.columnExists(any())).thenReturn(true);
   }
 
   @Nested

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/AnyFiltersResolverTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/AnyFiltersResolverTest.java
@@ -171,10 +171,10 @@ class AnyFiltersResolverTest extends AbstractDataStoreTest {
       doAnswer(i -> query2)
           .when(candidatesFilter2)
           .prepareQuery(datastore, configuration, KEYSPACE_NAME, COLLECTION_NAME);
-      doAnswer(i -> Maybe.just("you shall pass"))
+      doAnswer(i -> Maybe.empty())
           .when(candidatesFilter)
           .bindAndFilter(eq(queryExecutor), eq(configuration), eq(query1.blockingGet()), any());
-      doAnswer(i -> Maybe.empty())
+      doAnswer(i -> Maybe.just("you shall pass"))
           .when(candidatesFilter2)
           .bindAndFilter(eq(queryExecutor), eq(configuration), eq(query2.blockingGet()), any());
       DocumentsResolver candidatesResolver =

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/AnyFiltersResolverTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/AnyFiltersResolverTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.web.docsapi.service.query.search.resolver.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import io.stargate.db.datastore.AbstractDataStoreTest;
+import io.stargate.db.datastore.DataStore;
+import io.stargate.db.query.BoundQuery;
+import io.stargate.db.query.Query;
+import io.stargate.db.query.builder.BuiltQuery;
+import io.stargate.db.schema.Schema;
+import io.stargate.db.schema.Table;
+import io.stargate.web.docsapi.DocsApiTestSchemaProvider;
+import io.stargate.web.docsapi.dao.Paginator;
+import io.stargate.web.docsapi.service.DocsApiConfiguration;
+import io.stargate.web.docsapi.service.ExecutionContext;
+import io.stargate.web.docsapi.service.QueryExecutor;
+import io.stargate.web.docsapi.service.RawDocument;
+import io.stargate.web.docsapi.service.query.search.resolver.DocumentsResolver;
+import io.stargate.web.docsapi.service.query.search.resolver.filter.CandidatesFilter;
+import io.stargate.web.rx.RxUtils;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AnyFiltersResolverTest extends AbstractDataStoreTest {
+
+  private static final DocsApiTestSchemaProvider SCHEMA_PROVIDER = new DocsApiTestSchemaProvider(0);
+  private static final Table TABLE = SCHEMA_PROVIDER.getTable();
+  private static final String KEYSPACE_NAME = SCHEMA_PROVIDER.getKeyspace().name();
+  private static final String COLLECTION_NAME = SCHEMA_PROVIDER.getTable().name();
+
+  @Mock DocsApiConfiguration configuration;
+
+  QueryExecutor queryExecutor;
+
+  ExecutionContext executionContext;
+
+  @Override
+  protected Schema schema() {
+    return SCHEMA_PROVIDER.getSchema();
+  }
+
+  @BeforeEach
+  public void init() {
+    executionContext = ExecutionContext.create(true);
+    queryExecutor = new QueryExecutor(datastore());
+    lenient().when(configuration.getSearchPageSize()).thenReturn(100);
+  }
+
+  @Nested
+  class GetDocuments {
+
+    @Mock CandidatesFilter candidatesFilter;
+
+    @Mock CandidatesFilter candidatesFilter2;
+
+    @Mock RawDocument rawDocument;
+
+    @Mock RawDocument rawDocument2;
+
+    Single<? extends Query<? extends BoundQuery>> query1;
+
+    Single<? extends Query<? extends BoundQuery>> query2;
+
+    @BeforeEach
+    public void initQueries() {
+      DataStore datastore = datastore();
+
+      query1 =
+          RxUtils.singleFromFuture(
+                  () -> {
+                    BuiltQuery<? extends BoundQuery> built =
+                        datastore.queryBuilder().select().column("text_value").from(TABLE).build();
+                    return datastore.prepare(built);
+                  })
+              .cache();
+
+      query2 =
+          RxUtils.singleFromFuture(
+                  () -> {
+                    BuiltQuery<? extends BoundQuery> built =
+                        datastore.queryBuilder().select().column("dbl_value").from(TABLE).build();
+                    return datastore.prepare(built);
+                  })
+              .cache();
+    }
+
+    @Test
+    public void happyPath() {
+      withAnySelectFrom(TABLE).returningNothing();
+
+      DataStore datastore = datastore();
+      doAnswer(i -> query1)
+          .when(candidatesFilter)
+          .prepareQuery(datastore, configuration, KEYSPACE_NAME, COLLECTION_NAME);
+      doAnswer(i -> query2)
+          .when(candidatesFilter2)
+          .prepareQuery(datastore, configuration, KEYSPACE_NAME, COLLECTION_NAME);
+      doAnswer(i -> Maybe.just("you shall pass"))
+          .when(candidatesFilter)
+          .bindAndFilter(queryExecutor, configuration, query1.blockingGet(), rawDocument);
+      doAnswer(i -> Maybe.just("you shall pass"))
+          .when(candidatesFilter2)
+          .bindAndFilter(queryExecutor, configuration, query2.blockingGet(), rawDocument);
+      DocumentsResolver candidatesResolver =
+          (queryExecutor1, configuration1, keyspace, collection, paginator) ->
+              Flowable.just(rawDocument);
+
+      DocumentsResolver resolver =
+          new AnyFiltersResolver(
+              Arrays.asList((c) -> candidatesFilter, (c) -> candidatesFilter2),
+              executionContext,
+              candidatesResolver);
+      Flowable<RawDocument> results =
+          resolver.getDocuments(
+              queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, new Paginator(null, 1));
+
+      results.test().assertValue(rawDocument).assertComplete();
+
+      resetExpectations();
+
+      verify(candidatesFilter)
+          .prepareQuery(datastore, configuration, KEYSPACE_NAME, COLLECTION_NAME);
+      verify(candidatesFilter2)
+          .prepareQuery(datastore, configuration, KEYSPACE_NAME, COLLECTION_NAME);
+      verify(candidatesFilter)
+          .bindAndFilter(queryExecutor, configuration, query1.blockingGet(), rawDocument);
+      verify(candidatesFilter2)
+          .bindAndFilter(queryExecutor, configuration, query2.blockingGet(), rawDocument);
+      verifyNoMoreInteractions(candidatesFilter, candidatesFilter2);
+    }
+
+    @Test
+    public void multipleDocumentsOneFilterPassing() {
+      withAnySelectFrom(TABLE).returningNothing();
+
+      DataStore datastore = datastore();
+      doAnswer(i -> query1)
+          .when(candidatesFilter)
+          .prepareQuery(datastore, configuration, KEYSPACE_NAME, COLLECTION_NAME);
+      doAnswer(i -> query2)
+          .when(candidatesFilter2)
+          .prepareQuery(datastore, configuration, KEYSPACE_NAME, COLLECTION_NAME);
+      doAnswer(i -> Maybe.just("you shall pass"))
+          .when(candidatesFilter)
+          .bindAndFilter(eq(queryExecutor), eq(configuration), eq(query1.blockingGet()), any());
+      doAnswer(i -> Maybe.empty())
+          .when(candidatesFilter2)
+          .bindAndFilter(eq(queryExecutor), eq(configuration), eq(query2.blockingGet()), any());
+      DocumentsResolver candidatesResolver =
+          (queryExecutor1, configuration1, keyspace, collection, paginator) ->
+              Flowable.just(rawDocument, rawDocument2);
+
+      DocumentsResolver resolver =
+          new AnyFiltersResolver(
+              Arrays.asList((c) -> candidatesFilter, (c) -> candidatesFilter2),
+              executionContext,
+              candidatesResolver);
+      Flowable<RawDocument> results =
+          resolver.getDocuments(
+              queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, new Paginator(null, 1));
+
+      results.test().assertValueAt(0, rawDocument).assertValueAt(1, rawDocument2).assertComplete();
+
+      resetExpectations();
+
+      verify(candidatesFilter)
+          .prepareQuery(datastore, configuration, KEYSPACE_NAME, COLLECTION_NAME);
+      verify(candidatesFilter2)
+          .prepareQuery(datastore, configuration, KEYSPACE_NAME, COLLECTION_NAME);
+      verify(candidatesFilter)
+          .bindAndFilter(queryExecutor, configuration, query1.blockingGet(), rawDocument);
+      verify(candidatesFilter2)
+          .bindAndFilter(queryExecutor, configuration, query2.blockingGet(), rawDocument);
+      verify(candidatesFilter)
+          .bindAndFilter(queryExecutor, configuration, query1.blockingGet(), rawDocument2);
+      verify(candidatesFilter2)
+          .bindAndFilter(queryExecutor, configuration, query2.blockingGet(), rawDocument2);
+      verifyNoMoreInteractions(candidatesFilter, candidatesFilter2);
+    }
+
+    @Test
+    public void allFiltersNotPassed() {
+      withAnySelectFrom(TABLE).returningNothing();
+
+      DataStore datastore = datastore();
+      doAnswer(i -> query1)
+          .when(candidatesFilter)
+          .prepareQuery(datastore, configuration, KEYSPACE_NAME, COLLECTION_NAME);
+      doAnswer(i -> query2)
+          .when(candidatesFilter2)
+          .prepareQuery(datastore, configuration, KEYSPACE_NAME, COLLECTION_NAME);
+      doAnswer(i -> Maybe.empty())
+          .when(candidatesFilter)
+          .bindAndFilter(queryExecutor, configuration, query1.blockingGet(), rawDocument);
+      doAnswer(i -> Maybe.empty())
+          .when(candidatesFilter2)
+          .bindAndFilter(queryExecutor, configuration, query2.blockingGet(), rawDocument);
+      DocumentsResolver candidatesResolver =
+          (queryExecutor1, configuration1, keyspace, collection, paginator) ->
+              Flowable.just(rawDocument);
+
+      DocumentsResolver resolver =
+          new AnyFiltersResolver(
+              Arrays.asList((c) -> candidatesFilter, (c) -> candidatesFilter2),
+              executionContext,
+              candidatesResolver);
+      Flowable<RawDocument> results =
+          resolver.getDocuments(
+              queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, new Paginator(null, 1));
+
+      results.test().assertValueCount(0).assertComplete();
+
+      resetExpectations();
+
+      verify(candidatesFilter)
+          .prepareQuery(datastore, configuration, KEYSPACE_NAME, COLLECTION_NAME);
+      verify(candidatesFilter2)
+          .prepareQuery(datastore, configuration, KEYSPACE_NAME, COLLECTION_NAME);
+      verify(candidatesFilter)
+          .bindAndFilter(queryExecutor, configuration, query1.blockingGet(), rawDocument);
+      verify(candidatesFilter2)
+          .bindAndFilter(queryExecutor, configuration, query2.blockingGet(), rawDocument);
+      verifyNoMoreInteractions(candidatesFilter, candidatesFilter2);
+    }
+
+    @Test
+    public void noCandidates() {
+      withAnySelectFrom(TABLE).returningNothing();
+
+      DocumentsResolver candidatesResolver =
+          (queryExecutor1, configuration1, keyspace, collection, paginator) -> Flowable.empty();
+
+      DocumentsResolver resolver =
+          new AnyFiltersResolver(
+              Arrays.asList((c) -> candidatesFilter, (c) -> candidatesFilter2),
+              executionContext,
+              candidatesResolver);
+      Flowable<RawDocument> results =
+          resolver.getDocuments(
+              queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, new Paginator(null, 1));
+
+      results.test().assertValueCount(0).assertComplete();
+
+      resetExpectations();
+      verifyNoMoreInteractions(candidatesFilter, candidatesFilter2);
+    }
+  }
+}

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolverTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolverTest.java
@@ -1,0 +1,861 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.web.docsapi.service.query.search.resolver.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.bpodgursky.jbool_expressions.Or;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import io.reactivex.rxjava3.core.Flowable;
+import io.stargate.db.datastore.AbstractDataStoreTest;
+import io.stargate.db.datastore.ValidatingDataStore;
+import io.stargate.db.schema.Schema;
+import io.stargate.db.schema.Table;
+import io.stargate.web.docsapi.DocsApiTestSchemaProvider;
+import io.stargate.web.docsapi.dao.Paginator;
+import io.stargate.web.docsapi.service.DocsApiConfiguration;
+import io.stargate.web.docsapi.service.ExecutionContext;
+import io.stargate.web.docsapi.service.QueryExecutor;
+import io.stargate.web.docsapi.service.RawDocument;
+import io.stargate.web.docsapi.service.query.FilterExpression;
+import io.stargate.web.docsapi.service.query.FilterPath;
+import io.stargate.web.docsapi.service.query.ImmutableFilterExpression;
+import io.stargate.web.docsapi.service.query.ImmutableFilterPath;
+import io.stargate.web.docsapi.service.query.condition.BaseCondition;
+import io.stargate.web.docsapi.service.query.condition.impl.ImmutableGenericCondition;
+import io.stargate.web.docsapi.service.query.condition.impl.ImmutableNumberCondition;
+import io.stargate.web.docsapi.service.query.condition.impl.ImmutableStringCondition;
+import io.stargate.web.docsapi.service.query.filter.operation.impl.EqFilterOperation;
+import io.stargate.web.docsapi.service.query.filter.operation.impl.GtFilterOperation;
+import io.stargate.web.docsapi.service.query.filter.operation.impl.InFilterOperation;
+import io.stargate.web.docsapi.service.query.filter.operation.impl.LtFilterOperation;
+import io.stargate.web.docsapi.service.query.filter.operation.impl.NeFilterOperation;
+import io.stargate.web.docsapi.service.query.search.resolver.DocumentsResolver;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
+
+  private static final int MAX_DEPTH = 4;
+  private static final DocsApiTestSchemaProvider SCHEMA_PROVIDER =
+      new DocsApiTestSchemaProvider(MAX_DEPTH);
+  private static final Table TABLE = SCHEMA_PROVIDER.getTable();
+  private static final String KEYSPACE_NAME = SCHEMA_PROVIDER.getKeyspace().name();
+  private static final String COLLECTION_NAME = SCHEMA_PROVIDER.getTable().name();
+
+  @Override
+  protected Schema schema() {
+    return SCHEMA_PROVIDER.getSchema();
+  }
+
+  @Nested
+  class GetDocuments {
+
+    @Mock DocsApiConfiguration configuration;
+
+    QueryExecutor queryExecutor;
+
+    ExecutionContext executionContext;
+
+    @BeforeEach
+    public void init() {
+      executionContext = ExecutionContext.create(true);
+      queryExecutor = new QueryExecutor(datastore());
+      when(configuration.getSearchPageSize()).thenReturn(100);
+      when(configuration.getMaxDepth()).thenReturn(MAX_DEPTH);
+    }
+
+    @Test
+    public void twoPersistenceConditions() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      BaseCondition condition = ImmutableStringCondition.of(GtFilterOperation.of(), "query-value");
+      BaseCondition condition2 = ImmutableNumberCondition.of(LtFilterOperation.of(), 1);
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingDataStore.QueryAssert query1Assert =
+          withQuery(
+                  TABLE,
+                  "SELECT key, leaf, WRITETIME(leaf) FROM %s WHERE p0 = ? AND leaf = ? AND p1 = ? AND text_value > ? ALLOW FILTERING",
+                  "field",
+                  "field",
+                  "",
+                  "query-value")
+              .withPageSize(configuration.getSearchPageSize())
+              .returning(Collections.singletonList(ImmutableMap.of("key", "1")));
+
+      ValidatingDataStore.QueryAssert query2Assert =
+          withQuery(
+                  TABLE,
+                  "SELECT key, leaf, WRITETIME(leaf) FROM %s WHERE p0 = ? AND leaf = ? AND p1 = ? AND dbl_value < ? ALLOW FILTERING",
+                  "field",
+                  "field",
+                  "",
+                  1d)
+              .withPageSize(configuration.getSearchPageSize())
+              .returning(Collections.singletonList(ImmutableMap.of("key", "1")));
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver = new OrExpressionDocumentsResolver(or, executionContext);
+      Flowable<RawDocument> result =
+          resolver.getDocuments(
+              queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
+
+      result
+          .test()
+          .assertValue(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(1);
+                return true;
+              })
+          .assertComplete();
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+      query2Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo("MERGING OR: expression '(field GT query-value | field LT 1)'");
+                assertThat(nested.queries())
+                    .hasSize(2)
+                    .allSatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+    }
+
+    @Test
+    public void twoPersistenceConditionsOneQueryEmpty() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      BaseCondition condition = ImmutableStringCondition.of(GtFilterOperation.of(), "query-value");
+      BaseCondition condition2 = ImmutableNumberCondition.of(LtFilterOperation.of(), 1);
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingDataStore.QueryAssert query1Assert =
+          withQuery(
+                  TABLE,
+                  "SELECT key, leaf, WRITETIME(leaf) FROM %s WHERE p0 = ? AND leaf = ? AND p1 = ? AND text_value > ? ALLOW FILTERING",
+                  "field",
+                  "field",
+                  "",
+                  "query-value")
+              .withPageSize(configuration.getSearchPageSize())
+              .returning(Collections.singletonList(ImmutableMap.of("key", "1")));
+
+      ValidatingDataStore.QueryAssert query2Assert =
+          withQuery(
+                  TABLE,
+                  "SELECT key, leaf, WRITETIME(leaf) FROM %s WHERE p0 = ? AND leaf = ? AND p1 = ? AND dbl_value < ? ALLOW FILTERING",
+                  "field",
+                  "field",
+                  "",
+                  1d)
+              .withPageSize(configuration.getSearchPageSize())
+              .returningNothing();
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver = new OrExpressionDocumentsResolver(or, executionContext);
+      Flowable<RawDocument> result =
+          resolver.getDocuments(
+              queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
+
+      result
+          .test()
+          .assertValue(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(1);
+                return true;
+              })
+          .assertComplete();
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+      query2Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo("MERGING OR: expression '(field GT query-value | field LT 1)'");
+                assertThat(nested.queries())
+                    .hasSize(2)
+                    .anySatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        })
+                    .anySatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(0);
+                        });
+              });
+    }
+
+    @Test
+    public void twoPersistenceConditionsNothingReturned() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      BaseCondition condition = ImmutableStringCondition.of(GtFilterOperation.of(), "query-value");
+      BaseCondition condition2 = ImmutableNumberCondition.of(LtFilterOperation.of(), 1);
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingDataStore.QueryAssert query1Assert =
+          withQuery(
+                  TABLE,
+                  "SELECT key, leaf, WRITETIME(leaf) FROM %s WHERE p0 = ? AND leaf = ? AND p1 = ? AND text_value > ? ALLOW FILTERING",
+                  "field",
+                  "field",
+                  "",
+                  "query-value")
+              .withPageSize(configuration.getSearchPageSize())
+              .returningNothing();
+
+      ValidatingDataStore.QueryAssert query2Assert =
+          withQuery(
+                  TABLE,
+                  "SELECT key, leaf, WRITETIME(leaf) FROM %s WHERE p0 = ? AND leaf = ? AND p1 = ? AND dbl_value < ? ALLOW FILTERING",
+                  "field",
+                  "field",
+                  "",
+                  1d)
+              .withPageSize(configuration.getSearchPageSize())
+              .returningNothing();
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver = new OrExpressionDocumentsResolver(or, executionContext);
+      Flowable<RawDocument> result =
+          resolver.getDocuments(
+              queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
+
+      result.test().assertComplete();
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+      query2Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo("MERGING OR: expression '(field GT query-value | field LT 1)'");
+                assertThat(nested.queries())
+                    .hasSize(2)
+                    .allSatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(0);
+                        });
+              });
+    }
+
+    @Test
+    public void persistenceAndInMemoryConditionPersistenceTrue() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition = ImmutableStringCondition.of(EqFilterOperation.of(), "query-value");
+      BaseCondition condition2 =
+          ImmutableGenericCondition.of(InFilterOperation.of(), Collections.singletonList(1), false);
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingDataStore.QueryAssert query1Assert =
+          withQuery(
+                  TABLE,
+                  "SELECT key, leaf, text_value, dbl_value, bool_value, p0, p1, WRITETIME(leaf) FROM %s WHERE p0 = ? AND leaf = ? AND p1 = ? AND text_value = ? ALLOW FILTERING",
+                  "field",
+                  "field",
+                  "",
+                  "query-value")
+              .withPageSize(configuration.getSearchPageSize())
+              .returning(
+                  Collections.singletonList(
+                      ImmutableMap.of(
+                          "key",
+                          "1",
+                          "leaf",
+                          "field",
+                          "p0",
+                          "field",
+                          "p1",
+                          "",
+                          "text_value",
+                          "query-value")));
+
+      ValidatingDataStore.QueryAssert query2Assert =
+          withQuery(
+                  TABLE,
+                  "SELECT key, leaf, text_value, dbl_value, bool_value, p0, p1, WRITETIME(leaf) FROM %s WHERE p0 = ? AND leaf = ? AND p1 = ? ALLOW FILTERING",
+                  "field",
+                  "field",
+                  "")
+              .withPageSize(configuration.getSearchPageSize())
+              .returning(
+                  Collections.singletonList(
+                      ImmutableMap.of(
+                          "key", "1", "leaf", "field", "p0", "field", "p1", "", "dbl_value", 2d)));
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver = new OrExpressionDocumentsResolver(or, executionContext);
+      Flowable<RawDocument> result =
+          resolver.getDocuments(
+              queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
+
+      result
+          .test()
+          .assertValue(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(1);
+                return true;
+              })
+          .assertComplete();
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+      query2Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo("MERGING OR: expression '(field EQ query-value | field IN [1])'");
+                assertThat(nested.queries())
+                    .hasSize(2)
+                    .allSatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+    }
+
+    @Test
+    public void persistenceAndInMemoryConditionMemoryTrue() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition = ImmutableStringCondition.of(GtFilterOperation.of(), "query-value");
+      BaseCondition condition2 =
+          ImmutableGenericCondition.of(InFilterOperation.of(), Collections.singletonList(1), false);
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingDataStore.QueryAssert query1Assert =
+          withQuery(
+                  TABLE,
+                  "SELECT key, leaf, text_value, dbl_value, bool_value, p0, p1, WRITETIME(leaf) FROM %s WHERE p0 = ? AND leaf = ? AND p1 = ? AND text_value > ? ALLOW FILTERING",
+                  "field",
+                  "field",
+                  "",
+                  "query-value")
+              .withPageSize(configuration.getSearchPageSize())
+              .returningNothing();
+
+      ValidatingDataStore.QueryAssert query2Assert =
+          withQuery(
+                  TABLE,
+                  "SELECT key, leaf, text_value, dbl_value, bool_value, p0, p1, WRITETIME(leaf) FROM %s WHERE p0 = ? AND leaf = ? AND p1 = ? ALLOW FILTERING",
+                  "field",
+                  "field",
+                  "")
+              .withPageSize(configuration.getSearchPageSize())
+              .returning(
+                  Collections.singletonList(
+                      ImmutableMap.of(
+                          "key", "1", "leaf", "field", "p0", "field", "p1", "", "dbl_value", 1d)));
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver = new OrExpressionDocumentsResolver(or, executionContext);
+      Flowable<RawDocument> result =
+          resolver.getDocuments(
+              queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
+
+      result
+          .test()
+          .assertValue(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(1);
+                return true;
+              })
+          .assertComplete();
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+      query2Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo("MERGING OR: expression '(field GT query-value | field IN [1])'");
+                assertThat(nested.queries())
+                    .hasSize(2)
+                    .anySatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        })
+                    .anySatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(0);
+                        });
+              });
+    }
+
+    @Test
+    public void persistenceAndInMemoryConditionMemoryFalse() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition = ImmutableStringCondition.of(GtFilterOperation.of(), "query-value");
+      BaseCondition condition2 =
+          ImmutableGenericCondition.of(InFilterOperation.of(), Collections.singletonList(1), false);
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingDataStore.QueryAssert query1Assert =
+          withQuery(
+                  TABLE,
+                  "SELECT key, leaf, text_value, dbl_value, bool_value, p0, p1, WRITETIME(leaf) FROM %s WHERE p0 = ? AND leaf = ? AND p1 = ? AND text_value > ? ALLOW FILTERING",
+                  "field",
+                  "field",
+                  "",
+                  "query-value")
+              .withPageSize(configuration.getSearchPageSize())
+              .returningNothing();
+
+      ValidatingDataStore.QueryAssert query2Assert =
+          withQuery(
+                  TABLE,
+                  "SELECT key, leaf, text_value, dbl_value, bool_value, p0, p1, WRITETIME(leaf) FROM %s WHERE p0 = ? AND leaf = ? AND p1 = ? ALLOW FILTERING",
+                  "field",
+                  "field",
+                  "")
+              .withPageSize(configuration.getSearchPageSize())
+              .returning(
+                  Collections.singletonList(
+                      ImmutableMap.of(
+                          "key", "1", "leaf", "field", "p0", "field", "p1", "", "dbl_value", 2d)));
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver = new OrExpressionDocumentsResolver(or, executionContext);
+      Flowable<RawDocument> result =
+          resolver.getDocuments(
+              queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
+
+      result.test().assertComplete();
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+      query2Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo("MERGING OR: expression '(field GT query-value | field IN [1])'");
+                assertThat(nested.queries())
+                    .hasSize(2)
+                    .anySatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        })
+                    .anySatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(0);
+                        });
+              });
+    }
+
+    @Test
+    public void persistenceAndInMemoryConditionNothingReturned() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("path", "field"));
+      BaseCondition condition = ImmutableStringCondition.of(GtFilterOperation.of(), "query-value");
+      BaseCondition condition2 =
+          ImmutableGenericCondition.of(InFilterOperation.of(), Collections.singletonList(1), false);
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingDataStore.QueryAssert query1Assert =
+          withQuery(
+                  TABLE,
+                  "SELECT key, leaf, text_value, dbl_value, bool_value, p0, p1, p2, WRITETIME(leaf) FROM %s WHERE p0 = ? AND p1 = ? AND leaf = ? AND p2 = ? AND text_value > ? ALLOW FILTERING",
+                  "path",
+                  "field",
+                  "field",
+                  "",
+                  "query-value")
+              .withPageSize(configuration.getSearchPageSize())
+              .returningNothing();
+
+      ValidatingDataStore.QueryAssert query2Assert =
+          withQuery(
+                  TABLE,
+                  "SELECT key, leaf, text_value, dbl_value, bool_value, p0, p1, p2, WRITETIME(leaf) FROM %s WHERE p0 = ? AND p1 = ? AND leaf = ? AND p2 = ? ALLOW FILTERING",
+                  "path",
+                  "field",
+                  "field",
+                  "")
+              .withPageSize(configuration.getSearchPageSize())
+              .returningNothing();
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver = new OrExpressionDocumentsResolver(or, executionContext);
+      Flowable<RawDocument> result =
+          resolver.getDocuments(
+              queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
+
+      result.test().assertComplete();
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+      query2Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo(
+                        "MERGING OR: expression '(path.field IN [1] | path.field GT query-value)'");
+                assertThat(nested.queries())
+                    .hasSize(2)
+                    .allSatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(0);
+                        });
+              });
+    }
+
+    @Test
+    public void persistenceAndEvaluateOnMissing() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition = ImmutableStringCondition.of(GtFilterOperation.of(), "query-value");
+      BaseCondition condition2 = ImmutableStringCondition.of(NeFilterOperation.of(), "not-me");
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingDataStore.QueryAssert query1Assert =
+          withQuery(
+                  TABLE,
+                  "SELECT key, leaf, text_value, dbl_value, bool_value, p0, p1, p2, p3, WRITETIME(leaf) FROM %s")
+              .withPageSize(configuration.getSearchPageSize())
+              .returning(
+                  Collections.singletonList(
+                      ImmutableMap.of(
+                          "key",
+                          "1",
+                          "leaf",
+                          "field",
+                          "p0",
+                          "field",
+                          "p1",
+                          "",
+                          "text_value",
+                          "whatever")));
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver = new OrExpressionDocumentsResolver(or, executionContext);
+      Flowable<RawDocument> result =
+          resolver.getDocuments(
+              queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
+
+      result
+          .test()
+          .assertValue(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(1);
+                return true;
+              })
+          .assertComplete();
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo("MERGING OR: expression '(field GT query-value | field NE not-me)'");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+    }
+
+    @Test
+    public void persistenceAndEvaluateOnMissingNotMatched() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition = ImmutableStringCondition.of(GtFilterOperation.of(), "query-value");
+      BaseCondition condition2 = ImmutableStringCondition.of(NeFilterOperation.of(), "not-me");
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingDataStore.QueryAssert query1Assert =
+          withQuery(
+                  TABLE,
+                  "SELECT key, leaf, text_value, dbl_value, bool_value, p0, p1, p2, p3, WRITETIME(leaf) FROM %s")
+              .withPageSize(configuration.getSearchPageSize())
+              .returning(
+                  Collections.singletonList(
+                      ImmutableMap.of(
+                          "key",
+                          "1",
+                          "leaf",
+                          "field",
+                          "p0",
+                          "field",
+                          "p1",
+                          "",
+                          "text_value",
+                          "not-me")));
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver = new OrExpressionDocumentsResolver(or, executionContext);
+      Flowable<RawDocument> result =
+          resolver.getDocuments(
+              queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
+
+      result.test().assertComplete();
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo("MERGING OR: expression '(field GT query-value | field NE not-me)'");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+    }
+
+    @Test
+    public void inMemoryAndEvaluateOnMissing() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition =
+          ImmutableGenericCondition.of(
+              InFilterOperation.of(), Collections.singletonList("query-value"), false);
+      BaseCondition condition2 = ImmutableStringCondition.of(NeFilterOperation.of(), "not-me");
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingDataStore.QueryAssert query1Assert =
+          withQuery(
+                  TABLE,
+                  "SELECT key, leaf, text_value, dbl_value, bool_value, p0, p1, p2, p3, WRITETIME(leaf) FROM %s")
+              .withPageSize(configuration.getSearchPageSize())
+              .returning(
+                  Collections.singletonList(
+                      ImmutableMap.of(
+                          "key",
+                          "1",
+                          "leaf",
+                          "field",
+                          "p0",
+                          "field",
+                          "p1",
+                          "",
+                          "text_value",
+                          "query-value")));
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver = new OrExpressionDocumentsResolver(or, executionContext);
+      Flowable<RawDocument> result =
+          resolver.getDocuments(
+              queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
+
+      result
+          .test()
+          .assertValue(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(1);
+                return true;
+              })
+          .assertComplete();
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo(
+                        "MERGING OR: expression '(field NE not-me | field IN [query-value])'");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+    }
+
+    @Test
+    public void inMemoryAndEvaluateOnMissingNotMatching() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition =
+          ImmutableGenericCondition.of(
+              InFilterOperation.of(), Collections.singletonList("query-value"), false);
+      BaseCondition condition2 = ImmutableStringCondition.of(NeFilterOperation.of(), "not-me");
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingDataStore.QueryAssert query1Assert =
+          withQuery(
+                  TABLE,
+                  "SELECT key, leaf, text_value, dbl_value, bool_value, p0, p1, p2, p3, WRITETIME(leaf) FROM %s")
+              .withPageSize(configuration.getSearchPageSize())
+              .returning(
+                  Collections.singletonList(
+                      ImmutableMap.of(
+                          "key",
+                          "1",
+                          "leaf",
+                          "field",
+                          "p0",
+                          "field",
+                          "p1",
+                          "",
+                          "text_value",
+                          "not-me")));
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver = new OrExpressionDocumentsResolver(or, executionContext);
+      Flowable<RawDocument> result =
+          resolver.getDocuments(
+              queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
+
+      result.test().assertComplete();
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo(
+                        "MERGING OR: expression '(field NE not-me | field IN [query-value])'");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+    }
+  }
+}

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -2348,6 +2348,205 @@ public abstract class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   }
 
   @Test
+  public void searchOrPersistenceFilter() throws Exception {
+    JsonNode matching1 = OBJECT_MAPPER.readTree("{\"value\": \"a\"}");
+    JsonNode matching2 = OBJECT_MAPPER.readTree("{\"value\": \"b\"}");
+    JsonNode nonMatching = OBJECT_MAPPER.readTree("{\"value\": \"c\"}");
+    RestUtils.put(authToken, collectionPath + "/matching1", matching1.toString(), 200);
+    RestUtils.put(authToken, collectionPath + "/matching2", matching2.toString(), 200);
+    RestUtils.put(authToken, collectionPath + "/nonMatching", nonMatching.toString(), 200);
+
+    // Any filter on full collection search should only match the level of nesting of the where
+    // clause
+    String r =
+        RestUtils.get(
+            authToken,
+            hostWithPort
+                + "/v2/namespaces/"
+                + keyspace
+                + "/collections/collection?page-size=3&where={\"$or\": [{\"value\": {\"$eq\": \"a\"}}, {\"value\": {\"$eq\": \"b\"}}]}&raw=true",
+            200);
+
+    String expected = "{\"matching1\":{\"value\":\"a\"},\"matching2\":{\"value\":\"b\"}}";
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(expected));
+  }
+
+  @Test
+  public void searchOrInMemoryFilter() throws Exception {
+    JsonNode matching1 = OBJECT_MAPPER.readTree("{\"value\": \"a\"}");
+    JsonNode matching2 = OBJECT_MAPPER.readTree("{\"value\": \"b\"}");
+    JsonNode nonMatching = OBJECT_MAPPER.readTree("{\"value\": \"c\"}");
+    RestUtils.put(authToken, collectionPath + "/matching1", matching1.toString(), 200);
+    RestUtils.put(authToken, collectionPath + "/matching2", matching2.toString(), 200);
+    RestUtils.put(authToken, collectionPath + "/nonMatching", nonMatching.toString(), 200);
+
+    // Any filter on full collection search should only match the level of nesting of the where
+    // clause
+    String r =
+        RestUtils.get(
+            authToken,
+            hostWithPort
+                + "/v2/namespaces/"
+                + keyspace
+                + "/collections/collection?page-size=3&where={\"$or\": [{\"value\": {\"$in\": [\"a\"]}}, {\"value\": {\"$in\": [\"b\"]}}]}&raw=true",
+            200);
+
+    String expected = "{\"matching1\":{\"value\":\"a\"},\"matching2\":{\"value\":\"b\"}}";
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(expected));
+  }
+
+  @Test
+  public void searchOrMixedFilter() throws Exception {
+    JsonNode matching1 = OBJECT_MAPPER.readTree("{\"value\": \"a\"}");
+    JsonNode matching2 = OBJECT_MAPPER.readTree("{\"value\": \"b\"}");
+    JsonNode nonMatching = OBJECT_MAPPER.readTree("{\"value\": \"c\"}");
+    RestUtils.put(authToken, collectionPath + "/matching1", matching1.toString(), 200);
+    RestUtils.put(authToken, collectionPath + "/matching2", matching2.toString(), 200);
+    RestUtils.put(authToken, collectionPath + "/nonMatching", nonMatching.toString(), 200);
+
+    // Any filter on full collection search should only match the level of nesting of the where
+    // clause
+    String r =
+        RestUtils.get(
+            authToken,
+            hostWithPort
+                + "/v2/namespaces/"
+                + keyspace
+                + "/collections/collection?page-size=3&where={\"$or\": [{\"value\": {\"$eq\": \"a\"}}, {\"value\": {\"$in\": [\"b\"]}}]}&raw=true",
+            200);
+
+    String expected = "{\"matching1\":{\"value\":\"a\"},\"matching2\":{\"value\":\"b\"}}";
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(expected));
+  }
+
+  @Test
+  public void searchOrMixedFiltersDifferentPaths() throws Exception {
+    JsonNode matching1 = OBJECT_MAPPER.readTree("{\"value\": \"a\", \"count\": 1}");
+    JsonNode matching2 = OBJECT_MAPPER.readTree("{\"value\": \"b\", \"count\": 2}");
+    JsonNode nonMatching = OBJECT_MAPPER.readTree("{\"value\": \"c\", \"count\": 3}");
+    RestUtils.put(authToken, collectionPath + "/matching1", matching1.toString(), 200);
+    RestUtils.put(authToken, collectionPath + "/matching2", matching2.toString(), 200);
+    RestUtils.put(authToken, collectionPath + "/nonMatching", nonMatching.toString(), 200);
+
+    // Any filter on full collection search should only match the level of nesting of the where
+    // clause
+    String r =
+        RestUtils.get(
+            authToken,
+            hostWithPort
+                + "/v2/namespaces/"
+                + keyspace
+                + "/collections/collection?page-size=3&where={\"$or\": [{\"value\": {\"$eq\": \"a\"}}, {\"count\": {\"$in\": [2,4]}}]}&raw=true",
+            200);
+
+    String expected =
+        "{\"matching1\":{\"value\":\"a\",\"count\": 1},\"matching2\":{\"value\":\"b\",\"count\": 2}}";
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(expected));
+  }
+
+  @Test
+  public void searchAndWithOr() throws Exception {
+    JsonNode matching1 = OBJECT_MAPPER.readTree("{\"value\": \"a\", \"count\": 1}");
+    JsonNode matching2 = OBJECT_MAPPER.readTree("{\"value\": \"b\", \"count\": 2}");
+    JsonNode nonMatching = OBJECT_MAPPER.readTree("{\"value\": \"c\", \"count\": 3}");
+    RestUtils.put(authToken, collectionPath + "/matching1", matching1.toString(), 200);
+    RestUtils.put(authToken, collectionPath + "/matching2", matching2.toString(), 200);
+    RestUtils.put(authToken, collectionPath + "/nonMatching", nonMatching.toString(), 200);
+
+    // Any filter on full collection search should only match the level of nesting of the where
+    // clause
+    String r =
+        RestUtils.get(
+            authToken,
+            hostWithPort
+                + "/v2/namespaces/"
+                + keyspace
+                + "/collections/collection?page-size=3&where={\"count\": {\"$gt\": 0}}, \"$or\": [{\"value\": {\"$eq\": \"a\"}}, {\"value\": {\"$in\": [\"b\"]}}]}&raw=true",
+            200);
+
+    String expected =
+        "{\"matching1\":{\"value\":\"a\",\"count\": 1},\"matching2\":{\"value\":\"b\",\"count\": 2}}";
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(expected));
+  }
+
+  @Test
+  public void searchOrExists() throws Exception {
+    JsonNode matching1 = OBJECT_MAPPER.readTree("{\"value\": \"a\"}");
+    JsonNode matching2 = OBJECT_MAPPER.readTree("{\"other\": \"b\"}");
+    JsonNode nonMatching = OBJECT_MAPPER.readTree("{\"value\": \"c\"}");
+    RestUtils.put(authToken, collectionPath + "/matching1", matching1.toString(), 200);
+    RestUtils.put(authToken, collectionPath + "/matching2", matching2.toString(), 200);
+    RestUtils.put(authToken, collectionPath + "/nonMatching", nonMatching.toString(), 200);
+
+    // Any filter on full collection search should only match the level of nesting of the where
+    // clause
+    String r =
+        RestUtils.get(
+            authToken,
+            hostWithPort
+                + "/v2/namespaces/"
+                + keyspace
+                + "/collections/collection?page-size=3&where={\"$or\": [{\"value\": {\"$eq\": \"a\"}}, {\"other\": {\"$exists\": true}}]}&raw=true",
+            200);
+
+    String expected = "{\"matching1\":{\"value\":\"a\"},\"matching2\":{\"other\":\"b\"}}";
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(expected));
+  }
+
+  @Test
+  public void searchOrEvaluateOnMissing() throws Exception {
+    JsonNode matching1 = OBJECT_MAPPER.readTree("{\"value\": \"a\"}");
+    JsonNode matching2 = OBJECT_MAPPER.readTree("{\"other\": \"b\"}");
+    JsonNode nonMatching = OBJECT_MAPPER.readTree("{\"value\": \"c\"}");
+    RestUtils.put(authToken, collectionPath + "/matching1", matching1.toString(), 200);
+    RestUtils.put(authToken, collectionPath + "/matching2", matching2.toString(), 200);
+    RestUtils.put(authToken, collectionPath + "/nonMatching", nonMatching.toString(), 200);
+
+    // Any filter on full collection search should only match the level of nesting of the where
+    // clause
+    String r =
+        RestUtils.get(
+            authToken,
+            hostWithPort
+                + "/v2/namespaces/"
+                + keyspace
+                + "/collections/collection?page-size=3&where={\"$or\": [{\"value\": {\"$nin\": [\"b\",\"c\"]}}, {\"value\": {\"$eq\": \"a\"}}]}&raw=true",
+            200);
+
+    String expected = "{\"matching1\":{\"value\":\"a\"},\"matching2\":{\"other\":\"b\"}}";
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(expected));
+  }
+
+  @Test
+  public void searchOrPathSegmentsAndWildcards() throws Exception {
+    JsonNode matching1 =
+        OBJECT_MAPPER.readTree(
+            "{\"value\": [{ \"n\": { \"value\": 5} }, { \"m\": { \"value\": 8} }]}");
+    JsonNode matching2 =
+        OBJECT_MAPPER.readTree(
+            "{\"value\": [{ \"x\": { \"value\": 10} }, { \"y\": { \"value\": 20} }]}");
+    JsonNode nonMatching = OBJECT_MAPPER.readTree("{\"value\": [{ \"n\": { \"value\": 10} }]}");
+    RestUtils.put(authToken, collectionPath + "/matching1", matching1.toString(), 200);
+    RestUtils.put(authToken, collectionPath + "/matching2", matching2.toString(), 200);
+    RestUtils.put(authToken, collectionPath + "/non-matching", nonMatching.toString(), 200);
+
+    // Any filter on full collection search should only match the level of nesting of the where
+    // clause
+    String r =
+        RestUtils.get(
+            authToken,
+            hostWithPort
+                + "/v2/namespaces/"
+                + keyspace
+                + "/collections/collection?page-size=2&where={\"$or\": [{\"value.[*].*.value\": {\"$eq\": 20}}, {\"value.[1],[2].n,m.value\": {\"$eq\": 8}}]}&raw=true",
+            200);
+
+    String expected =
+        "{\"matching1\":{\"value\":[{\"n\":{\"value\":5}},{\"m\":{\"value\":8}}]},\"matching2\":{\"value\":[{\"x\":{\"value\":10}},{\"y\":{\"value\":20}}]}}";
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(expected));
+  }
+
+  @Test
   public void searchWithProfile() throws IOException {
     JsonNode fullObj1 =
         OBJECT_MAPPER.readTree("{\"someStuff\": {\"someOtherStuff\": {\"value\": \"a\"}}}");

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -2461,7 +2461,7 @@ public abstract class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             hostWithPort
                 + "/v2/namespaces/"
                 + keyspace
-                + "/collections/collection?page-size=3&where={\"count\": {\"$gt\": 0}}, \"$or\": [{\"value\": {\"$eq\": \"a\"}}, {\"value\": {\"$in\": [\"b\"]}}]}&raw=true",
+                + "/collections/collection?page-size=3&where={\"count\": {\"$gt\": 0}, \"$or\": [{\"value\": {\"$eq\": \"a\"}}, {\"value\": {\"$in\": [\"b\"]}}]}&raw=true",
             200);
 
     String expected =


### PR DESCRIPTION
Full support for the `$or` conditions when searching for the documents in the complete collection.

This is fully functional and done, but we need to agree on two final questions:

1. Can we do a optimization to run merging queries with different columns. This would save us both data we are fetching (less columns), as well as time to evaluate in some cases (although evaluation is fast).
2. Do we want to have implemented order of resolving conditions in the CNF form in the following order:
    a. Single persistence filter
    b. `OR` filters (order by "best")
    c. Single in-memory filter

Missing tasks:

* [x] Complete unit test for the `OrExpressionDocumentsResolver`
* [x] Add one INT test for paging
* [x] Fix codacy
* [x] Create documentation ticket once merged -> https://github.com/stargate/docs/issues/145
* [x] blocked by https://github.com/stargate/stargate/issues/1162

@polandll Lorina this is a new feature that needs to be documented. Simple example  would be 
`collection?where={\"$or\": [{\"price\": {\"$lt\": 200}}, {\"discountPrice\": {\"$lt\": 150}}]}`.
    