### PR TITLE
[WIP] fix dse ci to use the latest builder image version

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -42,7 +42,7 @@ RUN git clone --branch master --single-branch https://github.com/riptano/ccm.git
     sudo python setup.py install
 
 # Create clusters to pre-download necessary artifacts
-RUN ccm create -v 4.0-beta4 stargate_40 && ccm remove stargate_40
+RUN ccm create -v 4.0 stargate_40 && ccm remove stargate_40
 RUN ccm create -v 3.11.8 stargate_311 && ccm remove stargate_311
 RUN ccm create -v 6.8.13 --dse stargate_dse68 && ccm remove stargate_dse68
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -42,7 +42,7 @@ RUN git clone --branch master --single-branch https://github.com/riptano/ccm.git
     sudo python setup.py install
 
 # Create clusters to pre-download necessary artifacts
-RUN ccm create -v 4.0 stargate_40 && ccm remove stargate_40
+RUN ccm create -v 4.0.0 stargate_40 && ccm remove stargate_40
 RUN ccm create -v 3.11.8 stargate_311 && ccm remove stargate_311
 RUN ccm create -v 6.8.13 --dse stargate_dse68 && ccm remove stargate_dse68
 

--- a/cloudbuild-3_11.yaml
+++ b/cloudbuild-3_11.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.3'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.5'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'
@@ -29,7 +29,7 @@ steps:
         name: 'm2_cache'
   - id: 'cassandra-3.11'
     waitFor: [ 'fetch_secret', 'init_cache' ]
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.3'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.5'
     entrypoint: 'bash'
     args: [ 'ci/test.sh' ]
     volumes:

--- a/cloudbuild-4_0.yaml
+++ b/cloudbuild-4_0.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.3'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.5'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'
@@ -29,7 +29,7 @@ steps:
         name: 'm2_cache'
   - id: 'cassandra-4.0'
     waitFor: [ 'fetch_secret', 'init_cache' ]
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.3'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.5'
     entrypoint: 'bash'
     args: [ 'ci/test.sh' ]
     volumes:

--- a/cloudbuild-dse.yaml
+++ b/cloudbuild-dse.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.3'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.5'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'
@@ -29,7 +29,7 @@ steps:
         name: 'm2_cache'
   - id: 'dse-6.8'
     waitFor: [ 'fetch_secret', 'init_cache' ]
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.3'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.5'
     entrypoint: 'bash'
     args: [ 'ci/test.sh' ]
     volumes:

--- a/cloudbuild-dse.yaml
+++ b/cloudbuild-dse.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.3'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.4'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'
@@ -29,7 +29,7 @@ steps:
         name: 'm2_cache'
   - id: 'dse-6.8'
     waitFor: [ 'fetch_secret', 'init_cache' ]
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.3'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.4'
     entrypoint: 'bash'
     args: [ 'ci/test.sh' ]
     volumes:

--- a/cloudbuild-dse.yaml
+++ b/cloudbuild-dse.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.5'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.3'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'
@@ -29,7 +29,7 @@ steps:
         name: 'm2_cache'
   - id: 'dse-6.8'
     waitFor: [ 'fetch_secret', 'init_cache' ]
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.5'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.3'
     entrypoint: 'bash'
     args: [ 'ci/test.sh' ]
     volumes:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.3'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.5'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'

--- a/cql/pom.xml
+++ b/cql/pom.xml
@@ -12,7 +12,7 @@
     <dependency>
       <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-all</artifactId>
-      <version>4.0-alpha4</version>
+      <version>4.0.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.gridkit.jvmtool</groupId>

--- a/cql/src/main/java/io/stargate/cql/CqlActivator.java
+++ b/cql/src/main/java/io/stargate/cql/CqlActivator.java
@@ -26,8 +26,8 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.cassandra.config.Config;
-import org.jetbrains.annotations.Nullable;
 
 public class CqlActivator extends BaseActivator {
   private CqlImpl cql;

--- a/cql/src/main/java/io/stargate/cql/impl/CqlImpl.java
+++ b/cql/src/main/java/io/stargate/cql/impl/CqlImpl.java
@@ -85,7 +85,7 @@ public class CqlImpl {
             .withEventLoopGroup(workerGroup)
             .withHost(nativeAddr);
 
-    if (!TransportDescriptor.getNativeProtocolEncryptionOptions().enabled) {
+    if (!TransportDescriptor.getNativeProtocolEncryptionOptions().isEnabled()) {
       servers = Collections.singleton(builder.withSSL(false).withPort(nativePort).build());
     } else {
       if (nativePort != nativePortSSL) {

--- a/cql/src/main/java/io/stargate/cql/impl/CqlImpl.java
+++ b/cql/src/main/java/io/stargate/cql/impl/CqlImpl.java
@@ -85,6 +85,7 @@ public class CqlImpl {
             .withEventLoopGroup(workerGroup)
             .withHost(nativeAddr);
 
+    TransportDescriptor.getNativeProtocolEncryptionOptions().applyConfig();
     if (!TransportDescriptor.getNativeProtocolEncryptionOptions().isEnabled()) {
       servers = Collections.singleton(builder.withSSL(false).withPort(nativePort).build());
     } else {

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Server.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Server.java
@@ -138,7 +138,7 @@ public class Server implements CassandraDaemon.Server {
     if (this.useSSL) {
       final EncryptionOptions clientEnc = TransportDescriptor.getNativeProtocolEncryptionOptions();
 
-      if (clientEnc.optional) {
+      if (clientEnc.isOptional()) {
         logger.info("Enabling optionally encrypted CQL connections between client and server");
         bootstrap.childHandler(new OptionalSecureInitializer(this, clientEnc));
       } else {

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/ServerConnection.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/ServerConnection.java
@@ -27,10 +27,10 @@ import io.stargate.db.Persistence;
 import java.net.InetSocketAddress;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.security.cert.X509Certificate;
+import javax.validation.constraints.NotNull;
 import org.apache.cassandra.stargate.metrics.ClientMetrics;
 import org.apache.cassandra.stargate.transport.ProtocolException;
 import org.apache.cassandra.stargate.transport.ProtocolVersion;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/TransportDescriptor.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/TransportDescriptor.java
@@ -131,7 +131,9 @@ public class TransportDescriptor {
   }
 
   public static int getNativeTransportFrameBlockSize() {
-    return (int) ByteUnit.KIBI_BYTES.toBytes(conf.native_transport_frame_block_size_in_kb);
+    // TODO: Will need updated for protocol v5. The default of 32 was removed as part of this change
+    // https://github.com/apache/cassandra/commit/a7c4ba9eeecb365e7c4753d8eaab747edd9a632a#diff-e966f41bc2a418becfe687134ec8cf542eb051eead7fb4917e65a3a2e7c9bce3L191
+    return (int) ByteUnit.KIBI_BYTES.toBytes(32);
   }
 
   public static int getNativeTransportMaxFrameSize() {

--- a/persistence-api/pom.xml
+++ b/persistence-api/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-all</artifactId>
-      <version>4.0-alpha4</version>
+      <version>4.0.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/persistence-cassandra-4.0/pom.xml
+++ b/persistence-cassandra-4.0/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>persistence-cassandra-4.0</artifactId>
   <properties>
     <!-- If you update this, make sure to keep `cassandra.bundled-driver.version` in sync -->
-    <cassandra.version>4.0</cassandra.version>
+    <cassandra.version>4.0.0</cassandra.version>
     <!--
       The driver used internally by cassandra-all for UDFs (must match the version declared in
       cassandra-all's POM).

--- a/persistence-cassandra-4.0/pom.xml
+++ b/persistence-cassandra-4.0/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>persistence-cassandra-4.0</artifactId>
   <properties>
     <!-- If you update this, make sure to keep `cassandra.bundled-driver.version` in sync -->
-    <cassandra.version>4.0-rc2</cassandra.version>
+    <cassandra.version>4.0</cassandra.version>
     <!--
       The driver used internally by cassandra-all for UDFs (must match the version declared in
       cassandra-all's POM).

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -391,7 +391,7 @@
                 </goals>
                 <configuration>
                   <systemPropertyVariables>
-                    <ccm.version>4.0-rc2</ccm.version>
+                    <ccm.version>4.0</ccm.version>
                     <stargate.test.nodes>1</stargate.test.nodes>
                   </systemPropertyVariables>
                   <failIfNoTests>true</failIfNoTests>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -391,7 +391,7 @@
                 </goals>
                 <configuration>
                   <systemPropertyVariables>
-                    <ccm.version>4.0</ccm.version>
+                    <ccm.version>4.0.0</ccm.version>
                     <stargate.test.nodes>1</stargate.test.nodes>
                   </systemPropertyVariables>
                   <failIfNoTests>true</failIfNoTests>


### PR DESCRIPTION
Trying to see if `1.0.4` will work..

Fails with `1.0.4` as well, mabe the problem was introduced in #733 this change, when we updated the DSE version to the `6.8.5` to `6.8.9`. 

And seems that there was already a revert from `1.0.3` to `1.0.4` in https://github.com/stargate/stargate/commit/f8073debd799b8bcabd2cc029b6dfb3a69ae3f18.