### PR TITLE
closes #1027: support `$exists`  with false

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/impl/ExistsCondition.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/impl/ExistsCondition.java
@@ -18,8 +18,6 @@ package io.stargate.web.docsapi.service.query.condition.impl;
 
 import io.stargate.db.datastore.Row;
 import io.stargate.db.query.builder.BuiltCondition;
-import io.stargate.web.docsapi.exception.ErrorCode;
-import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
 import io.stargate.web.docsapi.service.query.condition.BaseCondition;
 import io.stargate.web.docsapi.service.query.filter.operation.FilterOperationCode;
 import java.util.Optional;
@@ -37,22 +35,10 @@ public abstract class ExistsCondition implements BaseCondition {
   @Value.Parameter
   public abstract Boolean getQueryValue();
 
-  /** Validates the filter value as we only accept true */
-  @Value.Check
-  protected void validate() {
-    boolean queryValue = getQueryValue();
-    if (!Boolean.TRUE.equals(queryValue)) {
-      String msg =
-          String.format(
-              "%s only supports the value `true`", FilterOperationCode.EXISTS.getRawValue());
-      throw new ErrorCodeRuntimeException(ErrorCode.DOCS_API_SEARCH_FILTER_INVALID, msg);
-    }
-  }
-
   /** {@inheritDoc} */
   @Override
   public boolean isPersistenceCondition() {
-    return true;
+    return getQueryValue();
   }
 
   /** {@inheritDoc} */
@@ -70,13 +56,18 @@ public abstract class ExistsCondition implements BaseCondition {
   /** {@inheritDoc} */
   @Override
   public boolean isEvaluateOnMissingFields() {
-    return false;
+    return !getQueryValue();
   }
 
   /** {@inheritDoc} */
   @Override
   public boolean test(Row row) {
-    // always test true when row is there :)
-    return true;
+    // if row exists then the test is true if query value is true
+    // if row is null, then the test is true if query value is false
+    if (null != row) {
+      return getQueryValue();
+    } else {
+      return !getQueryValue();
+    }
   }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/impl/ExistsCondition.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/impl/ExistsCondition.java
@@ -62,12 +62,8 @@ public abstract class ExistsCondition implements BaseCondition {
   /** {@inheritDoc} */
   @Override
   public boolean test(Row row) {
+    // row must always be non-null here
     // if row exists then the test is true if query value is true
-    // if row is null, then the test is true if query value is false
-    if (null != row) {
-      return getQueryValue();
-    } else {
-      return !getQueryValue();
-    }
+    return getQueryValue();
   }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/condition/impl/ExistsConditionTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/condition/impl/ExistsConditionTest.java
@@ -44,7 +44,6 @@ class ExistsConditionTest {
       ExistsCondition condition = ImmutableExistsCondition.of(true);
 
       assertThat(condition.test(row)).isTrue();
-      assertThat(condition.test(null)).isFalse();
     }
 
     @Test
@@ -52,7 +51,6 @@ class ExistsConditionTest {
       ExistsCondition condition = ImmutableExistsCondition.of(false);
 
       assertThat(condition.test(row)).isFalse();
-      assertThat(condition.test(null)).isTrue();
     }
   }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/condition/impl/ExistsConditionTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/condition/impl/ExistsConditionTest.java
@@ -1,33 +1,57 @@
 package io.stargate.web.docsapi.service.query.condition.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
 
-import io.stargate.web.docsapi.exception.ErrorCode;
-import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
+import io.stargate.db.datastore.Row;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class ExistsConditionTest {
 
   @Nested
   class Constructor {
 
     @Test
-    public void validated() {
-      Throwable throwable = catchThrowable(() -> ImmutableExistsCondition.of(false));
-
-      assertThat(throwable)
-          .isInstanceOf(ErrorCodeRuntimeException.class)
-          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_SEARCH_FILTER_INVALID);
-    }
-
-    @Test
-    public void assertProps() {
+    public void assertPropsTrue() {
       ExistsCondition condition = ImmutableExistsCondition.of(true);
 
       assertThat(condition.isPersistenceCondition()).isTrue();
+      assertThat(condition.isEvaluateOnMissingFields()).isFalse();
       assertThat(condition.getBuiltCondition()).isEmpty();
+    }
+
+    @Test
+    public void assertPropsFalse() {
+      ExistsCondition condition = ImmutableExistsCondition.of(false);
+
+      assertThat(condition.isPersistenceCondition()).isFalse();
+      assertThat(condition.isEvaluateOnMissingFields()).isTrue();
+      assertThat(condition.getBuiltCondition()).isEmpty();
+    }
+  }
+
+  @Nested
+  class DoTest {
+
+    @Mock Row row;
+
+    @Test
+    public void existsTrue() {
+      ExistsCondition condition = ImmutableExistsCondition.of(true);
+
+      assertThat(condition.test(row)).isTrue();
+      assertThat(condition.test(null)).isFalse();
+    }
+
+    @Test
+    public void assertPropsFalse() {
+      ExistsCondition condition = ImmutableExistsCondition.of(false);
+
+      assertThat(condition.test(row)).isFalse();
       assertThat(condition.test(null)).isTrue();
     }
   }

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -1496,14 +1496,6 @@ public abstract class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
 
     r =
         RestUtils.get(
-            authToken,
-            collectionPath + "/cool-search-id?where={\"a\": {\"$exists\": false}}}",
-            400);
-    assertThat(r)
-        .isEqualTo("{\"description\":\"$exists only supports the value `true`\",\"code\":400}");
-
-    r =
-        RestUtils.get(
             authToken, collectionPath + "/cool-search-id?where={\"a\": {\"exists\": true}}}", 400);
     assertThat(r).startsWith("{\"description\":\"Operation 'exists' is not supported.");
 
@@ -2427,6 +2419,64 @@ public abstract class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
             200);
 
     String expected = "{\"doc\":{\"value\":[{\"n\":{\"value\":5}}]}}";
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(expected));
+  }
+
+  @Test
+  public void searchExistsFalse() throws Exception {
+    JsonNode matching = OBJECT_MAPPER.readTree("{\"value\": \"b\"}");
+    JsonNode wildcardMatching =
+        OBJECT_MAPPER.readTree(
+            "{\"value\": \"b\", \"someStuff\": {\"1\": {\"first\": \"a\"}, \"2\": {\"second\": \"b\"}}}");
+    JsonNode wildcardNotMatching =
+        OBJECT_MAPPER.readTree(
+            "{\"value\": \"b\", \"someStuff\": {\"1\": {\"value\": \"c\"}, \"2\": {\"value\": \"d\"}}}");
+    RestUtils.put(authToken, collectionPath + "/matching", matching.toString(), 200);
+    RestUtils.put(authToken, collectionPath + "/wild-card", wildcardMatching.toString(), 200);
+    RestUtils.put(
+        authToken, collectionPath + "/wild-card-not-matching", wildcardNotMatching.toString(), 200);
+
+    // wild card path
+    String r =
+        RestUtils.get(
+            authToken,
+            hostWithPort
+                + "/v2/namespaces/"
+                + keyspace
+                + "/collections/collection?page-size=2&where={\"someStuff.*.value\": {\"$exists\": false}}&raw=true",
+            200);
+
+    String expected =
+        "{\"matching\":{\"value\": \"b\"}, \"wild-card\":{\"value\": \"b\", \"someStuff\": {\"1\": {\"first\": \"a\"}, \"2\": {\"second\": \"b\"}}}}";
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(expected));
+  }
+
+  @Test
+  public void searchExistsFalseMixed() throws Exception {
+    JsonNode matching = OBJECT_MAPPER.readTree("{\"value\": \"b\"}");
+    JsonNode wildcardMatching =
+        OBJECT_MAPPER.readTree(
+            "{\"value\": \"b\", \"someStuff\": {\"1\": {\"first\": \"a\"}, \"2\": {\"second\": \"b\"}}}");
+    JsonNode wildcardNotMatching =
+        OBJECT_MAPPER.readTree(
+            "{\"value\": \"b\", \"someStuff\": {\"1\": {\"value\": \"c\"}, \"2\": {\"value\": \"d\"}}}");
+    RestUtils.put(authToken, collectionPath + "/matching", matching.toString(), 200);
+    RestUtils.put(authToken, collectionPath + "/wild-card", wildcardMatching.toString(), 200);
+    RestUtils.put(
+        authToken, collectionPath + "/wild-card-not-matching", wildcardNotMatching.toString(), 200);
+
+    // wild card path
+    String r =
+        RestUtils.get(
+            authToken,
+            hostWithPort
+                + "/v2/namespaces/"
+                + keyspace
+                + "/collections/collection?page-size=2&where={\"value\": {\"$eq\": \"b\"}, \"someStuff.*.value\": {\"$exists\": false}}&raw=true",
+            200);
+
+    String expected =
+        "{\"matching\":{\"value\": \"b\"}, \"wild-card\":{\"value\": \"b\", \"someStuff\": {\"1\": {\"first\": \"a\"}, \"2\": {\"second\": \"b\"}}}}";
     assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(expected));
   }
 


### PR DESCRIPTION
Supports `$exists: false` for the docs api search. This is a quick fix, because it's a blocker for the #1071. 

It's implemented in the way that if `false` is given, this filter condition becomes in-memory one. The behavior with `true` is not changed and we can still leverage the C query here. 

@dimas-b I implemented this so you can focus on the #1071.
@polandll This is an extension of the existing feature