### PR TITLE
Do not block Rx operations when deleting "dead leaves" in Docs API

### DIFF
--- a/restapi/pom.xml
+++ b/restapi/pom.xml
@@ -180,6 +180,11 @@
           <artifactId>mockito-junit-jupiter</artifactId>
           <scope>test</scope>
       </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/restapi/src/test/java/io/stargate/web/docsapi/dao/DocumentDBTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/dao/DocumentDBTest.java
@@ -321,7 +321,7 @@ public class DocumentDBTest {
     deadLeaves.put("$.b", new HashSet<>());
     deadLeaves.get("$.b").add(DeadLeaf.ARRAYLEAF);
 
-    documentDB.deleteDeadLeaves("keyspace", "table", "key", 1L, deadLeaves, context);
+    documentDB.deleteDeadLeaves("keyspace", "table", "key", 1L, deadLeaves, context).join();
 
     List<BoundQuery> generatedQueries = ds.getRecentStatements();
     assertThat(generatedQueries).hasSize(2);


### PR DESCRIPTION
* Make DocumentDB.deleteDeadLeaves non-blocking

* Add a separate method to DocumentDB for authorizing
  "dead leaf" deletion separately from the deleteDeadLeaves
  call.

* Make the Rx pipeline wait for the DELETE batch submission
  in a non-blocking way (no user-level behaviour change)

Fixes #1151