### PR TITLE
gRPC: expose schema change data in responses (fixes #929)

### DIFF
--- a/grpc-proto/proto/query.proto
+++ b/grpc-proto/proto/query.proto
@@ -305,6 +305,33 @@ message Traces {
   repeated Event events = 4;
 }
 
+// If a Query message is a DDL statement, this will be included in the Response to describe the
+// how the CQL schema was impacted.
+message SchemaChange {
+  enum Type {
+    CREATED = 0;
+    UPDATED = 1;
+    DROPPED = 2;
+  }
+  enum Target {
+    KEYSPACE = 0;
+    TABLE = 1;
+    TYPE = 2;
+    FUNCTION = 3;
+    AGGREGATE = 4;
+  }
+  // The nature of the change (created, updated or dropped).
+  Type change_type = 1;
+  // The type of schema object that was affected.
+  Target target = 2;
+  // The name of the keyspace.
+  string keyspace = 3;
+  // If the target is a keyspace element (table, type, etc), its name.
+  google.protobuf.StringValue name = 4;
+  // If the target is a function or aggregate, the CQL types of the arguments.
+  repeated string argument_types = 5;
+}
+
 // The response to a Query or Batch message.
 message Response {
   // The result data.
@@ -314,6 +341,7 @@ message Response {
   repeated string warnings = 2;
   // The tracing information, if it was requested for the query.
   Traces traces = 3;
+  SchemaChange schema_change = 4;
 }
 
 // Thrown when the coordinator knows there is not enough replicas alive to perform a query with the

--- a/grpc-proto/proto/query.proto
+++ b/grpc-proto/proto/query.proto
@@ -334,14 +334,17 @@ message SchemaChange {
 
 // The response to a Query or Batch message.
 message Response {
-  // The result data.
-  // If the payload type is CQL, then the data is a ResultSet message.
-  Payload result_set = 1;
+  oneof result {
+    // The result data.
+    // If the payload type is CQL, then the data is a ResultSet message.
+    Payload result_set = 1;
+    // How the query changed the CQL schema.
+    SchemaChange schema_change = 4;
+  }
   // The server-side warnings for the query, if any.
   repeated string warnings = 2;
   // The tracing information, if it was requested for the query.
   Traces traces = 3;
-  SchemaChange schema_change = 4;
 }
 
 // Thrown when the coordinator knows there is not enough replicas alive to perform a query with the

--- a/testing/src/main/java/io/stargate/it/grpc/ExecuteBatchTest.java
+++ b/testing/src/main/java/io/stargate/it/grpc/ExecuteBatchTest.java
@@ -73,6 +73,7 @@ public class ExecuteBatchTest extends GrpcIntegrationTest {
   @Test
   public void simpleBatchAfterSchemaChange() throws InvalidProtocolBufferException {
     StargateBlockingStub stub = stubWithCallCredentials();
+    stub.executeQuery(cqlQuery("DROP KEYSPACE IF EXISTS ks1"));
 
     // Create keyspace, table, and then insert some data
     Response response =

--- a/testing/src/main/java/io/stargate/it/grpc/ExecuteQueryTest.java
+++ b/testing/src/main/java/io/stargate/it/grpc/ExecuteQueryTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
-import com.datastax.oss.driver.api.core.CqlSession;
 import com.google.protobuf.Int32Value;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.grpc.StatusRuntimeException;
@@ -76,10 +75,9 @@ public class ExecuteQueryTest extends GrpcIntegrationTest {
   }
 
   @Test
-  public void queryAfterSchemaChange(CqlSession session) {
+  public void queryAfterSchemaChange() {
     StargateBlockingStub stub = stubWithCallCredentials();
-
-    session.execute("DROP KEYSPACE IF EXISTS ks1");
+    stub.executeQuery(cqlQuery("DROP KEYSPACE IF EXISTS ks1"));
 
     // Create keyspace, table, and then insert some data
     Response response =

--- a/testing/src/main/java/io/stargate/it/grpc/ExecuteQueryTest.java
+++ b/testing/src/main/java/io/stargate/it/grpc/ExecuteQueryTest.java
@@ -31,6 +31,7 @@ import io.stargate.proto.QueryOuterClass.Query;
 import io.stargate.proto.QueryOuterClass.QueryParameters;
 import io.stargate.proto.QueryOuterClass.Response;
 import io.stargate.proto.QueryOuterClass.ResultSet;
+import io.stargate.proto.QueryOuterClass.SchemaChange;
 import io.stargate.proto.StargateGrpc.StargateBlockingStub;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -83,19 +84,50 @@ public class ExecuteQueryTest extends GrpcIntegrationTest {
             cqlQuery(
                 "CREATE KEYSPACE IF NOT EXISTS ks1 WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1};"));
     assertThat(response).isNotNull();
+    assertThat(response.hasSchemaChange()).isTrue();
+    assertThat(response.getSchemaChange())
+        .satisfies(
+            c -> {
+              assertThat(c.getChangeType()).isEqualTo(SchemaChange.Type.CREATED);
+              assertThat(c.getTarget()).isEqualTo(SchemaChange.Target.KEYSPACE);
+              assertThat(c.getKeyspace()).isEqualTo("ks1");
+              assertThat(c.hasName()).isFalse();
+              assertThat(c.getArgumentTypesCount()).isEqualTo(0);
+            });
 
     response =
         stub.executeQuery(
             cqlQuery("CREATE TABLE IF NOT EXISTS ks1.tbl1 (k text, v int, PRIMARY KEY (k));"));
     assertThat(response).isNotNull();
+    assertThat(response.hasSchemaChange()).isTrue();
+    assertThat(response.getSchemaChange())
+        .satisfies(
+            c -> {
+              assertThat(c.getChangeType()).isEqualTo(SchemaChange.Type.CREATED);
+              assertThat(c.getTarget()).isEqualTo(SchemaChange.Target.TABLE);
+              assertThat(c.getKeyspace()).isEqualTo("ks1");
+              assertThat(c.getName().getValue()).isEqualTo("tbl1");
+              assertThat(c.getArgumentTypesCount()).isEqualTo(0);
+            });
 
     response = stub.executeQuery(cqlQuery("INSERT INTO ks1.tbl1 (k, v) VALUES ('a', 1)"));
     assertThat(response).isNotNull();
+    assertThat(response.hasSchemaChange()).isFalse();
 
     // Drop the keyspace to cause the existing prepared queries to be purged from the backend query
     // cache
     response = stub.executeQuery(cqlQuery("DROP KEYSPACE ks1;"));
     assertThat(response).isNotNull();
+    assertThat(response.hasSchemaChange()).isTrue();
+    assertThat(response.getSchemaChange())
+        .satisfies(
+            c -> {
+              assertThat(c.getChangeType()).isEqualTo(SchemaChange.Type.DROPPED);
+              assertThat(c.getTarget()).isEqualTo(SchemaChange.Target.KEYSPACE);
+              assertThat(c.getKeyspace()).isEqualTo("ks1");
+              assertThat(c.hasName()).isFalse();
+              assertThat(c.getArgumentTypesCount()).isEqualTo(0);
+            });
 
     response =
         stub.executeQuery(

--- a/testing/src/main/java/io/stargate/it/grpc/ExecuteQueryTest.java
+++ b/testing/src/main/java/io/stargate/it/grpc/ExecuteQueryTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSession;
 import com.google.protobuf.Int32Value;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.grpc.StatusRuntimeException;
@@ -75,8 +76,10 @@ public class ExecuteQueryTest extends GrpcIntegrationTest {
   }
 
   @Test
-  public void queryAfterSchemaChange() {
+  public void queryAfterSchemaChange(CqlSession session) {
     StargateBlockingStub stub = stubWithCallCredentials();
+
+    session.execute("DROP KEYSPACE IF EXISTS ks1");
 
     // Create keyspace, table, and then insert some data
     Response response =


### PR DESCRIPTION
- [x] switch to `oneof`