### PR TITLE
Support $not operators in Docs API WHERE clauses

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/BaseCondition.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/BaseCondition.java
@@ -27,6 +27,10 @@ import javax.validation.constraints.NotNull;
 /** Interface for the base filtering condition. */
 public interface BaseCondition extends Predicate<Row> {
 
+  /** Returns a {@link BaseCondition} that is the logical negation of this condition. */
+  @Override
+  BaseCondition negate();
+
   /**
    * @return If this condition can be executed on the persistence level. The default implementation
    *     resolves to true if the {@link #getBuiltCondition()} returns non-empty value.

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/impl/BooleanCondition.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/impl/BooleanCondition.java
@@ -81,4 +81,10 @@ public abstract class BooleanCondition implements BaseCondition {
     Boolean dbValue = getBoolean(row, isNumericBooleans());
     return getFilterOperation().test(dbValue, getQueryValue());
   }
+
+  @Override
+  public BaseCondition negate() {
+    return ImmutableBooleanCondition.of(
+        getFilterOperation().negate(), getQueryValue(), isNumericBooleans());
+  }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/impl/ExistsCondition.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/impl/ExistsCondition.java
@@ -66,4 +66,9 @@ public abstract class ExistsCondition implements BaseCondition {
     // if row exists then the test is true if query value is true
     return getQueryValue();
   }
+
+  @Override
+  public BaseCondition negate() {
+    return ImmutableExistsCondition.of(!getQueryValue());
+  }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/impl/GenericCondition.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/impl/GenericCondition.java
@@ -93,4 +93,10 @@ public abstract class GenericCondition<V> implements BaseCondition {
       return filterOperation.test(dbValueString, queryValue);
     }
   }
+
+  @Override
+  public BaseCondition negate() {
+    return ImmutableGenericCondition.of(
+        getFilterOperation().negate(), getQueryValue(), isNumericBooleans());
+  }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/impl/NumberCondition.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/impl/NumberCondition.java
@@ -79,4 +79,9 @@ public abstract class NumberCondition implements BaseCondition {
     Double dbValue = getDouble(row);
     return getFilterOperation().test(dbValue, getQueryValue());
   }
+
+  @Override
+  public BaseCondition negate() {
+    return ImmutableNumberCondition.of(getFilterOperation().negate(), getQueryValue());
+  }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/impl/StringCondition.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/impl/StringCondition.java
@@ -77,4 +77,9 @@ public abstract class StringCondition implements BaseCondition {
     String dbValue = getString(row);
     return getFilterOperation().test(dbValue, getQueryValue());
   }
+
+  @Override
+  public BaseCondition negate() {
+    return ImmutableStringCondition.of(getFilterOperation().negate(), getQueryValue());
+  }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/BaseFilterOperation.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/BaseFilterOperation.java
@@ -36,4 +36,7 @@ public interface BaseFilterOperation {
   default boolean isEvaluateOnMissingFields() {
     return false;
   }
+
+  /** Returns a filter operation that is the logical opposite of this operation. */
+  BaseFilterOperation negate();
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/GenericFilterOperation.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/GenericFilterOperation.java
@@ -63,4 +63,6 @@ public interface GenericFilterOperation<FV> extends BaseFilterOperation {
   default void validateFilterInput(FV filterValue) {
     // default impl empty
   }
+
+  GenericFilterOperation<FV> negate();
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/ValueFilterOperation.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/ValueFilterOperation.java
@@ -87,4 +87,7 @@ public interface ValueFilterOperation extends BaseFilterOperation {
   default void validateBooleanFilterInput(Boolean filterValue) {
     // default impl empty
   }
+
+  @Override
+  ValueFilterOperation negate();
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/impl/EqFilterOperation.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/impl/EqFilterOperation.java
@@ -18,6 +18,7 @@ package io.stargate.web.docsapi.service.query.filter.operation.impl;
 
 import io.stargate.db.query.Predicate;
 import io.stargate.web.docsapi.service.query.filter.operation.FilterOperationCode;
+import io.stargate.web.docsapi.service.query.filter.operation.ValueFilterOperation;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -53,5 +54,10 @@ public abstract class EqFilterOperation extends NotNullValueFilterOperation {
   @Override
   public boolean compareNulls() {
     return true;
+  }
+
+  @Override
+  public ValueFilterOperation negate() {
+    return NeFilterOperation.of();
   }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/impl/GtFilterOperation.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/impl/GtFilterOperation.java
@@ -18,6 +18,7 @@ package io.stargate.web.docsapi.service.query.filter.operation.impl;
 
 import io.stargate.db.query.Predicate;
 import io.stargate.web.docsapi.service.query.filter.operation.FilterOperationCode;
+import io.stargate.web.docsapi.service.query.filter.operation.ValueFilterOperation;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -47,5 +48,10 @@ public abstract class GtFilterOperation extends NotNullValueFilterOperation {
   @Override
   public boolean isSatisfied(int compareValue) {
     return compareValue > 0;
+  }
+
+  @Override
+  public ValueFilterOperation negate() {
+    return LteFilterOperation.of();
   }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/impl/GteFilterOperation.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/impl/GteFilterOperation.java
@@ -18,6 +18,7 @@ package io.stargate.web.docsapi.service.query.filter.operation.impl;
 
 import io.stargate.db.query.Predicate;
 import io.stargate.web.docsapi.service.query.filter.operation.FilterOperationCode;
+import io.stargate.web.docsapi.service.query.filter.operation.ValueFilterOperation;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -47,5 +48,10 @@ public abstract class GteFilterOperation extends NotNullValueFilterOperation {
   @Override
   public boolean isSatisfied(int compareValue) {
     return compareValue >= 0;
+  }
+
+  @Override
+  public ValueFilterOperation negate() {
+    return LtFilterOperation.of();
   }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/impl/InFilterOperation.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/impl/InFilterOperation.java
@@ -98,4 +98,9 @@ public abstract class InFilterOperation implements GenericFilterOperation<List<?
       throw new ErrorCodeRuntimeException(ErrorCode.DOCS_API_SEARCH_FILTER_INVALID, msg);
     }
   }
+
+  @Override
+  public GenericFilterOperation<List<?>> negate() {
+    return NotInFilterOperation.of();
+  }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/impl/LtFilterOperation.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/impl/LtFilterOperation.java
@@ -18,6 +18,7 @@ package io.stargate.web.docsapi.service.query.filter.operation.impl;
 
 import io.stargate.db.query.Predicate;
 import io.stargate.web.docsapi.service.query.filter.operation.FilterOperationCode;
+import io.stargate.web.docsapi.service.query.filter.operation.ValueFilterOperation;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -47,5 +48,10 @@ public abstract class LtFilterOperation extends NotNullValueFilterOperation {
   @Override
   public boolean isSatisfied(int compareValue) {
     return compareValue < 0;
+  }
+
+  @Override
+  public ValueFilterOperation negate() {
+    return GteFilterOperation.of();
   }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/impl/LteFilterOperation.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/impl/LteFilterOperation.java
@@ -18,6 +18,7 @@ package io.stargate.web.docsapi.service.query.filter.operation.impl;
 
 import io.stargate.db.query.Predicate;
 import io.stargate.web.docsapi.service.query.filter.operation.FilterOperationCode;
+import io.stargate.web.docsapi.service.query.filter.operation.ValueFilterOperation;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -47,5 +48,10 @@ public abstract class LteFilterOperation extends NotNullValueFilterOperation {
   @Override
   public boolean isSatisfied(int compareValue) {
     return compareValue <= 0;
+  }
+
+  @Override
+  public ValueFilterOperation negate() {
+    return GtFilterOperation.of();
   }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/impl/NeFilterOperation.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/impl/NeFilterOperation.java
@@ -19,6 +19,7 @@ package io.stargate.web.docsapi.service.query.filter.operation.impl;
 import io.stargate.db.query.Predicate;
 import io.stargate.web.docsapi.service.query.filter.operation.ComparingValueFilterOperation;
 import io.stargate.web.docsapi.service.query.filter.operation.FilterOperationCode;
+import io.stargate.web.docsapi.service.query.filter.operation.ValueFilterOperation;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -60,5 +61,10 @@ public abstract class NeFilterOperation implements ComparingValueFilterOperation
   @Override
   public boolean compareNulls() {
     return true;
+  }
+
+  @Override
+  public ValueFilterOperation negate() {
+    return EqFilterOperation.of();
   }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/impl/NotInFilterOperation.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/impl/NotInFilterOperation.java
@@ -18,6 +18,7 @@ package io.stargate.web.docsapi.service.query.filter.operation.impl;
 
 import io.stargate.db.query.Predicate;
 import io.stargate.web.docsapi.service.query.filter.operation.FilterOperationCode;
+import io.stargate.web.docsapi.service.query.filter.operation.GenericFilterOperation;
 import java.util.List;
 import java.util.Optional;
 import org.immutables.value.Value;
@@ -69,5 +70,10 @@ public abstract class NotInFilterOperation extends InFilterOperation {
   @Override
   public boolean test(Double dbValue, List<?> filterValue) {
     return !super.test(dbValue, filterValue);
+  }
+
+  @Override
+  public GenericFilterOperation<List<?>> negate() {
+    return InFilterOperation.of();
   }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/rules/ExpressionUtils.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/rules/ExpressionUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.web.docsapi.service.query.rules;
+
+import com.bpodgursky.jbool_expressions.Expression;
+import com.bpodgursky.jbool_expressions.rules.RuleSet;
+import io.stargate.web.docsapi.service.query.FilterExpression;
+
+public class ExpressionUtils {
+
+  /**
+   * Converts the given expression to CNF and eliminates boolean NOT operators but inverting the
+   * negated {@link FilterExpression}s.
+   *
+   * <p>Note: If selectivity hints are not defined on all filters, the simplification process may
+   * lose user-provided hints. This can be avoided by the user by providing hints on all filters or
+   * by simplifying the expression up front.
+   */
+  public static Expression<FilterExpression> toSimplifiedCnf(
+      Expression<FilterExpression> expression) {
+    // Note: this will push NOTs down to the leaf (FilterExpression) level
+    Expression<FilterExpression> cnf = RuleSet.toCNF(expression);
+
+    // Resolve NOTs by inverting negated FilterExpressions
+    Expression<FilterExpression> negationResolved = NegateFilters.resolve(cnf);
+
+    // Re-simplify the expression after eliminating NOTs
+    return RuleSet.simplify(negationResolved);
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/rules/NegateFilters.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/rules/NegateFilters.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.web.docsapi.service.query.rules;
+
+import com.bpodgursky.jbool_expressions.Expression;
+import com.bpodgursky.jbool_expressions.Not;
+import com.bpodgursky.jbool_expressions.options.ExprOptions;
+import com.bpodgursky.jbool_expressions.rules.Rule;
+import com.bpodgursky.jbool_expressions.rules.RuleList;
+import com.bpodgursky.jbool_expressions.rules.RulesHelper;
+import io.stargate.web.docsapi.service.query.FilterExpression;
+import java.util.Collections;
+import java.util.List;
+
+public class NegateFilters extends Rule<Expression<FilterExpression>, FilterExpression> {
+
+  private static final RuleList<FilterExpression> rules =
+      new RuleList<>(Collections.singletonList(new NegateFilters()));
+
+  @Override
+  public Expression<FilterExpression> applyInternal(
+      Expression<FilterExpression> input, ExprOptions<FilterExpression> options) {
+    Not<FilterExpression> negated = (Not<FilterExpression>) input;
+    FilterExpression child = (FilterExpression) negated.getChildren().get(0);
+
+    return child.negate();
+  }
+
+  @Override
+  protected boolean isApply(Expression<FilterExpression> input) {
+    if (!(input instanceof Not)) {
+      return false;
+    }
+
+    Not<FilterExpression> negated = (Not<FilterExpression>) input;
+
+    List<Expression<FilterExpression>> children = negated.getChildren();
+    if (children.size() != 1) {
+      return false;
+    }
+
+    Expression<FilterExpression> child = children.get(0);
+    return child instanceof FilterExpression;
+  }
+
+  public static Expression<FilterExpression> resolve(Expression<FilterExpression> expression) {
+    return RulesHelper.applyAll(expression, rules, ExprOptions.noCaching());
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/BaseResolver.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/BaseResolver.java
@@ -20,9 +20,9 @@ package io.stargate.web.docsapi.service.query.search.resolver;
 import com.bpodgursky.jbool_expressions.And;
 import com.bpodgursky.jbool_expressions.Expression;
 import com.bpodgursky.jbool_expressions.Literal;
-import com.bpodgursky.jbool_expressions.rules.RuleSet;
 import io.stargate.web.docsapi.service.ExecutionContext;
 import io.stargate.web.docsapi.service.query.FilterExpression;
+import io.stargate.web.docsapi.service.query.rules.ExpressionUtils;
 
 /**
  * Base resolver knows what {@link DocumentsResolver} should be created for the given {@link
@@ -59,7 +59,7 @@ public final class BaseResolver {
     }
 
     // execute cnf optimization
-    Expression<FilterExpression> cnf = RuleSet.toCNF(expression);
+    Expression<FilterExpression> cnf = ExpressionUtils.toSimplifiedCnf(expression);
 
     // since this will simplify as well, check if we have And
     // if we have And proceed to the CNF resolver

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolver.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolver.java
@@ -186,6 +186,7 @@ public class OrExpressionDocumentsResolver implements DocumentsResolver {
 
   private ExecutionContext createContext(
       ExecutionContext context, Or<FilterExpression> expression) {
-    return context.nested("MERGING OR: expression '" + expression + "'");
+    // Note: use toLexicographicString to ensure a stable order of sub-expressions.
+    return context.nested("MERGING OR: expression '" + expression.toLexicographicString() + "'");
   }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/FilterExpressionTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/FilterExpressionTest.java
@@ -425,4 +425,26 @@ public class FilterExpressionTest {
       verifyNoMoreInteractions(condition);
     }
   }
+
+  @Nested
+  class Negate {
+
+    @Test
+    void selectivity() {
+      FilterExpression filter = ImmutableFilterExpression.of(filterPath, condition, 0, 0.2);
+
+      when(condition.negate()).thenReturn(condition2);
+
+      assertThat(filter.negate().getSelectivity()).isEqualTo(0.8);
+    }
+
+    @Test
+    void condition() {
+      FilterExpression filter = ImmutableFilterExpression.of(filterPath, condition, 0, 0.2);
+
+      when(condition.negate()).thenReturn(condition2);
+
+      assertThat(filter.negate().getCondition()).isEqualTo(condition2);
+    }
+  }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/condition/impl/BooleanConditionTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/condition/impl/BooleanConditionTest.java
@@ -30,6 +30,8 @@ import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -37,6 +39,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class BooleanConditionTest {
 
   @Mock ValueFilterOperation filterOperation;
+  @Mock ValueFilterOperation filterOperation2;
 
   @Nested
   class Constructor {
@@ -148,6 +151,26 @@ class BooleanConditionTest {
       boolean result = condition.test(row);
 
       assertThat(result).isTrue();
+    }
+  }
+
+  @Nested
+  class Negation {
+    @ParameterizedTest
+    @CsvSource({"true", "false"})
+    void simple(boolean queryValue) {
+      when(filterOperation.negate()).thenReturn(filterOperation2);
+
+      BooleanCondition condition = ImmutableBooleanCondition.of(filterOperation, queryValue, true);
+
+      assertThat(condition.negate())
+          .isInstanceOfSatisfying(
+              BooleanCondition.class,
+              negated -> {
+                assertThat(negated.getQueryValue()).isEqualTo(queryValue);
+                assertThat(negated.getFilterOperation()).isEqualTo(filterOperation2);
+                assertThat(negated.isNumericBooleans()).isEqualTo(true);
+              });
     }
   }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/condition/impl/ExistsConditionTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/condition/impl/ExistsConditionTest.java
@@ -6,6 +6,8 @@ import io.stargate.db.datastore.Row;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -51,6 +53,22 @@ class ExistsConditionTest {
       ExistsCondition condition = ImmutableExistsCondition.of(false);
 
       assertThat(condition.test(row)).isFalse();
+    }
+  }
+
+  @Nested
+  class Negation {
+    @ParameterizedTest
+    @CsvSource({"true", "false"})
+    void simple(boolean queryValue) {
+      ExistsCondition condition = ImmutableExistsCondition.of(queryValue);
+
+      assertThat(condition.negate())
+          .isInstanceOfSatisfying(
+              ExistsCondition.class,
+              negated -> {
+                assertThat(negated.getQueryValue()).isEqualTo(!queryValue);
+              });
     }
   }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/condition/impl/GenericConditionTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/condition/impl/GenericConditionTest.java
@@ -40,6 +40,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class GenericConditionTest {
 
   @Mock GenericFilterOperation<Object> filterOperation;
+  @Mock GenericFilterOperation<Object> filterOperation2;
 
   @Mock Row row;
 
@@ -234,6 +235,27 @@ class GenericConditionTest {
       boolean result = condition.test(row);
 
       assertThat(result).isTrue();
+    }
+  }
+
+  @Nested
+  class Negation {
+    @Test
+    void simple() {
+      List<?> queryValue = Collections.singletonList("test");
+      when(filterOperation.negate()).thenReturn(filterOperation2);
+
+      GenericCondition<Object> condition =
+          ImmutableGenericCondition.of(filterOperation, queryValue, true);
+
+      assertThat(condition.negate())
+          .isInstanceOfSatisfying(
+              GenericCondition.class,
+              negated -> {
+                assertThat(negated.getQueryValue()).isEqualTo(queryValue);
+                assertThat(negated.getFilterOperation()).isEqualTo(filterOperation2);
+                assertThat(negated.isNumericBooleans()).isEqualTo(true);
+              });
     }
   }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/condition/impl/NumberConditionTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/condition/impl/NumberConditionTest.java
@@ -37,6 +37,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class NumberConditionTest {
 
   @Mock ValueFilterOperation filterOperation;
+  @Mock ValueFilterOperation filterOperation2;
 
   @Nested
   class Constructor {
@@ -117,6 +118,24 @@ class NumberConditionTest {
       boolean result = condition.test(row);
 
       assertThat(result).isTrue();
+    }
+  }
+
+  @Nested
+  class Negation {
+    @Test
+    void simple() {
+      when(filterOperation.negate()).thenReturn(filterOperation2);
+
+      NumberCondition condition = ImmutableNumberCondition.of(filterOperation, 123);
+
+      assertThat(condition.negate())
+          .isInstanceOfSatisfying(
+              NumberCondition.class,
+              negated -> {
+                assertThat(negated.getQueryValue()).isEqualTo(123);
+                assertThat(negated.getFilterOperation()).isEqualTo(filterOperation2);
+              });
     }
   }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/condition/impl/StringConditionTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/condition/impl/StringConditionTest.java
@@ -37,6 +37,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class StringConditionTest {
 
   @Mock ValueFilterOperation filterOperation;
+  @Mock ValueFilterOperation filterOperation2;
 
   @Nested
   class Constructor {
@@ -117,6 +118,24 @@ class StringConditionTest {
       boolean result = condition.test(row);
 
       assertThat(result).isTrue();
+    }
+  }
+
+  @Nested
+  class Negation {
+    @Test
+    void simple() {
+      when(filterOperation.negate()).thenReturn(filterOperation2);
+
+      StringCondition condition = ImmutableStringCondition.of(filterOperation, "test123");
+
+      assertThat(condition.negate())
+          .isInstanceOfSatisfying(
+              StringCondition.class,
+              negated -> {
+                assertThat(negated.getQueryValue()).isEqualTo("test123");
+                assertThat(negated.getFilterOperation()).isEqualTo(filterOperation2);
+              });
     }
   }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/filter/operation/impl/EqFilterOperationTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/filter/operation/impl/EqFilterOperationTest.java
@@ -137,4 +137,12 @@ class EqFilterOperationTest {
       assertThat(result).isEqualTo(FilterOperationCode.EQ);
     }
   }
+
+  @Nested
+  class Negation {
+    @Test
+    public void negate() {
+      assertThat(eq.negate()).isInstanceOf(NeFilterOperation.class);
+    }
+  }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/filter/operation/impl/GtFilterOperationTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/filter/operation/impl/GtFilterOperationTest.java
@@ -141,4 +141,12 @@ class GtFilterOperationTest {
       assertThat(result).isEqualTo(FilterOperationCode.GT);
     }
   }
+
+  @Nested
+  class Negation {
+    @Test
+    public void negate() {
+      assertThat(gt.negate()).isInstanceOf(LteFilterOperation.class);
+    }
+  }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/filter/operation/impl/GteFilterOperationTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/filter/operation/impl/GteFilterOperationTest.java
@@ -141,4 +141,12 @@ class GteFilterOperationTest {
       assertThat(result).isEqualTo(FilterOperationCode.GTE);
     }
   }
+
+  @Nested
+  class Negation {
+    @Test
+    public void negate() {
+      assertThat(gte.negate()).isInstanceOf(LtFilterOperation.class);
+    }
+  }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/filter/operation/impl/InFilterOperationTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/filter/operation/impl/InFilterOperationTest.java
@@ -207,4 +207,12 @@ class InFilterOperationTest {
       assertThat(result).isEqualTo(FilterOperationCode.IN);
     }
   }
+
+  @Nested
+  class Negation {
+    @Test
+    public void negate() {
+      assertThat(in.negate()).isEqualTo(NotInFilterOperation.of());
+    }
+  }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/filter/operation/impl/LtFilterOperationTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/filter/operation/impl/LtFilterOperationTest.java
@@ -141,4 +141,12 @@ class LtFilterOperationTest {
       assertThat(result).isEqualTo(FilterOperationCode.LT);
     }
   }
+
+  @Nested
+  class Negation {
+    @Test
+    public void negate() {
+      assertThat(lt.negate()).isInstanceOf(GteFilterOperation.class);
+    }
+  }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/filter/operation/impl/LteFilterOperationTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/filter/operation/impl/LteFilterOperationTest.java
@@ -141,4 +141,12 @@ class LteFilterOperationTest {
       assertThat(result).isEqualTo(FilterOperationCode.LTE);
     }
   }
+
+  @Nested
+  class Negation {
+    @Test
+    public void negate() {
+      assertThat(lte.negate()).isInstanceOf(GtFilterOperation.class);
+    }
+  }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/filter/operation/impl/NeFilterOperationTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/filter/operation/impl/NeFilterOperationTest.java
@@ -148,4 +148,12 @@ class NeFilterOperationTest {
       assertThat(result).isTrue();
     }
   }
+
+  @Nested
+  class Negation {
+    @Test
+    public void negate() {
+      assertThat(ne.negate()).isInstanceOf(EqFilterOperation.class);
+    }
+  }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/filter/operation/impl/NotInFilterOperationTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/filter/operation/impl/NotInFilterOperationTest.java
@@ -182,4 +182,12 @@ class NotInFilterOperationTest {
       assertThat(result).isTrue();
     }
   }
+
+  @Nested
+  class Negation {
+    @Test
+    public void negate() {
+      assertThat(nin.negate()).isEqualTo(InFilterOperation.of());
+    }
+  }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/filter/operation/impl/NotNullValueFilterOperationTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/filter/operation/impl/NotNullValueFilterOperationTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 
 import io.stargate.db.query.Predicate;
 import io.stargate.web.docsapi.service.query.filter.operation.FilterOperationCode;
+import io.stargate.web.docsapi.service.query.filter.operation.ValueFilterOperation;
 import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,11 @@ class NotNullValueFilterOperationTest {
         @Override
         public Optional<Predicate> getQueryPredicate() {
           return Optional.empty();
+        }
+
+        @Override
+        public ValueFilterOperation negate() {
+          throw new UnsupportedOperationException();
         }
       };
 

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/rules/ExpressionUtilsTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/rules/ExpressionUtilsTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.web.docsapi.service.query.rules;
+
+import static io.stargate.web.docsapi.service.query.filter.operation.FilterOperationCode.GT;
+import static io.stargate.web.docsapi.service.query.filter.operation.FilterOperationCode.LTE;
+import static io.stargate.web.docsapi.service.query.rules.ExpressionUtils.toSimplifiedCnf;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bpodgursky.jbool_expressions.And;
+import com.bpodgursky.jbool_expressions.Expression;
+import com.bpodgursky.jbool_expressions.Not;
+import com.bpodgursky.jbool_expressions.Or;
+import io.stargate.web.docsapi.service.query.FilterExpression;
+import io.stargate.web.docsapi.service.query.FilterPath;
+import io.stargate.web.docsapi.service.query.ImmutableFilterExpression;
+import io.stargate.web.docsapi.service.query.ImmutableFilterPath;
+import io.stargate.web.docsapi.service.query.condition.BaseCondition;
+import io.stargate.web.docsapi.service.query.condition.impl.ImmutableNumberCondition;
+import io.stargate.web.docsapi.service.query.filter.operation.FilterOperationCode;
+import io.stargate.web.docsapi.service.query.filter.operation.ValueFilterOperation;
+import io.stargate.web.docsapi.service.query.filter.operation.impl.GtFilterOperation;
+import io.stargate.web.docsapi.service.query.filter.operation.impl.LteFilterOperation;
+import java.util.Collections;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ExpressionUtilsTest {
+
+  private FilterExpression e(FilterOperationCode op, int value) {
+    FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+
+    ValueFilterOperation operation;
+    switch (op) {
+      case GT:
+        operation = GtFilterOperation.of();
+        break;
+      case LTE:
+        operation = LteFilterOperation.of();
+        break;
+      default:
+        throw new UnsupportedOperationException("Unsupported op code: " + op);
+    }
+
+    BaseCondition condition = ImmutableNumberCondition.of(operation, value);
+    return ImmutableFilterExpression.of(filterPath, condition, 0);
+  }
+
+  @Nested
+  class CNF {
+
+    @Test
+    void oneCondition() {
+      Expression<FilterExpression> cnf = toSimplifiedCnf(e(GT, 1));
+      assertThat(cnf.toLexicographicString()).isEqualTo("field GT 1");
+    }
+
+    @Test
+    void simpleAnd() {
+      Expression<FilterExpression> cnf = toSimplifiedCnf(And.of(e(GT, 1), e(LTE, 2)));
+      assertThat(cnf.toLexicographicString()).isEqualTo("(field GT 1 & field LTE 2)");
+    }
+
+    @Test
+    void simpleOr() {
+      Expression<FilterExpression> cnf = toSimplifiedCnf(Or.of(e(GT, 1), e(LTE, 2)));
+      assertThat(cnf.toLexicographicString()).isEqualTo("(field GT 1 | field LTE 2)");
+    }
+
+    @Test
+    void orOfAnd() {
+      Expression<FilterExpression> cnf =
+          toSimplifiedCnf(Or.of(e(LTE, 1), And.of(e(GT, 2), e(LTE, 3))));
+      assertThat(cnf.toLexicographicString())
+          .isEqualTo("((field GT 2 | field LTE 1) & (field LTE 1 | field LTE 3))");
+    }
+
+    @Test
+    void andOfOr() {
+      Expression<FilterExpression> cnf =
+          toSimplifiedCnf(And.of(e(LTE, 1), Or.of(e(GT, 2), e(LTE, 3))));
+      assertThat(cnf.toLexicographicString())
+          .isEqualTo("((field GT 2 | field LTE 3) & field LTE 1)");
+    }
+
+    @Test
+    void wrappingOr() {
+      Expression<FilterExpression> cnf =
+          toSimplifiedCnf(Or.of(And.of(e(LTE, 1), Or.of(e(GT, 2), e(LTE, 3)))));
+      assertThat(cnf.toLexicographicString())
+          .isEqualTo("((field GT 2 | field LTE 3) & field LTE 1)");
+    }
+
+    @Test
+    void orOfAndWithNegation() {
+      Expression<FilterExpression> cnf =
+          toSimplifiedCnf(Or.of(Not.of(e(LTE, 1)), e(GT, 2), And.of(e(GT, 3), e(LTE, 4))));
+      // Note: the first predicate got inverted
+      // Note: predicate-specific simplification is not supported (yet?), as in:
+      // field GT 2 | field GT 3 => field GT 2
+      assertThat(cnf.toLexicographicString())
+          .isEqualTo(
+              "((field GT 1 | field GT 2 | field GT 3) & (field GT 1 | field GT 2 | field LTE 4))");
+    }
+  }
+
+  @Nested
+  class Negation {
+    @Test
+    void negatedAnd() {
+      Expression<FilterExpression> cnf = toSimplifiedCnf(Not.of(And.of(e(GT, 1), e(LTE, 2))));
+      // Note: predicates got inverted
+      assertThat(cnf.toLexicographicString()).isEqualTo("(field GT 2 | field LTE 1)");
+    }
+
+    @Test
+    void negatedOr() {
+      Expression<FilterExpression> cnf = toSimplifiedCnf(Not.of(Or.of(e(GT, 1), e(LTE, 2))));
+      // Note: predicates got inverted
+      assertThat(cnf.toLexicographicString()).isEqualTo("(field GT 2 & field LTE 1)");
+    }
+  }
+
+  @Nested
+  class Simplification {
+    @Test
+    void andWithSame() {
+      Expression<FilterExpression> cnf = toSimplifiedCnf(And.of(e(GT, 1), e(GT, 1)));
+      // Note: duplicate condition got removed
+      assertThat(cnf.toLexicographicString()).isEqualTo("field GT 1");
+    }
+
+    @Test
+    void andWithSameNegated() {
+      Expression<FilterExpression> cnf = toSimplifiedCnf(And.of(e(GT, 1), Not.of(e(GT, 1))));
+      assertThat(cnf.toLexicographicString()).isEqualTo("false");
+    }
+
+    @Test
+    void orWithSameNegated() {
+      Expression<FilterExpression> cnf = toSimplifiedCnf(Or.of(e(GT, 1), Not.of(e(GT, 1))));
+      assertThat(cnf.toLexicographicString()).isEqualTo("true");
+    }
+
+    @Test
+    void impliedAndSubExpression() {
+      // Note: the first OR condition implies the AND sub-expression
+      Expression<FilterExpression> cnf =
+          toSimplifiedCnf(Or.of(e(GT, 2), And.of(e(GT, 2), e(LTE, 3))));
+      assertThat(cnf.toLexicographicString()).isEqualTo("field GT 2");
+    }
+
+    @Test
+    void impliedNegatedAndSubExpression() {
+      // Note: the first OR condition implies the AND sub-expression
+      Expression<FilterExpression> cnf =
+          toSimplifiedCnf(Or.of(e(LTE, 2), And.of(Not.of(e(GT, 2)), e(LTE, 3))));
+      assertThat(cnf.toLexicographicString()).isEqualTo("field LTE 2");
+    }
+
+    @Test
+    void negatedImpliesAndSubExpression() {
+      // Note: the first OR condition implies the AND sub-expression
+      Expression<FilterExpression> cnf =
+          toSimplifiedCnf(Or.of(Not.of(e(LTE, 2)), And.of(e(GT, 2), e(LTE, 3))));
+      assertThat(cnf.toLexicographicString()).isEqualTo("field GT 2");
+    }
+
+    @Test
+    void andWithEquivalentInvertedNegatedPredicate() {
+      Expression<FilterExpression> cnf = toSimplifiedCnf(And.of(e(GT, 1), Not.of(e(LTE, 1))));
+      assertThat(cnf.toLexicographicString()).isEqualTo("field GT 1");
+    }
+
+    @Test
+    void impliedAndSubExpressionWithNegatedOrOfSame() {
+      // Note: the second OR condition implies the AND sub-expression
+      // Note: the first OR condition is equivalent to the second OR condition
+      Expression<FilterExpression> cnf =
+          toSimplifiedCnf(Or.of(Not.of(e(LTE, 2)), e(GT, 2), And.of(e(GT, 2), e(LTE, 3))));
+      assertThat(cnf.toLexicographicString()).isEqualTo("field GT 2");
+    }
+  }
+}

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolverTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolverTest.java
@@ -589,7 +589,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
               nested -> {
                 assertThat(nested.description())
                     .isEqualTo(
-                        "MERGING OR: expression '(path.field IN [1] | path.field GT query-value)'");
+                        "MERGING OR: expression '(path.field GT query-value | path.field IN [1])'");
                 assertThat(nested.queries())
                     .hasSize(2)
                     .allSatisfy(
@@ -785,7 +785,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
               nested -> {
                 assertThat(nested.description())
                     .isEqualTo(
-                        "MERGING OR: expression '(field NE not-me | field IN [query-value])'");
+                        "MERGING OR: expression '(field IN [query-value] | field NE not-me)'");
                 assertThat(nested.queries())
                     .singleElement()
                     .satisfies(
@@ -847,7 +847,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
               nested -> {
                 assertThat(nested.description())
                     .isEqualTo(
-                        "MERGING OR: expression '(field NE not-me | field IN [query-value])'");
+                        "MERGING OR: expression '(field IN [query-value] | field NE not-me)'");
                 assertThat(nested.queries())
                     .singleElement()
                     .satisfies(

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -1106,6 +1106,26 @@ public abstract class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
   }
 
   @Test
+  public void testBasicSearchWithNegation() throws IOException {
+    JsonNode fullObj =
+        OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));
+    RestUtils.put(authToken, collectionPath + "/cool-search-id", fullObj.toString(), 200);
+
+    // NOT NE === EQ
+    String r =
+        RestUtils.get(
+            authToken,
+            collectionPath
+                + "/cool-search-id?where={\"$not\": {\"products.electronics.Pixel_3a.price\": {\"$ne\": 600}}}",
+            200);
+
+    String searchResultStr =
+        "[{\"products\": {\"electronics\": {\"Pixel_3a\": {\"price\": 600}}}}]";
+    assertThat(OBJECT_MAPPER.readTree(r))
+        .isEqualTo(wrapResponse(OBJECT_MAPPER.readTree(searchResultStr), "cool-search-id", null));
+  }
+
+  @Test
   public void testBasicSearchWithSelectivityHints() throws IOException {
     JsonNode fullObj =
         OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));


### PR DESCRIPTION
* Parse $not operators in JSON allowing exactly one
  sub-expression.

* Add negation methods to filter expressions and
  conditions

* Add a rule for eliminating NOT boolean expressions
  by negating the child filter during expression
  resolution.

* Simplify expressions after eliminating negation

Note: Also remove selectivity from the identity of
FilterExpression. This is to give preference to boolean
expression simplification when equivalent filters happen
to have different selectivity hints specified by the user.

Fixes #1071
