### PR TITLE
relates to #1151: switch away from the core thread in the RX

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
@@ -24,6 +24,7 @@ import hu.akarnokd.rxjava3.operators.FlowableTransformers;
 import hu.akarnokd.rxjava3.operators.Flowables;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.stargate.db.ComparableKey;
 import io.stargate.db.ImmutableParameters;
 import io.stargate.db.PagingPosition;
@@ -212,6 +213,7 @@ public class QueryExecutor {
                 });
 
     return RxUtils.singleFromFuture(supplier)
+        .observeOn(Schedulers.io())
         .toFlowable()
         .compose(FlowableConnectOnRequest.with()) // separate subscription from query execution
         .take(1);

--- a/restapi/src/test/java/io/stargate/db/datastore/AbstractDataStoreTest.java
+++ b/restapi/src/test/java/io/stargate/db/datastore/AbstractDataStoreTest.java
@@ -45,8 +45,8 @@ public abstract class AbstractDataStoreTest {
     dataStore.validate();
   }
 
-  protected <T> List<T> values(Flowable<T> flowable) {
-    TestSubscriber<T> test = flowable.test();
+  protected <T> List<T> values(Flowable<T> flowable) throws Exception {
+    TestSubscriber<T> test = flowable.test().await();
     test.assertNoErrors();
     return test.values();
   }

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/QueryExecutorTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/QueryExecutorTest.java
@@ -112,7 +112,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
   }
 
   @Test
-  void testFullScan() {
+  void testFullScan() throws Exception {
     withQuery(table, "SELECT * FROM %s")
         .returning(ImmutableList.of(row("1", "x", 1.0d), row("1", "y", 2.0d), row("2", "x", 3.0d)));
 
@@ -149,7 +149,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
 
   @ParameterizedTest
   @CsvSource({"1", "3", "5", "100"})
-  void testFullScanPaged(int pageSize) {
+  void testFullScanPaged(int pageSize) throws Exception {
     withFiveTestDocs(pageSize);
 
     List<RawDocument> r1 = values(executor.queryDocs(allDocsQuery, pageSize, null, context));
@@ -174,7 +174,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
 
   @ParameterizedTest
   @CsvSource({"1", "100", "5000"})
-  void testFullScanDeep(int pageSize) {
+  void testFullScanDeep(int pageSize) throws Exception {
     int N = 100_000;
     Builder<Map<String, Object>> rows = ImmutableList.builder();
     for (int i = 0; i < N; i++) { // generate 10 pages of data
@@ -221,7 +221,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
 
   @ParameterizedTest
   @CsvSource({"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "100"})
-  void testFullScanFinalPagingState(int pageSize) {
+  void testFullScanFinalPagingState(int pageSize) throws Exception {
     // Note: the test result set has 8 rows.
     // If page size is a divisor of the result set size the test DataStore will return a non-null
     // paging state in the page that contains the last row to emulate C* behaviour, which cannot
@@ -245,7 +245,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
 
   @ParameterizedTest
   @CsvSource({"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "100"})
-  void testPopulate(int pageSize) {
+  void testPopulate(int pageSize) throws Exception {
     withFiveTestDocIds(pageSize);
     withQuery(table, "SELECT * FROM %s WHERE key = ?", "2")
         .withPageSize(pageSize)
@@ -290,13 +290,14 @@ class QueryExecutorTest extends AbstractDataStoreTest {
   }
 
   @Test
-  void testResultSetPagination() {
+  void testResultSetPagination() throws Exception {
     withFiveTestDocs(3);
 
     List<ResultSet> r1 =
         executor
             .execute(datastore().queryBuilder().select().star().from(table).build().bind(), 3, null)
             .test()
+            .await()
             .values();
 
     assertThat(r1.get(0).currentPageRows())
@@ -315,7 +316,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
   }
 
   @Test
-  void testSubDocuments() {
+  void testSubDocuments() throws Exception {
     withQuery(table, "SELECT * FROM %s WHERE key = ? AND p0 > ?", "a", "x")
         .withPageSize(3)
         .returning(
@@ -361,7 +362,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
 
   @ParameterizedTest
   @CsvSource({"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "100"})
-  void testSubDocumentsPaged(int pageSize) {
+  void testSubDocumentsPaged(int pageSize) throws Exception {
     withQuery(table, "SELECT * FROM %s WHERE key = ? AND p0 > ?", "a", "x")
         .withPageSize(pageSize)
         .returning(
@@ -427,7 +428,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
 
   @ParameterizedTest
   @CsvSource({"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "100"})
-  void testMergeByDocKey(int pageSize) {
+  void testMergeByDocKey(int pageSize) throws Exception {
     withQuery(table, "SELECT * FROM %s WHERE p0 > ?", "x")
         .withPageSize(pageSize)
         .returning(
@@ -464,7 +465,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
 
   @ParameterizedTest
   @CsvSource({"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "100"})
-  void testMergeSubDocuments(int pageSize) {
+  void testMergeSubDocuments(int pageSize) throws Exception {
     withQuery(table, "SELECT * FROM %s WHERE p0 > ?", "x")
         .withPageSize(pageSize)
         .returning(
@@ -511,7 +512,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
 
   @ParameterizedTest
   @CsvSource({"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "100"})
-  void testMergeWithPartialPath(int pageSize) {
+  void testMergeWithPartialPath(int pageSize) throws Exception {
     String cql = "SELECT key, p0, test_value FROM %s WHERE p0 > ?";
     withQuery(table, cql, "x")
         .withPageSize(pageSize)
@@ -563,7 +564,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
 
   @ParameterizedTest
   @CsvSource({"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "100"})
-  void testMergeByDocKeyPaged(int pageSize) {
+  void testMergeByDocKeyPaged(int pageSize) throws Exception {
     withQuery(table, "SELECT * FROM %s WHERE p0 > ?", "x")
         .withPageSize(pageSize)
         .returning(
@@ -635,7 +636,7 @@ class QueryExecutorTest extends AbstractDataStoreTest {
 
   @ParameterizedTest
   @CsvSource({"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "100"})
-  void testMergeResultPaginationWithExcludedRows(int pageSize) {
+  void testMergeResultPaginationWithExcludedRows(int pageSize) throws Exception {
     withQuery(table, "SELECT * FROM %s WHERE p0 > ?", "x")
         .withPageSize(pageSize)
         .returning(

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/ReactiveDocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/ReactiveDocumentServiceTest.java
@@ -180,6 +180,7 @@ class ReactiveDocumentServiceTest {
 
       result
           .test()
+          .await()
           .assertValue(
               wrapper -> {
                 assertThat(wrapper.getDocumentId()).isNull();
@@ -233,6 +234,7 @@ class ReactiveDocumentServiceTest {
 
       result
           .test()
+          .await()
           .assertValue(
               wrapper -> {
                 assertThat(wrapper.getDocumentId()).isNull();
@@ -285,6 +287,7 @@ class ReactiveDocumentServiceTest {
 
       result
           .test()
+          .await()
           .assertValue(
               wrapper -> {
                 assertThat(wrapper.getDocumentId()).isNull();
@@ -323,6 +326,7 @@ class ReactiveDocumentServiceTest {
 
       result
           .test()
+          .await()
           .assertValue(
               wrapper -> {
                 assertThat(wrapper.getDocumentId()).isNull();
@@ -356,6 +360,7 @@ class ReactiveDocumentServiceTest {
 
       result
           .test()
+          .await()
           .assertValue(
               wrapper -> {
                 assertThat(wrapper.getDocumentId()).isNull();
@@ -386,6 +391,7 @@ class ReactiveDocumentServiceTest {
 
       result
           .test()
+          .await()
           .assertError(
               e -> {
                 assertThat(e).isInstanceOf(UnauthorizedException.class);
@@ -397,7 +403,7 @@ class ReactiveDocumentServiceTest {
     }
 
     @Test
-    public void whereJsonException() {
+    public void whereJsonException() throws Exception {
       ExecutionContext context = ExecutionContext.create(true);
       Paginator paginator = new Paginator(null, 1);
       String namespace = RandomStringUtils.randomAlphanumeric(16);
@@ -410,6 +416,7 @@ class ReactiveDocumentServiceTest {
 
       result
           .test()
+          .await()
           .assertError(
               e -> {
                 assertThat(e)
@@ -422,7 +429,7 @@ class ReactiveDocumentServiceTest {
     }
 
     @Test
-    public void fieldsJsonException() {
+    public void fieldsJsonException() throws Exception {
       ExecutionContext context = ExecutionContext.create(true);
       Paginator paginator = new Paginator(null, 1);
       String namespace = RandomStringUtils.randomAlphanumeric(16);
@@ -435,6 +442,7 @@ class ReactiveDocumentServiceTest {
 
       result
           .test()
+          .await()
           .assertError(
               e -> {
                 assertThat(e)
@@ -483,6 +491,7 @@ class ReactiveDocumentServiceTest {
 
       result
           .test()
+          .await()
           .assertValue(
               wrapper -> {
                 assertThat(wrapper.getDocumentId()).isEqualTo(documentId);
@@ -537,7 +546,7 @@ class ReactiveDocumentServiceTest {
               documentDB, namespace, collection, documentId, prePath, fields, context);
 
       List<Pair<DocumentResponseWrapper<? extends JsonNode>, Disposable>> values =
-          result.test().assertComplete().assertNoErrors().values();
+          result.test().await().assertComplete().assertNoErrors().values();
       assertThat(values.size()).isEqualTo(1);
 
       DocumentResponseWrapper<? extends JsonNode> wrapper = values.get(0).getValue0();
@@ -599,6 +608,7 @@ class ReactiveDocumentServiceTest {
 
       result
           .test()
+          .await()
           .assertValue(
               wrapper -> {
                 assertThat(wrapper.getDocumentId()).isEqualTo(documentId);
@@ -673,6 +683,7 @@ class ReactiveDocumentServiceTest {
 
       result
           .test()
+          .await()
           .assertValue(
               wrapper -> {
                 assertThat(wrapper.getDocumentId()).isEqualTo(documentId);
@@ -737,6 +748,7 @@ class ReactiveDocumentServiceTest {
 
       result
           .test()
+          .await()
           .assertValue(
               wrapper -> {
                 assertThat(wrapper.getDocumentId()).isEqualTo(documentId);
@@ -808,6 +820,7 @@ class ReactiveDocumentServiceTest {
 
       result
           .test()
+          .await()
           .assertValue(
               wrapper -> {
                 assertThat(wrapper.getDocumentId()).isEqualTo(documentId);
@@ -852,6 +865,7 @@ class ReactiveDocumentServiceTest {
 
       result
           .test()
+          .await()
           .assertError(
               e -> {
                 assertThat(e).isInstanceOf(UnauthorizedException.class);
@@ -890,6 +904,7 @@ class ReactiveDocumentServiceTest {
 
       result
           .test()
+          .await()
           .assertError(
               e -> {
                 assertThat(e)
@@ -938,6 +953,7 @@ class ReactiveDocumentServiceTest {
 
       result
           .test()
+          .await()
           .assertError(
               e -> {
                 assertThat(e)
@@ -951,7 +967,7 @@ class ReactiveDocumentServiceTest {
     }
 
     @Test
-    public void whereJsonException() {
+    public void whereJsonException() throws Exception {
       String documentId = RandomStringUtils.randomAlphanumeric(16);
       ExecutionContext context = ExecutionContext.create(true);
       Paginator paginator = new Paginator(null, 1);
@@ -973,6 +989,7 @@ class ReactiveDocumentServiceTest {
 
       result
           .test()
+          .await()
           .assertError(
               e -> {
                 assertThat(e)
@@ -985,7 +1002,7 @@ class ReactiveDocumentServiceTest {
     }
 
     @Test
-    public void fieldsJsonException() {
+    public void fieldsJsonException() throws Exception {
       String documentId = RandomStringUtils.randomAlphanumeric(16);
       ExecutionContext context = ExecutionContext.create(true);
       Paginator paginator = new Paginator(null, 1);
@@ -1007,6 +1024,7 @@ class ReactiveDocumentServiceTest {
 
       result
           .test()
+          .await()
           .assertError(
               e -> {
                 assertThat(e)

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/DocumentSearchServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/DocumentSearchServiceTest.java
@@ -80,7 +80,7 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
   class SearchDocuments {
 
     @Test
-    public void happyPath() {
+    public void happyPath() throws Exception {
       Paginator paginator = new Paginator(null, 20);
       ExecutionContext context = ExecutionContext.create(true);
       FilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("some", "field"));
@@ -127,6 +127,7 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
       // assert results
       results
           .test()
+          .await()
           .assertValueAt(
               0,
               doc -> {
@@ -214,7 +215,7 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void limitedResults() {
+    public void limitedResults() throws Exception {
       Paginator paginator = new Paginator(null, 1);
       ExecutionContext context = ExecutionContext.create(true);
       FilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("some", "field"));
@@ -252,6 +253,7 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
       // assert results
       results
           .test()
+          .await()
           .assertValueAt(
               0,
               doc -> {
@@ -317,7 +319,7 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void nothingToPopulate() {
+    public void nothingToPopulate() throws Exception {
       Paginator paginator = new Paginator(null, 1);
       ExecutionContext context = ExecutionContext.create(true);
       FilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("some", "field"));
@@ -348,7 +350,7 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
               context);
 
       // assert results
-      results.test().assertValueCount(0).assertComplete();
+      results.test().await().assertValueCount(0).assertComplete();
 
       // assert queries execution
       candidatesAssert.assertExecuteCount().isEqualTo(1);
@@ -383,7 +385,7 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void fullSearch() {
+    public void fullSearch() throws Exception {
       Paginator paginator = new Paginator(null, 20);
       ExecutionContext context = ExecutionContext.create(true);
 
@@ -414,6 +416,7 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
       // assert results
       results
           .test()
+          .await()
           .assertValueAt(
               0,
               doc -> {
@@ -487,7 +490,7 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
   class SearchSubDocuments {
 
     @Test
-    public void searchFullDoc() {
+    public void searchFullDoc() throws Exception {
       String documentId = RandomStringUtils.randomAlphanumeric(16);
       Paginator paginator = new Paginator(null, 20);
       ExecutionContext context = ExecutionContext.create(true);
@@ -539,6 +542,7 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
       // assert results
       results
           .test()
+          .await()
           .assertValue(
               doc -> {
                 assertThat(doc.id()).isEqualTo(documentId);
@@ -586,7 +590,7 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void searchSubDoc() {
+    public void searchSubDoc() throws Exception {
       String documentId = RandomStringUtils.randomAlphanumeric(16);
       Paginator paginator = new Paginator(null, 20);
       ExecutionContext context = ExecutionContext.create(true);
@@ -628,6 +632,7 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
       // assert results
       results
           .test()
+          .await()
           .assertValue(
               doc -> {
                 assertThat(doc.id()).isEqualTo(documentId);
@@ -669,7 +674,7 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void searchSubDocPaginated() {
+    public void searchSubDocPaginated() throws Exception {
       String documentId = RandomStringUtils.randomAlphanumeric(16);
       Paginator paginator = new Paginator(null, 2);
       ExecutionContext context = ExecutionContext.create(true);
@@ -700,6 +705,7 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
       // assert results
       results
           .test()
+          .await()
           .assertValueAt(
               0,
               doc -> {
@@ -756,7 +762,7 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
   class GetDocument {
 
     @Test
-    public void getSubDoc() {
+    public void getSubDoc() throws Exception {
       String documentId = RandomStringUtils.randomAlphanumeric(16);
       ExecutionContext context = ExecutionContext.create(true);
       List<String> subPath = Collections.singletonList("field");
@@ -787,6 +793,7 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
       // assert results
       results
           .test()
+          .await()
           .assertValue(
               doc -> {
                 assertThat(doc.id()).isEqualTo(documentId);
@@ -822,7 +829,7 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
   class SelectivityHints {
 
     @Test
-    public void predicateOrderWithExplicitSelectivity() {
+    public void predicateOrderWithExplicitSelectivity() throws Exception {
       Paginator paginator = new Paginator(null, 20);
       ExecutionContext context = ExecutionContext.create(true);
       FilterPath filterPath1 = ImmutableFilterPath.of(Arrays.asList("some", "field1"));
@@ -865,6 +872,7 @@ class DocumentSearchServiceTest extends AbstractDataStoreTest {
               paginator,
               context)
           .test()
+          .await()
           .assertNoErrors();
 
       // Rely on profiling output to validate the order of filter execution

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/filter/impl/InMemoryCandidatesFilterTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/filter/impl/InMemoryCandidatesFilterTest.java
@@ -111,7 +111,7 @@ class InMemoryCandidatesFilterTest extends AbstractDataStoreTest {
   class PrepareQuery {
 
     @Test
-    public void fixedPath() {
+    public void fixedPath() throws Exception {
       // fixed path has limit
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
       when(filterExpression.getFilterPath()).thenReturn(filterPath);
@@ -127,7 +127,7 @@ class InMemoryCandidatesFilterTest extends AbstractDataStoreTest {
       Single<? extends Query<? extends BoundQuery>> single =
           filter.prepareQuery(datastore(), configuration, KEYSPACE_NAME, COLLECTION_NAME);
 
-      single.test().assertValueCount(1).assertComplete();
+      single.test().await().assertValueCount(1).assertComplete();
 
       // execution context not updated with execution
       assertThat(executionContext.toProfile().nested())
@@ -143,7 +143,7 @@ class InMemoryCandidatesFilterTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void globComplexPath() {
+    public void globComplexPath() throws Exception {
       // glob path has no limits and glob px has GT as condition
       FilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("some", "*", "field"));
       when(filterExpression.getFilterPath()).thenReturn(filterPath);
@@ -159,7 +159,7 @@ class InMemoryCandidatesFilterTest extends AbstractDataStoreTest {
       Single<? extends Query<? extends BoundQuery>> single =
           filter.prepareQuery(datastore(), configuration, KEYSPACE_NAME, COLLECTION_NAME);
 
-      single.test().assertValueCount(1).assertComplete();
+      single.test().await().assertValueCount(1).assertComplete();
 
       // execution context not updated with execution
       assertThat(executionContext.toProfile().nested())
@@ -185,7 +185,7 @@ class InMemoryCandidatesFilterTest extends AbstractDataStoreTest {
     @Captor ArgumentCaptor<List<Row>> testRowsCaptor;
 
     @Test
-    public void fixedPath() {
+    public void fixedPath() throws Exception {
       // fixed path has limit and page size 2 on the execution
       String documentId = RandomStringUtils.randomAlphabetic(16);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
@@ -215,7 +215,7 @@ class InMemoryCandidatesFilterTest extends AbstractDataStoreTest {
               .blockingGet();
       Maybe<?> result = filter.bindAndFilter(queryExecutor, configuration, query, rawDocument);
 
-      result.test().assertValueCount(1).assertComplete();
+      result.test().await().assertValueCount(1).assertComplete();
       queryAssert.assertExecuteCount().isEqualTo(1);
 
       // execution context
@@ -250,7 +250,7 @@ class InMemoryCandidatesFilterTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void globPathMultipleExpressions() {
+    public void globPathMultipleExpressions() throws Exception {
       // glob path has no limits and glob px has GT as condition
       String documentId = RandomStringUtils.randomAlphabetic(16);
       FilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("some", "*", "field"));
@@ -287,7 +287,7 @@ class InMemoryCandidatesFilterTest extends AbstractDataStoreTest {
               .blockingGet();
       Maybe<?> result = filter.bindAndFilter(queryExecutor, configuration, query, rawDocument);
 
-      result.test().assertValueCount(1).assertComplete();
+      result.test().await().assertValueCount(1).assertComplete();
 
       queryAssert.assertExecuteCount().isEqualTo(1);
 
@@ -324,7 +324,7 @@ class InMemoryCandidatesFilterTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void nothingReturned() {
+    public void nothingReturned() throws Exception {
       String documentId = RandomStringUtils.randomAlphabetic(16);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
       when(filterExpression.getFilterPath()).thenReturn(filterPath);
@@ -352,7 +352,7 @@ class InMemoryCandidatesFilterTest extends AbstractDataStoreTest {
               .blockingGet();
       Maybe<?> result = filter.bindAndFilter(queryExecutor, configuration, query, rawDocument);
 
-      result.test().assertValueCount(0).assertComplete();
+      result.test().await().assertValueCount(0).assertComplete();
 
       queryAssert.assertExecuteCount().isEqualTo(1);
 
@@ -376,7 +376,7 @@ class InMemoryCandidatesFilterTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void nothingReturnedButEvalOnMissing() {
+    public void nothingReturnedButEvalOnMissing() throws Exception {
       String documentId = RandomStringUtils.randomAlphabetic(16);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
       when(filterExpression.getFilterPath()).thenReturn(filterPath);
@@ -406,7 +406,7 @@ class InMemoryCandidatesFilterTest extends AbstractDataStoreTest {
               .blockingGet();
       Maybe<?> result = filter.bindAndFilter(queryExecutor, configuration, query, rawDocument);
 
-      result.test().assertValueCount(1).assertComplete();
+      result.test().await().assertValueCount(1).assertComplete();
 
       queryAssert.assertExecuteCount().isEqualTo(1);
 
@@ -430,7 +430,7 @@ class InMemoryCandidatesFilterTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void testNotPassed() {
+    public void testNotPassed() throws Exception {
       // fixed path has limit and page size 2 on the execution
       String documentId = RandomStringUtils.randomAlphabetic(16);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
@@ -460,7 +460,7 @@ class InMemoryCandidatesFilterTest extends AbstractDataStoreTest {
               .blockingGet();
       Maybe<?> result = filter.bindAndFilter(queryExecutor, configuration, query, rawDocument);
 
-      result.test().assertValueCount(0).assertComplete();
+      result.test().await().assertValueCount(0).assertComplete();
       queryAssert.assertExecuteCount().isEqualTo(1);
 
       // execution context

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/filter/impl/PersistenceCandidatesFilterTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/filter/impl/PersistenceCandidatesFilterTest.java
@@ -110,7 +110,7 @@ class PersistenceCandidatesFilterTest extends AbstractDataStoreTest {
   class PrepareQuery {
 
     @Test
-    public void fixedPath() {
+    public void fixedPath() throws Exception {
       // fixed path has limit
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
       BaseCondition condition = ImmutableStringCondition.of(EqFilterOperation.of(), "query-value");
@@ -127,7 +127,7 @@ class PersistenceCandidatesFilterTest extends AbstractDataStoreTest {
       Single<? extends Query<? extends BoundQuery>> single =
           filter.prepareQuery(datastore(), configuration, KEYSPACE_NAME, COLLECTION_NAME);
 
-      single.test().assertValueCount(1).assertComplete();
+      single.test().await().assertValueCount(1).assertComplete();
 
       // execution context not updated with execution
       assertThat(executionContext.toProfile().nested())
@@ -143,7 +143,7 @@ class PersistenceCandidatesFilterTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void globComplexPath() {
+    public void globComplexPath() throws Exception {
       // glob path has no limits and glob px has GT as condition
       FilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("some", "*", "field"));
       BaseCondition condition = ImmutableStringCondition.of(EqFilterOperation.of(), "query-value");
@@ -160,7 +160,7 @@ class PersistenceCandidatesFilterTest extends AbstractDataStoreTest {
       Single<? extends Query<? extends BoundQuery>> single =
           filter.prepareQuery(datastore(), configuration, KEYSPACE_NAME, COLLECTION_NAME);
 
-      single.test().assertValueCount(1).assertComplete();
+      single.test().await().assertValueCount(1).assertComplete();
 
       // execution context not updated with execution
       assertThat(executionContext.toProfile().nested())
@@ -184,7 +184,7 @@ class PersistenceCandidatesFilterTest extends AbstractDataStoreTest {
     @Mock FilterExpression filterExpression2;
 
     @Test
-    public void fixedPath() {
+    public void fixedPath() throws Exception {
       // fixed path has limit and page size 2 on the execution
       String documentId = RandomStringUtils.randomAlphabetic(16);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
@@ -215,7 +215,7 @@ class PersistenceCandidatesFilterTest extends AbstractDataStoreTest {
               .blockingGet();
       Maybe<?> result = filter.bindAndFilter(queryExecutor, configuration, query, rawDocument);
 
-      result.test().assertValueCount(1).assertComplete();
+      result.test().await().assertValueCount(1).assertComplete();
 
       queryAssert.assertExecuteCount().isEqualTo(1);
 
@@ -238,7 +238,7 @@ class PersistenceCandidatesFilterTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void globPathMultipleExpressions() {
+    public void globPathMultipleExpressions() throws Exception {
       // glob path has no limits and glob px has GT as condition
       String documentId = RandomStringUtils.randomAlphabetic(16);
       FilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("some", "*", "field"));
@@ -277,7 +277,7 @@ class PersistenceCandidatesFilterTest extends AbstractDataStoreTest {
               .blockingGet();
       Maybe<?> result = filter.bindAndFilter(queryExecutor, configuration, query, rawDocument);
 
-      result.test().assertValueCount(1).assertComplete();
+      result.test().await().assertValueCount(1).assertComplete();
 
       queryAssert.assertExecuteCount().isEqualTo(1);
 
@@ -299,7 +299,7 @@ class PersistenceCandidatesFilterTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void nothingReturned() {
+    public void nothingReturned() throws Exception {
       String documentId = RandomStringUtils.randomAlphabetic(16);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
       BaseCondition condition = ImmutableStringCondition.of(EqFilterOperation.of(), "query-value");
@@ -329,7 +329,7 @@ class PersistenceCandidatesFilterTest extends AbstractDataStoreTest {
               .blockingGet();
       Maybe<?> result = filter.bindAndFilter(queryExecutor, configuration, query, rawDocument);
 
-      result.test().assertValueCount(0).assertComplete();
+      result.test().await().assertValueCount(0).assertComplete();
 
       queryAssert.assertExecuteCount().isEqualTo(1);
 

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/AllFiltersResolverTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/AllFiltersResolverTest.java
@@ -116,7 +116,7 @@ class AllFiltersResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void happyPath() {
+    public void happyPath() throws Exception {
       withAnySelectFrom(TABLE).returningNothing();
 
       DataStore datastore = datastore();
@@ -145,7 +145,7 @@ class AllFiltersResolverTest extends AbstractDataStoreTest {
           resolver.getDocuments(
               queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, new Paginator(null, 1));
 
-      results.test().assertValue(rawDocument).assertComplete();
+      results.test().await().assertValue(rawDocument).assertComplete();
 
       resetExpectations();
 
@@ -161,7 +161,7 @@ class AllFiltersResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void multipleDocuments() {
+    public void multipleDocuments() throws Exception {
       withAnySelectFrom(TABLE).returningNothing();
 
       DataStore datastore = datastore();
@@ -190,7 +190,12 @@ class AllFiltersResolverTest extends AbstractDataStoreTest {
           resolver.getDocuments(
               queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, new Paginator(null, 1));
 
-      results.test().assertValueAt(0, rawDocument).assertValueAt(1, rawDocument2).assertComplete();
+      results
+          .test()
+          .await()
+          .assertValueAt(0, rawDocument)
+          .assertValueAt(1, rawDocument2)
+          .assertComplete();
 
       resetExpectations();
 
@@ -210,7 +215,7 @@ class AllFiltersResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void notAllFiltersPassed() {
+    public void notAllFiltersPassed() throws Exception {
       withAnySelectFrom(TABLE).returningNothing();
 
       DataStore datastore = datastore();
@@ -239,7 +244,7 @@ class AllFiltersResolverTest extends AbstractDataStoreTest {
           resolver.getDocuments(
               queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, new Paginator(null, 1));
 
-      results.test().assertValueCount(0).assertComplete();
+      results.test().await().assertValueCount(0).assertComplete();
 
       resetExpectations();
 
@@ -255,7 +260,7 @@ class AllFiltersResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void noCandidates() {
+    public void noCandidates() throws Exception {
       withAnySelectFrom(TABLE).returningNothing();
 
       DocumentsResolver candidatesResolver =
@@ -270,7 +275,7 @@ class AllFiltersResolverTest extends AbstractDataStoreTest {
           resolver.getDocuments(
               queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, new Paginator(null, 1));
 
-      results.test().assertValueCount(0).assertComplete();
+      results.test().await().assertValueCount(0).assertComplete();
 
       resetExpectations();
       verifyNoMoreInteractions(candidatesFilter, candidatesFilter2);

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/AnyFiltersResolverTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/AnyFiltersResolverTest.java
@@ -116,7 +116,7 @@ class AnyFiltersResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void happyPath() {
+    public void happyPath() throws Exception {
       withAnySelectFrom(TABLE).returningNothing();
 
       DataStore datastore = datastore();
@@ -145,7 +145,7 @@ class AnyFiltersResolverTest extends AbstractDataStoreTest {
           resolver.getDocuments(
               queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, new Paginator(null, 1));
 
-      results.test().assertValue(rawDocument).assertComplete();
+      results.test().await().assertValue(rawDocument).assertComplete();
 
       resetExpectations();
 
@@ -161,7 +161,7 @@ class AnyFiltersResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void multipleDocumentsOneFilterPassing() {
+    public void multipleDocumentsOneFilterPassing() throws Exception {
       withAnySelectFrom(TABLE).returningNothing();
 
       DataStore datastore = datastore();
@@ -190,7 +190,12 @@ class AnyFiltersResolverTest extends AbstractDataStoreTest {
           resolver.getDocuments(
               queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, new Paginator(null, 1));
 
-      results.test().assertValueAt(0, rawDocument).assertValueAt(1, rawDocument2).assertComplete();
+      results
+          .test()
+          .await()
+          .assertValueAt(0, rawDocument)
+          .assertValueAt(1, rawDocument2)
+          .assertComplete();
 
       resetExpectations();
 
@@ -210,7 +215,7 @@ class AnyFiltersResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void allFiltersNotPassed() {
+    public void allFiltersNotPassed() throws Exception {
       withAnySelectFrom(TABLE).returningNothing();
 
       DataStore datastore = datastore();
@@ -239,7 +244,7 @@ class AnyFiltersResolverTest extends AbstractDataStoreTest {
           resolver.getDocuments(
               queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, new Paginator(null, 1));
 
-      results.test().assertValueCount(0).assertComplete();
+      results.test().await().assertValueCount(0).assertComplete();
 
       resetExpectations();
 
@@ -255,7 +260,7 @@ class AnyFiltersResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void noCandidates() {
+    public void noCandidates() throws Exception {
       withAnySelectFrom(TABLE).returningNothing();
 
       DocumentsResolver candidatesResolver =
@@ -270,7 +275,7 @@ class AnyFiltersResolverTest extends AbstractDataStoreTest {
           resolver.getDocuments(
               queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, new Paginator(null, 1));
 
-      results.test().assertValueCount(0).assertComplete();
+      results.test().await().assertValueCount(0).assertComplete();
 
       resetExpectations();
       verifyNoMoreInteractions(candidatesFilter, candidatesFilter2);

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/InMemoryDocumentsResolverTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/InMemoryDocumentsResolverTest.java
@@ -93,7 +93,7 @@ class InMemoryDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void happyPath() {
+    public void happyPath() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
@@ -119,6 +119,7 @@ class InMemoryDocumentsResolverTest extends AbstractDataStoreTest {
 
       result
           .test()
+          .await()
           .assertValue(
               doc -> {
                 assertThat(doc.id()).isEqualTo("1");
@@ -148,7 +149,7 @@ class InMemoryDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void happyPathEvalOnMissing() {
+    public void happyPathEvalOnMissing() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       when(baseCondition.isEvaluateOnMissingFields()).thenReturn(true);
@@ -170,6 +171,7 @@ class InMemoryDocumentsResolverTest extends AbstractDataStoreTest {
 
       result
           .test()
+          .await()
           .assertValue(
               doc -> {
                 assertThat(doc.id()).isEqualTo("1");
@@ -199,7 +201,7 @@ class InMemoryDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void happyPathMultipleExpressions() {
+    public void happyPathMultipleExpressions() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
@@ -228,7 +230,7 @@ class InMemoryDocumentsResolverTest extends AbstractDataStoreTest {
           resolver.getDocuments(
               queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
 
-      result.test().assertComplete();
+      result.test().await().assertComplete();
 
       // one query only
       queryAssert.assertExecuteCount().isEqualTo(1);
@@ -252,7 +254,7 @@ class InMemoryDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void multipleDocuments() {
+    public void multipleDocuments() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
@@ -277,6 +279,7 @@ class InMemoryDocumentsResolverTest extends AbstractDataStoreTest {
 
       result
           .test()
+          .await()
           .assertValueAt(
               0,
               doc -> {
@@ -312,7 +315,7 @@ class InMemoryDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void nothingReturnedFromDataStore() {
+    public void nothingReturnedFromDataStore() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
@@ -334,7 +337,7 @@ class InMemoryDocumentsResolverTest extends AbstractDataStoreTest {
           resolver.getDocuments(
               queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
 
-      result.test().assertNoValues().assertComplete();
+      result.test().await().assertNoValues().assertComplete();
 
       // one query only
       queryAssert.assertExecuteCount().isEqualTo(1);
@@ -342,7 +345,7 @@ class InMemoryDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void complexFilterPath() {
+    public void complexFilterPath() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("field", "nested", "value"));
@@ -369,6 +372,7 @@ class InMemoryDocumentsResolverTest extends AbstractDataStoreTest {
 
       result
           .test()
+          .await()
           .assertValue(
               doc -> {
                 assertThat(doc.id()).isEqualTo("1");
@@ -383,7 +387,7 @@ class InMemoryDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void testNotPassed() {
+    public void testNotPassed() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
@@ -407,7 +411,7 @@ class InMemoryDocumentsResolverTest extends AbstractDataStoreTest {
           resolver.getDocuments(
               queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
 
-      result.test().assertValueCount(0).assertComplete();
+      result.test().await().assertValueCount(0).assertComplete();
 
       // one query only
       queryAssert.assertExecuteCount().isEqualTo(1);

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolverTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolverTest.java
@@ -89,7 +89,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void twoPersistenceConditions() {
+    public void twoPersistenceConditions() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
@@ -130,6 +130,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
 
       result
           .test()
+          .await()
           .assertValue(
               doc -> {
                 assertThat(doc.id()).isEqualTo("1");
@@ -160,7 +161,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void twoPersistenceConditionsOneQueryEmpty() {
+    public void twoPersistenceConditionsOneQueryEmpty() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
@@ -201,6 +202,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
 
       result
           .test()
+          .await()
           .assertValue(
               doc -> {
                 assertThat(doc.id()).isEqualTo("1");
@@ -236,7 +238,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void twoPersistenceConditionsNothingReturned() {
+    public void twoPersistenceConditionsNothingReturned() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
@@ -275,7 +277,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
           resolver.getDocuments(
               queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
 
-      result.test().assertComplete();
+      result.test().await().assertComplete();
 
       // each query run
       query1Assert.assertExecuteCount().isEqualTo(1);
@@ -299,7 +301,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void persistenceAndInMemoryConditionPersistenceTrue() {
+    public void persistenceAndInMemoryConditionPersistenceTrue() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
@@ -355,6 +357,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
 
       result
           .test()
+          .await()
           .assertValue(
               doc -> {
                 assertThat(doc.id()).isEqualTo("1");
@@ -385,7 +388,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void persistenceAndInMemoryConditionMemoryTrue() {
+    public void persistenceAndInMemoryConditionMemoryTrue() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
@@ -429,6 +432,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
 
       result
           .test()
+          .await()
           .assertValue(
               doc -> {
                 assertThat(doc.id()).isEqualTo("1");
@@ -464,7 +468,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void persistenceAndInMemoryConditionMemoryFalse() {
+    public void persistenceAndInMemoryConditionMemoryFalse() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
@@ -506,7 +510,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
           resolver.getDocuments(
               queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
 
-      result.test().assertComplete();
+      result.test().await().assertComplete();
 
       // each query run
       query1Assert.assertExecuteCount().isEqualTo(1);
@@ -535,7 +539,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void persistenceAndInMemoryConditionNothingReturned() {
+    public void persistenceAndInMemoryConditionNothingReturned() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("path", "field"));
@@ -576,7 +580,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
           resolver.getDocuments(
               queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
 
-      result.test().assertComplete();
+      result.test().await().assertComplete();
 
       // each query run
       query1Assert.assertExecuteCount().isEqualTo(1);
@@ -601,7 +605,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void persistenceAndEvaluateOnMissing() {
+    public void persistenceAndEvaluateOnMissing() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
@@ -639,6 +643,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
 
       result
           .test()
+          .await()
           .assertValue(
               doc -> {
                 assertThat(doc.id()).isEqualTo("1");
@@ -668,7 +673,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void persistenceAndEvaluateOnMissingNotMatched() {
+    public void persistenceAndEvaluateOnMissingNotMatched() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
@@ -704,7 +709,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
           resolver.getDocuments(
               queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
 
-      result.test().assertComplete();
+      result.test().await().assertComplete();
 
       // each query run
       query1Assert.assertExecuteCount().isEqualTo(1);
@@ -727,7 +732,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void inMemoryAndEvaluateOnMissing() {
+    public void inMemoryAndEvaluateOnMissing() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
@@ -767,6 +772,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
 
       result
           .test()
+          .await()
           .assertValue(
               doc -> {
                 assertThat(doc.id()).isEqualTo("1");
@@ -797,7 +803,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void inMemoryAndEvaluateOnMissingNotMatching() {
+    public void inMemoryAndEvaluateOnMissingNotMatching() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
@@ -835,7 +841,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
           resolver.getDocuments(
               queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
 
-      result.test().assertComplete();
+      result.test().await().assertComplete();
 
       // each query run
       query1Assert.assertExecuteCount().isEqualTo(1);

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/PersistenceDocumentsResolverTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/PersistenceDocumentsResolverTest.java
@@ -93,7 +93,7 @@ class PersistenceDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void happyPath() {
+    public void happyPath() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
@@ -121,6 +121,7 @@ class PersistenceDocumentsResolverTest extends AbstractDataStoreTest {
 
       result
           .test()
+          .await()
           .assertValue(
               doc -> {
                 assertThat(doc.id()).isEqualTo("1");
@@ -150,7 +151,7 @@ class PersistenceDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void happyPathMultipleExpressions() {
+    public void happyPathMultipleExpressions() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
@@ -182,7 +183,7 @@ class PersistenceDocumentsResolverTest extends AbstractDataStoreTest {
           resolver.getDocuments(
               queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
 
-      result.test().assertComplete();
+      result.test().await().assertComplete();
 
       // one query only
       queryAssert.assertExecuteCount().isEqualTo(1);
@@ -206,7 +207,7 @@ class PersistenceDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void multipleDocuments() {
+    public void multipleDocuments() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
@@ -233,6 +234,7 @@ class PersistenceDocumentsResolverTest extends AbstractDataStoreTest {
 
       result
           .test()
+          .await()
           .assertValueAt(
               0,
               doc -> {
@@ -268,7 +270,7 @@ class PersistenceDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void nothingReturnedFromDataStore() {
+    public void nothingReturnedFromDataStore() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
@@ -293,7 +295,7 @@ class PersistenceDocumentsResolverTest extends AbstractDataStoreTest {
           resolver.getDocuments(
               queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
 
-      result.test().assertNoValues().assertComplete();
+      result.test().await().assertNoValues().assertComplete();
 
       // one query only
       queryAssert.assertExecuteCount().isEqualTo(1);
@@ -301,7 +303,7 @@ class PersistenceDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void complexFilterPath() {
+    public void complexFilterPath() throws Exception {
       int pageSize = 1;
       Paginator paginator = new Paginator(null, pageSize);
       FilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("field", "nested", "value"));
@@ -330,6 +332,7 @@ class PersistenceDocumentsResolverTest extends AbstractDataStoreTest {
 
       result
           .test()
+          .await()
           .assertValue(
               doc -> {
                 assertThat(doc.id()).isEqualTo("1");

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/SubDocumentsResolverTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/SubDocumentsResolverTest.java
@@ -99,7 +99,7 @@ class SubDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void happyPath() {
+    public void happyPath() throws Exception {
       int pageSize = 1;
       String documentId = "d123456";
       List<String> subDocumentPath = Collections.singletonList("parent");
@@ -127,6 +127,7 @@ class SubDocumentsResolverTest extends AbstractDataStoreTest {
 
       result
           .test()
+          .await()
           .assertValueAt(
               0,
               doc -> {
@@ -173,7 +174,7 @@ class SubDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void complexPathWithMoreRows() {
+    public void complexPathWithMoreRows() throws Exception {
       int pageSize = 1;
       String documentId = "d123456";
       List<String> subDocumentPath = Arrays.asList("*", "reviews");
@@ -216,6 +217,7 @@ class SubDocumentsResolverTest extends AbstractDataStoreTest {
 
       result
           .test()
+          .await()
           .assertValueAt(
               0,
               doc -> {
@@ -275,7 +277,7 @@ class SubDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void orConditionOneTrue() {
+    public void orConditionOneTrue() throws Exception {
       int pageSize = 1;
       String documentId = "d123456";
       List<String> subDocumentPath = Collections.singletonList("*");
@@ -307,6 +309,7 @@ class SubDocumentsResolverTest extends AbstractDataStoreTest {
 
       result
           .test()
+          .await()
           .assertValueAt(
               0,
               doc -> {
@@ -363,7 +366,7 @@ class SubDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void orConditionNoneTrue() {
+    public void orConditionNoneTrue() throws Exception {
       int pageSize = 1;
       String documentId = "d123456";
       List<String> subDocumentPath = Collections.singletonList("*");
@@ -393,7 +396,7 @@ class SubDocumentsResolverTest extends AbstractDataStoreTest {
           resolver.getDocuments(
               queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
 
-      result.test().assertValueCount(0).assertComplete();
+      result.test().await().assertValueCount(0).assertComplete();
 
       // one query only
       queryAssert.assertExecuteCount().isEqualTo(1);
@@ -435,7 +438,7 @@ class SubDocumentsResolverTest extends AbstractDataStoreTest {
     }
 
     @Test
-    public void nothingFound() {
+    public void nothingFound() throws Exception {
       int pageSize = 1;
       String documentId = "d123456";
       List<String> subDocumentPath = Collections.singletonList("parent");
@@ -460,7 +463,7 @@ class SubDocumentsResolverTest extends AbstractDataStoreTest {
           resolver.getDocuments(
               queryExecutor, configuration, KEYSPACE_NAME, COLLECTION_NAME, paginator);
 
-      result.test().assertValueCount(0).assertComplete();
+      result.test().await().assertValueCount(0).assertComplete();
 
       // one query only
       queryAssert.assertExecuteCount().isEqualTo(1);

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -40,6 +40,7 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -561,7 +562,7 @@ public abstract class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(wrapResponse(fullObjNode, "1", null));
   }
 
-  @Test
+  @RepeatedTest(1000)
   public void testPutReplacingWithArray() throws IOException {
     JsonNode fullObj =
         OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -40,7 +40,6 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -562,7 +561,7 @@ public abstract class BaseDocumentApiV2Test extends BaseOsgiIntegrationTest {
     assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(wrapResponse(fullObjNode, "1", null));
   }
 
-  @RepeatedTest(1000)
+  @Test
   public void testPutReplacingWithArray() throws IOException {
     JsonNode fullObj =
         OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));


### PR DESCRIPTION
For me this is tackling the root cause for the #1151. We should switch away from the `CoreThread` after that data has been loaded from the C*. This would help us avoid problems like the one observed in future and release us from thinking what's done in the RX sequence and if there could be issues. In addition, we are releasing the `CoreThread` early.

The fix proposed by @dimas-b in the #1153 can be complimentary to this one if we decide to not-block on the dead leaves deletion..

 