### PR TITLE
Support more complex types grpc

### DIFF
--- a/grpc-proto/proto/query.proto
+++ b/grpc-proto/proto/query.proto
@@ -59,6 +59,11 @@ message BigInteger {
   bytes value = 1;
 }
 
+message BigDecimal {
+  uint32 scale = 1;
+  bytes value = 3;
+}
+
 message Value {
   message Null {}
   message Unset {}
@@ -108,6 +113,9 @@ message Value {
 
     // CQL types: varint
     BigInteger varint = 14;
+
+    // CQL types: decimal
+    BigDecimal decimal = 15;
   }
 }
 

--- a/grpc-proto/proto/query.proto
+++ b/grpc-proto/proto/query.proto
@@ -55,11 +55,11 @@ message Uuid {
   fixed64 lsb = 2;
 }
 
-message BigInteger {
+message Varint {
   bytes value = 1;
 }
 
-message BigDecimal {
+message Decimal {
   uint32 scale = 1;
   bytes value = 3;
 }
@@ -112,10 +112,10 @@ message Value {
     UdtValue udt = 13;
 
     // CQL types: varint
-    BigInteger varint = 14;
+    Varint varint = 14;
 
     // CQL types: decimal
-    BigDecimal decimal = 15;
+    Decimal decimal = 15;
   }
 }
 

--- a/grpc-proto/proto/query.proto
+++ b/grpc-proto/proto/query.proto
@@ -55,6 +55,10 @@ message Uuid {
   fixed64 lsb = 2;
 }
 
+message BigInteger {
+  bytes value = 1;
+}
+
 message Value {
   message Null {}
   message Unset {}
@@ -101,6 +105,9 @@ message Value {
 
     // CQL types: user defined types
     UdtValue udt = 13;
+
+    // CQL types: varint
+    BigInteger varint = 14;
   }
 }
 

--- a/grpc-proto/src/main/java/io/stargate/grpc/Values.java
+++ b/grpc-proto/src/main/java/io/stargate/grpc/Values.java
@@ -23,6 +23,7 @@ import io.stargate.proto.QueryOuterClass.Uuid;
 import io.stargate.proto.QueryOuterClass.Value;
 import io.stargate.proto.QueryOuterClass.Value.Null;
 import io.stargate.proto.QueryOuterClass.Value.Unset;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.time.LocalDate;
@@ -81,6 +82,16 @@ public class Values {
         .setVarint(
             QueryOuterClass.BigInteger.newBuilder()
                 .setValue(ByteString.copyFrom(value.toByteArray()))
+                .build())
+        .build();
+  }
+
+  public static Value of(BigDecimal value) {
+    return Value.newBuilder()
+        .setDecimal(
+            QueryOuterClass.BigDecimal.newBuilder()
+                .setValue(ByteString.copyFrom(value.unscaledValue().toByteArray()))
+                .setScale(value.scale())
                 .build())
         .build();
   }

--- a/grpc-proto/src/main/java/io/stargate/grpc/Values.java
+++ b/grpc-proto/src/main/java/io/stargate/grpc/Values.java
@@ -16,12 +16,14 @@
 package io.stargate.grpc;
 
 import com.google.protobuf.ByteString;
+import io.stargate.proto.QueryOuterClass;
 import io.stargate.proto.QueryOuterClass.Collection;
 import io.stargate.proto.QueryOuterClass.UdtValue;
 import io.stargate.proto.QueryOuterClass.Uuid;
 import io.stargate.proto.QueryOuterClass.Value;
 import io.stargate.proto.QueryOuterClass.Value.Null;
 import io.stargate.proto.QueryOuterClass.Value.Unset;
+import java.math.BigInteger;
 import java.net.InetAddress;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -72,6 +74,15 @@ public class Values {
 
   public static Value of(LocalTime value) {
     return Value.newBuilder().setTime(value.toNanoOfDay()).build();
+  }
+
+  public static Value of(BigInteger value) {
+    return Value.newBuilder()
+        .setVarint(
+            QueryOuterClass.BigInteger.newBuilder()
+                .setValue(ByteString.copyFrom(value.toByteArray()))
+                .build())
+        .build();
   }
 
   public static Value of(UUID value) {

--- a/grpc-proto/src/main/java/io/stargate/grpc/Values.java
+++ b/grpc-proto/src/main/java/io/stargate/grpc/Values.java
@@ -97,7 +97,7 @@ public class Values {
   public static Value of(BigInteger value) {
     return Value.newBuilder()
         .setVarint(
-            QueryOuterClass.BigInteger.newBuilder()
+            QueryOuterClass.Varint.newBuilder()
                 .setValue(ByteString.copyFrom(value.toByteArray()))
                 .build())
         .build();
@@ -106,7 +106,7 @@ public class Values {
   public static Value of(BigDecimal value) {
     return Value.newBuilder()
         .setDecimal(
-            QueryOuterClass.BigDecimal.newBuilder()
+            QueryOuterClass.Decimal.newBuilder()
                 .setValue(ByteString.copyFrom(value.unscaledValue().toByteArray()))
                 .setScale(value.scale())
                 .build())

--- a/grpc/src/main/java/io/stargate/grpc/codec/cql/DecimalCodec.java
+++ b/grpc/src/main/java/io/stargate/grpc/codec/cql/DecimalCodec.java
@@ -29,7 +29,7 @@ public class DecimalCodec implements ValueCodec {
     if (value.getInnerCase() != InnerCase.DECIMAL) {
       throw new IllegalArgumentException("Expected decimal type");
     }
-    QueryOuterClass.BigDecimal decimal = value.getDecimal();
+    QueryOuterClass.Decimal decimal = value.getDecimal();
     ByteString bi = decimal.getValue();
     int scale = decimal.getScale();
     byte[] bibytes = bi.toByteArray();
@@ -56,7 +56,7 @@ public class DecimalCodec implements ValueCodec {
     bytes.get(bibytes);
     return Value.newBuilder()
         .setDecimal(
-            QueryOuterClass.BigDecimal.newBuilder()
+            QueryOuterClass.Decimal.newBuilder()
                 .setValue(ByteString.copyFrom(bibytes))
                 .setScale(scale)
                 .build())

--- a/grpc/src/main/java/io/stargate/grpc/codec/cql/ValueCodecs.java
+++ b/grpc/src/main/java/io/stargate/grpc/codec/cql/ValueCodecs.java
@@ -33,6 +33,7 @@ public class ValueCodecs {
               .put(Type.Boolean, new BooleanCodec())
               .put(Type.Counter, new BigintCodec())
               .put(Type.Date, new DateCodec())
+              .put(Type.Decimal, new DecimalCodec())
               .put(Type.Double, new DoubleCodec())
               .put(Type.Float, new FloatCodec())
               .put(Type.Int, new IntCodec())
@@ -45,12 +46,12 @@ public class ValueCodecs {
               .put(Type.Tinyint, new TinyintCodec())
               .put(Type.Uuid, new UuidCodec(TypeCodecs.UUID))
               .put(Type.Varchar, new StringCodec(TypeCodecs.TEXT))
+              .put(Type.Varint, new VarintCodec())
               .put(Type.List, new CollectionCodec())
               .put(Type.Set, new CollectionCodec())
               .put(Type.Map, new MapCodec())
               .put(Type.Tuple, new TupleCodec())
               .put(Type.UDT, new UdtCodec())
-              .put(Type.Varint, new VarintCodec())
               .build());
 
   @NonNull

--- a/grpc/src/main/java/io/stargate/grpc/codec/cql/ValueCodecs.java
+++ b/grpc/src/main/java/io/stargate/grpc/codec/cql/ValueCodecs.java
@@ -50,6 +50,7 @@ public class ValueCodecs {
               .put(Type.Map, new MapCodec())
               .put(Type.Tuple, new TupleCodec())
               .put(Type.UDT, new UdtCodec())
+              .put(Type.Varint, new VarintCodec())
               .build());
 
   @NonNull

--- a/grpc/src/main/java/io/stargate/grpc/codec/cql/VarintCodec.java
+++ b/grpc/src/main/java/io/stargate/grpc/codec/cql/VarintCodec.java
@@ -18,9 +18,9 @@ package io.stargate.grpc.codec.cql;
 import com.google.protobuf.ByteString;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.stargate.db.schema.Column.ColumnType;
-import io.stargate.proto.QueryOuterClass.BigInteger;
 import io.stargate.proto.QueryOuterClass.Value;
 import io.stargate.proto.QueryOuterClass.Value.InnerCase;
+import io.stargate.proto.QueryOuterClass.Varint;
 import java.nio.ByteBuffer;
 
 public class VarintCodec implements ValueCodec {
@@ -29,7 +29,7 @@ public class VarintCodec implements ValueCodec {
     if (value.getInnerCase() != InnerCase.VARINT) {
       throw new IllegalArgumentException("Expected varint type");
     }
-    BigInteger varint = value.getVarint();
+    Varint varint = value.getVarint();
     return ByteBuffer.wrap(varint.getValue().toByteArray());
   }
 
@@ -40,7 +40,7 @@ public class VarintCodec implements ValueCodec {
     }
 
     return Value.newBuilder()
-        .setVarint(BigInteger.newBuilder().setValue(ByteString.copyFrom(bytes)).build())
+        .setVarint(Varint.newBuilder().setValue(ByteString.copyFrom(bytes)).build())
         .build();
   }
 }

--- a/grpc/src/main/java/io/stargate/grpc/codec/cql/VarintCodec.java
+++ b/grpc/src/main/java/io/stargate/grpc/codec/cql/VarintCodec.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.grpc.codec.cql;
+
+import com.google.protobuf.ByteString;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.stargate.db.schema.Column.ColumnType;
+import io.stargate.proto.QueryOuterClass.BigInteger;
+import io.stargate.proto.QueryOuterClass.Value;
+import io.stargate.proto.QueryOuterClass.Value.InnerCase;
+import java.nio.ByteBuffer;
+
+public class VarintCodec implements ValueCodec {
+  @Override
+  public ByteBuffer encode(@NonNull Value value, @NonNull ColumnType type) {
+    if (value.getInnerCase() != InnerCase.VARINT) {
+      throw new IllegalArgumentException("Expected varint type");
+    }
+    BigInteger varint = value.getVarint();
+    return ByteBuffer.wrap(varint.getValue().toByteArray());
+  }
+
+  @Override
+  public Value decode(@NonNull ByteBuffer bytes, @NonNull ColumnType type) {
+    return Value.newBuilder()
+        .setVarint(BigInteger.newBuilder().setValue(ByteString.copyFrom(bytes)).build())
+        .build();
+  }
+}

--- a/grpc/src/test/java/io/stargate/grpc/codec/cql/ValueCodecTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/codec/cql/ValueCodecTest.java
@@ -28,6 +28,7 @@ import io.stargate.db.schema.ImmutableUserDefinedType;
 import io.stargate.db.schema.UserDefinedType;
 import io.stargate.grpc.Values;
 import io.stargate.proto.QueryOuterClass.Value;
+import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.UnknownHostException;
@@ -62,6 +63,7 @@ public class ValueCodecTest {
     "setValues",
     "mapValues",
     "tupleValues",
+    "bigIntegerValues"
   })
   public void validValues(ColumnType type, Value expectedValue) {
     ValueCodec codec = ValueCodecs.get(type.rawType());
@@ -100,7 +102,8 @@ public class ValueCodecTest {
     "invalidSetValues",
     "invalidMapValues",
     "invalidTupleValues",
-    "invalidUdtValues"
+    "invalidUdtValues",
+    "invalidBigIntegerValues"
   })
   public void invalidValues(ColumnType type, Value value, String expectedMessage) {
     ValueCodec codec = ValueCodecs.get(type.rawType());
@@ -560,5 +563,19 @@ public class ValueCodecTest {
         .keyspace("keyspace") // Dummy value
         .columns(Arrays.asList(columns))
         .build();
+  }
+
+  public static Stream<Arguments> bigIntegerValues() {
+    return Stream.of(
+        arguments(Type.Varint, Values.of(BigInteger.ZERO)),
+        arguments(Type.Varint, Values.of(BigInteger.ONE)),
+        arguments(Type.Varint, Values.of(BigInteger.valueOf(Long.MAX_VALUE))),
+        arguments(Type.Varint, Values.of(BigInteger.valueOf(Long.MIN_VALUE))));
+  }
+
+  public static Stream<Arguments> invalidBigIntegerValues() {
+    return Stream.of(
+        arguments(Type.Varint, Values.NULL, "Expected varint type"),
+        arguments(Type.Varint, Values.UNSET, "Expected varint type"));
   }
 }

--- a/grpc/src/test/java/io/stargate/grpc/codec/cql/ValueCodecTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/codec/cql/ValueCodecTest.java
@@ -28,6 +28,7 @@ import io.stargate.db.schema.ImmutableUserDefinedType;
 import io.stargate.db.schema.UserDefinedType;
 import io.stargate.grpc.Values;
 import io.stargate.proto.QueryOuterClass.Value;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
@@ -63,7 +64,8 @@ public class ValueCodecTest {
     "setValues",
     "mapValues",
     "tupleValues",
-    "bigIntegerValues"
+    "bigIntegerValues",
+    "bigDecimalValues",
   })
   public void validValues(ColumnType type, Value expectedValue) {
     ValueCodec codec = ValueCodecs.get(type.rawType());
@@ -103,7 +105,8 @@ public class ValueCodecTest {
     "invalidMapValues",
     "invalidTupleValues",
     "invalidUdtValues",
-    "invalidBigIntegerValues"
+    "invalidBigIntegerValues",
+    "invalidBigDecimalValues"
   })
   public void invalidValues(ColumnType type, Value value, String expectedMessage) {
     ValueCodec codec = ValueCodecs.get(type.rawType());
@@ -577,5 +580,19 @@ public class ValueCodecTest {
     return Stream.of(
         arguments(Type.Varint, Values.NULL, "Expected varint type"),
         arguments(Type.Varint, Values.UNSET, "Expected varint type"));
+  }
+
+  public static Stream<Arguments> bigDecimalValues() {
+    return Stream.of(
+        arguments(Type.Decimal, Values.of(BigDecimal.ZERO)),
+        arguments(Type.Decimal, Values.of(BigDecimal.ONE)),
+        arguments(Type.Decimal, Values.of(BigDecimal.valueOf(Long.MAX_VALUE))),
+        arguments(Type.Decimal, Values.of(BigDecimal.valueOf(Long.MIN_VALUE))));
+  }
+
+  public static Stream<Arguments> invalidBigDecimalValues() {
+    return Stream.of(
+        arguments(Type.Decimal, Values.NULL, "Expected decimal type"),
+        arguments(Type.Decimal, Values.UNSET, "Expected decimal type"));
   }
 }


### PR DESCRIPTION
Provides support for C* `varint` and `decimal` in the gRPC API.

| Cassandra Type  | Java Type | gRPC Type |
| ------------- | ------------- | ------------- |
| Decimal | BigDecimal | Decimal { uint32 scale, bytes value} |
| Varint | BigInteger | Varint { bytes value } |
