### PR TITLE
gRPC: wait for schema agreement asynchronously (fixes #1145)

### DIFF
--- a/grpc/src/main/java/io/stargate/grpc/service/BatchHandler.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/BatchHandler.java
@@ -103,9 +103,7 @@ class BatchHandler extends MessageHandler<Batch, BatchHandler.BatchAndIdempotenc
   }
 
   @Override
-  protected ResponseAndTraceId buildResponse(Result result) {
-    ResponseAndTraceId responseAndTraceId = new ResponseAndTraceId();
-    responseAndTraceId.setTracingId(result.getTracingId());
+  protected CompletionStage<ResponseAndTraceId> buildResponse(Result result) {
     Response.Builder responseBuilder = makeResponseBuilder(result);
 
     if (result.kind != Result.Kind.Void && result.kind != Result.Kind.Rows) {
@@ -125,8 +123,7 @@ class BatchHandler extends MessageHandler<Batch, BatchHandler.BatchAndIdempotenc
       }
     }
 
-    responseAndTraceId.setResponseBuilder(responseBuilder);
-    return responseAndTraceId;
+    return CompletableFuture.completedFuture(ResponseAndTraceId.from(result, responseBuilder));
   }
 
   @Override

--- a/grpc/src/main/java/io/stargate/grpc/service/GrpcService.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/GrpcService.java
@@ -64,6 +64,7 @@ public class GrpcService extends io.stargate.proto.StargateGrpc.StargateImplBase
   private final Metrics metrics;
 
   private final ScheduledExecutorService executor;
+  private final int schemaAgreementRetries;
 
   /** Used as key for the the local prepare cache. */
   @Value.Immutable
@@ -79,9 +80,18 @@ public class GrpcService extends io.stargate.proto.StargateGrpc.StargateImplBase
   }
 
   public GrpcService(Persistence persistence, Metrics metrics, ScheduledExecutorService executor) {
+    this(persistence, metrics, executor, Persistence.SCHEMA_AGREEMENT_WAIT_RETRIES);
+  }
+
+  Service(
+      Persistence persistence,
+      Metrics metrics,
+      ScheduledExecutorService executor,
+      int schemaAgreementRetries) {
     this.persistence = persistence;
     this.metrics = metrics;
     this.executor = executor;
+    this.schemaAgreementRetries = schemaAgreementRetries;
     assert this.metrics != null;
   }
 
@@ -91,7 +101,13 @@ public class GrpcService extends io.stargate.proto.StargateGrpc.StargateImplBase
         .ifPresent(
             connection ->
                 new QueryHandler(
-                        query, connection, preparedCache, persistence, executor, responseObserver)
+                        query,
+                        connection,
+                        preparedCache,
+                        persistence,
+                        executor,
+                        schemaAgreementRetries,
+                        responseObserver)
                     .handle());
   }
 

--- a/grpc/src/main/java/io/stargate/grpc/service/GrpcService.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/GrpcService.java
@@ -83,7 +83,7 @@ public class GrpcService extends io.stargate.proto.StargateGrpc.StargateImplBase
     this(persistence, metrics, executor, Persistence.SCHEMA_AGREEMENT_WAIT_RETRIES);
   }
 
-  Service(
+  GrpcService(
       Persistence persistence,
       Metrics metrics,
       ScheduledExecutorService executor,

--- a/grpc/src/main/java/io/stargate/grpc/service/MessageHandler.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/MessageHandler.java
@@ -149,7 +149,7 @@ abstract class MessageHandler<MessageT extends GeneratedMessageV3, PreparedT> {
   private CompletionStage<Response> executeQuery() {
     CompletionStage<Result> resultFuture = prepare(false).thenCompose(this::executePrepared);
     return handleUnprepared(resultFuture)
-        .thenApply(this::buildResponse)
+        .thenCompose(this::buildResponse)
         .thenCompose(this::executeTracingQueryIfNeeded);
   }
 
@@ -220,7 +220,7 @@ abstract class MessageHandler<MessageT extends GeneratedMessageV3, PreparedT> {
   protected abstract CompletionStage<Result> executePrepared(PreparedT prepared);
 
   /** Builds the gRPC response from the CQL result. */
-  protected abstract ResponseAndTraceId buildResponse(Result result);
+  protected abstract CompletionStage<ResponseAndTraceId> buildResponse(Result result);
 
   /** Computes the consistency level to use for tracing queries. */
   protected abstract ConsistencyLevel getTracingConsistency();

--- a/grpc/src/main/java/io/stargate/grpc/service/QueryHandler.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/QueryHandler.java
@@ -217,10 +217,12 @@ class QueryHandler extends MessageHandler<Query, Prepared> {
     }
     if (remainingAttempts <= 1) {
       agreementFuture.completeExceptionally(
-          new IllegalStateException(
-              "Failed to reach schema agreement after "
-                  + (200 * Persistence.SCHEMA_AGREEMENT_WAIT_RETRIES)
-                  + " milliseconds."));
+          Status.DEADLINE_EXCEEDED
+              .withDescription(
+                  "Failed to reach schema agreement after "
+                      + (200 * Persistence.SCHEMA_AGREEMENT_WAIT_RETRIES)
+                      + " milliseconds.")
+              .asException());
       return;
     }
     executor.schedule(

--- a/grpc/src/main/java/io/stargate/grpc/service/QueryHandler.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/QueryHandler.java
@@ -215,7 +215,7 @@ class QueryHandler extends MessageHandler<Query, Prepared> {
       agreementFuture.complete(null);
       return;
     }
-    if (remainingAttempts == 1) {
+    if (remainingAttempts <= 1) {
       agreementFuture.completeExceptionally(
           new IllegalStateException(
               "Failed to reach schema agreement after "

--- a/grpc/src/main/java/io/stargate/grpc/service/QueryHandler.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/QueryHandler.java
@@ -40,21 +40,26 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.apache.cassandra.stargate.db.ConsistencyLevel;
 
 class QueryHandler extends MessageHandler<Query, Prepared> {
 
   private final PrepareInfo prepareInfo;
+  private final ScheduledExecutorService executor;
 
   QueryHandler(
       Query query,
       Connection connection,
       Cache<PrepareInfo, CompletionStage<Prepared>> preparedCache,
       Persistence persistence,
+      ScheduledExecutorService executor,
       StreamObserver<Response> responseObserver) {
     super(query, connection, preparedCache, persistence, responseObserver);
+    this.executor = executor;
     QueryParameters queryParameters = query.getParameters();
     this.prepareInfo =
         ImmutablePrepareInfo.builder()
@@ -95,51 +100,55 @@ class QueryHandler extends MessageHandler<Query, Prepared> {
   }
 
   @Override
-  protected ResponseAndTraceId buildResponse(Result result) {
-    ResponseAndTraceId responseAndTraceId = new ResponseAndTraceId();
-    responseAndTraceId.setTracingId(result.getTracingId());
+  protected CompletionStage<ResponseAndTraceId> buildResponse(Result result) {
     Response.Builder responseBuilder = makeResponseBuilder(result);
     switch (result.kind) {
       case Void:
-        break;
+        return CompletableFuture.completedFuture(ResponseAndTraceId.from(result, responseBuilder));
       case SchemaChange:
-        // TODO make this non-blocking (see #1145)
-        persistence.waitForSchemaAgreement();
-        Result.SchemaChangeMetadata metadata = ((Result.SchemaChange) result).metadata;
-        SchemaChange.Builder schemaChangeBuilder =
-            SchemaChange.newBuilder()
-                .setChangeType(SchemaChange.Type.valueOf(metadata.change))
-                .setTarget(SchemaChange.Target.valueOf(metadata.target))
-                .setKeyspace(metadata.keyspace);
-        if (metadata.name != null) {
-          schemaChangeBuilder.setName(StringValue.of(metadata.name));
-        }
-        if (metadata.argTypes != null) {
-          schemaChangeBuilder.addAllArgumentTypes(metadata.argTypes);
-        }
-        responseBuilder.setSchemaChange(schemaChangeBuilder.build());
-        break;
+        return waitForSchemaAgreement()
+            .thenApply(
+                __ -> {
+                  SchemaChange schemaChange = buildSchemaChange((Result.SchemaChange) result);
+                  responseBuilder.setSchemaChange(schemaChange);
+                  return ResponseAndTraceId.from(result, responseBuilder);
+                });
       case Rows:
         Payload values = message.getValues();
         PayloadHandler handler = PayloadHandlers.get(values.getType());
         try {
-          responseBuilder.setResultSet(
+          Payload.Builder resultSet =
               Payload.newBuilder()
                   .setType(message.getValues().getType())
-                  .setData(handler.processResult((Result.Rows) result, message.getParameters())));
+                  .setData(handler.processResult((Result.Rows) result, message.getParameters()));
+          responseBuilder.setResultSet(resultSet);
+          return CompletableFuture.completedFuture(
+              ResponseAndTraceId.from(result, responseBuilder));
         } catch (Exception e) {
-          throw new CompletionException(e);
+          return failedFuture(e);
         }
-        break;
       case SetKeyspace:
-        throw new CompletionException(
+        return failedFuture(
             Status.INVALID_ARGUMENT.withDescription("USE <keyspace> not supported").asException());
       default:
-        throw new CompletionException(
-            Status.INTERNAL.withDescription("Unhandled result kind").asException());
+        return failedFuture(Status.INTERNAL.withDescription("Unhandled result kind").asException());
     }
-    responseAndTraceId.setResponseBuilder(responseBuilder);
-    return responseAndTraceId;
+  }
+
+  private SchemaChange buildSchemaChange(Result.SchemaChange result) {
+    Result.SchemaChangeMetadata metadata = result.metadata;
+    SchemaChange.Builder schemaChangeBuilder =
+        SchemaChange.newBuilder()
+            .setChangeType(SchemaChange.Type.valueOf(metadata.change))
+            .setTarget(SchemaChange.Target.valueOf(metadata.target))
+            .setKeyspace(metadata.keyspace);
+    if (metadata.name != null) {
+      schemaChangeBuilder.setName(StringValue.of(metadata.name));
+    }
+    if (metadata.argTypes != null) {
+      schemaChangeBuilder.addAllArgumentTypes(metadata.argTypes);
+    }
+    return schemaChangeBuilder.build();
   }
 
   @Override
@@ -192,5 +201,31 @@ class QueryHandler extends MessageHandler<Query, Prepared> {
         });
 
     return builder.tracingRequested(parameters.getTracing()).build();
+  }
+
+  private CompletionStage<Void> waitForSchemaAgreement() {
+    CompletableFuture<Void> agreementFuture = new CompletableFuture<>();
+    waitForSchemaAgreement(Persistence.SCHEMA_AGREEMENT_WAIT_RETRIES, agreementFuture);
+    return agreementFuture;
+  }
+
+  private void waitForSchemaAgreement(
+      int remainingAttempts, CompletableFuture<Void> agreementFuture) {
+    if (persistence.isInSchemaAgreement()) {
+      agreementFuture.complete(null);
+      return;
+    }
+    if (remainingAttempts == 1) {
+      agreementFuture.completeExceptionally(
+          new IllegalStateException(
+              "Failed to reach schema agreement after "
+                  + (200 * Persistence.SCHEMA_AGREEMENT_WAIT_RETRIES)
+                  + " milliseconds."));
+      return;
+    }
+    executor.schedule(
+        () -> waitForSchemaAgreement(remainingAttempts - 1, agreementFuture),
+        200,
+        TimeUnit.MILLISECONDS);
   }
 }

--- a/grpc/src/test/java/io/stargate/grpc/service/BaseGrpcServiceTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/BaseGrpcServiceTest.java
@@ -15,10 +15,6 @@
  */
 package io.stargate.grpc.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-
 import com.google.protobuf.Any;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -55,12 +51,17 @@ import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 @ExtendWith(MockitoExtension.class)
 public class BaseGrpcServiceTest {
@@ -129,7 +130,9 @@ public class BaseGrpcServiceTest {
             .directExecutor()
             .intercept(new MockInterceptor())
             .intercept(new HeadersInterceptor())
-            .addService(new GrpcService(persistence, mock(Metrics.class)))
+            .addService(
+                new GrpcService(
+                    persistence, mock(Metrics.class), mock(ScheduledExecutorService.class)))
             .build();
     try {
       server.start();

--- a/grpc/src/test/java/io/stargate/grpc/service/SchemaAgreementTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/SchemaAgreementTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.grpc.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import io.grpc.StatusRuntimeException;
+import io.stargate.db.Parameters;
+import io.stargate.db.Result;
+import io.stargate.db.Statement;
+import io.stargate.grpc.Utils;
+import io.stargate.proto.QueryOuterClass;
+import io.stargate.proto.StargateGrpc;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class SchemaAgreementTest extends BaseServiceTest {
+
+  @Test
+  @DisplayName("Should succeed if schema agreement reached")
+  public void schemaAgreementSuccess() {
+    // Given
+    StargateGrpc.StargateBlockingStub stub = makeBlockingStub();
+    when(persistence.isInSchemaAgreement()).thenReturn(true);
+    mockAnyQueryAsSchemaChange();
+    when(persistence.newConnection()).thenReturn(connection);
+    startServer(persistence);
+
+    // When
+    QueryOuterClass.Response response = executeQuery(stub, "mock query");
+
+    // Then
+    assertThat(response.hasSchemaChange()).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should fail if schema agreement can't be reached")
+  public void schemaAgreementFailure() {
+    // Given
+    StargateGrpc.StargateBlockingStub stub = makeBlockingStub();
+    when(persistence.isInSchemaAgreement()).thenReturn(false);
+    mockAnyQueryAsSchemaChange();
+    when(persistence.newConnection()).thenReturn(connection);
+    startServer(persistence);
+
+    // Then
+    assertThatThrownBy(() -> executeQuery(stub, "mock query"))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessage("DEADLINE_EXCEEDED: Failed to reach schema agreement after 400 milliseconds.");
+  }
+
+  private void mockAnyQueryAsSchemaChange() {
+    Result.Prepared prepared =
+        new Result.Prepared(
+            Utils.STATEMENT_ID,
+            Utils.RESULT_METADATA_ID,
+            Utils.makeResultMetadata(),
+            Utils.makePreparedMetadata(),
+            true);
+    when(connection.prepare(any(String.class), any(Parameters.class)))
+        .thenReturn(CompletableFuture.completedFuture(prepared));
+    when(connection.execute(any(Statement.class), any(Parameters.class), anyLong()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new Result.SchemaChange(
+                    new Result.SchemaChangeMetadata(
+                        "CREATED", "KEYSPACE", "ks1", null, Collections.emptyList()))));
+  }
+}

--- a/grpc/src/test/java/io/stargate/grpc/service/SchemaAgreementTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/SchemaAgreementTest.java
@@ -33,7 +33,7 @@ import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-public class SchemaAgreementTest extends BaseServiceTest {
+public class SchemaAgreementTest extends BaseGrpcServiceTest {
 
   @Test
   @DisplayName("Should succeed if schema agreement reached")


### PR DESCRIPTION
The most tricky part is that we need an executor to schedule the retries. Ideally, I would have liked to expose the feature directly on `Persistence`, but not all implementations use an executor internally, and for those that do it doesn't allow scheduled tasks. So the next best thing is to use the executor of the gRPC service.