### PR TITLE
gRPC: set default consistency levels in the service (fixes #1157)

### DIFF
--- a/grpc-proto/proto/query.proto
+++ b/grpc-proto/proto/query.proto
@@ -177,7 +177,7 @@ message QueryParameters {
   google.protobuf.StringValue keyspace = 1;
 
   // The consistency level.
-  // If unset, it defaults to ONE.
+  // If unset, it defaults to LOCAL_QUORUM.
   ConsistencyValue consistency = 2;
 
   // The maximum number of rows that will be returned in the response. If there are more results,
@@ -210,8 +210,7 @@ message QueryParameters {
   google.protobuf.Int64Value timestamp = 7;
 
   // The serial consistency level (if the query is a lightweight transaction).
-  // If unset, a default will be used but is unspecified and might depend of the Persistence
-  // implementation.
+  // If unset, it defaults to SERIAL.
   ConsistencyValue serial_consistency = 8;
 
   // Forces the current time for the query (for testing purposes).
@@ -514,7 +513,7 @@ message BatchParameters {
   google.protobuf.StringValue keyspace = 1;
 
   // The consistency level.
-  // If unset, it defaults to ONE.
+  // If unset, it defaults to LOCAL_QUORUM.
   ConsistencyValue consistency = 2;
 
   // Whether the server should collect tracing information about the execution of the query.
@@ -526,8 +525,7 @@ message BatchParameters {
   google.protobuf.Int64Value timestamp = 4;
 
   // The serial consistency level (if the batch contains lightweight transactions).
-  // If unset, a default will be used but is unspecified and might depend of the Persistence
-  // implementation.
+  // If unset, it defaults to SERIAL.
   ConsistencyValue serial_consistency = 5;
 
   // Forces the current time for the query (for testing purposes).

--- a/grpc/src/main/java/io/stargate/grpc/service/BatchHandler.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/BatchHandler.java
@@ -137,19 +137,19 @@ class BatchHandler extends MessageHandler<Batch, io.stargate.db.Batch> {
   private Parameters makeParameters(BatchParameters parameters, Optional<ClientInfo> clientInfo) {
     ImmutableParameters.Builder builder = ImmutableParameters.builder();
 
-    if (parameters.hasConsistency()) {
-      builder.consistencyLevel(
-          ConsistencyLevel.fromCode(parameters.getConsistency().getValue().getNumber()));
-    }
+    builder.consistencyLevel(
+        parameters.hasConsistency()
+            ? ConsistencyLevel.fromCode(parameters.getConsistency().getValue().getNumber())
+            : Service.DEFAULT_CONSISTENCY);
 
     if (parameters.hasKeyspace()) {
       builder.defaultKeyspace(parameters.getKeyspace().getValue());
     }
 
-    if (parameters.hasSerialConsistency()) {
-      builder.serialConsistencyLevel(
-          ConsistencyLevel.fromCode(parameters.getSerialConsistency().getValue().getNumber()));
-    }
+    builder.serialConsistencyLevel(
+        parameters.hasSerialConsistency()
+            ? ConsistencyLevel.fromCode(parameters.getSerialConsistency().getValue().getNumber())
+            : Service.DEFAULT_SERIAL_CONSISTENCY);
 
     if (parameters.hasTimestamp()) {
       builder.defaultTimestamp(parameters.getTimestamp().getValue());

--- a/grpc/src/main/java/io/stargate/grpc/service/QueryHandler.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/QueryHandler.java
@@ -153,10 +153,10 @@ class QueryHandler extends MessageHandler<Query, Prepared> {
   private Parameters makeParameters(QueryParameters parameters, Optional<ClientInfo> clientInfo) {
     ImmutableParameters.Builder builder = ImmutableParameters.builder();
 
-    if (parameters.hasConsistency()) {
-      builder.consistencyLevel(
-          ConsistencyLevel.fromCode(parameters.getConsistency().getValue().getNumber()));
-    }
+    builder.consistencyLevel(
+        parameters.hasConsistency()
+            ? ConsistencyLevel.fromCode(parameters.getConsistency().getValue().getNumber())
+            : Service.DEFAULT_CONSISTENCY);
 
     if (parameters.hasKeyspace()) {
       builder.defaultKeyspace(parameters.getKeyspace().getValue());
@@ -169,10 +169,10 @@ class QueryHandler extends MessageHandler<Query, Prepared> {
       builder.pagingState(ByteBuffer.wrap(parameters.getPagingState().getValue().toByteArray()));
     }
 
-    if (parameters.hasSerialConsistency()) {
-      builder.serialConsistencyLevel(
-          ConsistencyLevel.fromCode(parameters.getSerialConsistency().getValue().getNumber()));
-    }
+    builder.serialConsistencyLevel(
+        parameters.hasSerialConsistency()
+            ? ConsistencyLevel.fromCode(parameters.getSerialConsistency().getValue().getNumber())
+            : Service.DEFAULT_SERIAL_CONSISTENCY);
 
     if (parameters.hasTimestamp()) {
       builder.defaultTimestamp(parameters.getTimestamp().getValue());

--- a/grpc/src/main/java/io/stargate/grpc/service/Service.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/Service.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 import javax.annotation.Nullable;
+import org.apache.cassandra.stargate.db.ConsistencyLevel;
 import org.immutables.value.Value;
 
 public class Service extends io.stargate.proto.StargateGrpc.StargateImplBase {
@@ -44,6 +45,8 @@ public class Service extends io.stargate.proto.StargateGrpc.StargateImplBase {
       Context.key("authentication");
   public static final Context.Key<SocketAddress> REMOTE_ADDRESS_KEY = Context.key("remoteAddress");
   public static final int DEFAULT_PAGE_SIZE = 100;
+  public static final ConsistencyLevel DEFAULT_CONSISTENCY = ConsistencyLevel.LOCAL_QUORUM;
+  public static final ConsistencyLevel DEFAULT_SERIAL_CONSISTENCY = ConsistencyLevel.SERIAL;
 
   private static final InetSocketAddress DUMMY_ADDRESS = new InetSocketAddress(9042);
 

--- a/grpc/src/test/java/io/stargate/grpc/service/BatchParametersTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/BatchParametersTest.java
@@ -76,37 +76,68 @@ public class BatchParametersTest extends BaseServiceTest {
 
   public static Stream<Arguments> batchParameterValues() {
     return Stream.of(
-        arguments(batchParameters().build(), Parameters.builder().build()),
+        arguments(
+            batchParameters().build(),
+            Parameters.builder()
+                .consistencyLevel(Service.DEFAULT_CONSISTENCY)
+                .serialConsistencyLevel(Service.DEFAULT_SERIAL_CONSISTENCY)
+                .build()),
         arguments(
             batchParameters().setKeyspace(StringValue.newBuilder().setValue("abc")).build(),
-            Parameters.builder().defaultKeyspace("abc").build()),
+            Parameters.builder()
+                .consistencyLevel(Service.DEFAULT_CONSISTENCY)
+                .serialConsistencyLevel(Service.DEFAULT_SERIAL_CONSISTENCY)
+                .defaultKeyspace("abc")
+                .build()),
         arguments(
             batchParameters()
                 .setConsistency(ConsistencyValue.newBuilder().setValue(Consistency.THREE))
                 .build(),
-            Parameters.builder().consistencyLevel(ConsistencyLevel.THREE).build()),
+            Parameters.builder()
+                .consistencyLevel(ConsistencyLevel.THREE)
+                .serialConsistencyLevel(Service.DEFAULT_SERIAL_CONSISTENCY)
+                .build()),
         arguments(
             batchParameters()
                 .setSerialConsistency(
                     ConsistencyValue.newBuilder().setValue(Consistency.LOCAL_SERIAL))
                 .build(),
-            Parameters.builder().serialConsistencyLevel(ConsistencyLevel.LOCAL_SERIAL).build()),
+            Parameters.builder()
+                .consistencyLevel(Service.DEFAULT_CONSISTENCY)
+                .serialConsistencyLevel(ConsistencyLevel.LOCAL_SERIAL)
+                .build()),
         arguments(
             batchParameters()
                 .setNowInSeconds(Int32Value.newBuilder().setValue(12345).build())
                 .build(),
-            Parameters.builder().nowInSeconds(12345).build()),
+            Parameters.builder()
+                .consistencyLevel(Service.DEFAULT_CONSISTENCY)
+                .serialConsistencyLevel(Service.DEFAULT_SERIAL_CONSISTENCY)
+                .nowInSeconds(12345)
+                .build()),
         arguments(
             batchParameters()
                 .setTimestamp(Int64Value.newBuilder().setValue(1234567890).build())
                 .build(),
-            Parameters.builder().defaultTimestamp(1234567890).build()),
+            Parameters.builder()
+                .consistencyLevel(Service.DEFAULT_CONSISTENCY)
+                .serialConsistencyLevel(Service.DEFAULT_SERIAL_CONSISTENCY)
+                .defaultTimestamp(1234567890)
+                .build()),
         arguments(
             batchParameters().setTracing(true).build(),
-            Parameters.builder().tracingRequested(true).build()),
+            Parameters.builder()
+                .consistencyLevel(Service.DEFAULT_CONSISTENCY)
+                .serialConsistencyLevel(Service.DEFAULT_SERIAL_CONSISTENCY)
+                .tracingRequested(true)
+                .build()),
         arguments(
             batchParameters().setTracing(false).build(),
-            Parameters.builder().tracingRequested(false).build()),
+            Parameters.builder()
+                .consistencyLevel(Service.DEFAULT_CONSISTENCY)
+                .serialConsistencyLevel(Service.DEFAULT_SERIAL_CONSISTENCY)
+                .tracingRequested(false)
+                .build()),
         arguments(
             batchParameters()
                 .setKeyspace(StringValue.newBuilder().setValue("def"))

--- a/grpc/src/test/java/io/stargate/grpc/service/QueryParametersTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/QueryParametersTest.java
@@ -83,11 +83,17 @@ public class QueryParametersTest extends BaseServiceTest {
     return Stream.of(
         arguments(
             cqlQueryParameters().build(),
-            Parameters.builder().pageSize(Service.DEFAULT_PAGE_SIZE).build()),
+            Parameters.builder()
+                .pageSize(Service.DEFAULT_PAGE_SIZE)
+                .consistencyLevel(Service.DEFAULT_CONSISTENCY)
+                .serialConsistencyLevel(Service.DEFAULT_SERIAL_CONSISTENCY)
+                .build()),
         arguments(
             cqlQueryParameters().setKeyspace(StringValue.newBuilder().setValue("abc")).build(),
             Parameters.builder()
                 .pageSize(Service.DEFAULT_PAGE_SIZE)
+                .consistencyLevel(Service.DEFAULT_CONSISTENCY)
+                .serialConsistencyLevel(Service.DEFAULT_SERIAL_CONSISTENCY)
                 .defaultKeyspace("abc")
                 .build()),
         arguments(
@@ -97,6 +103,7 @@ public class QueryParametersTest extends BaseServiceTest {
             Parameters.builder()
                 .pageSize(Service.DEFAULT_PAGE_SIZE)
                 .consistencyLevel(ConsistencyLevel.THREE)
+                .serialConsistencyLevel(Service.DEFAULT_SERIAL_CONSISTENCY)
                 .build()),
         arguments(
             cqlQueryParameters()
@@ -105,38 +112,54 @@ public class QueryParametersTest extends BaseServiceTest {
                 .build(),
             Parameters.builder()
                 .pageSize(Service.DEFAULT_PAGE_SIZE)
+                .consistencyLevel(Service.DEFAULT_CONSISTENCY)
                 .serialConsistencyLevel(ConsistencyLevel.LOCAL_SERIAL)
                 .build()),
         arguments(
             cqlQueryParameters()
                 .setNowInSeconds(Int32Value.newBuilder().setValue(12345).build())
                 .build(),
-            Parameters.builder().pageSize(Service.DEFAULT_PAGE_SIZE).nowInSeconds(12345).build()),
+            Parameters.builder()
+                .pageSize(Service.DEFAULT_PAGE_SIZE)
+                .consistencyLevel(Service.DEFAULT_CONSISTENCY)
+                .serialConsistencyLevel(Service.DEFAULT_SERIAL_CONSISTENCY)
+                .nowInSeconds(12345)
+                .build()),
         arguments(
             cqlQueryParameters()
                 .setTimestamp(Int64Value.newBuilder().setValue(1234567890).build())
                 .build(),
             Parameters.builder()
                 .pageSize(Service.DEFAULT_PAGE_SIZE)
+                .consistencyLevel(Service.DEFAULT_CONSISTENCY)
+                .serialConsistencyLevel(Service.DEFAULT_SERIAL_CONSISTENCY)
                 .defaultTimestamp(1234567890)
                 .build()),
         arguments(
             cqlQueryParameters().setTracing(true).build(),
             Parameters.builder()
                 .pageSize(Service.DEFAULT_PAGE_SIZE)
+                .consistencyLevel(Service.DEFAULT_CONSISTENCY)
+                .serialConsistencyLevel(Service.DEFAULT_SERIAL_CONSISTENCY)
                 .tracingRequested(true)
                 .build()),
         arguments(
             cqlQueryParameters().setTracing(false).build(),
             Parameters.builder()
                 .pageSize(Service.DEFAULT_PAGE_SIZE)
+                .consistencyLevel(Service.DEFAULT_CONSISTENCY)
+                .serialConsistencyLevel(Service.DEFAULT_SERIAL_CONSISTENCY)
                 .tracingRequested(false)
                 .build()),
         arguments(
             cqlQueryParameters()
                 .setPageSize(Int32Value.newBuilder().setValue(99999).build())
                 .build(),
-            Parameters.builder().pageSize(99999).build()),
+            Parameters.builder()
+                .consistencyLevel(Service.DEFAULT_CONSISTENCY)
+                .serialConsistencyLevel(Service.DEFAULT_SERIAL_CONSISTENCY)
+                .pageSize(99999)
+                .build()),
         arguments(
             cqlQueryParameters()
                 .setPagingState(
@@ -146,6 +169,8 @@ public class QueryParametersTest extends BaseServiceTest {
                 .build(),
             Parameters.builder()
                 .pageSize(Service.DEFAULT_PAGE_SIZE)
+                .consistencyLevel(Service.DEFAULT_CONSISTENCY)
+                .serialConsistencyLevel(Service.DEFAULT_SERIAL_CONSISTENCY)
                 .pagingState(ByteBuffer.wrap(new byte[] {'a', 'b', 'c'}))
                 .build()),
         arguments(


### PR DESCRIPTION
I've used the same defaults as the GraphQL API.