### PR TITLE
gRPC: propagate HTTP headers to the persistence layer

### DIFF
--- a/grpc/src/main/java/io/stargate/grpc/impl/GrpcImpl.java
+++ b/grpc/src/main/java/io/stargate/grpc/impl/GrpcImpl.java
@@ -22,6 +22,7 @@ import io.stargate.core.metrics.api.Metrics;
 import io.stargate.db.Persistence;
 import io.stargate.grpc.service.Service;
 import io.stargate.grpc.service.interceptors.AuthenticationInterceptor;
+import io.stargate.grpc.service.interceptors.HeadersInterceptor;
 import io.stargate.grpc.service.interceptors.RemoteAddressInterceptor;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -57,6 +58,7 @@ public class GrpcImpl {
         NettyServerBuilder.forAddress(new InetSocketAddress(listenAddress, port))
             .intercept(new AuthenticationInterceptor(authenticationService))
             .intercept(new RemoteAddressInterceptor())
+            .intercept(new HeadersInterceptor())
             .addService(new Service(persistence, metrics))
             .build();
   }

--- a/grpc/src/main/java/io/stargate/grpc/service/Service.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/Service.java
@@ -32,6 +32,7 @@ import io.stargate.proto.QueryOuterClass.Query;
 import io.stargate.proto.QueryOuterClass.Response;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
@@ -44,6 +45,7 @@ public class Service extends io.stargate.proto.StargateGrpc.StargateImplBase {
   public static final Context.Key<AuthenticationSubject> AUTHENTICATION_KEY =
       Context.key("authentication");
   public static final Context.Key<SocketAddress> REMOTE_ADDRESS_KEY = Context.key("remoteAddress");
+  public static final Context.Key<Map<String, String>> HEADERS_KEY = Context.key("headers");
   public static final int DEFAULT_PAGE_SIZE = 100;
   public static final ConsistencyLevel DEFAULT_CONSISTENCY = ConsistencyLevel.LOCAL_QUORUM;
   public static final ConsistencyLevel DEFAULT_SERIAL_CONSISTENCY = ConsistencyLevel.SERIAL;
@@ -115,6 +117,8 @@ public class Service extends io.stargate.proto.StargateGrpc.StargateImplBase {
       if (user.token() != null) {
         connection.clientInfo().ifPresent(c -> c.setAuthenticatedUser(user));
       }
+      Map<String, String> headers = HEADERS_KEY.get();
+      connection.setCustomProperties(headers);
       return Optional.of(connection);
     } catch (Throwable throwable) {
       responseObserver.onError(

--- a/grpc/src/main/java/io/stargate/grpc/service/interceptors/HeadersInterceptor.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/interceptors/HeadersInterceptor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.grpc.service.interceptors;
+
+import io.grpc.Context;
+import io.grpc.Contexts;
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.stargate.grpc.service.Service;
+import java.util.HashMap;
+import java.util.Map;
+
+public class HeadersInterceptor implements ServerInterceptor {
+  @Override
+  public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+      ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+    Map<String, String> stringHeaders = new HashMap<>();
+    for (String key : headers.keys()) {
+      if (key.endsWith("-bin")) {
+        continue;
+      }
+      String value = headers.get(Key.of(key, Metadata.ASCII_STRING_MARSHALLER));
+      stringHeaders.put(key, value);
+    }
+    Context context = Context.current();
+    context = context.withValue(Service.HEADERS_KEY, stringHeaders);
+    return Contexts.interceptCall(context, call, headers, next);
+  }
+}

--- a/grpc/src/test/java/io/stargate/grpc/service/HeadersTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/HeadersTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.grpc.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+import io.stargate.db.Parameters;
+import io.stargate.db.Result;
+import io.stargate.db.Statement;
+import io.stargate.grpc.Utils;
+import io.stargate.proto.StargateGrpc;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+
+public class HeadersTest extends BaseServiceTest {
+
+  private static final Key<String> HEADER1_KEY =
+      Key.of("header1", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Key<String> HEADER2_KEY =
+      Key.of("header2", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Key<byte[]> HEADER3_KEY_BIN =
+      Key.of("header3-bin", Metadata.BINARY_BYTE_MARSHALLER);
+
+  @Captor private ArgumentCaptor<Map<String, String>> propertiesCaptor;
+
+  @Test
+  @DisplayName("Should propagate gRPC string headers as connection properties")
+  public void propagateStringHeaders() {
+    // Given
+    StargateGrpc.StargateBlockingStub stub =
+        makeBlockingStubWithClientHeaders(
+            headers -> {
+              headers.put(HEADER1_KEY, "value1");
+              headers.put(HEADER2_KEY, "value2");
+              headers.put(HEADER3_KEY_BIN, new byte[] {});
+            });
+    mockAnyQueryAsVoid();
+    when(persistence.newConnection()).thenReturn(connection);
+    startServer(persistence);
+
+    // When
+    executeQuery(stub, "mock query");
+
+    // Then
+    verify(connection).setCustomProperties(propertiesCaptor.capture());
+    assertThat(propertiesCaptor.getValue())
+        .containsEntry(HEADER1_KEY.name(), "value1")
+        .containsEntry(HEADER2_KEY.name(), "value2")
+        .doesNotContainKey(HEADER3_KEY_BIN.name());
+  }
+
+  private void mockAnyQueryAsVoid() {
+    Result.Prepared prepared =
+        new Result.Prepared(
+            Utils.STATEMENT_ID,
+            Utils.RESULT_METADATA_ID,
+            Utils.makeResultMetadata(),
+            Utils.makePreparedMetadata());
+    when(connection.prepare(any(String.class), any(Parameters.class)))
+        .thenReturn(CompletableFuture.completedFuture(prepared));
+    when(connection.execute(any(Statement.class), any(Parameters.class), anyLong()))
+        .thenReturn(CompletableFuture.completedFuture(new Result.Void()));
+  }
+}


### PR DESCRIPTION
Opening as a draft because I still need to test manually against serverless.