### PR TITLE
Fix #1178 by removing unused/unnecessary dep to `json-simple` from poms

### DIFF
--- a/health-checker/pom.xml
+++ b/health-checker/pom.xml
@@ -54,11 +54,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
-      <version>1.1</version>
-    </dependency>
-    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>4.0.1</version>

--- a/restapi/pom.xml
+++ b/restapi/pom.xml
@@ -58,11 +58,6 @@
       <artifactId>dropwizard-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
-      <version>1.1</version>
-    </dependency>
-    <dependency>
       <groupId>com.github.java-json-tools</groupId>
       <artifactId>json-schema-validator</artifactId>
       <version>2.2.14</version>


### PR DESCRIPTION
As per title, simple dependency pruning.
