### PR TITLE
closes #1185: docsapi to have it's own module in the metrics

### DIFF
--- a/metrics-jersey/src/main/java/io/stargate/metrics/jersey/DocsApiModuleTagsProvider.java
+++ b/metrics-jersey/src/main/java/io/stargate/metrics/jersey/DocsApiModuleTagsProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.metrics.jersey;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.jersey2.server.JerseyTagsProvider;
+import io.stargate.core.metrics.api.Metrics;
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.glassfish.jersey.server.monitoring.RequestEvent;
+
+/**
+ * A simple tag provider that overwrites the module tags if the HTTP request is targeting our Docs
+ * API.
+ */
+public class DocsApiModuleTagsProvider implements JerseyTagsProvider {
+
+  public static final String DOCS_API_MODULE_NAME = "docsapi";
+
+  private final Metrics metrics;
+
+  public DocsApiModuleTagsProvider(Metrics metrics) {
+    this.metrics = metrics;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Iterable<Tag> httpRequestTags(RequestEvent event) {
+    return tagsInternal(event);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Iterable<Tag> httpLongRequestTags(RequestEvent event) {
+    return tagsInternal(event);
+  }
+
+  private Iterable<Tag> tagsInternal(RequestEvent event) {
+    if (isDocsApiRequest(event.getUriInfo())) {
+      return metrics.tagsForModule(DOCS_API_MODULE_NAME);
+    }
+    return Tags.empty();
+  }
+
+  // we are on docs api if there is /namespaces in the URL path
+  private boolean isDocsApiRequest(ExtendedUriInfo uriInfo) {
+    return uriInfo.getPath(true).contains("/namespaces");
+  }
+}

--- a/metrics-jersey/src/main/java/io/stargate/metrics/jersey/ResourceMetricsEventListener.java
+++ b/metrics-jersey/src/main/java/io/stargate/metrics/jersey/ResourceMetricsEventListener.java
@@ -20,7 +20,7 @@ import io.micrometer.jersey2.server.MetricsApplicationEventListener;
 import io.stargate.core.metrics.StargateMetricConstants;
 import io.stargate.core.metrics.api.HttpMetricsTagProvider;
 import io.stargate.core.metrics.api.Metrics;
-import java.util.Collections;
+import java.util.Arrays;
 
 public class ResourceMetricsEventListener extends MetricsApplicationEventListener {
 
@@ -31,7 +31,8 @@ public class ResourceMetricsEventListener extends MetricsApplicationEventListene
         new ResourceTagsProvider(
             httpMetricsTagProvider,
             metrics.tagsForModule(module),
-            Collections.singleton(new PathParametersTagsProvider())),
+            Arrays.asList(
+                new PathParametersTagsProvider(), new DocsApiModuleTagsProvider(metrics))),
         StargateMetricConstants.METRIC_HTTP_SERVER_REQUESTS,
         true);
   }

--- a/metrics-jersey/src/test/java/io/stargate/metrics/jersey/DocsApiModuleTagsProviderTest.java
+++ b/metrics-jersey/src/test/java/io/stargate/metrics/jersey/DocsApiModuleTagsProviderTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.metrics.jersey;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.stargate.core.metrics.api.Metrics;
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.glassfish.jersey.server.monitoring.RequestEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DocsApiModuleTagsProviderTest {
+
+  @InjectMocks DocsApiModuleTagsProvider provider;
+
+  @Mock Metrics metrics;
+
+  @Mock RequestEvent requestEvent;
+
+  @Mock ExtendedUriInfo extendedUriInfo;
+
+  @BeforeEach
+  public void mockEvent() {
+    lenient().when(requestEvent.getUriInfo()).thenReturn(extendedUriInfo);
+  }
+
+  @Nested
+  class HttpRequestTags {
+
+    @Test
+    public void happyPath() {
+      Tags tags = Tags.of("module", "docsapi");
+      when(extendedUriInfo.getPath(true)).thenReturn("/v2/namespaces/my-keyspace");
+      when(metrics.tagsForModule("docsapi")).thenReturn(tags);
+
+      Iterable<Tag> result = provider.httpRequestTags(requestEvent);
+
+      assertThat(result).containsAll(tags);
+      verify(metrics).tagsForModule("docsapi");
+      verifyNoMoreInteractions(metrics);
+    }
+
+    @Test
+    public void notDocsApiRequest() {
+      when(extendedUriInfo.getPath(true)).thenReturn("/v1/keyspaces/my-keyspace");
+
+      Iterable<Tag> result = provider.httpRequestTags(requestEvent);
+
+      assertThat(result).isEmpty();
+      verifyNoInteractions(metrics);
+    }
+  }
+
+  @Nested
+  class HttpLongRequestTags {
+
+    @Test
+    public void happyPath() {
+      Tags tags = Tags.of("module", "docsapi");
+      when(extendedUriInfo.getPath(true)).thenReturn("/v2/namespaces/my-keyspace");
+      when(metrics.tagsForModule("docsapi")).thenReturn(tags);
+
+      Iterable<Tag> result = provider.httpLongRequestTags(requestEvent);
+
+      assertThat(result).containsAll(tags);
+      verify(metrics).tagsForModule("docsapi");
+      verifyNoMoreInteractions(metrics);
+    }
+
+    @Test
+    public void notDocsApiRequest() {
+      when(extendedUriInfo.getPath(true)).thenReturn("/v1/keyspaces/my-keyspace");
+
+      Iterable<Tag> result = provider.httpLongRequestTags(requestEvent);
+
+      assertThat(result).isEmpty();
+      verifyNoInteractions(metrics);
+    }
+  }
+}


### PR DESCRIPTION
@dougwettlaufer and I agreed to overwrite the default module tag set by the bundle, so that we can clearly separate docsapi requests in the metrics.