### PR TITLE
Catch JsonProcessingException and return 400 status

### DIFF
--- a/restapi/src/main/java/io/stargate/web/resources/ResourceUtils.java
+++ b/restapi/src/main/java/io/stargate/web/resources/ResourceUtils.java
@@ -3,15 +3,21 @@ package io.stargate.web.resources;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import java.util.HashMap;
 import java.util.Map;
 
 public class ResourceUtils {
 
-  public static Map<String, Object> readJson(String payload, ObjectMapper mapper) {
+  private static final ObjectMapper mapper = new ObjectMapper();
+  private static final ObjectReader MAP_READER =
+      mapper.readerFor(
+          mapper.getTypeFactory().constructType(new TypeReference<HashMap<String, Object>>() {}));
+
+  public static Map<String, Object> readJson(String payload) {
     Map<String, Object> requestBody;
     try {
-      requestBody = mapper.readValue(payload, new TypeReference<HashMap<String, Object>>() {});
+      requestBody = MAP_READER.readValue(payload);
     } catch (JsonProcessingException e) {
       throw new IllegalArgumentException(
           String.format("Input provided is not valid json. %s", e.getMessage()));

--- a/restapi/src/main/java/io/stargate/web/resources/ResourceUtils.java
+++ b/restapi/src/main/java/io/stargate/web/resources/ResourceUtils.java
@@ -1,0 +1,21 @@
+package io.stargate.web.resources;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ResourceUtils {
+
+  public static Map<String, Object> readJson(String payload, ObjectMapper mapper) {
+    Map<String, Object> requestBody;
+    try {
+      requestBody = mapper.readValue(payload, new TypeReference<HashMap<String, Object>>() {});
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException(
+          String.format("Input provided is not valid json. %s", e.getMessage()));
+    }
+    return requestBody;
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/resources/v2/RowsResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/RowsResource.java
@@ -19,7 +19,6 @@ import static io.stargate.web.docsapi.resources.RequestToHeadersMapper.getAllHea
 
 import com.codahale.metrics.annotation.Timed;
 import com.datastax.oss.driver.shaded.guava.common.base.Strings;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.TypedKeyValue;
@@ -88,7 +87,7 @@ import org.apache.cassandra.stargate.db.ConsistencyLevel;
 public class RowsResource {
 
   @Inject private Db db;
-  private static final ObjectMapper mapper = new ObjectMapper();
+
   private final int DEFAULT_PAGE_SIZE = 100;
 
   @Timed
@@ -381,7 +380,7 @@ public class RowsResource {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
 
-          Map<String, Object> requestBody = ResourceUtils.readJson(payload, mapper);
+          Map<String, Object> requestBody = ResourceUtils.readJson(payload);
 
           Table table = authenticatedDB.getTable(keyspaceName, tableName);
 
@@ -602,7 +601,7 @@ public class RowsResource {
           .build();
     }
 
-    Map<String, Object> requestBody = ResourceUtils.readJson(payload, mapper);
+    Map<String, Object> requestBody = ResourceUtils.readJson(payload);
     List<ValueModifier> changes =
         requestBody.entrySet().stream()
             .map(e -> Converters.colToValue(e.getKey(), e.getValue(), tableMetadata))
@@ -698,7 +697,7 @@ public class RowsResource {
     }
 
     List<ColumnOrder> order = new ArrayList<>();
-    Map<String, Object> sortOrder = ResourceUtils.readJson(sort, mapper);
+    Map<String, Object> sortOrder = ResourceUtils.readJson(sort);
 
     for (Map.Entry<String, Object> entry : sortOrder.entrySet()) {
       Column.Order colOrder =

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/KeyspacesResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/KeyspacesResource.java
@@ -18,6 +18,8 @@ package io.stargate.web.resources.v2.schemas;
 import static io.stargate.web.docsapi.resources.RequestToHeadersMapper.getAllHeaders;
 
 import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
@@ -220,7 +222,14 @@ public class KeyspacesResource {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
 
-          Map<String, Object> requestBody = mapper.readValue(payload, Map.class);
+          Map<String, Object> requestBody;
+          try {
+            requestBody =
+                mapper.readValue(payload, new TypeReference<HashMap<String, Object>>() {});
+          } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(
+                String.format("Input provided is not valid json. %s", e.getMessage()));
+          }
 
           String keyspaceName = (String) requestBody.get("name");
           db.getAuthorizationService()

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/KeyspacesResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/KeyspacesResource.java
@@ -18,8 +18,6 @@ package io.stargate.web.resources.v2.schemas;
 import static io.stargate.web.docsapi.resources.RequestToHeadersMapper.getAllHeaders;
 
 import com.codahale.metrics.annotation.Timed;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
@@ -33,6 +31,7 @@ import io.stargate.web.resources.AuthenticatedDB;
 import io.stargate.web.resources.Converters;
 import io.stargate.web.resources.Db;
 import io.stargate.web.resources.RequestHandler;
+import io.stargate.web.resources.ResourceUtils;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -222,14 +221,7 @@ public class KeyspacesResource {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
 
-          Map<String, Object> requestBody;
-          try {
-            requestBody =
-                mapper.readValue(payload, new TypeReference<HashMap<String, Object>>() {});
-          } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException(
-                String.format("Input provided is not valid json. %s", e.getMessage()));
-          }
+          Map<String, Object> requestBody = ResourceUtils.readJson(payload, mapper);
 
           String keyspaceName = (String) requestBody.get("name");
           db.getAuthorizationService()

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/KeyspacesResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/KeyspacesResource.java
@@ -18,7 +18,6 @@ package io.stargate.web.resources.v2.schemas;
 import static io.stargate.web.docsapi.resources.RequestToHeadersMapper.getAllHeaders;
 
 import com.codahale.metrics.annotation.Timed;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.entity.ResourceKind;
@@ -66,7 +65,6 @@ import org.apache.cassandra.stargate.db.ConsistencyLevel;
 @Produces(MediaType.APPLICATION_JSON)
 public class KeyspacesResource {
   @Inject private Db db;
-  private static final ObjectMapper mapper = new ObjectMapper();
 
   @Timed
   @GET
@@ -221,7 +219,7 @@ public class KeyspacesResource {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
 
-          Map<String, Object> requestBody = ResourceUtils.readJson(payload, mapper);
+          Map<String, Object> requestBody = ResourceUtils.readJson(payload);
 
           String keyspaceName = (String) requestBody.get("name");
           db.getAuthorizationService()

--- a/restapi/src/test/java/io/stargate/web/resources/ResourceUtilsTest.java
+++ b/restapi/src/test/java/io/stargate/web/resources/ResourceUtilsTest.java
@@ -3,7 +3,6 @@ package io.stargate.web.resources;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,12 +12,10 @@ class ResourceUtilsTest {
   @Nested
   class ReadJson {
 
-    ObjectMapper mapper = new ObjectMapper();
-
     @Test
     public void readValidJson() {
       String payload = "{\"a\": \"alpha\", \"b\": 1}";
-      Map<String, Object> requestBodyMap = ResourceUtils.readJson(payload, mapper);
+      Map<String, Object> requestBodyMap = ResourceUtils.readJson(payload);
 
       assertThat(requestBodyMap.get("a")).isEqualTo("alpha");
       assertThat(requestBodyMap.get("b")).isEqualTo(1);
@@ -28,8 +25,7 @@ class ResourceUtilsTest {
     public void readInvalidJsonMissingColon() {
       String payload = "{\"a\": \"alpha\", \"b\" 1}";
       IllegalArgumentException ex =
-          assertThrows(
-              IllegalArgumentException.class, () -> ResourceUtils.readJson(payload, mapper));
+          assertThrows(IllegalArgumentException.class, () -> ResourceUtils.readJson(payload));
       assertThat(ex)
           .hasMessage(
               "Input provided is not valid json. Unexpected character ('1' (code 49)): was expecting a colon to separate field name and value\n"
@@ -40,8 +36,7 @@ class ResourceUtilsTest {
     public void readInvalidJsonDoubleQuote() {
       String payload = "{\"a\": \"\"alpha\", \"b\": 1}";
       IllegalArgumentException ex =
-          assertThrows(
-              IllegalArgumentException.class, () -> ResourceUtils.readJson(payload, mapper));
+          assertThrows(IllegalArgumentException.class, () -> ResourceUtils.readJson(payload));
       assertThat(ex)
           .hasMessage(
               "Input provided is not valid json. Unexpected character ('a' (code 97)): was expecting comma to separate Object entries\n"

--- a/restapi/src/test/java/io/stargate/web/resources/ResourceUtilsTest.java
+++ b/restapi/src/test/java/io/stargate/web/resources/ResourceUtilsTest.java
@@ -1,0 +1,51 @@
+package io.stargate.web.resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ResourceUtilsTest {
+
+  @Nested
+  class ReadJson {
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void readValidJson() {
+      String payload = "{\"a\": \"alpha\", \"b\": 1}";
+      Map<String, Object> requestBodyMap = ResourceUtils.readJson(payload, mapper);
+
+      assertThat(requestBodyMap.get("a")).isEqualTo("alpha");
+      assertThat(requestBodyMap.get("b")).isEqualTo(1);
+    }
+
+    @Test
+    public void readInvalidJsonMissingColon() {
+      String payload = "{\"a\": \"alpha\", \"b\" 1}";
+      IllegalArgumentException ex =
+          assertThrows(
+              IllegalArgumentException.class, () -> ResourceUtils.readJson(payload, mapper));
+      assertThat(ex)
+          .hasMessage(
+              "Input provided is not valid json. Unexpected character ('1' (code 49)): was expecting a colon to separate field name and value\n"
+                  + " at [Source: (String)\"{\"a\": \"alpha\", \"b\" 1}\"; line: 1, column: 21]");
+    }
+
+    @Test
+    public void readInvalidJsonDoubleQuote() {
+      String payload = "{\"a\": \"\"alpha\", \"b\": 1}";
+      IllegalArgumentException ex =
+          assertThrows(
+              IllegalArgumentException.class, () -> ResourceUtils.readJson(payload, mapper));
+      assertThat(ex)
+          .hasMessage(
+              "Input provided is not valid json. Unexpected character ('a' (code 97)): was expecting comma to separate Object entries\n"
+                  + " at [Source: (String)\"{\"a\": \"\"alpha\", \"b\": 1}\"; line: 1, column: 10]");
+    }
+  }
+}

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -881,6 +881,20 @@ public class RestApiv2Test extends BaseOsgiIntegrationTest {
   }
 
   @Test
+  public void getRowsWithQueryAndInvalidSort() throws IOException {
+    String rowIdentifier = setupClusteringTestCase();
+
+    String whereClause = String.format("{\"id\":{\"$eq\":\"%s\"}}", rowIdentifier);
+    String body =
+        RestUtils.get(
+            authToken,
+            String.format(
+                "%s:8082/v2/keyspaces/%s/%s?where=%s&sort={\"expense_id\"\":\"desc\"}",
+                host, keyspaceName, tableName, whereClause),
+            HttpStatus.SC_BAD_REQUEST);
+  }
+
+  @Test
   public void getRowsWithNotFound() throws IOException {
     createKeyspace(keyspaceName);
     createTable(keyspaceName, tableName);

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -198,6 +198,15 @@ public class RestApiv2Test extends BaseOsgiIntegrationTest {
   }
 
   @Test
+  public void createKeyspaceWithInvalidJson() throws IOException {
+    RestUtils.post(
+        authToken,
+        String.format("%s:8082/v2/schemas/keyspaces", host),
+        "{\"name\" \"badjsonkeyspace\", \"replicas\": 1}",
+        HttpStatus.SC_BAD_REQUEST);
+  }
+
+  @Test
   public void deleteKeyspace() throws IOException {
     String keyspaceName = "ks_createkeyspace_" + System.currentTimeMillis();
     createKeyspace(keyspaceName);
@@ -1418,6 +1427,18 @@ public class RestApiv2Test extends BaseOsgiIntegrationTest {
   }
 
   @Test
+  public void addRowWithInvalidJson() throws IOException {
+    createKeyspace(keyspaceName);
+    createTable(keyspaceName, tableName);
+
+    RestUtils.post(
+        authToken,
+        String.format("%s:8082/v2/keyspaces/%s/%s", host, keyspaceName, tableName),
+        "{\"id\": \"af2603d2-8c03-11eb-a03f-0ada685e0000\",\"firstName: \"john\"}",
+        HttpStatus.SC_BAD_REQUEST);
+  }
+
+  @Test
   public void updateRow() throws IOException {
     createKeyspace(keyspaceName);
     createTable(keyspaceName, tableName);
@@ -1592,6 +1613,30 @@ public class RestApiv2Test extends BaseOsgiIntegrationTest {
     assertThat(dataList.get(0).get("id")).isEqualTo(rowIdentifier);
     assertThat(dataList.get(0).get("counter1")).isEqualTo("1");
     assertThat(dataList.get(0).get("counter2")).isEqualTo("-1");
+  }
+
+  @Test
+  public void updateRowWithInvalidJson() throws IOException {
+    createKeyspace(keyspaceName);
+    createTable(keyspaceName, tableName);
+
+    String rowIdentifier = UUID.randomUUID().toString();
+    Map<String, String> row = new HashMap<>();
+    row.put("id", rowIdentifier);
+    row.put("firstName", "John");
+
+    RestUtils.post(
+        authToken,
+        String.format("%s:8082/v2/keyspaces/%s/%s", host, keyspaceName, tableName),
+        objectMapper.writeValueAsString(row),
+        HttpStatus.SC_CREATED);
+
+    RestUtils.put(
+        authToken,
+        String.format(
+            "%s:8082/v2/keyspaces/%s/%s/%s", host, keyspaceName, tableName, rowIdentifier),
+        "{\"firstName\": \"Robert,\"lastName\": \"Plant\"}",
+        HttpStatus.SC_BAD_REQUEST);
   }
 
   @Test


### PR DESCRIPTION
**What this PR does**:
Bringing the catch logic over from docsapi to restapi so that if JSON input is malformed its caught and an expected 400 is returned instead of a 500.

**Which issue(s) this PR fixes**:
Fixes #1110 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
