### PR TITLE
Retries for gRPC

### DIFF
--- a/grpc/src/main/java/io/stargate/grpc/retries/DefaultRetryPolicy.java
+++ b/grpc/src/main/java/io/stargate/grpc/retries/DefaultRetryPolicy.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.grpc.retries;
+
+import com.google.common.annotations.VisibleForTesting;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.ThreadSafe;
+import org.apache.cassandra.stargate.db.WriteType;
+import org.apache.cassandra.stargate.exceptions.ReadTimeoutException;
+import org.apache.cassandra.stargate.exceptions.UnavailableException;
+import org.apache.cassandra.stargate.exceptions.WriteTimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The default retry policy.
+ *
+ * <p>This is a very conservative implementation: it triggers a maximum of one retry per request,
+ * and only in cases that have a high chance of success (see the method javadocs for detailed
+ * explanations of each case).
+ */
+@ThreadSafe
+public class DefaultRetryPolicy implements RetryPolicy {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultRetryPolicy.class);
+
+  @VisibleForTesting
+  public static final String RETRYING_ON_READ_TIMEOUT =
+      "Retrying on read timeout (consistency: {}, required responses: {}, "
+          + "received responses: {}, data retrieved: {}, retries: {})";
+
+  @VisibleForTesting
+  public static final String RETRYING_ON_WRITE_TIMEOUT =
+      "Retrying on write timeout (consistency: {}, write type: {}, "
+          + "required acknowledgments: {}, received acknowledgments: {}, retries: {})";
+
+  @VisibleForTesting
+  public static final String RETRYING_ON_UNAVAILABLE =
+      "Retrying on unavailable exception (consistency: {}, "
+          + "required replica: {}, alive replica: {}, retries: {})";
+
+  public DefaultRetryPolicy() {}
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation triggers a maximum of one retry (to the same node), and only if enough
+   * replicas had responded to the read request but data was not retrieved amongst those. That
+   * usually means that enough replicas are alive to satisfy the consistency, but the coordinator
+   * picked a dead one for data retrieval, not having detected that replica as dead yet. The
+   * reasoning is that by the time we get the timeout, the dead replica will likely have been
+   * detected as dead and the retry has a high chance of success.
+   *
+   * <p>Otherwise, the exception is rethrown.
+   */
+  @Override
+  public RetryDecision onReadTimeout(@NonNull ReadTimeoutException rte, int retryCount) {
+
+    RetryDecision decision =
+        (retryCount == 0 && rte.received >= rte.blockFor && !rte.dataPresent)
+            ? RetryDecision.RETRY
+            : RetryDecision.RETHROW;
+
+    if (decision == RetryDecision.RETRY && LOG.isTraceEnabled()) {
+      LOG.trace(
+          RETRYING_ON_READ_TIMEOUT, rte.consistency, rte.blockFor, rte.received, false, retryCount);
+    }
+
+    return decision;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation triggers a maximum of one retry, and only for a {@code
+   * WriteType.BATCH_LOG} write. The reasoning is that the coordinator tries to write the
+   * distributed batch log against a small subset of nodes in the local datacenter; a timeout
+   * usually means that none of these nodes were alive but the coordinator hadn't detected them as
+   * dead yet. By the time we get the timeout, the dead nodes will likely have been detected as
+   * dead, and the retry has thus a high chance of success.
+   *
+   * <p>Otherwise, the exception is rethrown.
+   */
+  @Override
+  public RetryDecision onWriteTimeout(@NonNull WriteTimeoutException wte, int retryCount) {
+
+    RetryDecision decision =
+        (retryCount == 0 && wte.writeType == WriteType.BATCH_LOG)
+            ? RetryDecision.RETRY
+            : RetryDecision.RETHROW;
+
+    if (decision == RetryDecision.RETRY && LOG.isTraceEnabled()) {
+      LOG.trace(
+          RETRYING_ON_WRITE_TIMEOUT,
+          wte.consistency,
+          wte.writeType,
+          wte.blockFor,
+          wte.received,
+          retryCount);
+    }
+    return decision;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation triggers a maximum of one retry.
+   *
+   * <p>Otherwise, the exception is rethrown.
+   */
+  @Override
+  public RetryDecision onUnavailable(@NonNull UnavailableException ue, int retryCount) {
+
+    RetryDecision decision = (retryCount == 0) ? RetryDecision.RETRY : RetryDecision.RETHROW;
+
+    if (decision == RetryDecision.RETRY && LOG.isTraceEnabled()) {
+      LOG.trace(RETRYING_ON_UNAVAILABLE, ue.consistency, ue.required, ue.alive, retryCount);
+    }
+
+    return decision;
+  }
+}

--- a/grpc/src/main/java/io/stargate/grpc/retries/DefaultRetryPolicy.java
+++ b/grpc/src/main/java/io/stargate/grpc/retries/DefaultRetryPolicy.java
@@ -52,8 +52,6 @@ public class DefaultRetryPolicy implements RetryPolicy {
       "Retrying on unavailable exception (consistency: {}, "
           + "required replica: {}, alive replica: {}, retries: {})";
 
-  public DefaultRetryPolicy() {}
-
   /**
    * {@inheritDoc}
    *

--- a/grpc/src/main/java/io/stargate/grpc/retries/DefaultRetryPolicy.java
+++ b/grpc/src/main/java/io/stargate/grpc/retries/DefaultRetryPolicy.java
@@ -20,7 +20,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import net.jcip.annotations.ThreadSafe;
 import org.apache.cassandra.stargate.db.WriteType;
 import org.apache.cassandra.stargate.exceptions.ReadTimeoutException;
-import org.apache.cassandra.stargate.exceptions.UnavailableException;
 import org.apache.cassandra.stargate.exceptions.WriteTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,11 +45,6 @@ public class DefaultRetryPolicy implements RetryPolicy {
   public static final String RETRYING_ON_WRITE_TIMEOUT =
       "Retrying on write timeout (consistency: {}, write type: {}, "
           + "required acknowledgments: {}, received acknowledgments: {}, retries: {})";
-
-  @VisibleForTesting
-  public static final String RETRYING_ON_UNAVAILABLE =
-      "Retrying on unavailable exception (consistency: {}, "
-          + "required replica: {}, alive replica: {}, retries: {})";
 
   /**
    * {@inheritDoc}
@@ -109,25 +103,6 @@ public class DefaultRetryPolicy implements RetryPolicy {
           wte.received,
           retryCount);
     }
-    return decision;
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * <p>This implementation triggers a maximum of one retry.
-   *
-   * <p>Otherwise, the exception is rethrown.
-   */
-  @Override
-  public RetryDecision onUnavailable(@NonNull UnavailableException ue, int retryCount) {
-
-    RetryDecision decision = (retryCount == 0) ? RetryDecision.RETRY : RetryDecision.RETHROW;
-
-    if (decision == RetryDecision.RETRY && LOG.isTraceEnabled()) {
-      LOG.trace(RETRYING_ON_UNAVAILABLE, ue.consistency, ue.required, ue.alive, retryCount);
-    }
-
     return decision;
   }
 }

--- a/grpc/src/main/java/io/stargate/grpc/retries/RetryDecision.java
+++ b/grpc/src/main/java/io/stargate/grpc/retries/RetryDecision.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.grpc.retries;
+
+import com.datastax.oss.driver.api.core.retry.RetryPolicy;
+
+/** A decision from the {@link RetryPolicy} on how to handle a retry. */
+public enum RetryDecision {
+  /** Retry the operation. */
+  RETRY,
+  /** Rethrow to the calling code, as the result of the execute operation. */
+  RETHROW,
+  ;
+}

--- a/grpc/src/main/java/io/stargate/grpc/retries/RetryPolicy.java
+++ b/grpc/src/main/java/io/stargate/grpc/retries/RetryPolicy.java
@@ -17,7 +17,6 @@ package io.stargate.grpc.retries;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.cassandra.stargate.exceptions.ReadTimeoutException;
-import org.apache.cassandra.stargate.exceptions.UnavailableException;
 import org.apache.cassandra.stargate.exceptions.WriteTimeoutException;
 
 /** Defines the behavior to adopt when a request fails. */
@@ -61,20 +60,4 @@ public interface RetryPolicy {
    */
   RetryDecision onWriteTimeout(
       @NonNull WriteTimeoutException writeTimeoutException, int retryCount);
-
-  /**
-   * Whether to retry when the server replied with an {@code UNAVAILABLE} error; this indicates that
-   * the coordinator determined that there were not enough replicas alive to perform a query with
-   * the requested consistency level.
-   *
-   * <p>{@link UnavailableException#consistency} the requested consistency level. {@link
-   * UnavailableException#required} the number of replica acknowledgements/responses required to
-   * perform the operation (with its required consistency level). {@link UnavailableException#alive}
-   * the number of replicas that were known to be alive by the coordinator node when it tried to
-   * execute the operation.
-   *
-   * @param retryCount how many times the retry policy has been invoked already for this request
-   *     (not counting the current invocation).
-   */
-  RetryDecision onUnavailable(@NonNull UnavailableException pe, int retryCount);
 }

--- a/grpc/src/main/java/io/stargate/grpc/retries/RetryPolicy.java
+++ b/grpc/src/main/java/io/stargate/grpc/retries/RetryPolicy.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.grpc.retries;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.apache.cassandra.stargate.exceptions.ReadTimeoutException;
+import org.apache.cassandra.stargate.exceptions.UnavailableException;
+import org.apache.cassandra.stargate.exceptions.WriteTimeoutException;
+
+/** Defines the behavior to adopt when a request fails. */
+public interface RetryPolicy {
+
+  /**
+   * Whether to retry when the server replied with a {@code READ_TIMEOUT} error; this indicates a
+   * <b>server-side</b> timeout during a read query, i.e. some replicas did not reply to the
+   * coordinator in time.
+   *
+   * <p>{@link ReadTimeoutException#consistency} the requested consistency level. {@link
+   * ReadTimeoutException#blockFor} the minimum number of replica acknowledgements/responses that
+   * were required to fulfill the operation. {@link ReadTimeoutException#received} the number of
+   * replica that had acknowledged/responded to the operation before it failed. {@link
+   * ReadTimeoutException#dataPresent} whether the actual data was amongst the received replica
+   * responses.
+   *
+   * @param retryCount how many times the retry policy has been invoked already for this request
+   *     (not counting the current invocation).
+   */
+  RetryDecision onReadTimeout(@NonNull ReadTimeoutException readTimeoutException, int retryCount);
+
+  /**
+   * Whether to retry when the server replied with a {@code WRITE_TIMEOUT} error; this indicates a
+   * <b>server-side</b> timeout during a write query, i.e. some replicas did not reply to the
+   * coordinator in time.
+   *
+   * <p>Note that this method will only be invoked for {@link isIdempotent()} idempotent} requests:
+   * when a write times out, it is impossible to determine with 100% certainty whether the mutation
+   * was applied or not, so the write is never safe to retry; the driver will rethrow the error
+   * directly, without invoking the retry policy.
+   *
+   * <p>{@link WriteTimeoutException#consistency} the requested consistency level. {@link
+   * WriteTimeoutException#writeType} the type of the write for which the timeout was raised. {@link
+   * WriteTimeoutException#blockFor} the minimum number of replica acknowledgements/responses that
+   * were required to fulfill the operation. {@link WriteTimeoutException#received} the number of
+   * replica that had acknowledged/responded to the operation before it failed.
+   *
+   * @param retryCount how many times the retry policy has been invoked already for this request
+   *     (not counting the current invocation).
+   */
+  RetryDecision onWriteTimeout(
+      @NonNull WriteTimeoutException writeTimeoutException, int retryCount);
+
+  /**
+   * Whether to retry when the server replied with an {@code UNAVAILABLE} error; this indicates that
+   * the coordinator determined that there were not enough replicas alive to perform a query with
+   * the requested consistency level.
+   *
+   * <p>{@link UnavailableException#consistency} the requested consistency level. {@link
+   * UnavailableException#required} the number of replica acknowledgements/responses required to
+   * perform the operation (with its required consistency level). {@link UnavailableException#alive}
+   * the number of replicas that were known to be alive by the coordinator node when it tried to
+   * execute the operation.
+   *
+   * @param retryCount how many times the retry policy has been invoked already for this request
+   *     (not counting the current invocation).
+   */
+  RetryDecision onUnavailable(@NonNull UnavailableException pe, int retryCount);
+}

--- a/grpc/src/main/java/io/stargate/grpc/retries/RetryPolicy.java
+++ b/grpc/src/main/java/io/stargate/grpc/retries/RetryPolicy.java
@@ -27,13 +27,7 @@ public interface RetryPolicy {
    * <b>server-side</b> timeout during a read query, i.e. some replicas did not reply to the
    * coordinator in time.
    *
-   * <p>{@link ReadTimeoutException#consistency} the requested consistency level. {@link
-   * ReadTimeoutException#blockFor} the minimum number of replica acknowledgements/responses that
-   * were required to fulfill the operation. {@link ReadTimeoutException#received} the number of
-   * replica that had acknowledged/responded to the operation before it failed. {@link
-   * ReadTimeoutException#dataPresent} whether the actual data was amongst the received replica
-   * responses.
-   *
+   * @param readTimeoutException the exception used to determine if the query should be retried.
    * @param retryCount how many times the retry policy has been invoked already for this request
    *     (not counting the current invocation).
    */
@@ -50,12 +44,7 @@ public interface RetryPolicy {
    * write is never safe to retry; the driver will rethrow the error directly, without invoking the
    * retry policy.
    *
-   * <p>{@link WriteTimeoutException#consistency} the requested consistency level. {@link
-   * WriteTimeoutException#writeType} the type of the write for which the timeout was raised. {@link
-   * WriteTimeoutException#blockFor} the minimum number of replica acknowledgements/responses that
-   * were required to fulfill the operation. {@link WriteTimeoutException#received} the number of
-   * replica that had acknowledged/responded to the operation before it failed.
-   *
+   * @param writeTimeoutException the exception used to determine if the query should be retried.
    * @param retryCount how many times the retry policy has been invoked already for this request
    *     (not counting the current invocation).
    */

--- a/grpc/src/main/java/io/stargate/grpc/retries/RetryPolicy.java
+++ b/grpc/src/main/java/io/stargate/grpc/retries/RetryPolicy.java
@@ -44,10 +44,11 @@ public interface RetryPolicy {
    * <b>server-side</b> timeout during a write query, i.e. some replicas did not reply to the
    * coordinator in time.
    *
-   * <p>Note that this method will only be invoked for {@link isIdempotent()} idempotent} requests:
-   * when a write times out, it is impossible to determine with 100% certainty whether the mutation
-   * was applied or not, so the write is never safe to retry; the driver will rethrow the error
-   * directly, without invoking the retry policy.
+   * <p>Note that this method will only be invoked for {@link
+   * io.stargate.db.Result.Prepared#isIdempotent()} idempotent} requests: when a write times out, it
+   * is impossible to determine with 100% certainty whether the mutation was applied or not, so the
+   * write is never safe to retry; the driver will rethrow the error directly, without invoking the
+   * retry policy.
    *
    * <p>{@link WriteTimeoutException#consistency} the requested consistency level. {@link
    * WriteTimeoutException#writeType} the type of the write for which the timeout was raised. {@link

--- a/grpc/src/main/java/io/stargate/grpc/service/BatchHandler.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/BatchHandler.java
@@ -32,7 +32,7 @@ import io.stargate.db.Statement;
 import io.stargate.grpc.payload.PayloadHandler;
 import io.stargate.grpc.payload.PayloadHandlers;
 import io.stargate.grpc.service.Service.PrepareInfo;
-import io.stargate.grpc.service.Service.ResponseWithTracingId;
+import io.stargate.grpc.service.Service.ResponseAndTraceId;
 import io.stargate.proto.QueryOuterClass.Batch;
 import io.stargate.proto.QueryOuterClass.BatchParameters;
 import io.stargate.proto.QueryOuterClass.BatchQuery;
@@ -103,9 +103,9 @@ class BatchHandler extends MessageHandler<Batch, BatchHandler.BatchAndIdempotenc
   }
 
   @Override
-  protected ResponseWithTracingId buildResponse(Result result) {
-    ResponseWithTracingId responseWithTracingId = new ResponseWithTracingId();
-    responseWithTracingId.setTracingId(result.getTracingId());
+  protected ResponseAndTraceId buildResponse(Result result) {
+    ResponseAndTraceId responseAndTraceId = new ResponseAndTraceId();
+    responseAndTraceId.setTracingId(result.getTracingId());
     Response.Builder responseBuilder = makeResponseBuilder(result);
 
     if (result.kind != Result.Kind.Void && result.kind != Result.Kind.Rows) {
@@ -125,8 +125,8 @@ class BatchHandler extends MessageHandler<Batch, BatchHandler.BatchAndIdempotenc
       }
     }
 
-    responseWithTracingId.setResponseBuilder(responseBuilder);
-    return responseWithTracingId;
+    responseAndTraceId.setResponseBuilder(responseBuilder);
+    return responseAndTraceId;
   }
 
   @Override

--- a/grpc/src/main/java/io/stargate/grpc/service/BatchHandler.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/BatchHandler.java
@@ -32,7 +32,7 @@ import io.stargate.db.Statement;
 import io.stargate.grpc.payload.PayloadHandler;
 import io.stargate.grpc.payload.PayloadHandlers;
 import io.stargate.grpc.service.Service.PrepareInfo;
-import io.stargate.grpc.service.Service.ResponseAndTraceId;
+import io.stargate.grpc.service.Service.ResponseBuilderWithDetails;
 import io.stargate.proto.QueryOuterClass.Batch;
 import io.stargate.proto.QueryOuterClass.BatchParameters;
 import io.stargate.proto.QueryOuterClass.BatchQuery;
@@ -106,10 +106,11 @@ class BatchHandler extends MessageHandler<Batch, BatchHandler.BatchAndIdempotenc
   }
 
   @Override
-  protected ResponseAndTraceId buildResponse(ResultAndIdempotencyInfo resultAndIdempotencyInfo) {
+  protected ResponseBuilderWithDetails buildResponse(
+      ResultAndIdempotencyInfo resultAndIdempotencyInfo) {
     Result result = resultAndIdempotencyInfo.result;
-    ResponseAndTraceId responseAndTraceId = new ResponseAndTraceId();
-    responseAndTraceId.setTracingId(result.getTracingId());
+    ResponseBuilderWithDetails responseBuilderWithDetails = new ResponseBuilderWithDetails();
+    responseBuilderWithDetails.setTracingId(result.getTracingId());
     Response.Builder responseBuilder = makeResponseBuilder(result);
 
     if (result.kind != Result.Kind.Void && result.kind != Result.Kind.Rows) {
@@ -129,8 +130,9 @@ class BatchHandler extends MessageHandler<Batch, BatchHandler.BatchAndIdempotenc
       }
     }
 
-    responseAndTraceId.setResponseBuilder(responseBuilder);
-    return responseAndTraceId;
+    responseBuilderWithDetails.setResponseBuilder(responseBuilder);
+    responseBuilderWithDetails.setIdempotent(resultAndIdempotencyInfo.isIdempotent);
+    return responseBuilderWithDetails;
   }
 
   @Override

--- a/grpc/src/main/java/io/stargate/grpc/service/MessageHandler.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/MessageHandler.java
@@ -145,10 +145,11 @@ abstract class MessageHandler<MessageT extends GeneratedMessageV3, PreparedT> {
     }
     PersistenceException pe = cause.get();
     switch (pe.code()) {
-      case UNAVAILABLE:
-        return retryPolicy.onUnavailable((UnavailableException) pe, retryCount);
       case READ_TIMEOUT:
         return retryPolicy.onReadTimeout((ReadTimeoutException) pe, retryCount);
+      case WRITE_TIMEOUT:
+        // todo only if isIdempotent
+        return retryPolicy.onWriteTimeout((WriteTimeoutException) pe, retryCount);
       default:
         return RetryDecision.RETHROW;
     }

--- a/grpc/src/main/java/io/stargate/grpc/service/MessageHandler.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/MessageHandler.java
@@ -335,7 +335,8 @@ abstract class MessageHandler<MessageT extends GeneratedMessageV3, PreparedT> {
   }
 
   protected void handleException(Throwable throwable) {
-    if (throwable instanceof CompletionException) {
+    if (throwable instanceof CompletionException
+        || throwable instanceof ExceptionWithIdempotencyInfo) {
       handleException(throwable.getCause());
     } else if (throwable instanceof StatusException
         || throwable instanceof StatusRuntimeException) {

--- a/grpc/src/main/java/io/stargate/grpc/service/QueryHandler.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/QueryHandler.java
@@ -30,7 +30,7 @@ import io.stargate.db.Result.Prepared;
 import io.stargate.grpc.payload.PayloadHandler;
 import io.stargate.grpc.payload.PayloadHandlers;
 import io.stargate.grpc.service.Service.PrepareInfo;
-import io.stargate.grpc.service.Service.ResponseWithTracingId;
+import io.stargate.grpc.service.Service.ResponseAndTraceId;
 import io.stargate.proto.QueryOuterClass.Payload;
 import io.stargate.proto.QueryOuterClass.Query;
 import io.stargate.proto.QueryOuterClass.QueryParameters;
@@ -95,9 +95,9 @@ class QueryHandler extends MessageHandler<Query, Prepared> {
   }
 
   @Override
-  protected ResponseWithTracingId buildResponse(Result result) {
-    ResponseWithTracingId responseWithTracingId = new ResponseWithTracingId();
-    responseWithTracingId.setTracingId(result.getTracingId());
+  protected ResponseAndTraceId buildResponse(Result result) {
+    ResponseAndTraceId responseAndTraceId = new ResponseAndTraceId();
+    responseAndTraceId.setTracingId(result.getTracingId());
     Response.Builder responseBuilder = makeResponseBuilder(result);
     switch (result.kind) {
       case Void:
@@ -138,8 +138,8 @@ class QueryHandler extends MessageHandler<Query, Prepared> {
         throw new CompletionException(
             Status.INTERNAL.withDescription("Unhandled result kind").asException());
     }
-    responseWithTracingId.setResponseBuilder(responseBuilder);
-    return responseWithTracingId;
+    responseAndTraceId.setResponseBuilder(responseBuilder);
+    return responseAndTraceId;
   }
 
   @Override

--- a/grpc/src/main/java/io/stargate/grpc/service/Service.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/Service.java
@@ -130,10 +130,15 @@ public class Service extends io.stargate.proto.StargateGrpc.StargateImplBase {
     }
   }
 
-  static class ResponseAndTraceId {
+  static class ResponseBuilderWithDetails {
 
     @Nullable UUID tracingId;
     Response.Builder responseBuilder;
+    boolean isIdempotent;
+
+    public void setIdempotent(boolean idempotent) {
+      isIdempotent = idempotent;
+    }
 
     void setTracingId(UUID tracingId) {
       this.tracingId = tracingId;

--- a/grpc/src/main/java/io/stargate/grpc/service/Service.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/Service.java
@@ -130,7 +130,7 @@ public class Service extends io.stargate.proto.StargateGrpc.StargateImplBase {
     }
   }
 
-  static class ResponseWithTracingId {
+  static class ResponseAndTraceId {
 
     @Nullable UUID tracingId;
     Response.Builder responseBuilder;

--- a/grpc/src/main/java/io/stargate/grpc/service/Service.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/Service.java
@@ -130,15 +130,10 @@ public class Service extends io.stargate.proto.StargateGrpc.StargateImplBase {
     }
   }
 
-  static class ResponseBuilderWithDetails {
+  static class ResponseWithTracingId {
 
     @Nullable UUID tracingId;
     Response.Builder responseBuilder;
-    boolean isIdempotent;
-
-    public void setIdempotent(boolean idempotent) {
-      isIdempotent = idempotent;
-    }
 
     void setTracingId(UUID tracingId) {
       this.tracingId = tracingId;

--- a/grpc/src/test/java/io/stargate/grpc/retries/DefaultRetryPolicyTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/retries/DefaultRetryPolicyTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.grpc.retries;
+
+import static io.stargate.grpc.retries.RetryDecision.RETHROW;
+import static io.stargate.grpc.retries.RetryDecision.RETRY;
+import static org.apache.cassandra.stargate.db.ConsistencyLevel.QUORUM;
+import static org.apache.cassandra.stargate.db.WriteType.BATCH_LOG;
+import static org.apache.cassandra.stargate.db.WriteType.SIMPLE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.apache.cassandra.stargate.db.ConsistencyLevel;
+import org.apache.cassandra.stargate.db.WriteType;
+import org.apache.cassandra.stargate.exceptions.ReadTimeoutException;
+import org.apache.cassandra.stargate.exceptions.WriteTimeoutException;
+import org.assertj.core.api.Assert;
+import org.junit.jupiter.api.Test;
+
+class DefaultRetryPolicyTest {
+
+  private static final RetryPolicy retryPolicy = new DefaultRetryPolicy();
+
+  @Test
+  public void should_process_read_timeouts() {
+    assertOnReadTimeout(QUORUM, 2, 2, false, 0).isEqualTo(RETRY);
+    assertOnReadTimeout(QUORUM, 2, 2, false, 1).isEqualTo(RETHROW);
+    assertOnReadTimeout(QUORUM, 2, 2, true, 0).isEqualTo(RETHROW);
+    assertOnReadTimeout(QUORUM, 2, 1, true, 0).isEqualTo(RETHROW);
+    assertOnReadTimeout(QUORUM, 2, 1, false, 0).isEqualTo(RETHROW);
+  }
+
+  @Test
+  public void should_process_write_timeouts() {
+    assertOnWriteTimeout(QUORUM, BATCH_LOG, 2, 0, 0).isEqualTo(RETRY);
+    assertOnWriteTimeout(QUORUM, BATCH_LOG, 2, 0, 1).isEqualTo(RETHROW);
+    assertOnWriteTimeout(QUORUM, SIMPLE, 2, 0, 0).isEqualTo(RETHROW);
+  }
+
+  protected Assert<?, RetryDecision> assertOnReadTimeout(
+      ConsistencyLevel cl, int blockFor, int received, boolean dataPresent, int retryCount) {
+    return assertThat(
+        retryPolicy.onReadTimeout(
+            new ReadTimeoutException(cl, received, blockFor, dataPresent), retryCount));
+  }
+
+  protected Assert<?, RetryDecision> assertOnWriteTimeout(
+      ConsistencyLevel cl, WriteType writeType, int blockFor, int received, int retryCount) {
+    return assertThat(
+        retryPolicy.onWriteTimeout(
+            new WriteTimeoutException(writeType, cl, blockFor, received), retryCount));
+  }
+}

--- a/grpc/src/test/java/io/stargate/grpc/retries/DefaultRetryPolicyTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/retries/DefaultRetryPolicyTest.java
@@ -35,7 +35,7 @@ class DefaultRetryPolicyTest {
   private static final RetryPolicy retryPolicy = new DefaultRetryPolicy();
 
   @Test
-  public void should_process_read_timeouts() {
+  public void shouldProcessReadTimeouts() {
     assertOnReadTimeout(QUORUM, 2, 2, false, 0).isEqualTo(RETRY);
     assertOnReadTimeout(QUORUM, 2, 2, false, 1).isEqualTo(RETHROW);
     assertOnReadTimeout(QUORUM, 2, 2, true, 0).isEqualTo(RETHROW);
@@ -44,7 +44,7 @@ class DefaultRetryPolicyTest {
   }
 
   @Test
-  public void should_process_write_timeouts() {
+  public void shouldProcessWriteTimeouts() {
     assertOnWriteTimeout(QUORUM, BATCH_LOG, 2, 0, 0).isEqualTo(RETRY);
     assertOnWriteTimeout(QUORUM, BATCH_LOG, 2, 0, 1).isEqualTo(RETHROW);
     assertOnWriteTimeout(QUORUM, SIMPLE, 2, 0, 0).isEqualTo(RETHROW);

--- a/grpc/src/test/java/io/stargate/grpc/service/ExecuteQueryTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/ExecuteQueryTest.java
@@ -55,8 +55,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
-import org.apache.cassandra.stargate.db.ConsistencyLevel;
-import org.apache.cassandra.stargate.exceptions.ReadTimeoutException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -314,47 +312,6 @@ public class ExecuteQueryTest extends BaseServiceTest {
             .addActual(Column.create("c2", Column.Type.Varchar))
             .addActual(Column.create("c3", Column.Type.Uuid))
             .build(true));
-  }
-
-  @Test
-  public void shouldRetryOnReadTimeout() throws InvalidProtocolBufferException {
-    final String query = "SELECT release_version FROM system.local WHERE key = ?";
-    final String releaseVersion = "4.0.0";
-
-    ResultMetadata resultMetadata =
-        Utils.makeResultMetadata(Column.create("release_version", Type.Varchar));
-    Prepared prepared =
-        new Prepared(
-            Utils.STATEMENT_ID,
-            Utils.RESULT_METADATA_ID,
-            resultMetadata,
-            Utils.makePreparedMetadata(Column.create("key", Type.Varchar)));
-    when(connection.prepare(eq(query), any(Parameters.class)))
-        .thenReturn(CompletableFuture.completedFuture(prepared));
-
-    when(connection.execute(any(Statement.class), any(Parameters.class), anyLong()))
-        .thenThrow(new ReadTimeoutException(ConsistencyLevel.QUORUM, 1, 1, false))
-        .then(
-            invocation -> {
-              BoundStatement statement =
-                  (BoundStatement) invocation.getArgument(0, Statement.class);
-              assertStatement(prepared, statement, Values.of("local"));
-              List<List<ByteBuffer>> rows =
-                  Collections.singletonList(
-                      Collections.singletonList(
-                          TypeCodecs.TEXT.encode(releaseVersion, ProtocolVersion.DEFAULT)));
-              return CompletableFuture.completedFuture(new Result.Rows(rows, resultMetadata));
-            });
-
-    when(persistence.newConnection()).thenReturn(connection);
-
-    startServer(persistence);
-
-    StargateBlockingStub stub = makeBlockingStub();
-
-    QueryOuterClass.Response response = executeQuery(stub, query, Values.of("local"));
-
-    validateResponse(releaseVersion, response);
   }
 
   private void validateResponse(String releaseVersion, QueryOuterClass.Response response)

--- a/grpc/src/test/java/io/stargate/grpc/service/ExecuteQueryTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/ExecuteQueryTest.java
@@ -56,9 +56,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import org.apache.cassandra.stargate.db.ConsistencyLevel;
-import org.apache.cassandra.stargate.db.WriteType;
 import org.apache.cassandra.stargate.exceptions.ReadTimeoutException;
-import org.apache.cassandra.stargate.exceptions.WriteTimeoutException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -367,47 +365,6 @@ public class ExecuteQueryTest extends BaseServiceTest {
     assertThat(rs.getRowsCount()).isEqualTo(1);
     assertThat(rs.getRows(0).getValuesCount()).isEqualTo(1);
     assertThat(rs.getRows(0).getValues(0).getString()).isEqualTo(releaseVersion);
-  }
-
-  @Test
-  public void shouldRetryOnWriteTimeout() throws InvalidProtocolBufferException {
-    final String query = "SELECT release_version FROM system.local WHERE key = ?";
-    final String releaseVersion = "4.0.0";
-
-    ResultMetadata resultMetadata =
-        Utils.makeResultMetadata(Column.create("release_version", Type.Varchar));
-    Prepared prepared =
-        new Prepared(
-            Utils.STATEMENT_ID,
-            Utils.RESULT_METADATA_ID,
-            resultMetadata,
-            Utils.makePreparedMetadata(Column.create("key", Type.Varchar)));
-    when(connection.prepare(eq(query), any(Parameters.class)))
-        .thenReturn(CompletableFuture.completedFuture(prepared));
-
-    when(connection.execute(any(Statement.class), any(Parameters.class), anyLong()))
-        .thenThrow(new WriteTimeoutException(WriteType.BATCH_LOG, ConsistencyLevel.QUORUM, 1, 1))
-        .then(
-            invocation -> {
-              BoundStatement statement =
-                  (BoundStatement) invocation.getArgument(0, Statement.class);
-              assertStatement(prepared, statement, Values.of("local"));
-              List<List<ByteBuffer>> rows =
-                  Collections.singletonList(
-                      Collections.singletonList(
-                          TypeCodecs.TEXT.encode(releaseVersion, ProtocolVersion.DEFAULT)));
-              return CompletableFuture.completedFuture(new Result.Rows(rows, resultMetadata));
-            });
-
-    when(persistence.newConnection()).thenReturn(connection);
-
-    startServer(persistence);
-
-    StargateBlockingStub stub = makeBlockingStub();
-
-    QueryOuterClass.Response response = executeQuery(stub, query, Values.of("local"));
-
-    validateResponse(releaseVersion, response);
   }
 
   private static class ColumnMetadataBuilder {

--- a/grpc/src/test/java/io/stargate/grpc/service/RetryTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/RetryTest.java
@@ -202,6 +202,7 @@ public class RetryTest extends BaseServiceTest {
 
     QueryOuterClass.Response response = executeQuery(stub, query, Values.of("local"));
 
+    assertThat(response.hasResultSet()).isTrue();
     validateResponse(releaseVersion, response);
   }
 
@@ -233,6 +234,7 @@ public class RetryTest extends BaseServiceTest {
 
     QueryOuterClass.Response response = executeQuery(stub, query, Values.of("local"));
 
+    assertThat(response.hasResultSet()).isTrue();
     validateResponse(releaseVersion, response);
   }
 
@@ -301,7 +303,6 @@ public class RetryTest extends BaseServiceTest {
 
   private void validateResponse(String releaseVersion, QueryOuterClass.Response response)
       throws InvalidProtocolBufferException {
-    assertThat(response.hasResultSet()).isTrue();
     assertThat(response.getResultSet().getType()).isEqualTo(Payload.Type.CQL);
     ResultSet rs = response.getResultSet().getData().unpack(ResultSet.class);
     assertThat(rs.getRowsCount()).isEqualTo(1);

--- a/grpc/src/test/java/io/stargate/grpc/service/RetryTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/RetryTest.java
@@ -276,8 +276,7 @@ public class RetryTest extends BaseServiceTest {
         .hasMessageContaining("Operation timed out - received only 1 responses");
   }
 
-  // todo
-  //  @Test
+  @Test
   public void shouldNotRetryOnWriteTimeoutIfWriteTypeBatchLogButNonIdempotent() {
     final String query = "SELECT release_version FROM system.local WHERE key = ?";
     final String releaseVersion = "4.0.0";

--- a/grpc/src/test/java/io/stargate/grpc/service/RetryTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/RetryTest.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.grpc.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.ProtocolVersion;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.grpc.StatusRuntimeException;
+import io.stargate.db.Batch;
+import io.stargate.db.BatchType;
+import io.stargate.db.BoundStatement;
+import io.stargate.db.Parameters;
+import io.stargate.db.Result;
+import io.stargate.db.Result.Prepared;
+import io.stargate.db.Result.ResultMetadata;
+import io.stargate.db.Statement;
+import io.stargate.db.schema.Column;
+import io.stargate.db.schema.Column.Type;
+import io.stargate.grpc.Utils;
+import io.stargate.grpc.Values;
+import io.stargate.proto.QueryOuterClass;
+import io.stargate.proto.QueryOuterClass.Payload;
+import io.stargate.proto.QueryOuterClass.ResultSet;
+import io.stargate.proto.StargateGrpc.StargateBlockingStub;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.apache.cassandra.stargate.db.ConsistencyLevel;
+import org.apache.cassandra.stargate.db.WriteType;
+import org.apache.cassandra.stargate.exceptions.ReadTimeoutException;
+import org.apache.cassandra.stargate.exceptions.WriteTimeoutException;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
+
+public class RetryTest extends BaseServiceTest {
+
+  @Test
+  public void shouldNotRetryOnReadTimeoutWhenDataPresent() {
+    final String query = "SELECT release_version FROM system.local WHERE key = ?";
+    final String releaseVersion = "4.0.0";
+
+    ResultMetadata resultMetadata =
+        Utils.makeResultMetadata(Column.create("release_version", Type.Varchar));
+    Prepared prepared =
+        new Prepared(
+            Utils.STATEMENT_ID,
+            Utils.RESULT_METADATA_ID,
+            resultMetadata,
+            Utils.makePreparedMetadata(Column.create("key", Type.Varchar)));
+    when(connection.prepare(eq(query), any(Parameters.class)))
+        .thenReturn(CompletableFuture.completedFuture(prepared));
+
+    when(connection.execute(any(Statement.class), any(Parameters.class), anyLong()))
+        .thenThrow(new ReadTimeoutException(ConsistencyLevel.QUORUM, 1, 3, true))
+        .then(correctResponse(releaseVersion, resultMetadata, prepared));
+
+    when(persistence.newConnection()).thenReturn(connection);
+
+    startServer(persistence);
+
+    StargateBlockingStub stub = makeBlockingStub();
+
+    assertThatThrownBy(() -> executeQuery(stub, query, Values.of("local")))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("Operation timed out - received only 1 responses");
+  }
+
+  @Test
+  public void shouldRetryBatchRequestOnReadTimeout() {
+    Prepared prepared =
+        new Prepared(
+            Utils.STATEMENT_ID,
+            Utils.RESULT_METADATA_ID,
+            Utils.makeResultMetadata(),
+            Utils.makePreparedMetadata(
+                Column.create("k", Type.Varchar), Column.create("v", Type.Int)));
+    when(connection.prepare(anyString(), any(Parameters.class)))
+        .thenReturn(CompletableFuture.completedFuture(prepared));
+
+    when(connection.batch(any(Batch.class), any(Parameters.class), anyLong()))
+        .thenThrow(new ReadTimeoutException(ConsistencyLevel.QUORUM, 3, 3, false))
+        .then(correctBatchResponse(prepared));
+
+    when(persistence.newConnection()).thenReturn(connection);
+
+    startServer(persistence);
+
+    StargateBlockingStub stub = makeBlockingStub();
+
+    QueryOuterClass.Response response = stub.executeBatch(createBatch());
+
+    assertThat(response.hasResultSet()).isFalse();
+  }
+
+  @Test
+  public void shouldRetryBatchRequestOnWriteTimeout() {
+    Prepared prepared =
+        new Prepared(
+            Utils.STATEMENT_ID,
+            Utils.RESULT_METADATA_ID,
+            Utils.makeResultMetadata(),
+            Utils.makePreparedMetadata(
+                Column.create("k", Type.Varchar), Column.create("v", Type.Int)));
+    when(connection.prepare(anyString(), any(Parameters.class)))
+        .thenReturn(CompletableFuture.completedFuture(prepared));
+
+    when(connection.batch(any(Batch.class), any(Parameters.class), anyLong()))
+        .thenThrow(new WriteTimeoutException(WriteType.BATCH_LOG, ConsistencyLevel.QUORUM, 3, 3))
+        .then(correctBatchResponse(prepared));
+
+    when(persistence.newConnection()).thenReturn(connection);
+
+    startServer(persistence);
+
+    StargateBlockingStub stub = makeBlockingStub();
+
+    QueryOuterClass.Response response = stub.executeBatch(createBatch());
+
+    assertThat(response.hasResultSet()).isFalse();
+  }
+
+  @Test
+  public void shouldNotRetryOnReadTimeoutWhenLessThanBlockForReceived() {
+    final String query = "SELECT release_version FROM system.local WHERE key = ?";
+    final String releaseVersion = "4.0.0";
+
+    ResultMetadata resultMetadata =
+        Utils.makeResultMetadata(Column.create("release_version", Type.Varchar));
+    Prepared prepared =
+        new Prepared(
+            Utils.STATEMENT_ID,
+            Utils.RESULT_METADATA_ID,
+            resultMetadata,
+            Utils.makePreparedMetadata(Column.create("key", Type.Varchar)));
+    when(connection.prepare(eq(query), any(Parameters.class)))
+        .thenReturn(CompletableFuture.completedFuture(prepared));
+
+    when(connection.execute(any(Statement.class), any(Parameters.class), anyLong()))
+        .thenThrow(new ReadTimeoutException(ConsistencyLevel.QUORUM, 2, 3, false))
+        .then(correctResponse(releaseVersion, resultMetadata, prepared));
+
+    when(persistence.newConnection()).thenReturn(connection);
+
+    startServer(persistence);
+
+    StargateBlockingStub stub = makeBlockingStub();
+
+    assertThatThrownBy(() -> executeQuery(stub, query, Values.of("local")))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("Operation timed out - received only 2 responses");
+  }
+
+  @Test
+  public void shouldRetryOnReadTimeoutWhenEnoughResponsesAndDataNotPresent()
+      throws InvalidProtocolBufferException {
+    final String query = "SELECT release_version FROM system.local WHERE key = ?";
+    final String releaseVersion = "4.0.0";
+
+    ResultMetadata resultMetadata =
+        Utils.makeResultMetadata(Column.create("release_version", Type.Varchar));
+    Prepared prepared =
+        new Prepared(
+            Utils.STATEMENT_ID,
+            Utils.RESULT_METADATA_ID,
+            resultMetadata,
+            Utils.makePreparedMetadata(Column.create("key", Type.Varchar)));
+    when(connection.prepare(eq(query), any(Parameters.class)))
+        .thenReturn(CompletableFuture.completedFuture(prepared));
+
+    when(connection.execute(any(Statement.class), any(Parameters.class), anyLong()))
+        .thenThrow(new ReadTimeoutException(ConsistencyLevel.QUORUM, 3, 3, false))
+        .then(correctResponse(releaseVersion, resultMetadata, prepared));
+
+    when(persistence.newConnection()).thenReturn(connection);
+
+    startServer(persistence);
+
+    StargateBlockingStub stub = makeBlockingStub();
+
+    QueryOuterClass.Response response = executeQuery(stub, query, Values.of("local"));
+
+    validateResponse(releaseVersion, response);
+  }
+
+  @Test
+  public void shouldRetryOnWriteTimeoutIfWriteTypeBatchLog() throws InvalidProtocolBufferException {
+    final String query = "SELECT release_version FROM system.local WHERE key = ?";
+    final String releaseVersion = "4.0.0";
+
+    ResultMetadata resultMetadata =
+        Utils.makeResultMetadata(Column.create("release_version", Type.Varchar));
+    Prepared prepared =
+        new Prepared(
+            Utils.STATEMENT_ID,
+            Utils.RESULT_METADATA_ID,
+            resultMetadata,
+            Utils.makePreparedMetadata(Column.create("key", Type.Varchar)));
+    when(connection.prepare(eq(query), any(Parameters.class)))
+        .thenReturn(CompletableFuture.completedFuture(prepared));
+
+    when(connection.execute(any(Statement.class), any(Parameters.class), anyLong()))
+        .thenThrow(new WriteTimeoutException(WriteType.BATCH_LOG, ConsistencyLevel.QUORUM, 1, 1))
+        .then(correctResponse(releaseVersion, resultMetadata, prepared));
+
+    when(persistence.newConnection()).thenReturn(connection);
+
+    startServer(persistence);
+
+    StargateBlockingStub stub = makeBlockingStub();
+
+    QueryOuterClass.Response response = executeQuery(stub, query, Values.of("local"));
+
+    validateResponse(releaseVersion, response);
+  }
+
+  @Test
+  public void shouldNotRetryOnWriteTimeoutIfWriteTypeNonBatchLog() {
+    final String query = "SELECT release_version FROM system.local WHERE key = ?";
+    final String releaseVersion = "4.0.0";
+
+    ResultMetadata resultMetadata =
+        Utils.makeResultMetadata(Column.create("release_version", Type.Varchar));
+    Prepared prepared =
+        new Prepared(
+            Utils.STATEMENT_ID,
+            Utils.RESULT_METADATA_ID,
+            resultMetadata,
+            Utils.makePreparedMetadata(Column.create("key", Type.Varchar)));
+    when(connection.prepare(eq(query), any(Parameters.class)))
+        .thenReturn(CompletableFuture.completedFuture(prepared));
+
+    when(connection.execute(any(Statement.class), any(Parameters.class), anyLong()))
+        .thenThrow(new WriteTimeoutException(WriteType.SIMPLE, ConsistencyLevel.QUORUM, 1, 1))
+        .then(correctResponse(releaseVersion, resultMetadata, prepared));
+
+    when(persistence.newConnection()).thenReturn(connection);
+
+    startServer(persistence);
+
+    StargateBlockingStub stub = makeBlockingStub();
+
+    assertThatThrownBy(() -> executeQuery(stub, query, Values.of("local")))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("Operation timed out - received only 1 responses");
+  }
+
+  // todo
+  //  @Test
+  public void shouldNotRetryOnWriteTimeoutIfWriteTypeBatchLogButNonIdempotent() {
+    final String query = "SELECT release_version FROM system.local WHERE key = ?";
+    final String releaseVersion = "4.0.0";
+
+    ResultMetadata resultMetadata =
+        Utils.makeResultMetadata(Column.create("release_version", Type.Varchar));
+    Prepared prepared =
+        new Prepared(
+            Utils.STATEMENT_ID,
+            Utils.RESULT_METADATA_ID,
+            resultMetadata,
+            Utils.makePreparedMetadata(Column.create("key", Type.Varchar)));
+    when(connection.prepare(eq(query), any(Parameters.class)))
+        .thenReturn(CompletableFuture.completedFuture(prepared));
+
+    when(connection.execute(any(Statement.class), any(Parameters.class), anyLong()))
+        .thenThrow(new WriteTimeoutException(WriteType.BATCH_LOG, ConsistencyLevel.QUORUM, 1, 1))
+        .then(correctResponse(releaseVersion, resultMetadata, prepared));
+
+    when(persistence.newConnection()).thenReturn(connection);
+
+    startServer(persistence);
+
+    StargateBlockingStub stub = makeBlockingStub();
+
+    assertThatThrownBy(() -> executeQuery(stub, query, Values.of("local")))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("Operation timed out - received only 1 responses");
+  }
+
+  private void validateResponse(String releaseVersion, QueryOuterClass.Response response)
+      throws InvalidProtocolBufferException {
+    assertThat(response.hasResultSet()).isTrue();
+    assertThat(response.getResultSet().getType()).isEqualTo(Payload.Type.CQL);
+    ResultSet rs = response.getResultSet().getData().unpack(ResultSet.class);
+    assertThat(rs.getRowsCount()).isEqualTo(1);
+    assertThat(rs.getRows(0).getValuesCount()).isEqualTo(1);
+    assertThat(rs.getRows(0).getValues(0).getString()).isEqualTo(releaseVersion);
+  }
+
+  @NotNull
+  private Answer<Object> correctResponse(
+      String releaseVersion, ResultMetadata resultMetadata, Prepared prepared) {
+    return invocation -> {
+      BoundStatement statement = (BoundStatement) invocation.getArgument(0, Statement.class);
+      assertStatement(prepared, statement, Values.of("local"));
+      List<List<ByteBuffer>> rows =
+          Collections.singletonList(
+              Collections.singletonList(
+                  TypeCodecs.TEXT.encode(releaseVersion, ProtocolVersion.DEFAULT)));
+      return CompletableFuture.completedFuture(new Result.Rows(rows, resultMetadata));
+    };
+  }
+
+  @NotNull
+  private QueryOuterClass.Batch createBatch() {
+    return QueryOuterClass.Batch.newBuilder()
+        .addQueries(
+            cqlBatchQuery("INSERT INTO test (k, v) VALUES (?, ?)", Values.of("a"), Values.of(1)))
+        .addQueries(
+            cqlBatchQuery("INSERT INTO test (k, v) VALUES (?, ?)", Values.of("b"), Values.of(2)))
+        .addQueries(
+            cqlBatchQuery("INSERT INTO test (k, v) VALUES (?, ?)", Values.of("c"), Values.of(3)))
+        .build();
+  }
+
+  @NotNull
+  private Answer<Object> correctBatchResponse(Prepared prepared) {
+    return invocation -> {
+      Batch batch = invocation.getArgument(0, Batch.class);
+
+      assertThat(batch.type()).isEqualTo(BatchType.LOGGED);
+      assertThat(batch.size()).isEqualTo(3);
+
+      assertStatement(prepared, batch.statements().get(0), Values.of("a"), Values.of(1));
+      assertStatement(prepared, batch.statements().get(1), Values.of("b"), Values.of(2));
+      assertStatement(prepared, batch.statements().get(2), Values.of("c"), Values.of(3));
+
+      return CompletableFuture.completedFuture(new Result.Void());
+    };
+  }
+}

--- a/persistence-api/src/main/java/org/apache/cassandra/stargate/exceptions/ReadTimeoutException.java
+++ b/persistence-api/src/main/java/org/apache/cassandra/stargate/exceptions/ReadTimeoutException.java
@@ -22,6 +22,14 @@ import org.apache.cassandra.stargate.db.ConsistencyLevel;
 public class ReadTimeoutException extends RequestTimeoutException {
   public final boolean dataPresent;
 
+  /**
+   * @param consistency the requested consistency level.
+   * @param received the number of replica that had acknowledged/responded to the operation before
+   *     it failed.
+   * @param blockFor the minimum number of replica acknowledgements/responses that were required to
+   *     fulfill the operation.
+   * @param dataPresent whether the actual data was amongst the received replica responses.
+   */
   public ReadTimeoutException(
       ConsistencyLevel consistency, int received, int blockFor, boolean dataPresent) {
     super(ExceptionCode.READ_TIMEOUT, consistency, received, blockFor);

--- a/persistence-api/src/main/java/org/apache/cassandra/stargate/exceptions/WriteTimeoutException.java
+++ b/persistence-api/src/main/java/org/apache/cassandra/stargate/exceptions/WriteTimeoutException.java
@@ -23,6 +23,14 @@ import org.apache.cassandra.stargate.db.WriteType;
 public class WriteTimeoutException extends RequestTimeoutException {
   public final WriteType writeType;
 
+  /**
+   * @param writeType the type of the write for which the timeout was raised.
+   * @param consistency the requested consistency level.
+   * @param received the number of replica that had acknowledged/responded to the operation before
+   *     it failed.
+   * @param blockFor the minimum number of replica acknowledgements/responses that were required to
+   *     fulfill the operation.
+   */
   public WriteTimeoutException(
       WriteType writeType, ConsistencyLevel consistency, int received, int blockFor) {
     super(ExceptionCode.WRITE_TIMEOUT, consistency, received, blockFor);


### PR DESCRIPTION
**What this PR does**:
Provides retry capabilities for the gRPC API. This is based on the production-proven Java-Driver retry policy (https://github.com/datastax/java-driver/tree/ef56d561d97adcae48e0e6e8807f334aedc0d783/core/src/main/java/com/datastax/oss/driver/api/core/retry).

It provides a way to retry:
- `ReadTimeoutException`
-  `WriteTimeoutException`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated

todo:
- [x] plug `is_idempotent` implemented in https://github.com/stargate/stargate/pull/1194