### PR TITLE
provide is_idempotent by the caller

### DIFF
--- a/grpc-proto/proto/query.proto
+++ b/grpc-proto/proto/query.proto
@@ -221,6 +221,9 @@ message QueryParameters {
   // The consistency level to use to retrieve the query trace (if tracing is set).
   // If unset, it defaults to ONE.
   ConsistencyValue tracing_consistency = 10;
+
+  // Denotes if the query is idempotent or not. If it is, it may be retried server-side
+  bool is_idempotent = 11;
 }
 
 // A CQL column type.
@@ -537,6 +540,9 @@ message BatchParameters {
   // Whether to omit ResultSet.columns in the response.
   // This can be used to optimize response size when the client already knows that information.
   bool skip_metadata = 8;
+
+  // Denotes if the query is idempotent or not. If it is, it may be retried server-side
+  bool is_idempotent = 9;
 }
 
 // A batch containing multiple CQL queries.


### PR DESCRIPTION
**What this PR does**:
An alternative solution to https://github.com/stargate/stargate/pull/1194.
It requires the client to provide an information whether the request is idempotent or not.

**Which issue(s) this PR fixes**:
Fixes #1196

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
