### PR TITLE
Exclude azure-storage-blob dependency from DSE dependencies

### DIFF
--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -79,6 +79,10 @@
           <groupId>dnsjava</groupId>
           <artifactId>dnsjava</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.azure</groupId>
+          <artifactId>azure-storage-blob</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -89,6 +93,10 @@
         <exclusion>
           <groupId>org.gridkit.jvmtool</groupId>
           <artifactId>sjk-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.azure</groupId>
+          <artifactId>azure-storage-blob</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
The current version of DSE that we're using is 6.8.13 and it depends on
azure-storage-blob 12.4.0 which has been removed from maven central. Per the GH
issue (https://github.com/Azure/azure-sdk-for-java/issues/23562) it looks like
they will not be adding it back which means until DSE is updated to the latest
version we won't be able to build. So instead of waiting for a newer DSE dependency
we'll exclude azure-storage-blob in order to fix our builds since Stargate is not
making use of any of the DSE functionality that requires talking to the Azure Blob Store.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
