### PR TITLE
Add reference to c*4.0 persistence module in readme (no longer an extension)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ Stargate contains the following components:
 
     - persistence-api: Interface for working with persistence services
     - persistence-common: Utilities shared by the persistence services
-    - persistence-cassandra-3.11: Joins C* ring as coordinator only node (does not store data),
+    - persistence-cassandra-3.11: Joins C* 3.11 cluster as coordinator only node (does not store data),
     mocks C* system tables for native driver integration,
     executes requests with C* storage nodes using C* QueryHandler/QueryProcessor,
     converts internal C* objects and ResultSets to Stargate Datastore objects.
+    - persistence-cassandra-4.0: (same as above but for Cassandra 4.0)
 
 - **Authentication Services**: Responsible for authentication to Stargate
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Stargate contains the following components:
 
     - persistence-api: Interface for working with persistence services
     - persistence-common: Utilities shared by the persistence services
-    - persistence-cassandra-3.11: Joins C* 3.11 cluster as coordinator only node (does not store data),
+    - persistence-cassandra-3.11: Joins C* 3.11 cluster as coordinator-only node (does not store data),
     mocks C* system tables for native driver integration,
     executes requests with C* storage nodes using C* QueryHandler/QueryProcessor,
     converts internal C* objects and ResultSets to Stargate Datastore objects.


### PR DESCRIPTION
**What this PR does**:

Adds a reference to persistence backend impl for Cassandra 4.0; minor wording change for 3.11 backend description.

**Which issue(s) this PR fixes**:

No issue filed for README

**Checklist**
- [n/a ] Changes manually tested
- [n/a] Automated Tests added/updated
- [x ] Documentation added/updated
