### PR TITLE
fixed Cassandra predicate when searching docs with a boolean value

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/impl/BooleanCondition.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/condition/impl/BooleanCondition.java
@@ -58,9 +58,11 @@ public abstract class BooleanCondition implements BaseCondition {
     return getFilterOperation()
         .getQueryPredicate()
         .map(
-            predicate ->
-                BuiltCondition.of(
-                    QueryConstants.BOOLEAN_VALUE_COLUMN_NAME, predicate, getQueryValue()));
+            predicate -> {
+              // note that if we have numeric booleans then we need to adapt the query value
+              Object value = isNumericBooleans() ? (getQueryValue() ? 1 : 0) : getQueryValue();
+              return BuiltCondition.of(QueryConstants.BOOLEAN_VALUE_COLUMN_NAME, predicate, value);
+            });
   }
 
   /** {@inheritDoc} */

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/condition/impl/BooleanConditionTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/condition/impl/BooleanConditionTest.java
@@ -65,7 +65,7 @@ class BooleanConditionTest {
       when(filterOperation.getQueryPredicate()).thenReturn(Optional.of(eq));
 
       ImmutableBooleanCondition condition =
-          ImmutableBooleanCondition.of(filterOperation, value, true);
+          ImmutableBooleanCondition.of(filterOperation, value, false);
       Optional<BuiltCondition> result = condition.getBuiltCondition();
 
       assertThat(result)
@@ -73,6 +73,42 @@ class BooleanConditionTest {
               builtCondition -> {
                 assertThat(builtCondition.predicate()).isEqualTo(eq);
                 assertThat(builtCondition.value().get()).isEqualTo(value);
+                assertThat(builtCondition.lhs()).isEqualTo(BuiltCondition.LHS.column("bool_value"));
+              });
+    }
+
+    @Test
+    public void numericConditionsTrue() {
+      Predicate eq = Predicate.EQ;
+      when(filterOperation.getQueryPredicate()).thenReturn(Optional.of(eq));
+
+      ImmutableBooleanCondition condition =
+          ImmutableBooleanCondition.of(filterOperation, true, true);
+      Optional<BuiltCondition> result = condition.getBuiltCondition();
+
+      assertThat(result)
+          .hasValueSatisfying(
+              builtCondition -> {
+                assertThat(builtCondition.predicate()).isEqualTo(eq);
+                assertThat(builtCondition.value().get()).isEqualTo(1);
+                assertThat(builtCondition.lhs()).isEqualTo(BuiltCondition.LHS.column("bool_value"));
+              });
+    }
+
+    @Test
+    public void numericConditionsFalse() {
+      Predicate eq = Predicate.EQ;
+      when(filterOperation.getQueryPredicate()).thenReturn(Optional.of(eq));
+
+      ImmutableBooleanCondition condition =
+          ImmutableBooleanCondition.of(filterOperation, false, true);
+      Optional<BuiltCondition> result = condition.getBuiltCondition();
+
+      assertThat(result)
+          .hasValueSatisfying(
+              builtCondition -> {
+                assertThat(builtCondition.predicate()).isEqualTo(eq);
+                assertThat(builtCondition.value().get()).isEqualTo(0);
                 assertThat(builtCondition.lhs()).isEqualTo(BuiltCondition.LHS.column("bool_value"));
               });
     }


### PR DESCRIPTION
**What this PR does**:

Fix a bug when searching for docs and matching on a boolean value, in case when numeric booleans are used. Unfortunately, this bug was not caught with the integration tests and the unit test was wrong.

**Checklist**
- [x] Added integration test
- [x] Fixed unit test 
