### PR TITLE
document gRPC deadlines

### DIFF
--- a/grpc/README.md
+++ b/grpc/README.md
@@ -1,0 +1,21 @@
+# gRPC Service
+
+## Timeouts (Deadlines)
+The gRPC client (generated stub) [deadline] should be set for all your clients.
+Depending on the language, the default value may be infinite or very high. 
+For Java, it is set to 10 seconds by default.
+The deadline can be set using the `withDeadlineAfter` method:
+```
+blockingStub.withDeadlineAfter(deadlineMs, TimeUnit.MILLISECONDS);
+```
+
+For the Stargate gRPC client, we recommend setting it to at most 5 seconds.
+The reason for it is the fact that Stargate sets the Cassandra timeout to 5 seconds:
+```
+read_request_timeout_in_ms: 5000 
+```
+If the client sets the deadline to > 5 seconds, there will be a situation when a request times out on the Stargate server-side, but the client will still wait for it.
+
+[deadline]: https://grpc.io/blog/deadlines/ 
+[IdempotencyAnalyzer]: ../persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/idempotency/IdempotencyAnalyzer.java
+ 

--- a/grpc/README.md
+++ b/grpc/README.md
@@ -5,17 +5,15 @@ The gRPC client (generated stub) [deadline] should be set for all your clients.
 Depending on the language, the default value may be infinite or very high. 
 For Java, it is set to 10 seconds by default.
 The deadline can be set using the `withDeadlineAfter` method:
-```
+```java
 blockingStub.withDeadlineAfter(deadlineMs, TimeUnit.MILLISECONDS);
 ```
 
 For the Stargate gRPC client, we recommend setting it to at most 5 seconds.
 The reason for it is the fact that Stargate sets the Cassandra timeout to 5 seconds:
-```
+```yaml
 read_request_timeout_in_ms: 5000 
 ```
 If the client sets the deadline to > 5 seconds, there will be a situation when a request times out on the Stargate server-side, but the client will still wait for it.
 
 [deadline]: https://grpc.io/blog/deadlines/ 
-[IdempotencyAnalyzer]: ../persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/idempotency/IdempotencyAnalyzer.java
- 


### PR DESCRIPTION
**What this PR does**:
Add the document for the gRPC module. Focus on the documentation of client-side deadlines/timeouts
