### PR TITLE
use health-check from `BaseActivator` for graphQL module

### DIFF
--- a/testing/src/main/java/io/stargate/it/http/HealthCheckerTest.java
+++ b/testing/src/main/java/io/stargate/it/http/HealthCheckerTest.java
@@ -84,6 +84,6 @@ public class HealthCheckerTest extends BaseOsgiIntegrationTest {
     assertThat(json)
         .extracting("graphql", InstanceOfAssertFactories.MAP)
         .containsEntry("healthy", true)
-        .containsEntry("message", "Ready to process requests");
+        .containsEntry("message", "Available");
   }
 }

--- a/testing/src/main/java/io/stargate/it/http/HealthCheckerTest.java
+++ b/testing/src/main/java/io/stargate/it/http/HealthCheckerTest.java
@@ -48,6 +48,7 @@ public class HealthCheckerTest extends BaseOsgiIntegrationTest {
     ",",
     "?check=deadlocks",
     "?check=graphql",
+    "?check=grpc",
     "?check=deadlocks&check=graphql",
     "?check=datastore",
     "?check=storage"


### PR DESCRIPTION
**What this PR does**:
Use health-check from `BaseActivator` for graphQL module instead of creating a custom one.

**Which issue(s) this PR fixes**:
Fixes #1221
Fixes #1219

**Checklist**
- [x] Changes manually tested
