### PR TITLE
Fix #1231: improve WARN message for `MeterRegistryConfiguration` wrt invalid config value

### DIFF
--- a/core/src/main/java/io/stargate/core/metrics/impl/MeterRegistryConfiguration.java
+++ b/core/src/main/java/io/stargate/core/metrics/impl/MeterRegistryConfiguration.java
@@ -54,24 +54,15 @@ public final class MeterRegistryConfiguration {
                   p -> {
                     try {
                       double percentile = Double.parseDouble(p);
-                      if (percentile < 0
-                          || percentile > 1
-                          || Double.isNaN(percentile)
-                          || Double.isInfinite(percentile)) {
-                        logger.warn(
-                            "Value {} can not be used as the percentile for the http.server.request.metrics, was expecting a double [0, 1].",
-                            percentile);
-                        return DoubleStream.empty();
-                      } else {
+                      if (Double.isFinite(percentile) && percentile >= 0.0 && percentile <= 1.0) {
                         return DoubleStream.of(percentile);
                       }
-                    } catch (Exception e) {
-                      logger.warn(
-                          "Value {} can not be used as the percentile for the http.server.request.metrics, was expecting a double [0, 1].",
-                          p,
-                          e);
-                      return DoubleStream.empty();
+                    } catch (NumberFormatException e) {
                     }
+                    logger.warn(
+                        "Value \"{}\" can not be used as the percentile for the {}, was expecting a double [0, 1].",
+                        p, HTTP_PERCENTILES_PROPERTY);
+                    return DoubleStream.empty();
                   })
               .toArray();
 

--- a/core/src/main/java/io/stargate/core/metrics/impl/MeterRegistryConfiguration.java
+++ b/core/src/main/java/io/stargate/core/metrics/impl/MeterRegistryConfiguration.java
@@ -61,7 +61,8 @@ public final class MeterRegistryConfiguration {
                     }
                     logger.warn(
                         "Value \"{}\" can not be used as the percentile for the {}, was expecting a double [0, 1].",
-                        p, HTTP_PERCENTILES_PROPERTY);
+                        p,
+                        HTTP_PERCENTILES_PROPERTY);
                     return DoubleStream.empty();
                   })
               .toArray();


### PR DESCRIPTION
**What this PR does**:

Improves warning message for config value validation by `MeterRegistryConfiguration` so that:

1. Invalid value is added in quotes (helps with things like empty Strings, non-numbers)
2. Removes inclusion of stack trace: in this particular case failure is from `Double.parseDouble()`, details of which do not seem useful (but can clog output logs) -- we already indicate that value is invalid and show that value.

**Which issue(s) this PR fixes**:
Fixes #12311

**Checklist**
- [-] Changes manually tested -- covered by existing unit tests
- [-] Automated Tests added/updated -- covered by existing unit tests
- [-] Documentation added/updated -- does not change observed behavior from user perspective
