### PR TITLE
Fix #1227: replace gson-backed j[son]surfer with jackson-backed one

### DIFF
--- a/restapi/pom.xml
+++ b/restapi/pom.xml
@@ -123,8 +123,8 @@
     </dependency>
     <dependency>
       <groupId>com.github.jsurfer</groupId>
-      <artifactId>jsurfer-gson</artifactId>
-      <version>1.6.0</version>
+      <artifactId>jsurfer-jackson</artifactId>
+      <version>1.6.2</version>
     </dependency>
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -5,13 +5,18 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.ValueNode;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import com.google.common.base.Splitter;
+/*
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+*/
 import io.stargate.auth.UnauthorizedException;
 import io.stargate.web.docsapi.dao.DocumentDB;
 import io.stargate.web.docsapi.exception.ErrorCode;
@@ -34,7 +39,7 @@ import javax.inject.Inject;
 import javax.ws.rs.core.PathSegment;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.jsfr.json.JsonSurfer;
-import org.jsfr.json.JsonSurferGson;
+import org.jsfr.json.JsonSurferJackson;
 import org.jsfr.json.compiler.JsonPathCompiler;
 import org.jsfr.json.path.JsonPath;
 import org.jsfr.json.path.PathOperator;
@@ -66,16 +71,12 @@ public class DocumentService {
     this.jsonSchemaHandler = jsonSchemaHandler;
   }
 
-  private boolean isEmptyObject(Object v) {
-    return v instanceof JsonElement
-        && ((JsonElement) v).isJsonObject()
-        && ((JsonObject) v).size() == 0;
+  private boolean isEmptyObject(JsonNode v) {
+    return v.isObject() && v.isEmpty();
   }
 
-  private boolean isEmptyArray(Object v) {
-    return v instanceof JsonElement
-        && ((JsonElement) v).isJsonArray()
-        && ((JsonArray) v).size() == 0;
+  private boolean isEmptyArray(JsonNode v) {
+    return v.isArray() && v.isEmpty();
   }
 
   /**
@@ -124,7 +125,8 @@ public class DocumentService {
           .configBuilder()
           .bind(
               "$..*",
-              (v, parsingContext) -> {
+              (v0, parsingContext) -> {
+                final JsonNode v = (JsonNode) v0;
                 String fieldName = parsingContext.getCurrentFieldName();
                 if (fieldName != null && DocsApiUtils.containsIllegalSequences(fieldName)) {
                   String msg =
@@ -135,8 +137,7 @@ public class DocumentService {
                       ErrorCode.DOCS_API_GENERAL_INVALID_FIELD_NAME, msg);
                 }
 
-                if (v instanceof JsonPrimitive
-                    || v instanceof JsonNull
+                if (v.isValueNode() // scalar or explicit null
                     || isEmptyObject(v)
                     || isEmptyArray(v)) {
                   JsonPath p =
@@ -191,11 +192,11 @@ public class DocumentService {
 
                   bindMap.put("leaf", leaf);
 
-                  if (v instanceof JsonPrimitive) {
-                    JsonPrimitive value = (JsonPrimitive) v;
+                  if (v.isValueNode() && !v.isNull()) {
+                    ValueNode value = (ValueNode) v;
 
                     if (value.isNumber()) {
-                      bindMap.put("dbl_value", value.getAsDouble());
+                      bindMap.put("dbl_value", value.asDouble());
                       bindMap.put("bool_value", null);
                       bindMap.put("text_value", null);
                     } else if (value.isBoolean()) {
@@ -203,12 +204,12 @@ public class DocumentService {
                       bindMap.put(
                           "bool_value",
                           convertToBackendBooleanValue(
-                              value.getAsBoolean(), db.treatBooleansAsNumeric()));
+                              value.asBoolean(), db.treatBooleansAsNumeric()));
                       bindMap.put("text_value", null);
                     } else {
                       bindMap.put("dbl_value", null);
                       bindMap.put("bool_value", null);
-                      bindMap.put("text_value", value.getAsString());
+                      bindMap.put("text_value", value.asText());
                     }
                   } else if (isEmptyObject(v)) {
                     bindMap.put("dbl_value", null);
@@ -380,7 +381,7 @@ public class DocumentService {
       throws IOException, UnauthorizedException {
 
     DocumentDB db = dbFactory.getDocDataStoreForToken(authToken, headers);
-    JsonSurfer surfer = JsonSurferGson.INSTANCE;
+    JsonSurfer surfer = JsonSurferJackson.INSTANCE;
 
     db = maybeCreateTableAndIndexes(dbFactory, db, keyspace, collection, headers, authToken);
     List<String> idsWritten = new ArrayList<>();
@@ -470,7 +471,7 @@ public class DocumentService {
       ExecutionContext context)
       throws UnauthorizedException, ProcessingException {
     DocumentDB db = dbFactory.getDocDataStoreForToken(authToken, headers);
-    JsonSurfer surfer = JsonSurferGson.INSTANCE;
+    JsonSurfer surfer = JsonSurferJackson.INSTANCE;
 
     db = maybeCreateTableAndIndexes(dbFactory, db, keyspace, collection, headers, authToken);
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -5,18 +5,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.ValueNode;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import com.google.common.base.Splitter;
-/*
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonNull;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
-*/
 import io.stargate.auth.UnauthorizedException;
 import io.stargate.web.docsapi.dao.DocumentDB;
 import io.stargate.web.docsapi.exception.ErrorCode;


### PR DESCRIPTION
Change (as explained in #1227) is to unify JSON handling: Jackson used for everything else, gson only here.

**What this PR does**:

Replaces `jsurfer-gson` (JSON Surfer using GSON for parsing) with `jsurfer-jackson` (JSON Surfer using Jackson for parsing), to unify underlying JSON library.

**Which issue(s) this PR fixes**:
Fixes #1227

**Checklist**
- [-] Changes manually tested: Automated test coverage exists, no need to manually test.
- [-] Automated Tests added/updated: Existing test suite seems to cover all aspects; no functional changes
- [-] Documentation added/updated: Use of JsonSurfer implementation detail, not documented (nor part of API)
