### PR TITLE
Report OverloadedException as a 429 in HTTP APIs (fixes #1233)

### DIFF
--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/CassandraFetcherExceptionHandler.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/CassandraFetcherExceptionHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.graphql.schema;
+
+import graphql.execution.DataFetcherExceptionHandlerParameters;
+import graphql.execution.DataFetcherExceptionHandlerResult;
+import graphql.execution.SimpleDataFetcherExceptionHandler;
+import io.stargate.graphql.web.StargateGraphqlContext;
+import org.apache.cassandra.stargate.exceptions.OverloadedException;
+
+public class CassandraFetcherExceptionHandler extends SimpleDataFetcherExceptionHandler {
+
+  public static CassandraFetcherExceptionHandler INSTANCE = new CassandraFetcherExceptionHandler();
+
+  @Override
+  public DataFetcherExceptionHandlerResult onException(
+      DataFetcherExceptionHandlerParameters handlerParameters) {
+    if (handlerParameters.getException() instanceof OverloadedException) {
+      StargateGraphqlContext context = handlerParameters.getDataFetchingEnvironment().getContext();
+      context.setOverloaded();
+    }
+
+    return super.onException(handlerParameters);
+  }
+}

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/SchemaProcessor.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/SchemaProcessor.java
@@ -56,6 +56,7 @@ import graphql.util.TraverserContext;
 import graphql.util.TreeTransformerUtil;
 import io.stargate.db.Persistence;
 import io.stargate.db.schema.Keyspace;
+import io.stargate.graphql.schema.CassandraFetcherExceptionHandler;
 import io.stargate.graphql.schema.SchemaConstants;
 import io.stargate.graphql.schema.graphqlfirst.fetchers.deployed.FederatedEntity;
 import io.stargate.graphql.schema.graphqlfirst.fetchers.deployed.FederatedEntityFetcher;
@@ -228,7 +229,12 @@ public class SchemaProcessor {
     } else {
       graphqlBuilder = GraphQL.newGraphQL(schema);
     }
-    return graphqlBuilder.mutationExecutionStrategy(new AsyncExecutionStrategy()).build();
+    return graphqlBuilder
+        .defaultDataFetcherExceptionHandler(CassandraFetcherExceptionHandler.INSTANCE)
+        // Use parallel execution strategy for mutations (serial is default)
+        .mutationExecutionStrategy(
+            new AsyncExecutionStrategy(CassandraFetcherExceptionHandler.INSTANCE))
+        .build();
   }
 
   /**

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/StargateGraphqlContext.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/StargateGraphqlContext.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.cassandra.stargate.exceptions.OverloadedException;
 
 public class StargateGraphqlContext implements HTTPRequestHeaders {
 
@@ -96,6 +97,10 @@ public class StargateGraphqlContext implements HTTPRequestHeaders {
     return graphqlCache;
   }
 
+  /**
+   * Records the fact that at least one CQL query in the current execution failed with {@link
+   * OverloadedException}. This will be translated into an HTTP 429 error at the resource layer.
+   */
   public void setOverloaded() {
     this.overloaded = true;
   }

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/StargateGraphqlContext.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/StargateGraphqlContext.java
@@ -53,6 +53,8 @@ public class StargateGraphqlContext implements HTTPRequestHeaders {
   // For more information.
   private final BatchContext batchContext = new BatchContext();
 
+  private volatile boolean overloaded;
+
   public StargateGraphqlContext(
       HttpServletRequest request,
       AuthorizationService authorizationService,
@@ -92,6 +94,14 @@ public class StargateGraphqlContext implements HTTPRequestHeaders {
 
   public GraphqlCache getGraphqlCache() {
     return graphqlCache;
+  }
+
+  public void setOverloaded() {
+    this.overloaded = true;
+  }
+
+  public boolean isOverloaded() {
+    return overloaded;
   }
 
   /**

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/error/ErrorHandler.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/error/ErrorHandler.java
@@ -22,6 +22,7 @@ import io.stargate.auth.UnauthorizedException;
 import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
 import io.stargate.web.models.Error;
 import javax.ws.rs.core.Response;
+import org.apache.cassandra.stargate.exceptions.OverloadedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +48,12 @@ public final class ErrorHandler
               new Error(
                   "Role unauthorized for operation: " + throwable.getMessage(),
                   Response.Status.UNAUTHORIZED.getStatusCode()))
+          .build();
+    } else if (throwable instanceof OverloadedException) {
+      return Response.status(Response.Status.TOO_MANY_REQUESTS)
+          .entity(
+              new Error(
+                  "Database is overloaded", Response.Status.TOO_MANY_REQUESTS.getStatusCode()))
           .build();
     } else if (throwable instanceof NoNodeAvailableException) {
       return Response.status(Response.Status.SERVICE_UNAVAILABLE)

--- a/restapi/src/main/java/io/stargate/web/resources/RequestHandler.java
+++ b/restapi/src/main/java/io/stargate/web/resources/RequestHandler.java
@@ -25,6 +25,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.cassandra.stargate.exceptions.InvalidRequestException;
+import org.apache.cassandra.stargate.exceptions.OverloadedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,6 +45,13 @@ public class RequestHandler {
               new Error(
                   "Resource not found: " + nfe.getMessage(),
                   Response.Status.NOT_FOUND.getStatusCode()))
+          .build();
+    } catch (OverloadedException e) {
+      logger.info("Overloaded", e);
+      return Response.status(Response.Status.TOO_MANY_REQUESTS)
+          .entity(
+              new Error(
+                  "Database is overloaded", Response.Status.TOO_MANY_REQUESTS.getStatusCode()))
           .build();
     } catch (IllegalArgumentException iae) {
       logger.info("Bad request (IllegalArgumentException->BAD_REQUEST): {}", iae.getMessage());

--- a/restapi/src/main/java/io/stargate/web/resources/RequestHandler.java
+++ b/restapi/src/main/java/io/stargate/web/resources/RequestHandler.java
@@ -47,7 +47,6 @@ public class RequestHandler {
                   Response.Status.NOT_FOUND.getStatusCode()))
           .build();
     } catch (OverloadedException e) {
-      logger.info("Overloaded", e);
       return Response.status(Response.Status.TOO_MANY_REQUESTS)
           .entity(
               new Error(


### PR DESCRIPTION
**What this PR does**:
Handle Cassandra's `OverloadedException` specially in HTTP APIs in order to return a 429 response code.

**Which issue(s) this PR fixes**:
Fixes #1233

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] ~Documentation added/updated~
