### PR TITLE
use cache in AuthnTableBasedService

### DIFF
--- a/auth-table-based-service/pom.xml
+++ b/auth-table-based-service/pom.xml
@@ -16,6 +16,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+      <version>2.8.5</version>
+    </dependency>
+    <dependency>
       <groupId>io.stargate.core</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>

--- a/auth-table-based-service/src/main/java/io/stargate/auth/table/AuthnTableBasedService.java
+++ b/auth-table-based-service/src/main/java/io/stargate/auth/table/AuthnTableBasedService.java
@@ -232,20 +232,20 @@ public class AuthnTableBasedService implements AuthenticationService {
   }
 
   @Override
-  public AuthenticationSubject validateToken(String t) throws UnauthorizedException {
-    if (Strings.isNullOrEmpty(t)) {
+  public AuthenticationSubject validateToken(String token) throws UnauthorizedException {
+    if (Strings.isNullOrEmpty(token)) {
       throw new UnauthorizedException("authorization failed - missing token");
     }
 
     try {
       return (AuthenticationSubject)
           tokenCache.get(
-              t,
+              token,
               (Callable<AuthenticationSubject>)
                   () -> {
                     UUID uuid;
                     try {
-                      uuid = UUID.fromString(t);
+                      uuid = UUID.fromString(token);
                     } catch (IllegalArgumentException exception) {
                       throw new UnauthorizedException("authorization failed - bad token");
                     }
@@ -281,7 +281,7 @@ public class AuthnTableBasedService implements AuthenticationService {
                           .ttl(tokenTTL)
                           .value("username", username)
                           .value("created_timestamp", timestamp)
-                          .where("auth_token", Predicate.EQ, UUID.fromString(t))
+                          .where("auth_token", Predicate.EQ, UUID.fromString(token))
                           .build()
                           .execute(ConsistencyLevel.LOCAL_QUORUM)
                           .get();
@@ -290,7 +290,7 @@ public class AuthnTableBasedService implements AuthenticationService {
                       throw new RuntimeException(e);
                     }
 
-                    return AuthenticationSubject.of(t, username);
+                    return AuthenticationSubject.of(token, username);
                   });
     } catch (ExecutionException e) {
       throw new RuntimeException(e);

--- a/auth-table-based-service/src/main/java/io/stargate/auth/table/AuthnTableBasedService.java
+++ b/auth-table-based-service/src/main/java/io/stargate/auth/table/AuthnTableBasedService.java
@@ -45,6 +45,11 @@ public class AuthnTableBasedService implements AuthenticationService {
 
   private static final Logger logger = LoggerFactory.getLogger(AuthnTableBasedService.class);
 
+  private static final int CACHE_TTL_SECONDS =
+      Integer.getInteger("stargate.auth_tablebased.token_cache_ttl_seconds", 60);
+  private static final int CACHE_MAX_SIZE =
+      Integer.getInteger("stargate.auth_tablebased.token_cache_max_size", 100_000);
+
   private static final String AUTH_KEYSPACE =
       System.getProperty("stargate.auth_keyspace", "data_endpoint_auth");
   private static final String AUTH_TABLE = System.getProperty("stargate.auth_table", "token");
@@ -54,7 +59,10 @@ public class AuthnTableBasedService implements AuthenticationService {
       Boolean.parseBoolean(System.getProperty("stargate.auth_tablebased_init", "true"));
 
   private final Cache<String, AuthenticationSubject> tokenCache =
-      CacheBuilder.newBuilder().expireAfterWrite(Duration.ofMinutes(1)).build();
+      CacheBuilder.newBuilder()
+          .expireAfterWrite(Duration.ofSeconds(CACHE_TTL_SECONDS))
+          .maximumSize(CACHE_MAX_SIZE)
+          .build();
 
   private DataStore dataStore;
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Introduces cache in the `AuthnTableBasedService` so that token must not be validated against the data store each time.

**Which issue(s) this PR fixes**:
Fixes performance for all the calls that end-up on this path. issue #1251
