### PR TITLE
Minor renaming to improve readability of results (Cass 3.11 vs 4.0 IT)

### DIFF
--- a/persistence-cassandra-3.11/src/test/java/io/stargate/db/cassandra/Cassandra311PersistenceActivatorTest.java
+++ b/persistence-cassandra-3.11/src/test/java/io/stargate/db/cassandra/Cassandra311PersistenceActivatorTest.java
@@ -27,13 +27,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class CassandraPersistenceActivatorTest {
+class Cassandra311PersistenceActivatorTest {
   File baseDir;
 
   @BeforeEach
   void setUp() throws IOException {
     System.clearProperty("stargate.unsafe.cassandra_config_path");
-    baseDir = Files.createTempDirectory("stargate-cassandra-4.0-test").toFile();
+    baseDir = Files.createTempDirectory("stargate-cassandra-3.11-test").toFile();
   }
 
   @AfterEach
@@ -50,7 +50,7 @@ class CassandraPersistenceActivatorTest {
 
   @Test
   void testMakeConfigWithCustomConfig() throws IOException {
-    // This is the path to the default Cassandra 4.0 cassandra.yaml
+    // This is the path to the default Cassandra 3.11.8 cassandra.yaml
     // with row_cache_size_in_mb set to 1024 to test the override.
     System.setProperty(
         "stargate.unsafe.cassandra_config_path", "src/test/resources/cassandra.yaml");

--- a/persistence-cassandra-3.11/src/test/java/io/stargate/db/cassandra/impl/Cassandra311PersistenceIT.java
+++ b/persistence-cassandra-3.11/src/test/java/io/stargate/db/cassandra/impl/Cassandra311PersistenceIT.java
@@ -9,7 +9,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
-import org.apache.cassandra.config.Config;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
@@ -28,21 +27,21 @@ import org.junit.jupiter.api.BeforeAll;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-class CassandraPersistenceIT extends PersistenceTest {
+class Cassandra311PersistenceIT extends PersistenceTest {
 
   private static CassandraPersistence persistence;
   private static File baseDir;
 
   @BeforeAll
   public static void createPersistence(ClusterConnectionInfo backend) throws IOException {
-    baseDir = Files.createTempDirectory("stargate-cassandra-4.0-test").toFile();
+    baseDir = Files.createTempDirectory("stargate-cassandra-3.11-test").toFile();
     baseDir.deleteOnExit();
 
     System.setProperty("stargate.listen_address", "127.0.0.11");
     System.setProperty("stargate.cluster_name", backend.clusterName());
     System.setProperty("stargate.datacenter", backend.datacenter());
     System.setProperty("stargate.rack", backend.rack());
-    ClassLoader classLoader = CassandraPersistenceIT.class.getClassLoader();
+    ClassLoader classLoader = Cassandra311PersistenceIT.class.getClassLoader();
     URL resource = classLoader.getResource("logback-test.xml");
 
     if (resource != null) {
@@ -51,14 +50,12 @@ class CassandraPersistenceIT extends PersistenceTest {
     }
 
     persistence = new CassandraPersistence();
-    Config config = makeConfig(baseDir);
-    config.enable_materialized_views = true;
-    persistence.initialize(config);
+    persistence.initialize(makeConfig(baseDir));
   }
 
   @AfterAll
   public static void cleanup() throws IOException {
-    // TODO: persistence.destroy() - it fails with a NPE in NativeTransportService.destroy ATM
+    // TODO: persistence.destroy() - note: it gets an NPE in NativeTransportService.destroy ATM
     //    if (persistence != null) {
     //      persistence.destroy();
     //    }

--- a/persistence-cassandra-3.11/src/test/java/io/stargate/db/cassandra/impl/Cassandra311PersistenceTest.java
+++ b/persistence-cassandra-3.11/src/test/java/io/stargate/db/cassandra/impl/Cassandra311PersistenceTest.java
@@ -36,9 +36,9 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link CassandraPersistence}. See also integration tests: {@link
- * CassandraPersistenceIT}.
+ * Cassandra311PersistenceIT}.
  */
-class CassandraPersistenceTest {
+class Cassandra311PersistenceTest {
   private static final IPartitioner partitioner = Murmur3Partitioner.instance;
   private static final VersionedValue.VersionedValueFactory valueFactory =
       new VersionedValue.VersionedValueFactory(partitioner);

--- a/persistence-cassandra-4.0/src/test/java/io/stargate/db/cassandra/Cassandra40PersistenceActivatorTest.java
+++ b/persistence-cassandra-4.0/src/test/java/io/stargate/db/cassandra/Cassandra40PersistenceActivatorTest.java
@@ -27,13 +27,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class CassandraPersistenceActivatorTest {
+class Cassandra40PersistenceActivatorTest {
   File baseDir;
 
   @BeforeEach
   void setUp() throws IOException {
     System.clearProperty("stargate.unsafe.cassandra_config_path");
-    baseDir = Files.createTempDirectory("stargate-cassandra-3.11-test").toFile();
+    baseDir = Files.createTempDirectory("stargate-cassandra-4.0-test").toFile();
   }
 
   @AfterEach
@@ -50,7 +50,7 @@ class CassandraPersistenceActivatorTest {
 
   @Test
   void testMakeConfigWithCustomConfig() throws IOException {
-    // This is the path to the default Cassandra 3.11.8 cassandra.yaml
+    // This is the path to the default Cassandra 4.0 cassandra.yaml
     // with row_cache_size_in_mb set to 1024 to test the override.
     System.setProperty(
         "stargate.unsafe.cassandra_config_path", "src/test/resources/cassandra.yaml");

--- a/persistence-cassandra-4.0/src/test/java/io/stargate/db/cassandra/impl/Cassandra40PersistenceIT.java
+++ b/persistence-cassandra-4.0/src/test/java/io/stargate/db/cassandra/impl/Cassandra40PersistenceIT.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
+import org.apache.cassandra.config.Config;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
@@ -27,21 +28,21 @@ import org.junit.jupiter.api.BeforeAll;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-class CassandraPersistenceIT extends PersistenceTest {
+class Cassandra40PersistenceIT extends PersistenceTest {
 
   private static CassandraPersistence persistence;
   private static File baseDir;
 
   @BeforeAll
   public static void createPersistence(ClusterConnectionInfo backend) throws IOException {
-    baseDir = Files.createTempDirectory("stargate-cassandra-3.11-test").toFile();
+    baseDir = Files.createTempDirectory("stargate-cassandra-4.0-test").toFile();
     baseDir.deleteOnExit();
 
     System.setProperty("stargate.listen_address", "127.0.0.11");
     System.setProperty("stargate.cluster_name", backend.clusterName());
     System.setProperty("stargate.datacenter", backend.datacenter());
     System.setProperty("stargate.rack", backend.rack());
-    ClassLoader classLoader = CassandraPersistenceIT.class.getClassLoader();
+    ClassLoader classLoader = Cassandra40PersistenceIT.class.getClassLoader();
     URL resource = classLoader.getResource("logback-test.xml");
 
     if (resource != null) {
@@ -50,12 +51,14 @@ class CassandraPersistenceIT extends PersistenceTest {
     }
 
     persistence = new CassandraPersistence();
-    persistence.initialize(makeConfig(baseDir));
+    Config config = makeConfig(baseDir);
+    config.enable_materialized_views = true;
+    persistence.initialize(config);
   }
 
   @AfterAll
   public static void cleanup() throws IOException {
-    // TODO: persistence.destroy() - note: it gets an NPE in NativeTransportService.destroy ATM
+    // TODO: persistence.destroy() - it fails with a NPE in NativeTransportService.destroy ATM
     //    if (persistence != null) {
     //      persistence.destroy();
     //    }

--- a/persistence-cassandra-4.0/src/test/java/io/stargate/db/cassandra/impl/Cassandra40PersistenceTest.java
+++ b/persistence-cassandra-4.0/src/test/java/io/stargate/db/cassandra/impl/Cassandra40PersistenceTest.java
@@ -36,9 +36,9 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link CassandraPersistence}. See also integration tests: {@link
- * CassandraPersistenceIT}.
+ * Cassandra40PersistenceIT}.
  */
-class CassandraPersistenceTest {
+class Cassandra40PersistenceTest {
   private static final IPartitioner partitioner = Murmur3Partitioner.instance;
   private static final VersionedValue.VersionedValueFactory valueFactory =
       new VersionedValue.VersionedValueFactory(partitioner);


### PR DESCRIPTION
**What this PR does**:

Renames 2 integration tests for Cassandra 3.11 and 4.0 backends, to avoid name overlap: just to reduce confusion for similarly named tests (junit has no problem running them, but for new devs can be confusing).

**Which issue(s) this PR fixes**:

No separate issue filed for simple renaming.

**Checklist**
- [x] Changes manually tested -- ran tests locally
- [ ] Automated Tests added/updated -- simple renaming not needed
- [ ] Documentation added/updated -- IT test naming not documented.
