### PR TITLE
CQL: Expose backpressure options and set sensible defaults

### DIFF
--- a/cql/src/main/java/io/stargate/cql/CqlActivator.java
+++ b/cql/src/main/java/io/stargate/cql/CqlActivator.java
@@ -99,6 +99,19 @@ public class CqlActivator extends BaseActivator {
       c.rpc_address = listenAddress;
       c.native_transport_port = cqlPort;
 
+      c.native_transport_max_concurrent_connections =
+          Long.getLong("stargate.cql.native_transport_max_concurrent_connections", -1);
+      c.native_transport_max_concurrent_connections_per_ip =
+          Long.getLong("stargate.cql.native_transport_max_concurrent_connections_per_ip", -1);
+      c.native_transport_max_concurrent_requests_in_bytes =
+          Long.getLong(
+              "stargate.cql.native_transport_max_concurrent_requests_in_bytes",
+              Runtime.getRuntime().maxMemory() / 10);
+      c.native_transport_max_concurrent_requests_in_bytes_per_ip =
+          Long.getLong(
+              "stargate.cql.native_transport_max_concurrent_requests_in_bytes_per_ip",
+              Runtime.getRuntime().maxMemory() / 40);
+
       return c;
     } catch (UnknownHostException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
**What this PR does**:

Fix the initialization of the CQL module to correctly configure the built-in backpressure mechanism.

Also expose the options to limit the number of connections. They're unset by default, but we might want to set them in Astra in the future.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
