### PR TITLE
 GraphQL CQL-first: add groupBy (fixes #1170)

### DIFF
--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/SampleKeyspaces.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/SampleKeyspaces.java
@@ -224,4 +224,50 @@ public class SampleKeyspaces {
                           .build())
                   .build())
           .build();
+
+  public static final Keyspace IOT =
+      ImmutableKeyspace.builder()
+          .name("iot")
+          .addTables(
+              ImmutableTable.builder()
+                  .keyspace("iot")
+                  .name("readings")
+                  .addColumns(
+                      ImmutableColumn.builder()
+                          .keyspace("iot")
+                          .table("readings")
+                          .name("id")
+                          .type(Type.Int)
+                          .kind(Column.Kind.PartitionKey)
+                          .build(),
+                      ImmutableColumn.builder()
+                          .keyspace("iot")
+                          .table("readings")
+                          .name("year")
+                          .type(Type.Int)
+                          .kind(Column.Kind.Clustering)
+                          .build(),
+                      ImmutableColumn.builder()
+                          .keyspace("iot")
+                          .table("readings")
+                          .name("month")
+                          .type(Type.Int)
+                          .kind(Column.Kind.Clustering)
+                          .build(),
+                      ImmutableColumn.builder()
+                          .keyspace("iot")
+                          .table("readings")
+                          .name("day")
+                          .type(Type.Int)
+                          .kind(Column.Kind.Clustering)
+                          .build(),
+                      ImmutableColumn.builder()
+                          .keyspace("iot")
+                          .table("readings")
+                          .name("value")
+                          .type(Type.Float)
+                          .kind(Column.Kind.Clustering)
+                          .build())
+                  .build())
+          .build();
 }

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/QueryFetcherAggregationsTest.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/QueryFetcherAggregationsTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.graphql.schema.cqlfirst.dml.fetchers;
+
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import graphql.schema.GraphQLSchema;
+import io.stargate.db.schema.Schema;
+import io.stargate.graphql.schema.SampleKeyspaces;
+import io.stargate.graphql.schema.cqlfirst.dml.DmlTestBase;
+import java.util.Collections;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class QueryFetcherAggregationsTest extends DmlTestBase {
+  private final GraphQLSchema schema = createGraphQlSchema();
+
+  @Override
+  public Schema getCQLSchema() {
+    return Schema.create(Collections.singleton(SampleKeyspaces.IOT));
+  }
+
+  @ParameterizedTest
+  @MethodSource("successfulQueries")
+  @DisplayName("Should execute GraphQL and generate expected CQL query")
+  public void queryTest(String graphQlQuery, String expectedCqlQuery) {
+    assertQuery(String.format("query { %s }", graphQlQuery), expectedCqlQuery);
+  }
+
+  public static Arguments[] successfulQueries() {
+    return new Arguments[] {
+      arguments(
+          "readings(value: {id: 1}, groupBy: {year: true}) { "
+              + "values { _float_function(name: \"sum\", args: [\"value\"]) } }",
+          "SELECT SUM(value) FROM iot.readings WHERE id = 1 GROUP BY year"),
+      arguments(
+          "readings(value: {id: 1}, groupBy: {month: true, year: true}) { "
+              + "values { _float_function(name: \"sum\", args: [\"value\"]) } }",
+          "SELECT SUM(value) FROM iot.readings WHERE id = 1 GROUP BY year, month"),
+    };
+  }
+}

--- a/persistence-api/src/test/java/io/stargate/db/query/builder/BuiltSelectTest.java
+++ b/persistence-api/src/test/java/io/stargate/db/query/builder/BuiltSelectTest.java
@@ -11,7 +11,11 @@ import io.stargate.db.query.Predicate;
 import io.stargate.db.query.QueryType;
 import io.stargate.db.schema.Column;
 import io.stargate.db.schema.Column.Type;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -413,5 +417,18 @@ class BuiltSelectTest extends BuiltQueryTest {
         newBuilder().select().star().from(KS_NAME, "t1").perPartitionLimit().limit(456).build(),
         "SELECT * FROM ks.t1 PER PARTITION LIMIT ? LIMIT 456",
         markerFor("[per-partition-limit]", Type.Int));
+  }
+
+  @Test
+  public void testGroupBy() {
+    assertBuiltQuery(
+        newBuilder()
+            .select()
+            .star()
+            .from(KS_NAME, "t1")
+            .groupBy(Column.reference("c1"), Column.reference("c2"))
+            .build(),
+        "SELECT * FROM ks.t1 GROUP BY c1, c2",
+        emptyList());
   }
 }

--- a/testing/src/main/java/io/stargate/it/http/graphql/cqlfirst/GroupByTest.java
+++ b/testing/src/main/java/io/stargate/it/http/graphql/cqlfirst/GroupByTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.it.http.graphql.cqlfirst;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.jayway.jsonpath.JsonPath;
+import io.stargate.it.BaseOsgiIntegrationTest;
+import io.stargate.it.driver.CqlSessionExtension;
+import io.stargate.it.driver.CqlSessionSpec;
+import io.stargate.it.driver.TestKeyspace;
+import io.stargate.it.http.RestUtils;
+import io.stargate.it.storage.StargateConnectionInfo;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(CqlSessionExtension.class)
+@CqlSessionSpec(
+    initQueries = {
+      "CREATE TABLE IF NOT EXISTS readings (\n"
+          + "    id int, year int, month int, day int,\n"
+          + "    value decimal,\n"
+          + "    PRIMARY KEY (id, year, month, day)"
+          + ") WITH CLUSTERING ORDER BY (year DESC, month DESC, day DESC)\n",
+      "INSERT INTO readings (id, year, month, day, value) VALUES (1, 2021, 8, 30, 1.0)",
+      "INSERT INTO readings (id, year, month, day, value) VALUES (1, 2021, 8, 31, 2.1)",
+      "INSERT INTO readings (id, year, month, day, value) VALUES (1, 2021, 9, 1, 3.7)",
+    })
+public class GroupByTest extends BaseOsgiIntegrationTest {
+  private static CqlFirstClient CLIENT;
+
+  @BeforeAll
+  public static void setup(StargateConnectionInfo cluster) {
+    String host = cluster.seedAddress();
+    CLIENT = new CqlFirstClient(host, RestUtils.getAuthToken(host));
+  }
+
+  @Test
+  @DisplayName("Should execute query with groupBy")
+  public void groupBy(@TestKeyspace CqlIdentifier keyspaceId) {
+    Map<String, Object> response =
+        CLIENT.executeDmlQuery(
+            keyspaceId,
+            "{ readings(value: {id: 1}, groupBy: {month: true, year: true}) { "
+                + "values { "
+                + "  id"
+                + "  year "
+                + "  month "
+                + "  totalValue: _decimal_function(name: \"sum\", args: [\"value\"]) } }"
+                + "}");
+
+    assertThat(JsonPath.<Integer>read(response, "$.readings.values[0].id")).isEqualTo(1);
+    assertThat(JsonPath.<Integer>read(response, "$.readings.values[0].year")).isEqualTo(2021);
+    assertThat(JsonPath.<Integer>read(response, "$.readings.values[0].month")).isEqualTo(9);
+    assertThat(JsonPath.<String>read(response, "$.readings.values[0].totalValue")).isEqualTo("3.7");
+
+    assertThat(JsonPath.<Integer>read(response, "$.readings.values[1].id")).isEqualTo(1);
+    assertThat(JsonPath.<Integer>read(response, "$.readings.values[1].year")).isEqualTo(2021);
+    assertThat(JsonPath.<Integer>read(response, "$.readings.values[1].month")).isEqualTo(8);
+    assertThat(JsonPath.<String>read(response, "$.readings.values[1].totalValue")).isEqualTo("3.1");
+  }
+}


### PR DESCRIPTION
**What this PR does**:
Add a new `groupBy` argument to CQL-first tables queries. This is useful with aggregation functions introduced in #901.

**Which issue(s) this PR fixes**:
Fixes #1170

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
