### PR TITLE
gRPC tuning: Use direct executor instead of separate threadpool

### DIFF
--- a/grpc/src/main/java/io/stargate/grpc/impl/GrpcImpl.java
+++ b/grpc/src/main/java/io/stargate/grpc/impl/GrpcImpl.java
@@ -66,7 +66,9 @@ public class GrpcImpl {
             EXECUTOR_SIZE, GrpcUtil.getThreadFactory("grpc-stargate-executor", true));
     server =
         NettyServerBuilder.forAddress(new InetSocketAddress(listenAddress, port))
-            .executor(executor)
+            // `Persistence` operations are done asynchronously so there isn't a need for a separate
+            // thread pool for handling gRPC callbacks in `GrpcService`.
+            .directExecutor()
             .intercept(new NewConnectionInterceptor(persistence, authenticationService))
             .intercept(new MetricCollectingServerInterceptor(metrics.getMeterRegistry()))
             .addService(new GrpcService(persistence, metrics, executor))


### PR DESCRIPTION
All our operations are non-blocking so it makes sense to use the
transport threadpool directly instead of paying the extra cost of moving
the operations to another worker pool. In local testing this improves
throughput approx. 10-15%.

**Checklist**
- [X] Changes manually tested
- [ ] ~Automated Tests added/updated~
- [ ] ~Documentation added/updated~
