### PR TITLE
Fix a merge-induced formatting fail (not caught be CI)

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -1,6 +1,5 @@
 package io.stargate.web.docsapi.service;
 
-import com.datastax.oss.driver.shaded.guava.common.base.Splitter;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;


### PR DESCRIPTION
Hot fix to address formatting change that breaks build, induced by merge, somehow (not rebasing/merging from master before merging a PR).

