### PR TITLE
(WIP) Fix #1263: add "-q" option for `gsutil` to remove progress bar noise.

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -317,17 +317,18 @@ do
     sudo /sbin/ifconfig lo0 alias 127.0.0.$i;
 done
 
-# 127.0.2.1 - 127.0.2.48
-for ((i=1;i<49;i++))
-do
-    sudo /sbin/ifconfig lo0 alias 127.0.2.$i;
-done
-
 # 127.0.1.11 - 127.0.1.12
 for ((i=11;i<13;i++))
 do
     sudo /sbin/ifconfig lo0 alias 127.0.1.$i;
 done
+
+# 127.0.2.1 - 127.0.2.60
+for ((i=1;i<61;i++))
+do
+    sudo /sbin/ifconfig lo0 alias 127.0.2.$i;
+done
+
 ```
 
 Set access of the script:

--- a/cloudbuild-3_11.yaml
+++ b/cloudbuild-3_11.yaml
@@ -18,6 +18,7 @@ steps:
     waitFor: [ '-' ]
     args:
       - '-m'
+      - '-q'
       - 'rsync'
       - '-r'
       - '-x'
@@ -43,6 +44,7 @@ steps:
     waitFor: [ 'cassandra-3.11' ]
     args:
       - '-m'
+      - '-q'
       - 'rsync'
       - '-r'
       - '-x'

--- a/cloudbuild-4_0.yaml
+++ b/cloudbuild-4_0.yaml
@@ -18,6 +18,7 @@ steps:
     waitFor: [ '-' ]
     args:
       - '-m'
+      - '-q'
       - 'rsync'
       - '-r'
       - '-x'
@@ -43,6 +44,7 @@ steps:
     waitFor: [ 'cassandra-4.0' ]
     args:
       - '-m'
+      - '-q'
       - 'rsync'
       - '-r'
       - '-x'

--- a/cloudbuild-dse.yaml
+++ b/cloudbuild-dse.yaml
@@ -18,6 +18,7 @@ steps:
     waitFor: [ '-' ]
     args:
       - '-m'
+      - '-q'
       - 'rsync'
       - '-r'
       - '-x'
@@ -43,6 +44,7 @@ steps:
     waitFor: [ 'dse-6.8' ]
     args:
       - '-m'
+      - '-q'
       - 'rsync'
       - '-r'
       - '-x'


### PR DESCRIPTION
**What this PR does**:

Reduces CI test noise by adding "-q" (quiet) option. Also improves developer-doc/readme; was missing part of a range needed for Integration Tests to pass locally.

**Which issue(s) this PR fixes**:
Fixes #1263

**Checklist**
- [x] Changes manually tested (verified with CI run)
- [ ] Automated Tests added/updated - no tests for CI tests
- [ ] Documentation added/updated - no documentation for CI tests at this point
