### PR TITLE
Headers needed to correctly validate token in all envs

### DIFF
--- a/grpc/src/main/java/io/stargate/grpc/service/interceptors/NewConnectionInterceptor.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/interceptors/NewConnectionInterceptor.java
@@ -103,7 +103,8 @@ public class NewConnectionInterceptor implements ServerInterceptor {
   }
 
   private Connection newConnection(RequestInfo info) throws UnauthorizedException {
-    AuthenticationSubject authenticationSubject = authenticationService.validateToken(info.token(), info.headers());
+    AuthenticationSubject authenticationSubject =
+        authenticationService.validateToken(info.token(), info.headers());
 
     AuthenticatedUser user = authenticationSubject.asUser();
     Connection connection;

--- a/grpc/src/main/java/io/stargate/grpc/service/interceptors/NewConnectionInterceptor.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/interceptors/NewConnectionInterceptor.java
@@ -103,7 +103,7 @@ public class NewConnectionInterceptor implements ServerInterceptor {
   }
 
   private Connection newConnection(RequestInfo info) throws UnauthorizedException {
-    AuthenticationSubject authenticationSubject = authenticationService.validateToken(info.token());
+    AuthenticationSubject authenticationSubject = authenticationService.validateToken(info.token(), info.headers());
 
     AuthenticatedUser user = authenticationSubject.asUser();
     Connection connection;

--- a/grpc/src/test/java/io/stargate/grpc/service/HeadersTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/HeadersTest.java
@@ -75,7 +75,8 @@ public class HeadersTest extends BaseGrpcServiceTest {
     when(authenticationSubject.asUser()).thenReturn(authenticatedUser);
 
     AuthenticationService authenticationService = mock(AuthenticationService.class);
-    when(authenticationService.validateToken(anyString())).thenReturn(authenticationSubject);
+    when(authenticationService.validateToken(anyString(), any(Map.class)))
+        .thenReturn(authenticationSubject);
 
     startServer(new NewConnectionInterceptor(persistence, authenticationService));
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Adds headers to the token validation so that this works for all `AuthenticationService` implementations. Some implementations require extra header information for validation. We should probably deprecate the non-header version of that method.

**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [ ] ~Documentation added/updated~
