### PR TITLE
(WIP) Fix #1271: remove inclusion of stack trace for logging

### DIFF
--- a/auth-jwt-service/src/main/java/io/stargate/auth/jwt/AuthnJwtService.java
+++ b/auth-jwt-service/src/main/java/io/stargate/auth/jwt/AuthnJwtService.java
@@ -77,7 +77,8 @@ public class AuthnJwtService implements AuthenticationService {
     try {
       roleName = getRoleForJWT(claimsSet.getJSONObjectClaim(CLAIMS_FIELD));
     } catch (IllegalArgumentException | ParseException e) {
-      logger.info("Failed to parse claim from JWT", e);
+      logger.info(
+          "Failed to parse claim from JWT ({}): {}", e.getClass().getName(), e.getMessage());
       throw new UnauthorizedException("Failed to parse claim from JWT", e);
     }
 
@@ -122,10 +123,11 @@ public class AuthnJwtService implements AuthenticationService {
     try {
       claimsSet = jwtProcessor.process(token, null); // context is an optional param so passing null
     } catch (ParseException | JOSEException e) {
-      logger.info("Failed to process JWT", e);
+      logger.info("Failed to process JWT ({}): {}", e.getClass().getName(), e.getMessage());
       throw new UnauthorizedException("Failed to process JWT: " + e.getMessage(), e);
     } catch (BadJOSEException badJOSEException) {
-      logger.info("Tried to validate invalid JWT", badJOSEException);
+      logger.info(
+          "Tried to validate invalid JWT (BadJOSEException): {}", badJOSEException.getMessage());
       throw new UnauthorizedException(
           "Invalid JWT: " + badJOSEException.getMessage(), badJOSEException);
     }

--- a/graphqlapi/pom.xml
+++ b/graphqlapi/pom.xml
@@ -101,21 +101,17 @@
       <artifactId>jetty-servlet</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.javassist</groupId>
-      <artifactId>javassist</artifactId>
-      <version>3.27.0-GA</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlets</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <version>3.27.0-GA</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/restapi/src/main/java/io/stargate/web/resources/RequestHandler.java
+++ b/restapi/src/main/java/io/stargate/web/resources/RequestHandler.java
@@ -38,7 +38,7 @@ public class RequestHandler {
     } catch (ErrorCodeRuntimeException errorCodeException) {
       return errorCodeException.getResponse();
     } catch (NotFoundException nfe) {
-      logger.info("Resource not found", nfe);
+      logger.info("Resource not found (NotFoundException->NOT_FOUND): {}", nfe.getMessage());
       return Response.status(Response.Status.NOT_FOUND)
           .entity(
               new Error(
@@ -46,21 +46,23 @@ public class RequestHandler {
                   Response.Status.NOT_FOUND.getStatusCode()))
           .build();
     } catch (IllegalArgumentException iae) {
-      logger.info("Bad request", iae);
+      logger.info("Bad request (IllegalArgumentException->BAD_REQUEST): {}", iae.getMessage());
       return Response.status(Response.Status.BAD_REQUEST)
           .entity(
               new Error(
                   "Bad request: " + iae.getMessage(), Response.Status.BAD_REQUEST.getStatusCode()))
           .build();
     } catch (InvalidRequestException ire) {
-      logger.info("Bad request", ire);
+      logger.info("Bad request (InvalidRequestException->BAD_REQUEST): {}", ire.getMessage());
       return Response.status(Response.Status.BAD_REQUEST)
           .entity(
               new Error(
                   "Bad request: " + ire.getMessage(), Response.Status.BAD_REQUEST.getStatusCode()))
           .build();
     } catch (UnauthorizedException uae) {
-      logger.info("Role unauthorized for operation", uae);
+      logger.info(
+          "Role unauthorized for operation (UnauthorizedException->UNAUTHORIZED): {}",
+          uae.getMessage());
       return Response.status(Response.Status.UNAUTHORIZED)
           .entity(
               new Error(
@@ -69,7 +71,9 @@ public class RequestHandler {
           .build();
     } catch (ExecutionException ee) {
       if (ee.getCause() instanceof org.apache.cassandra.stargate.exceptions.UnauthorizedException) {
-        logger.info("Role unauthorized for operation", ee);
+        logger.info(
+            "Role unauthorized for operation (ExecutionException/UnauthorizedException->UNAUTHORIZED): {}",
+            ee.getMessage());
         return Response.status(Response.Status.UNAUTHORIZED)
             .entity(
                 new Error(
@@ -77,7 +81,9 @@ public class RequestHandler {
                     Response.Status.UNAUTHORIZED.getStatusCode()))
             .build();
       } else if (ee.getCause() instanceof InvalidRequestException) {
-        logger.info("Bad request", ee);
+        logger.info(
+            "Bad request (ExecutionException/InvalidRequestException->BAD_REQUEST): {}",
+            ee.getMessage());
         return Response.status(Response.Status.BAD_REQUEST)
             .entity(
                 new Error(
@@ -85,6 +91,7 @@ public class RequestHandler {
             .build();
       }
 
+      // Do log underlying Exception with Stack trace since this is unknown, unexpected:
       logger.error("Error when executing request", ee);
       return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
           .entity(
@@ -93,6 +100,7 @@ public class RequestHandler {
                   Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()))
           .build();
     } catch (Exception e) {
+      // Do log underlying Exception with Stack trace since this is unknown, unexpected:
       logger.error("Error when executing request", e);
       return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
           .entity(


### PR DESCRIPTION
**What this PR does**:

Main thing is to remove inclusion of stack trace for selected cases of logging, where trace adds no valuable information (where we know from context, exception type and message all pertitent info).

Also removes one extra Maven dependency that mvn build complained about.

**Which issue(s) this PR fixes**:
Fixes #1271

**Checklist**
- [x] Changes manually tested -- check out CI logs to verify (compared to earlier)
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
