### PR TITLE
Fix #1273: add explicit handling of Assume-sourced exceptions for Integ tests

### DIFF
--- a/persistence-test/src/main/java/io/stargate/it/storage/ExternalStorage.java
+++ b/persistence-test/src/main/java/io/stargate/it/storage/ExternalStorage.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+import org.opentest4j.TestAbortedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -138,8 +139,21 @@ public class ExternalStorage extends ExternalResource<ClusterSpec, ExternalStora
   @Override
   public void handleTestExecutionException(ExtensionContext context, Throwable throwable)
       throws Throwable {
-    LOG.warn("Error in {}", context.getUniqueId(), throwable);
-    getResource(context).ifPresent(Cluster::markError);
+    // 24-Sep-2021, tatu: When using "assume()" methods for dynamic disabling/skipping
+    //    of tests, we still get an exception -- but those are not fails, need to filter out
+    //    so that we do not unnecessarily dump output logs
+    if ((throwable instanceof TestAbortedException) // opentest4j
+        || "AssumptionViolatedException".equals(throwable.getClass().getSimpleName()) // junit
+    ) {
+      LOG.warn(
+          "Test skipped due to failed Assume in {}: {}",
+          context.getUniqueId(),
+          throwable.getMessage());
+      getResource(context).ifPresent(Cluster::markSkippedTest);
+    } else {
+      LOG.warn("Test error in {}", context.getUniqueId(), throwable);
+      getResource(context).ifPresent(Cluster::markErroredTest);
+    }
     throw throwable;
   }
 
@@ -149,6 +163,7 @@ public class ExternalStorage extends ExternalResource<ClusterSpec, ExternalStora
     private final UUID id = UUID.randomUUID();
     private final ClusterSpec spec;
     private final AtomicInteger errorsInTest = new AtomicInteger(0);
+    private final AtomicInteger skippedTests = new AtomicInteger(0);
 
     protected Cluster(ClusterSpec spec) {
       this.spec = spec;
@@ -163,8 +178,16 @@ public class ExternalStorage extends ExternalResource<ClusterSpec, ExternalStora
 
     public abstract String infoForTestLog();
 
-    private void markError() {
+    private void markSkippedTest() {
+      skippedTests.incrementAndGet();
+    }
+
+    private void markErroredTest() {
       errorsInTest.incrementAndGet();
+    }
+
+    public int testsSkipped() {
+      return skippedTests.get();
     }
 
     public int errorsDetected() {
@@ -306,12 +329,18 @@ public class ExternalStorage extends ExternalResource<ClusterSpec, ExternalStora
     private void dumpLogs() {
       final int errors = errorsDetected();
       if (errors == 0) {
-        LOG.info("Skipping dumping storage cluster ({}) logs: no test failures.", infoForTestLog());
+        LOG.info(
+            "Skipping dumping storage cluster ({}) logs: no test failures ({} tests skipped).",
+            infoForTestLog(),
+            testsSkipped());
         return;
       }
 
       LOG.warn(
-          "Dumping storage cluster ({}) logs due to {}} test failures.", infoForTestLog(), errors);
+          "Dumping storage cluster ({}) logs due to {} test failures ({} tests skipped).",
+          infoForTestLog(),
+          errors,
+          testsSkipped());
       Path configDir = configDirectory();
 
       final Collection<File> files =

--- a/testing/src/main/java/io/stargate/it/cql/AuthorizationCommandInterceptorTest.java
+++ b/testing/src/main/java/io/stargate/it/cql/AuthorizationCommandInterceptorTest.java
@@ -96,7 +96,7 @@ public class AuthorizationCommandInterceptorTest extends BaseOsgiIntegrationTest
 
   @Test
   public void grantDescribeAllKeyspaces() {
-    assumeTrue(backend.isDse());
+    assumeTrue(backend.isDse(), "Test disabled when not running on DSE");
     assertThat(addedMsgs("GRANT DESCRIBE ON ALL KEYSPACES TO 'auth_user1'"))
         .containsExactly(
             "cassandra, ALLOW, ACCESS, [DESCRIBE], AuthorizedResource{kind=KEYSPACE, keyspace=*, element=*}, auth_user1");
@@ -104,7 +104,7 @@ public class AuthorizationCommandInterceptorTest extends BaseOsgiIntegrationTest
 
   @Test
   public void revokeDescribeKeyspace() {
-    assumeTrue(backend.isDse());
+    assumeTrue(backend.isDse(), "Test disabled when not running on DSE");
     assertThat(removedMsgs("REVOKE DESCRIBE ON KEYSPACE auth_keyspace2 FROM 'auth_user1'"))
         .containsExactly(
             "cassandra, ALLOW, ACCESS, [DESCRIBE], AuthorizedResource{kind=KEYSPACE, keyspace=auth_keyspace2, element=*}, auth_user1");
@@ -112,7 +112,7 @@ public class AuthorizationCommandInterceptorTest extends BaseOsgiIntegrationTest
 
   @Test
   public void grantTruncateAllTables() {
-    assumeTrue(backend.isDse());
+    assumeTrue(backend.isDse(), "Test disabled when not running on DSE");
     assertThat(addedMsgs("GRANT TRUNCATE ON ALL TABLES IN KEYSPACE auth_keyspace2 TO 'auth_user1'"))
         .containsExactly(
             "cassandra, ALLOW, ACCESS, [TRUNCATE], AuthorizedResource{kind=TABLE, keyspace=auth_keyspace2, element=*}, auth_user1");
@@ -148,7 +148,7 @@ public class AuthorizationCommandInterceptorTest extends BaseOsgiIntegrationTest
 
   @Test
   public void restrictUpdate() {
-    assumeTrue(backend.isDse());
+    assumeTrue(backend.isDse(), "Test disabled when not running on DSE");
     assertThat(addedMsgs("RESTRICT UPDATE on table3 TO 'auth_user1'"))
         .containsExactly(
             "cassandra, DENY, ACCESS, [UPDATE], AuthorizedResource{kind=TABLE, keyspace=auth_keyspace2, element=table3}, auth_user1");
@@ -156,7 +156,7 @@ public class AuthorizationCommandInterceptorTest extends BaseOsgiIntegrationTest
 
   @Test
   public void unrestrictUpdate() {
-    assumeTrue(backend.isDse());
+    assumeTrue(backend.isDse(), "Test disabled when not running on DSE");
     assertThat(removedMsgs("UNRESTRICT UPDATE on auth_keyspace2.table3 FROM 'auth_user1'"))
         .containsExactly(
             "cassandra, DENY, ACCESS, [UPDATE], AuthorizedResource{kind=TABLE, keyspace=auth_keyspace2, element=table3}, auth_user1");
@@ -178,7 +178,7 @@ public class AuthorizationCommandInterceptorTest extends BaseOsgiIntegrationTest
 
   @Test
   public void grantAuthorizeTruncate(ClusterConnectionInfo backend) {
-    assumeTrue(backend.isDse());
+    assumeTrue(backend.isDse(), "Test disabled when not running on DSE");
     assertThat(addedMsgs("GRANT AUTHORIZE FOR SELECT, TRUNCATE on table3 TO 'auth_user1'"))
         .containsExactly(
             "cassandra, ALLOW, AUTHORITY, [SELECT, TRUNCATE], AuthorizedResource{kind=TABLE, keyspace=auth_keyspace2, element=table3}, auth_user1");
@@ -186,7 +186,7 @@ public class AuthorizationCommandInterceptorTest extends BaseOsgiIntegrationTest
 
   @Test
   public void revokeAuthorizeTruncate() {
-    assumeTrue(backend.isDse());
+    assumeTrue(backend.isDse(), "Test disabled when not running on DSE");
     assertThat(removedMsgs("REVOKE AUTHORIZE FOR SELECT, TRUNCATE on table3 FROM 'auth_user1'"))
         .containsExactly(
             "cassandra, ALLOW, AUTHORITY, [SELECT, TRUNCATE], AuthorizedResource{kind=TABLE, keyspace=auth_keyspace2, element=table3}, auth_user1");

--- a/testing/src/main/java/io/stargate/it/cql/BatchStatementTest.java
+++ b/testing/src/main/java/io/stargate/it/cql/BatchStatementTest.java
@@ -228,8 +228,7 @@ public class BatchStatementTest extends BaseOsgiIntegrationTest {
   @Test
   @DisplayName("Should execute counter batch")
   public void counterTest(CqlSession session, TestInfo name) {
-    assumeTrue(backend.supportsCounters());
-
+    assumeTrue(backend.supportsCounters(), "Test disabled if backend does not support counters()");
     BatchStatementBuilder builder = BatchStatement.builder(DefaultBatchType.COUNTER);
 
     for (int i = 1; i <= 3; i++) {

--- a/testing/src/main/java/io/stargate/it/cql/GeoTypeTest.java
+++ b/testing/src/main/java/io/stargate/it/cql/GeoTypeTest.java
@@ -61,7 +61,7 @@ public class GeoTypeTest extends BaseOsgiIntegrationTest {
 
   @BeforeAll
   public static void validateAssumptions(ClusterConnectionInfo backend) {
-    Assumptions.assumeTrue(backend.isDse());
+    Assumptions.assumeTrue(backend.isDse(), "Test disabled when not running on DSE");
   }
 
   @BeforeAll

--- a/testing/src/main/java/io/stargate/it/http/docsapi/CollectionsResourceIntTest.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/CollectionsResourceIntTest.java
@@ -224,7 +224,7 @@ public class CollectionsResourceIntTest extends BaseOsgiIntegrationTest {
     public void upgrade(@TestKeyspace CqlIdentifier keyspace, CqlSession cqlSession)
         throws IOException {
       // ignore if not dse
-      assumeTrue(isDse);
+      assumeTrue(isDse, "Test disabled when not running on DSE");
 
       // Create a brand new collection, it should already have SAI so drop it before calling
       String newColl = "{\"name\": \"newcollection\"}";
@@ -245,7 +245,7 @@ public class CollectionsResourceIntTest extends BaseOsgiIntegrationTest {
     @Test
     public void upgradeNotAvailable(@TestKeyspace CqlIdentifier keyspace) throws IOException {
       // ignore if not dse
-      assumeTrue(isDse);
+      assumeTrue(isDse, "Test disabled when not running on DSE");
 
       // Create a brand new collection, it should already have SAI so it requires no upgrade
       String newColl = "{\"name\": \"othercollection\"}";


### PR DESCRIPTION
**What this PR does**:

Adds explicit handling of 2 kinds of exceptions junit throws to implement "Assume" functionality (ability to dynamically skip tests) -- here used to ignore non-applicable tests for some persistence backends.
Before change these are considered test failures wrt dumping out `ExternalStorage` buffered logs; after change they are not considered test failures any more. Although there are only 12 of such cases for C*4.0 backend, they are responsible for probably 30,000 more log lines.

**Which issue(s) this PR fixes**:
Fixes #1273

**Checklist**
- [x] Changes manually tested - will verify changes to logging
- [ ] Automated Tests added/updated - yes, tests were changed (although not in the sense asked here maybe)
- [ ] Documentation added/updated - no documentation about ITs.
