### PR TITLE
Fix #1276: handle Jackson-originating parsing fails more gracefully

### DIFF
--- a/persistence-api/src/main/java/io/stargate/db/AuthenticatedUser.java
+++ b/persistence-api/src/main/java/io/stargate/db/AuthenticatedUser.java
@@ -16,7 +16,6 @@
 package io.stargate.db;
 
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
-import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap.Builder;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -77,7 +76,8 @@ public interface AuthenticatedUser extends Serializable {
     private static final String ROLE = "stargate.auth.subject.role";
     private static final String EXTERNAL = "stargate.auth.subject.fromExternalAuth";
 
-    private static void encode(Builder<String, ByteBuffer> map, String key, String value) {
+    private static void encode(
+        ImmutableMap.Builder<String, ByteBuffer> map, String key, String value) {
       if (value == null) {
         return;
       }
@@ -87,7 +87,7 @@ public interface AuthenticatedUser extends Serializable {
     }
 
     public static Map<String, ByteBuffer> serialize(AuthenticatedUser user) {
-      Builder<String, ByteBuffer> map = ImmutableMap.builder();
+      ImmutableMap.Builder<String, ByteBuffer> map = ImmutableMap.builder();
       encode(map, TOKEN, user.token());
       encode(map, ROLE, user.name());
 
@@ -112,7 +112,7 @@ public interface AuthenticatedUser extends Serializable {
         throw new IllegalStateException("token and roleName must be provided");
       }
 
-      Builder<String, String> map = ImmutableMap.builder();
+      ImmutableMap.Builder<String, String> map = ImmutableMap.builder();
       for (Entry<String, ByteBuffer> e : customPayload.entrySet()) {
         String key = e.getKey();
         if (key.startsWith(CUSTOM_PAYLOAD_NAME_PREFIX)) {

--- a/persistence-api/src/main/java/io/stargate/db/schema/Table.java
+++ b/persistence-api/src/main/java/io/stargate/db/schema/Table.java
@@ -62,6 +62,7 @@ public abstract class Table extends AbstractTable {
   }
 
   @Value.Default
+  @Override
   public String comment() {
     return "";
   }

--- a/persistence-api/src/test/java/io/stargate/db/limiter/AsyncRateLimiterTest.java
+++ b/persistence-api/src/test/java/io/stargate/db/limiter/AsyncRateLimiterTest.java
@@ -135,6 +135,7 @@ public class AsyncRateLimiterTest {
   }
 
   private static class AcquireAndExecute implements Tester {
+    @Override
     public long startTasks(
         AsyncRateLimiter limiter, int permitsPerCall, int count, AtomicLong counter) {
       long start;

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/DsePersistenceActivator.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/DsePersistenceActivator.java
@@ -2,7 +2,6 @@ package io.stargate.db.dse;
 
 import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
-import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList.Builder;
 import io.stargate.auth.AuthorizationProcessor;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.core.activator.BaseActivator;
@@ -204,7 +203,7 @@ public class DsePersistenceActivator extends BaseActivator {
 
   @Override
   protected List<ServicePointer<?>> dependencies() {
-    Builder<ServicePointer<?>> dependencies = ImmutableList.builder();
+    ImmutableList.Builder<ServicePointer<?>> dependencies = ImmutableList.builder();
     dependencies.add(metrics);
 
     if (AUTHZ_PROCESSOR_ID != null) {

--- a/persistence-test/src/main/java/io/stargate/it/storage/ExternalStorage.java
+++ b/persistence-test/src/main/java/io/stargate/it/storage/ExternalStorage.java
@@ -18,7 +18,6 @@ package io.stargate.it.storage;
 import com.datastax.oss.driver.api.core.Version;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
-import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList.Builder;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -207,7 +206,7 @@ public class ExternalStorage extends ExternalResource<ClusterSpec, ExternalStora
 
       this.ccm = builder.build();
 
-      Builder<StorageNode> nodes = ImmutableList.builder();
+      ImmutableList.Builder<StorageNode> nodes = ImmutableList.builder();
       for (int i = 0; i < numNodes; i++) {
         nodes.add(new StorageNode(this, i));
       }

--- a/restapi/src/main/java/io/stargate/web/docsapi/exception/RuntimeExceptionPassHandlingStrategy.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/exception/RuntimeExceptionPassHandlingStrategy.java
@@ -1,5 +1,6 @@
 package io.stargate.web.docsapi.exception;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.jsfr.json.ErrorHandlingStrategy;
 import org.jsfr.json.ParsingContext;
 
@@ -8,16 +9,20 @@ public class RuntimeExceptionPassHandlingStrategy implements ErrorHandlingStrate
 
   @Override
   public void handleParsingException(Exception e) {
-    if (e instanceof RuntimeException) {
-      throw (RuntimeException) e;
-    }
-    throw new RuntimeException(e.getLocalizedMessage(), e);
+    throw translate(e);
   }
 
   @Override
   public void handleExceptionFromListener(Exception e, ParsingContext context) {
+    throw translate(e);
+  }
+
+  private RuntimeException translate(Exception e) {
     if (e instanceof RuntimeException) {
       throw (RuntimeException) e;
+    }
+    if (e instanceof JsonProcessingException) { // from Jackson
+      throw new UncheckedJacksonException((JsonProcessingException) e);
     }
     throw new RuntimeException(e.getLocalizedMessage(), e);
   }

--- a/restapi/src/main/java/io/stargate/web/docsapi/exception/UncheckedJacksonException.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/exception/UncheckedJacksonException.java
@@ -1,0 +1,18 @@
+package io.stargate.web.docsapi.exception;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+/**
+ * Simple unchecked exception wrapper needed to expose Jackson-originated exceptions via JsonSurfer
+ * handlers, while making it easier to recognize the underlying type (usually to avoid things like
+ * printing stack traces for "well-known" failure types).
+ */
+public class UncheckedJacksonException extends RuntimeException {
+  public UncheckedJacksonException(JsonProcessingException cause) {
+    super(cause);
+  }
+
+  public UncheckedJacksonException(String messsage, JsonProcessingException cause) {
+    super(messsage, cause);
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/QueryExecutor.java
@@ -18,7 +18,6 @@ package io.stargate.web.docsapi.service;
 import static io.stargate.web.docsapi.service.CombinedPagingState.EXHAUSTED_PAGE_STATE;
 
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
-import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList.Builder;
 import hu.akarnokd.rxjava3.operators.ExpandStrategy;
 import hu.akarnokd.rxjava3.operators.FlowableTransformers;
 import hu.akarnokd.rxjava3.operators.Flowables;
@@ -280,7 +279,7 @@ public class QueryExecutor {
       DocProperty property, Comparator<DocProperty> comparator, List<Column> keyColumns) {
     Row row = property.row();
     String id = row.getString(QueryConstants.KEY_COLUMN_NAME);
-    Builder<String> docKey = ImmutableList.builder();
+    ImmutableList.Builder<String> docKey = ImmutableList.builder();
     for (Column c : keyColumns) {
       docKey.add(Objects.requireNonNull(row.getString(c.name())));
     }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/ComparingValueFilterOperation.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/filter/operation/ComparingValueFilterOperation.java
@@ -49,6 +49,7 @@ public interface ComparingValueFilterOperation extends ValueFilterOperation {
   }
 
   /** {@inheritDoc} */
+  @Override
   default boolean test(String dbValue, String filterValue) {
     if (null == dbValue && !compareNulls()) {
       return false;
@@ -59,6 +60,7 @@ public interface ComparingValueFilterOperation extends ValueFilterOperation {
   }
 
   /** {@inheritDoc} */
+  @Override
   default boolean test(Double dbValue, Number filterValue) {
     if (null == dbValue && !compareNulls()) {
       return false;
@@ -70,6 +72,7 @@ public interface ComparingValueFilterOperation extends ValueFilterOperation {
   }
 
   /** {@inheritDoc} */
+  @Override
   default boolean test(Boolean dbValue, Boolean filterValue) {
     if (null == dbValue && !compareNulls()) {
       return false;

--- a/restapi/src/main/java/io/stargate/web/resources/v2/RowsResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/RowsResource.java
@@ -24,7 +24,6 @@ import io.stargate.auth.SourceAPI;
 import io.stargate.auth.TypedKeyValue;
 import io.stargate.core.util.ByteBufferUtils;
 import io.stargate.db.ImmutableParameters;
-import io.stargate.db.ImmutableParameters.Builder;
 import io.stargate.db.Parameters;
 import io.stargate.db.datastore.ResultSet;
 import io.stargate.db.query.BoundDMLQuery;
@@ -667,7 +666,8 @@ public class RowsResource {
 
     UnaryOperator<Parameters> parametersModifier =
         p -> {
-          Builder parametersBuilder = ImmutableParameters.builder().pageSize(pageSize);
+          ImmutableParameters.Builder parametersBuilder =
+              ImmutableParameters.builder().pageSize(pageSize);
           if (pageState != null) {
             parametersBuilder.pagingState(pageState);
           }


### PR DESCRIPTION
**What this PR does**:

Adds bit more explicit handling for JSON parsing fails for Document API, by wrapping jackson's exceptions at JsonSurfer handler, then taking bit different action: logging only at WARN (or maybe in future, not at all?), and not adding stack trace.
Leaving ERROR/stack-trace for "unknown" fails.

**Which issue(s) this PR fixes**:
Fixes #1276

**Checklist**

- [x] Changes manually tested - checked that log output changed to omit Stack trace for cases found
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated

Changed output on C*4.0 CI logs:

```
Step #4 - "cassandra-4.0": INFO  [Exec Stream Pumper] 2021-09-27 15:56:25,902 ProcessRunner.java:78 - stargate6-0> WARN  [jersey-server-managed-async-executor-31] 2021-09-27 15:56:25,902 DocsShredder.java:208 - Invalid JSON payload encountered during JSON read (com.fasterxml.jackson.core.io.JsonEOFException): Unexpected end-of-input within/between Object entries
Step #4 - "cassandra-4.0": INFO  [Exec Stream Pumper] 2021-09-27 15:56:25,902 ProcessRunner.java:78 - stargate6-0>  at [Source: (String)"{"malformed":"; line: 1, column: 14]
[NEXT LOG LINE, NOT STACK TRACE]
```

