### PR TITLE
relates to #1280: make resources and services singletons in Docs API

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/CollectionsResource.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/CollectionsResource.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -55,6 +56,7 @@ import javax.ws.rs.core.Response;
     tags = {"documents"})
 @Path("/v2/namespaces/{namespace-id: [a-zA-Z_0-9]+}")
 @Produces(MediaType.APPLICATION_JSON)
+@Singleton
 public class CollectionsResource {
 
   @Inject private Db db;

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -60,6 +61,7 @@ import org.slf4j.LoggerFactory;
     consumes = MediaType.APPLICATION_JSON,
     tags = {"documents"})
 @Produces(MediaType.APPLICATION_JSON)
+@Singleton
 public class DocumentResourceV2 {
   private static final Logger logger = LoggerFactory.getLogger(DocumentResourceV2.class);
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/JsonSchemaResource.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/JsonSchemaResource.java
@@ -14,6 +14,7 @@ import io.stargate.web.resources.Db;
 import io.stargate.web.resources.RequestHandler;
 import io.swagger.annotations.*;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
@@ -27,6 +28,7 @@ import org.glassfish.jersey.server.ManagedAsync;
     tags = {"documents"})
 @Path("/v2/namespaces/{namespace-id: [a-zA-Z_0-9]+}")
 @Produces(MediaType.APPLICATION_JSON)
+@Singleton
 public class JsonSchemaResource {
   @Inject private Db dbFactory;
   @Inject private ObjectMapper mapper;

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/NamespacesResource.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/NamespacesResource.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -66,6 +67,7 @@ import org.apache.cassandra.stargate.db.ConsistencyLevel;
     tags = {"documents"})
 @Path("/v2/schemas/namespaces")
 @Produces(MediaType.APPLICATION_JSON)
+@Singleton
 public class NamespacesResource {
 
   @Inject private Db db;

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/ReactiveDocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/ReactiveDocumentResourceV2.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
@@ -60,6 +61,7 @@ import org.glassfish.jersey.server.ManagedAsync;
     consumes = MediaType.APPLICATION_JSON,
     tags = {"documents"})
 @Produces(MediaType.APPLICATION_JSON)
+@Singleton
 public class ReactiveDocumentResourceV2 {
 
   private static final String WHERE_DESCRIPTION =

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocsApiComponentsBinder.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocsApiComponentsBinder.java
@@ -1,32 +1,29 @@
 package io.stargate.web.docsapi.service;
 
-import io.dropwizard.setup.Environment;
 import io.stargate.web.docsapi.service.query.DocumentSearchService;
 import io.stargate.web.docsapi.service.query.ExpressionParser;
 import io.stargate.web.docsapi.service.query.condition.ConditionParser;
+import javax.inject.Singleton;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 
 public class DocsApiComponentsBinder extends AbstractBinder {
-  private final Environment environment;
-
-  public DocsApiComponentsBinder(Environment environment) {
-    this.environment = environment;
-  }
 
   protected void configure() {
+    // configuration
     DocsApiConfiguration conf = DocsApiConfiguration.DEFAULT;
-    bind(conf).to(DocsApiConfiguration.class);
-    bind(TimeSource.SYSTEM).to(TimeSource.class);
+    bind(conf).to(DocsApiConfiguration.class).in(Singleton.class);
+    bind(TimeSource.SYSTEM).to(TimeSource.class).in(Singleton.class);
 
-    bindAsContract(JsonConverter.class);
-    bindAsContract(DocsShredder.class);
-    bindAsContract(DocsSchemaChecker.class);
-    bindAsContract(DocumentService.class);
-    bindAsContract(CollectionService.class);
-    bindAsContract(JsonSchemaHandler.class);
-    bindAsContract(ExpressionParser.class);
-    bindAsContract(ConditionParser.class);
-    bindAsContract(DocumentSearchService.class);
-    bindAsContract(ReactiveDocumentService.class);
+    // services
+    bindAsContract(JsonConverter.class).in(Singleton.class);
+    bindAsContract(DocsShredder.class).in(Singleton.class);
+    bindAsContract(DocsSchemaChecker.class).in(Singleton.class);
+    bindAsContract(DocumentService.class).in(Singleton.class);
+    bindAsContract(CollectionService.class).in(Singleton.class);
+    bindAsContract(JsonSchemaHandler.class).in(Singleton.class);
+    bindAsContract(ExpressionParser.class).in(Singleton.class);
+    bindAsContract(ConditionParser.class).in(Singleton.class);
+    bindAsContract(DocumentSearchService.class).in(Singleton.class);
+    bindAsContract(ReactiveDocumentService.class).in(Singleton.class);
   }
 }

--- a/restapi/src/main/java/io/stargate/web/impl/RestApiServer.java
+++ b/restapi/src/main/java/io/stargate/web/impl/RestApiServer.java
@@ -156,7 +156,7 @@ public class RestApiServer extends Application<ApplicationConfiguration> {
     environment.jersey().register(UserDefinedTypesResource.class);
 
     // Documents API
-    environment.jersey().register(new DocsApiComponentsBinder(environment));
+    environment.jersey().register(new DocsApiComponentsBinder());
     environment.jersey().register(ReactiveDocumentResourceV2.class);
     environment.jersey().register(DocumentResourceV2.class);
     environment.jersey().register(JsonSchemaResource.class);


### PR DESCRIPTION
**What this PR does**:
Makes resources and the services/components of the Docs API singletons (other modules are affected as well!). Seems this was not the case until now and new object for a resource and all dependencies were recreated on each request.

The only way to make resources a singleton is that `@Singleton` annotation. For the services I took the explicit scope definition in the binder, though most likely both `@Singleton` and HK2 `@Service` would work as well.

In my perf tests I did not see considerable improvements though, by I am sure the fix works as the new profiling session I took does not contain the blocking stack I had before. 

I would apply this to other modules in additional PR, let's see if this is fine and if tests run green.

**Which issue(s) this PR fixes**:
Partly fixes #1280, other modules have to be patched as well.

**Checklist**
- [x] Changes manually tested
- ~[ ] Automated Tests added/updated~
- ~[ ] Documentation added/updated~
