### PR TITLE
Fix #1284: rename v1 endpoint classes, Server->RestApiServer

### DIFF
--- a/restapi/README-docsapi.md
+++ b/restapi/README-docsapi.md
@@ -15,8 +15,8 @@ online docs]).
 
 [RestApiActivator] manages the starting and stopping of the OSGi bundle, which runs both the Documents API and the more general REST API.
 
-[Server] is the HTTP server that exposes the Documents API services as REST resources. It is implemented with
-[Dropwizard](https://www.dropwizard.io/en/latest/).
+[RestApiServer] is the HTTP server that exposes both the REST and Documents API services as REST resources.
+It is implemented with [Dropwizard](https://www.dropwizard.io/en/latest/).
 
 ### Authentication
 
@@ -24,7 +24,7 @@ Every HTTP request performs token-based authentication. This is done by calling 
 This method will either return an instance of [DocumentDB] which can be used for querying the underlying persistence and contains the authenticated subject,
 or will throw an `UnauthorizedException` causing the appropriate 4XX response to be returned.
 
-The DocumentDB gets stored in a simple cache (using [Caffeine](https://github.com/ben-manes/caffeine)) so the subsequent requests within a short
+The `DocumentDB` gets stored in a simple cache (using [Caffeine](https://github.com/ben-manes/caffeine)) so the subsequent requests within a short
 time-frame using the same token and headers need not suffer performance penalties.
 
 ### Resources
@@ -186,7 +186,7 @@ It is expected when adding or changing features that both Unit tests and Integra
 [NamespaceResourceIntTest]: testing/src/main/java/io/stargate/it/http/docsapi/NamespaceResourceIntTest.java
 [ReactiveDocumentResource]: src/main/java/io/stargate/web/docsapi/resources/ReactiveDocumentResourceV2.java
 [RestApiActivator]: src/main/java/io/stargate/web/RestApiActivator.java
-[Server]: src/main/java/io/stargate/web/impl/Server.java
+[RestApiServer]: src/main/java/io/stargate/web/impl/RestApiServer.java
 
 [Stargate online docs]: https://stargate.io/docs/stargate/1.0/quickstart/quick_start-document.html
 [Json schema docs]: https://json-schema.org/

--- a/restapi/src/main/java/io/stargate/web/RestApiActivator.java
+++ b/restapi/src/main/java/io/stargate/web/RestApiActivator.java
@@ -21,7 +21,7 @@ import io.stargate.core.activator.BaseActivator;
 import io.stargate.core.metrics.api.HttpMetricsTagProvider;
 import io.stargate.core.metrics.api.Metrics;
 import io.stargate.db.datastore.DataStoreFactory;
-import io.stargate.web.impl.WebImpl;
+import io.stargate.web.impl.RestApiRunner;
 import java.util.Arrays;
 import java.util.List;
 import org.slf4j.Logger;
@@ -32,7 +32,7 @@ public class RestApiActivator extends BaseActivator {
 
   public static final String MODULE_NAME = "restapi";
   private static final Logger logger = LoggerFactory.getLogger(RestApiActivator.class);
-  private final WebImpl web = new WebImpl();
+  private final RestApiRunner runner = new RestApiRunner();
   private final ServicePointer<AuthenticationService> authenticationService =
       ServicePointer.create(
           AuthenticationService.class,
@@ -53,16 +53,17 @@ public class RestApiActivator extends BaseActivator {
 
   @Override
   protected ServiceAndProperties createService() {
-    web.setAuthenticationService(authenticationService.get());
-    web.setMetrics(metrics.get());
-    web.setHttpMetricsTagProvider(httpTagProvider.get());
-    web.setAuthorizationService(authorizationService.get());
-    web.setDataStoreFactory(dataStoreFactory.get());
+    runner.setAuthenticationService(authenticationService.get());
+    runner.setMetrics(metrics.get());
+    runner.setHttpMetricsTagProvider(httpTagProvider.get());
+    runner.setAuthorizationService(authorizationService.get());
+    runner.setDataStoreFactory(dataStoreFactory.get());
     try {
-      this.web.start();
+      runner.start();
     } catch (Exception e) {
-      logger.error("Failed", e);
+      logger.error("Running RestApiRunner Failed", e);
     }
+    // Shouldn't we return something to avoid add logging for "service null"?
     return null;
   }
 

--- a/restapi/src/main/java/io/stargate/web/impl/RestApiRunner.java
+++ b/restapi/src/main/java/io/stargate/web/impl/RestApiRunner.java
@@ -21,17 +21,13 @@ import io.stargate.core.metrics.api.HttpMetricsTagProvider;
 import io.stargate.core.metrics.api.Metrics;
 import io.stargate.db.datastore.DataStoreFactory;
 
-public class WebImpl {
+public class RestApiRunner {
 
   private AuthenticationService authenticationService;
   private AuthorizationService authorizationService;
   private Metrics metrics;
   private HttpMetricsTagProvider httpMetricsTagProvider;
   private DataStoreFactory dataStoreFactory;
-
-  public AuthenticationService getAuthenticationService() {
-    return authenticationService;
-  }
 
   public void setAuthenticationService(AuthenticationService authenticationService) {
     this.authenticationService = authenticationService;
@@ -41,24 +37,12 @@ public class WebImpl {
     this.authorizationService = authorizationService;
   }
 
-  public Metrics getMetrics() {
-    return metrics;
-  }
-
   public void setMetrics(Metrics metrics) {
     this.metrics = metrics;
   }
 
   public void setHttpMetricsTagProvider(HttpMetricsTagProvider httpMetricsTagProvider) {
     this.httpMetricsTagProvider = httpMetricsTagProvider;
-  }
-
-  public AuthorizationService getAuthorizationService() {
-    return authorizationService;
-  }
-
-  public DataStoreFactory getDataStoreFactory() {
-    return dataStoreFactory;
   }
 
   public void setDataStoreFactory(DataStoreFactory dataStoreFactory) {

--- a/restapi/src/main/java/io/stargate/web/impl/RestApiServer.java
+++ b/restapi/src/main/java/io/stargate/web/impl/RestApiServer.java
@@ -38,12 +38,12 @@ import io.stargate.web.docsapi.resources.JsonSchemaResource;
 import io.stargate.web.docsapi.resources.NamespacesResource;
 import io.stargate.web.docsapi.resources.ReactiveDocumentResourceV2;
 import io.stargate.web.docsapi.service.DocsApiComponentsBinder;
-import io.stargate.web.resources.ColumnResource;
 import io.stargate.web.resources.Db;
 import io.stargate.web.resources.HealthResource;
-import io.stargate.web.resources.KeyspaceResource;
-import io.stargate.web.resources.RowResource;
-import io.stargate.web.resources.TableResource;
+import io.stargate.web.resources.v1.ColumnResource;
+import io.stargate.web.resources.v1.KeyspaceResource;
+import io.stargate.web.resources.v1.RowResource;
+import io.stargate.web.resources.v1.TableResource;
 import io.stargate.web.resources.v2.RowsResource;
 import io.stargate.web.resources.v2.schemas.ColumnsResource;
 import io.stargate.web.resources.v2.schemas.IndexesResource;
@@ -67,7 +67,8 @@ import org.glassfish.jersey.server.ServerProperties;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
-public class Server extends Application<ApplicationConfiguration> {
+/** DropWizard {@code Application} that will serve both REST (v1, v2) and Document API endpoints. */
+public class RestApiServer extends Application<ApplicationConfiguration> {
 
   private final AuthenticationService authenticationService;
   private final AuthorizationService authorizationService;
@@ -75,7 +76,7 @@ public class Server extends Application<ApplicationConfiguration> {
   private final HttpMetricsTagProvider httpMetricsTagProvider;
   private final DataStoreFactory dataStoreFactory;
 
-  public Server(
+  public RestApiServer(
       AuthenticationService authenticationService,
       AuthorizationService authorizationService,
       Metrics metrics,
@@ -136,16 +137,22 @@ public class Server extends Application<ApplicationConfiguration> {
                 bind(environment.getObjectMapper()).to(ObjectMapper.class);
               }
             });
-    environment.jersey().register(KeyspaceResource.class);
-    environment.jersey().register(TableResource.class);
-    environment.jersey().register(RowResource.class);
-    environment.jersey().register(ColumnResource.class);
+
+    // General healthcheck endpoint
     environment.jersey().register(HealthResource.class);
-    environment.jersey().register(RowsResource.class);
-    environment.jersey().register(TablesResource.class);
-    environment.jersey().register(KeyspacesResource.class);
+
+    // Rest API V1 endpoints (legacy):
+    environment.jersey().register(ColumnResource.class);
+    environment.jersey().register(KeyspaceResource.class);
+    environment.jersey().register(RowResource.class);
+    environment.jersey().register(TableResource.class);
+
+    // Rest API V2 endpoints
     environment.jersey().register(ColumnsResource.class);
     environment.jersey().register(IndexesResource.class);
+    environment.jersey().register(KeyspacesResource.class);
+    environment.jersey().register(RowsResource.class);
+    environment.jersey().register(TablesResource.class);
     environment.jersey().register(UserDefinedTypesResource.class);
 
     // Documents API
@@ -156,6 +163,7 @@ public class Server extends Application<ApplicationConfiguration> {
     environment.jersey().register(CollectionsResource.class);
     environment.jersey().register(NamespacesResource.class);
 
+    // Swagger endpoints
     environment.jersey().register(ApiListingResource.class);
     environment.jersey().register(SwaggerSerializers.class);
 

--- a/restapi/src/main/java/io/stargate/web/impl/RestApiServer.java
+++ b/restapi/src/main/java/io/stargate/web/impl/RestApiServer.java
@@ -164,9 +164,6 @@ public class RestApiServer extends Application<ApplicationConfiguration> {
     environment.jersey().register(NamespacesResource.class);
 
     // Swagger endpoints
-    environment.jersey().register(ApiListingResource.class);
-    environment.jersey().register(SwaggerSerializers.class);
-
     environment
         .jersey()
         .register(
@@ -176,8 +173,10 @@ public class RestApiServer extends Application<ApplicationConfiguration> {
                 bind(FrameworkUtil.getBundle(RestApiActivator.class)).to(Bundle.class);
               }
             });
-
+    environment.jersey().register(SwaggerSerializers.class);
+    environment.jersey().register(ApiListingResource.class);
     environment.jersey().register(SwaggerUIResource.class);
+
     enableCors(environment);
 
     ResourceMetricsEventListener metricListener =

--- a/restapi/src/main/java/io/stargate/web/impl/WebImpl.java
+++ b/restapi/src/main/java/io/stargate/web/impl/WebImpl.java
@@ -66,8 +66,8 @@ public class WebImpl {
   }
 
   public void start() throws Exception {
-    Server server =
-        new Server(
+    RestApiServer server =
+        new RestApiServer(
             this.authenticationService,
             this.authorizationService,
             this.metrics,

--- a/restapi/src/main/java/io/stargate/web/resources/AuthenticatedDB.java
+++ b/restapi/src/main/java/io/stargate/web/resources/AuthenticatedDB.java
@@ -26,8 +26,8 @@ import javax.ws.rs.NotFoundException;
 
 public class AuthenticatedDB {
 
-  private DataStore dataStore;
-  private AuthenticationSubject authenticationSubject;
+  private final DataStore dataStore;
+  private final AuthenticationSubject authenticationSubject;
 
   public AuthenticatedDB(DataStore dataStore, AuthenticationSubject authenticationSubject) {
     this.dataStore = dataStore;
@@ -68,16 +68,8 @@ public class AuthenticatedDB {
     return dataStore;
   }
 
-  public void setDataStore(DataStore dataStore) {
-    this.dataStore = dataStore;
-  }
-
   public AuthenticationSubject getAuthenticationSubject() {
     return authenticationSubject;
-  }
-
-  public void setAuthenticationSubject(AuthenticationSubject authenticationSubject) {
-    this.authenticationSubject = authenticationSubject;
   }
 
   /**

--- a/restapi/src/main/java/io/stargate/web/resources/v1/ColumnResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v1/ColumnResource.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.stargate.web.resources;
+package io.stargate.web.resources.v1;
 
 import static io.stargate.web.docsapi.resources.RequestToHeadersMapper.getAllHeaders;
 
@@ -22,38 +22,33 @@ import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.entity.ResourceKind;
 import io.stargate.db.schema.Column;
-import io.stargate.db.schema.Column.ColumnType;
 import io.stargate.db.schema.Column.Kind;
-import io.stargate.db.schema.Column.Order;
-import io.stargate.db.schema.Column.Type;
+import io.stargate.db.schema.ImmutableColumn;
 import io.stargate.db.schema.Keyspace;
 import io.stargate.db.schema.Table;
-import io.stargate.web.models.ClusteringExpression;
 import io.stargate.web.models.ColumnDefinition;
+import io.stargate.web.models.ColumnUpdate;
 import io.stargate.web.models.Error;
-import io.stargate.web.models.PrimaryKey;
 import io.stargate.web.models.SuccessResponse;
-import io.stargate.web.models.TableAdd;
-import io.stargate.web.models.TableOptions;
-import io.stargate.web.models.TableResponse;
+import io.stargate.web.resources.AuthenticatedDB;
+import io.stargate.web.resources.Db;
+import io.stargate.web.resources.RequestHandler;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -66,195 +61,37 @@ import org.apache.cassandra.stargate.db.ConsistencyLevel;
     produces = MediaType.APPLICATION_JSON,
     consumes = MediaType.APPLICATION_JSON,
     tags = {"schemas"})
-@Path("/v1/keyspaces/{keyspaceName}/tables")
-@Consumes(MediaType.APPLICATION_JSON)
+@Path("/v1/keyspaces/{keyspaceName}/tables/{tableName}/columns")
 @Produces(MediaType.APPLICATION_JSON)
-public class TableResource {
-  @Inject private Db db;
+public class ColumnResource {
+
+  private Db db;
+
+  @Inject
+  public ColumnResource(Db db) {
+    this.db = db;
+  }
 
   @Timed
   @GET
   @ApiOperation(
-      value = "Return all tables",
-      notes = "Retrieve all tables in a specific keyspace.",
-      response = String.class,
+      value = "Retrieve all columns",
+      notes = "Return all columns for a specified table.",
+      response = ColumnDefinition.class,
       responseContainer = "List")
   @ApiResponses(
       value = {
         @ApiResponse(
             code = 200,
             message = "OK",
-            response = String.class,
+            response = ColumnDefinition.class,
             responseContainer = "List"),
         @ApiResponse(code = 400, message = "Bad request", response = Error.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
         @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
         @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
       })
-  public Response listAllTables(
-      @ApiParam(
-              value =
-                  "The token returned from the authorization endpoint. Use this token in each request.",
-              required = true)
-          @HeaderParam("X-Cassandra-Token")
-          String token,
-      @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
-          @PathParam("keyspaceName")
-          final String keyspaceName,
-      @Context HttpServletRequest request) {
-    return RequestHandler.handle(
-        () -> {
-          AuthenticatedDB authenticatedDB =
-              db.getRestDataStoreForToken(token, getAllHeaders(request));
-
-          List<String> tableNames =
-              authenticatedDB.getTables(keyspaceName).stream()
-                  .map(Table::name)
-                  .collect(Collectors.toList());
-
-          db.getAuthorizationService()
-              .authorizeSchemaRead(
-                  authenticatedDB.getAuthenticationSubject(),
-                  Collections.singletonList(keyspaceName),
-                  tableNames,
-                  SourceAPI.REST,
-                  ResourceKind.TABLE);
-
-          return Response.status(Response.Status.OK).entity(tableNames).build();
-        });
-  }
-
-  @Timed
-  @POST
-  @ApiOperation(
-      value = "Add a table",
-      notes = "Add a table in a specific keyspace.",
-      response = SuccessResponse.class,
-      code = 201)
-  @ApiResponses(
-      value = {
-        @ApiResponse(code = 201, message = "Created", response = SuccessResponse.class),
-        @ApiResponse(code = 400, message = "Bad request", response = Error.class),
-        @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
-        @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
-        @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
-      })
-  public Response addTable(
-      @ApiParam(
-              value =
-                  "The token returned from the authorization endpoint. Use this token in each request.",
-              required = true)
-          @HeaderParam("X-Cassandra-Token")
-          String token,
-      @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
-          @PathParam("keyspaceName")
-          final String keyspaceName,
-      @ApiParam(value = "Table object that needs to be added to the keyspace", required = true)
-          @NotNull
-          final TableAdd tableAdd,
-      @Context HttpServletRequest request) {
-    return RequestHandler.handle(
-        () -> {
-          AuthenticatedDB authenticatedDB =
-              db.getRestDataStoreForToken(token, getAllHeaders(request));
-          Keyspace keyspace = authenticatedDB.getDataStore().schema().keyspace(keyspaceName);
-          if (keyspace == null) {
-            return Response.status(Response.Status.BAD_REQUEST)
-                .entity(
-                    new Error(
-                        "keyspace does not exists", Response.Status.BAD_REQUEST.getStatusCode()))
-                .build();
-          }
-
-          String tableName = tableAdd.getName();
-          if (tableName == null || tableName.equals("")) {
-            return Response.status(Response.Status.BAD_REQUEST)
-                .entity(new Error("table name must be provided"))
-                .build();
-          }
-
-          PrimaryKey primaryKey = tableAdd.getPrimaryKey();
-          if (primaryKey == null) {
-            return Response.status(Response.Status.BAD_REQUEST)
-                .entity(new Error("primary key must be provided"))
-                .build();
-          }
-
-          List<Column> columns = new ArrayList<>();
-          TableOptions options = tableAdd.getTableOptions();
-          for (ColumnDefinition colDef : tableAdd.getColumnDefinitions()) {
-            String columnName = colDef.getName();
-            if (columnName == null || columnName.equals("")) {
-              return Response.status(Response.Status.BAD_REQUEST)
-                  .entity(
-                      new Error(
-                          "column name must be provided",
-                          Response.Status.BAD_REQUEST.getStatusCode()))
-                  .build();
-            }
-
-            Kind kind = Converters.getColumnKind(colDef, primaryKey);
-            ColumnType type = Type.fromCqlDefinitionOf(keyspace, colDef.getTypeDefinition());
-            Order order;
-            try {
-              order = kind == Kind.Clustering ? Converters.getColumnOrder(colDef, options) : null;
-            } catch (Exception e) {
-              return Response.status(Response.Status.BAD_REQUEST)
-                  .entity(
-                      new Error(
-                          "Unable to create table options " + e.getMessage(),
-                          Response.Status.BAD_REQUEST.getStatusCode()))
-                  .build();
-            }
-            columns.add(Column.create(columnName, kind, type, order));
-          }
-
-          db.getAuthorizationService()
-              .authorizeSchemaWrite(
-                  authenticatedDB.getAuthenticationSubject(),
-                  keyspaceName,
-                  tableName,
-                  Scope.CREATE,
-                  SourceAPI.REST,
-                  ResourceKind.TABLE);
-
-          int ttl = 0;
-          if (options != null && options.getDefaultTimeToLive() != null) {
-            ttl = options.getDefaultTimeToLive();
-          }
-
-          authenticatedDB
-              .getDataStore()
-              .queryBuilder()
-              .create()
-              .table(keyspaceName, tableName)
-              .ifNotExists(tableAdd.getIfNotExists())
-              .column(columns)
-              .withDefaultTTL(ttl)
-              .build()
-              .execute(ConsistencyLevel.LOCAL_QUORUM)
-              .get();
-          return Response.status(Response.Status.CREATED).entity(new SuccessResponse()).build();
-        });
-  }
-
-  @Timed
-  @GET
-  @ApiOperation(
-      value = "Return a table",
-      notes = "Retrieve data for a single table in a specific keyspace.",
-      response = Table.class)
-  @ApiResponses(
-      value = {
-        @ApiResponse(code = 200, message = "OK", response = Table.class),
-        @ApiResponse(code = 400, message = "Bad request", response = Error.class),
-        @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
-        @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
-        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
-        @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
-      })
-  @Path("/{tableName}")
-  public Response getOneTable(
+  public Response listAllColumns(
       @ApiParam(
               value =
                   "The token returned from the authorization endpoint. Use this token in each request.",
@@ -280,67 +117,40 @@ public class TableResource {
                   SourceAPI.REST,
                   ResourceKind.TABLE);
 
-          Table tableMetadata = authenticatedDB.getTable(keyspaceName, tableName);
+          final Table tableMetadata = authenticatedDB.getTable(keyspaceName, tableName);
 
-          final List<ColumnDefinition> columnDefinitions =
+          List<ColumnDefinition> collect =
               tableMetadata.columns().stream()
                   .map(
                       (col) -> {
-                        ColumnType type = col.type();
+                        //noinspection ConstantConditions
+                        String type = col.type() != null ? col.type().cqlDefinition() : null;
                         return new ColumnDefinition(
-                            col.name(),
-                            type == null ? null : type.cqlDefinition(),
-                            col.kind() == Kind.Static);
+                            col.name(), type, col.kind() == Column.Kind.Static);
                       })
                   .collect(Collectors.toList());
 
-          final List<String> partitionKey =
-              tableMetadata.partitionKeyColumns().stream()
-                  .map(Column::name)
-                  .collect(Collectors.toList());
-          final List<String> clusteringKey =
-              tableMetadata.clusteringKeyColumns().stream()
-                  .map(Column::name)
-                  .collect(Collectors.toList());
-          final List<ClusteringExpression> clusteringExpression =
-              tableMetadata.clusteringKeyColumns().stream()
-                  .map(
-                      (col) ->
-                          new ClusteringExpression(
-                              col.name(), Objects.requireNonNull(col.order()).name()))
-                  .collect(Collectors.toList());
-
-          final PrimaryKey primaryKey = new PrimaryKey(partitionKey, clusteringKey);
-          final int ttl = 0; // no way to get this without querying schema currently
-          final TableOptions tableOptions = new TableOptions(ttl, clusteringExpression);
-
-          return Response.ok(
-                  new TableResponse(
-                      tableMetadata.name(),
-                      keyspaceName,
-                      columnDefinitions,
-                      primaryKey,
-                      tableOptions))
-              .build();
+          return Response.status(Response.Status.OK).entity(collect).build();
         });
   }
 
   @Timed
-  @DELETE
+  @POST
   @ApiOperation(
-      value = "Delete a table",
-      notes = "Delete a single table in the specified keyspace.")
+      value = "Add a column",
+      notes = "Add a single column to a table.",
+      response = SuccessResponse.class,
+      code = 201)
   @ApiResponses(
       value = {
-        @ApiResponse(code = 204, message = "No Content"),
+        @ApiResponse(code = 201, message = "Created", response = SuccessResponse.class),
         @ApiResponse(code = 400, message = "Bad request", response = Error.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
         @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
-        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 409, message = "Conflict", response = Error.class),
         @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
       })
-  @Path("/{tableName}")
-  public Response deleteTable(
+  public Response addColumn(
       @ApiParam(
               value =
                   "The token returned from the authorization endpoint. Use this token in each request.",
@@ -353,6 +163,149 @@ public class TableResource {
       @ApiParam(value = "Name of the table to use for the request.", required = true)
           @PathParam("tableName")
           final String tableName,
+      @ApiParam(value = "", required = true) @NotNull final ColumnDefinition columnDefinition,
+      @Context HttpServletRequest request) {
+    return RequestHandler.handle(
+        () -> {
+          AuthenticatedDB authenticatedDB =
+              db.getRestDataStoreForToken(token, getAllHeaders(request));
+          Keyspace keyspace = authenticatedDB.getKeyspace(keyspaceName);
+          if (keyspace == null) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(
+                    new Error(
+                        String.format("keyspace '%s' not found", keyspaceName),
+                        Response.Status.BAD_REQUEST.getStatusCode()))
+                .build();
+          }
+
+          String name = columnDefinition.getName();
+          Kind kind = Kind.Regular;
+          if (columnDefinition.getIsStatic()) {
+            kind = Kind.Static;
+          }
+
+          Column column =
+              ImmutableColumn.builder()
+                  .name(name)
+                  .kind(kind)
+                  .type(
+                      Column.Type.fromCqlDefinitionOf(
+                          keyspace, columnDefinition.getTypeDefinition()))
+                  .build();
+
+          db.getAuthorizationService()
+              .authorizeSchemaWrite(
+                  authenticatedDB.getAuthenticationSubject(),
+                  keyspaceName,
+                  tableName,
+                  Scope.ALTER,
+                  SourceAPI.REST,
+                  ResourceKind.TABLE);
+
+          authenticatedDB
+              .getDataStore()
+              .queryBuilder()
+              .alter()
+              .table(keyspaceName, tableName)
+              .addColumn(column)
+              .build()
+              .execute(ConsistencyLevel.LOCAL_QUORUM)
+              .get();
+
+          return Response.status(Response.Status.CREATED).entity(new SuccessResponse()).build();
+        });
+  }
+
+  @Timed
+  @GET
+  @ApiOperation(
+      value = "Retrieve a column",
+      notes = "Return a single column specification in a specific table.",
+      response = ColumnDefinition.class)
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 200, message = "OK", response = ColumnDefinition.class),
+        @ApiResponse(code = 400, message = "Bad request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
+      })
+  @Path("/{columnName}")
+  public Response getOneColumn(
+      @ApiParam(
+              value =
+                  "The token returned from the authorization endpoint. Use this token in each request.",
+              required = true)
+          @HeaderParam("X-Cassandra-Token")
+          String token,
+      @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
+          @PathParam("keyspaceName")
+          final String keyspaceName,
+      @ApiParam(value = "Name of the table to use for the request.", required = true)
+          @PathParam("tableName")
+          final String tableName,
+      @ApiParam(value = "Name of the column to use for the request.", required = true)
+          @PathParam("columnName")
+          final String columnName,
+      @Context HttpServletRequest request) {
+    return RequestHandler.handle(
+        () -> {
+          AuthenticatedDB authenticatedDB =
+              db.getRestDataStoreForToken(token, getAllHeaders(request));
+          db.getAuthorizationService()
+              .authorizeSchemaRead(
+                  authenticatedDB.getAuthenticationSubject(),
+                  Collections.singletonList(keyspaceName),
+                  Collections.singletonList(tableName),
+                  SourceAPI.REST,
+                  ResourceKind.TABLE);
+
+          final Table tableMetadata = authenticatedDB.getTable(keyspaceName, tableName);
+          final Column col = tableMetadata.column(columnName);
+          if (col == null) {
+            return Response.status(Response.Status.NOT_FOUND)
+                .entity(new Error(String.format("column '%s' not found in table", columnName)))
+                .build();
+          }
+
+          //noinspection ConstantConditions
+          String type = col.type() != null ? col.type().cqlDefinition() : null;
+          return Response.status(Response.Status.OK)
+              .entity(new ColumnDefinition(col.name(), type, col.kind() == Kind.Static))
+              .build();
+        });
+  }
+
+  @Timed
+  @DELETE
+  @ApiOperation(value = "Delete a column", notes = "Delete a single column in a specific table.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 204, message = "No Content"),
+        @ApiResponse(code = 400, message = "Bad request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
+      })
+  @Path("/{columnName}")
+  public Response deleteColumn(
+      @ApiParam(
+              value =
+                  "The token returned from the authorization endpoint. Use this token in each request.",
+              required = true)
+          @HeaderParam("X-Cassandra-Token")
+          String token,
+      @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
+          @PathParam("keyspaceName")
+          final String keyspaceName,
+      @ApiParam(value = "Name of the table to use for the request.", required = true)
+          @PathParam("tableName")
+          final String tableName,
+      @ApiParam(value = "Name of the column to use for the request.", required = true)
+          @PathParam("columnName")
+          final String columnName,
       @Context HttpServletRequest request) {
     return RequestHandler.handle(
         () -> {
@@ -364,20 +317,80 @@ public class TableResource {
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
                   tableName,
-                  Scope.DROP,
+                  Scope.ALTER,
                   SourceAPI.REST,
                   ResourceKind.TABLE);
 
           authenticatedDB
               .getDataStore()
               .queryBuilder()
-              .drop()
+              .alter()
               .table(keyspaceName, tableName)
+              .dropColumn(columnName)
               .build()
               .execute(ConsistencyLevel.LOCAL_QUORUM)
               .get();
 
-          return Response.status(Response.Status.NO_CONTENT).build();
+          return Response.status(Response.Status.NO_CONTENT).entity(new SuccessResponse()).build();
+        });
+  }
+
+  @Timed
+  @PUT
+  @ApiOperation(
+      value = "Update a column",
+      notes = "Update a single column in a specific table.",
+      response = SuccessResponse.class)
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 200, message = "OK", response = SuccessResponse.class),
+        @ApiResponse(code = 400, message = "Bad request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
+      })
+  @Path("/{columnName}")
+  public Response updateColumn(
+      @ApiParam(
+              value =
+                  "The token returned from the authorization endpoint. Use this token in each request.",
+              required = true)
+          @HeaderParam("X-Cassandra-Token")
+          String token,
+      @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
+          @PathParam("keyspaceName")
+          final String keyspaceName,
+      @ApiParam(value = "Name of the table to use for the request.", required = true)
+          @PathParam("tableName")
+          final String tableName,
+      @PathParam("columnName") final String columnName,
+      @ApiParam(value = "", required = true) @NotNull final ColumnUpdate columnUpdate,
+      @Context HttpServletRequest request) {
+    return RequestHandler.handle(
+        () -> {
+          AuthenticatedDB authenticatedDB =
+              db.getRestDataStoreForToken(token, getAllHeaders(request));
+
+          db.getAuthorizationService()
+              .authorizeSchemaWrite(
+                  authenticatedDB.getAuthenticationSubject(),
+                  keyspaceName,
+                  tableName,
+                  Scope.ALTER,
+                  SourceAPI.REST,
+                  ResourceKind.TABLE);
+
+          authenticatedDB
+              .getDataStore()
+              .queryBuilder()
+              .alter()
+              .table(keyspaceName, tableName)
+              .renameColumn(columnName, columnUpdate.getNewName())
+              .build()
+              .execute()
+              .get();
+          return Response.status(Response.Status.OK).entity(new SuccessResponse()).build();
         });
   }
 }

--- a/restapi/src/main/java/io/stargate/web/resources/v1/KeyspaceResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v1/KeyspaceResource.java
@@ -13,13 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.stargate.web.resources;
+package io.stargate.web.resources.v1;
 
 import static io.stargate.web.docsapi.resources.RequestToHeadersMapper.getAllHeaders;
 
 import com.codahale.metrics.annotation.Timed;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.entity.ResourceKind;
+import io.stargate.web.resources.AuthenticatedDB;
+import io.stargate.web.resources.Db;
+import io.stargate.web.resources.RequestHandler;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;

--- a/restapi/src/main/java/io/stargate/web/resources/v1/RowResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v1/RowResource.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.stargate.web.resources;
+package io.stargate.web.resources.v1;
 
 import static io.stargate.web.docsapi.resources.RequestToHeadersMapper.getAllHeaders;
 
@@ -45,6 +45,10 @@ import io.stargate.web.models.RowUpdate;
 import io.stargate.web.models.Rows;
 import io.stargate.web.models.RowsResponse;
 import io.stargate.web.models.SuccessResponse;
+import io.stargate.web.resources.AuthenticatedDB;
+import io.stargate.web.resources.Converters;
+import io.stargate.web.resources.Db;
+import io.stargate.web.resources.RequestHandler;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;

--- a/restapi/src/main/java/io/stargate/web/resources/v1/TableResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v1/TableResource.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.stargate.web.resources;
+package io.stargate.web.resources.v1;
 
 import static io.stargate.web.docsapi.resources.RequestToHeadersMapper.getAllHeaders;
 
@@ -22,30 +22,42 @@ import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.entity.ResourceKind;
 import io.stargate.db.schema.Column;
+import io.stargate.db.schema.Column.ColumnType;
 import io.stargate.db.schema.Column.Kind;
-import io.stargate.db.schema.ImmutableColumn;
+import io.stargate.db.schema.Column.Order;
+import io.stargate.db.schema.Column.Type;
 import io.stargate.db.schema.Keyspace;
 import io.stargate.db.schema.Table;
+import io.stargate.web.models.ClusteringExpression;
 import io.stargate.web.models.ColumnDefinition;
-import io.stargate.web.models.ColumnUpdate;
 import io.stargate.web.models.Error;
+import io.stargate.web.models.PrimaryKey;
 import io.stargate.web.models.SuccessResponse;
+import io.stargate.web.models.TableAdd;
+import io.stargate.web.models.TableOptions;
+import io.stargate.web.models.TableResponse;
+import io.stargate.web.resources.AuthenticatedDB;
+import io.stargate.web.resources.Converters;
+import io.stargate.web.resources.Db;
+import io.stargate.web.resources.RequestHandler;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -58,37 +70,32 @@ import org.apache.cassandra.stargate.db.ConsistencyLevel;
     produces = MediaType.APPLICATION_JSON,
     consumes = MediaType.APPLICATION_JSON,
     tags = {"schemas"})
-@Path("/v1/keyspaces/{keyspaceName}/tables/{tableName}/columns")
+@Path("/v1/keyspaces/{keyspaceName}/tables")
+@Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
-public class ColumnResource {
-
-  private Db db;
-
-  @Inject
-  public ColumnResource(Db db) {
-    this.db = db;
-  }
+public class TableResource {
+  @Inject private Db db;
 
   @Timed
   @GET
   @ApiOperation(
-      value = "Retrieve all columns",
-      notes = "Return all columns for a specified table.",
-      response = ColumnDefinition.class,
+      value = "Return all tables",
+      notes = "Retrieve all tables in a specific keyspace.",
+      response = String.class,
       responseContainer = "List")
   @ApiResponses(
       value = {
         @ApiResponse(
             code = 200,
             message = "OK",
-            response = ColumnDefinition.class,
+            response = String.class,
             responseContainer = "List"),
         @ApiResponse(code = 400, message = "Bad request", response = Error.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
         @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
         @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
       })
-  public Response listAllColumns(
+  public Response listAllTables(
       @ApiParam(
               value =
                   "The token returned from the authorization endpoint. Use this token in each request.",
@@ -98,44 +105,34 @@ public class ColumnResource {
       @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
           @PathParam("keyspaceName")
           final String keyspaceName,
-      @ApiParam(value = "Name of the table to use for the request.", required = true)
-          @PathParam("tableName")
-          final String tableName,
       @Context HttpServletRequest request) {
     return RequestHandler.handle(
         () -> {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
+
+          List<String> tableNames =
+              authenticatedDB.getTables(keyspaceName).stream()
+                  .map(Table::name)
+                  .collect(Collectors.toList());
+
           db.getAuthorizationService()
               .authorizeSchemaRead(
                   authenticatedDB.getAuthenticationSubject(),
                   Collections.singletonList(keyspaceName),
-                  Collections.singletonList(tableName),
+                  tableNames,
                   SourceAPI.REST,
                   ResourceKind.TABLE);
 
-          final Table tableMetadata = authenticatedDB.getTable(keyspaceName, tableName);
-
-          List<ColumnDefinition> collect =
-              tableMetadata.columns().stream()
-                  .map(
-                      (col) -> {
-                        //noinspection ConstantConditions
-                        String type = col.type() != null ? col.type().cqlDefinition() : null;
-                        return new ColumnDefinition(
-                            col.name(), type, col.kind() == Column.Kind.Static);
-                      })
-                  .collect(Collectors.toList());
-
-          return Response.status(Response.Status.OK).entity(collect).build();
+          return Response.status(Response.Status.OK).entity(tableNames).build();
         });
   }
 
   @Timed
   @POST
   @ApiOperation(
-      value = "Add a column",
-      notes = "Add a single column to a table.",
+      value = "Add a table",
+      notes = "Add a table in a specific keyspace.",
       response = SuccessResponse.class,
       code = 201)
   @ApiResponses(
@@ -144,10 +141,9 @@ public class ColumnResource {
         @ApiResponse(code = 400, message = "Bad request", response = Error.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
         @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
-        @ApiResponse(code = 409, message = "Conflict", response = Error.class),
         @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
       })
-  public Response addColumn(
+  public Response addTable(
       @ApiParam(
               value =
                   "The token returned from the authorization endpoint. Use this token in each request.",
@@ -157,59 +153,91 @@ public class ColumnResource {
       @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
           @PathParam("keyspaceName")
           final String keyspaceName,
-      @ApiParam(value = "Name of the table to use for the request.", required = true)
-          @PathParam("tableName")
-          final String tableName,
-      @ApiParam(value = "", required = true) @NotNull final ColumnDefinition columnDefinition,
+      @ApiParam(value = "Table object that needs to be added to the keyspace", required = true)
+          @NotNull
+          final TableAdd tableAdd,
       @Context HttpServletRequest request) {
     return RequestHandler.handle(
         () -> {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
-          Keyspace keyspace = authenticatedDB.getKeyspace(keyspaceName);
+          Keyspace keyspace = authenticatedDB.getDataStore().schema().keyspace(keyspaceName);
           if (keyspace == null) {
             return Response.status(Response.Status.BAD_REQUEST)
                 .entity(
                     new Error(
-                        String.format("keyspace '%s' not found", keyspaceName),
-                        Response.Status.BAD_REQUEST.getStatusCode()))
+                        "keyspace does not exists", Response.Status.BAD_REQUEST.getStatusCode()))
                 .build();
           }
 
-          String name = columnDefinition.getName();
-          Kind kind = Kind.Regular;
-          if (columnDefinition.getIsStatic()) {
-            kind = Kind.Static;
+          String tableName = tableAdd.getName();
+          if (tableName == null || tableName.equals("")) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(new Error("table name must be provided"))
+                .build();
           }
 
-          Column column =
-              ImmutableColumn.builder()
-                  .name(name)
-                  .kind(kind)
-                  .type(
-                      Column.Type.fromCqlDefinitionOf(
-                          keyspace, columnDefinition.getTypeDefinition()))
+          PrimaryKey primaryKey = tableAdd.getPrimaryKey();
+          if (primaryKey == null) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(new Error("primary key must be provided"))
+                .build();
+          }
+
+          List<Column> columns = new ArrayList<>();
+          TableOptions options = tableAdd.getTableOptions();
+          for (ColumnDefinition colDef : tableAdd.getColumnDefinitions()) {
+            String columnName = colDef.getName();
+            if (columnName == null || columnName.equals("")) {
+              return Response.status(Response.Status.BAD_REQUEST)
+                  .entity(
+                      new Error(
+                          "column name must be provided",
+                          Response.Status.BAD_REQUEST.getStatusCode()))
                   .build();
+            }
+
+            Kind kind = Converters.getColumnKind(colDef, primaryKey);
+            ColumnType type = Type.fromCqlDefinitionOf(keyspace, colDef.getTypeDefinition());
+            Order order;
+            try {
+              order = kind == Kind.Clustering ? Converters.getColumnOrder(colDef, options) : null;
+            } catch (Exception e) {
+              return Response.status(Response.Status.BAD_REQUEST)
+                  .entity(
+                      new Error(
+                          "Unable to create table options " + e.getMessage(),
+                          Response.Status.BAD_REQUEST.getStatusCode()))
+                  .build();
+            }
+            columns.add(Column.create(columnName, kind, type, order));
+          }
 
           db.getAuthorizationService()
               .authorizeSchemaWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
                   tableName,
-                  Scope.ALTER,
+                  Scope.CREATE,
                   SourceAPI.REST,
                   ResourceKind.TABLE);
+
+          int ttl = 0;
+          if (options != null && options.getDefaultTimeToLive() != null) {
+            ttl = options.getDefaultTimeToLive();
+          }
 
           authenticatedDB
               .getDataStore()
               .queryBuilder()
-              .alter()
+              .create()
               .table(keyspaceName, tableName)
-              .addColumn(column)
+              .ifNotExists(tableAdd.getIfNotExists())
+              .column(columns)
+              .withDefaultTTL(ttl)
               .build()
               .execute(ConsistencyLevel.LOCAL_QUORUM)
               .get();
-
           return Response.status(Response.Status.CREATED).entity(new SuccessResponse()).build();
         });
   }
@@ -217,20 +245,20 @@ public class ColumnResource {
   @Timed
   @GET
   @ApiOperation(
-      value = "Retrieve a column",
-      notes = "Return a single column specification in a specific table.",
-      response = ColumnDefinition.class)
+      value = "Return a table",
+      notes = "Retrieve data for a single table in a specific keyspace.",
+      response = Table.class)
   @ApiResponses(
       value = {
-        @ApiResponse(code = 200, message = "OK", response = ColumnDefinition.class),
+        @ApiResponse(code = 200, message = "OK", response = Table.class),
         @ApiResponse(code = 400, message = "Bad request", response = Error.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
         @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
         @ApiResponse(code = 404, message = "Not Found", response = Error.class),
         @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
       })
-  @Path("/{columnName}")
-  public Response getOneColumn(
+  @Path("/{tableName}")
+  public Response getOneTable(
       @ApiParam(
               value =
                   "The token returned from the authorization endpoint. Use this token in each request.",
@@ -243,9 +271,6 @@ public class ColumnResource {
       @ApiParam(value = "Name of the table to use for the request.", required = true)
           @PathParam("tableName")
           final String tableName,
-      @ApiParam(value = "Name of the column to use for the request.", required = true)
-          @PathParam("columnName")
-          final String columnName,
       @Context HttpServletRequest request) {
     return RequestHandler.handle(
         () -> {
@@ -259,35 +284,67 @@ public class ColumnResource {
                   SourceAPI.REST,
                   ResourceKind.TABLE);
 
-          final Table tableMetadata = authenticatedDB.getTable(keyspaceName, tableName);
-          final Column col = tableMetadata.column(columnName);
-          if (col == null) {
-            return Response.status(Response.Status.NOT_FOUND)
-                .entity(new Error(String.format("column '%s' not found in table", columnName)))
-                .build();
-          }
+          Table tableMetadata = authenticatedDB.getTable(keyspaceName, tableName);
 
-          //noinspection ConstantConditions
-          String type = col.type() != null ? col.type().cqlDefinition() : null;
-          return Response.status(Response.Status.OK)
-              .entity(new ColumnDefinition(col.name(), type, col.kind() == Kind.Static))
+          final List<ColumnDefinition> columnDefinitions =
+              tableMetadata.columns().stream()
+                  .map(
+                      (col) -> {
+                        ColumnType type = col.type();
+                        return new ColumnDefinition(
+                            col.name(),
+                            type == null ? null : type.cqlDefinition(),
+                            col.kind() == Kind.Static);
+                      })
+                  .collect(Collectors.toList());
+
+          final List<String> partitionKey =
+              tableMetadata.partitionKeyColumns().stream()
+                  .map(Column::name)
+                  .collect(Collectors.toList());
+          final List<String> clusteringKey =
+              tableMetadata.clusteringKeyColumns().stream()
+                  .map(Column::name)
+                  .collect(Collectors.toList());
+          final List<ClusteringExpression> clusteringExpression =
+              tableMetadata.clusteringKeyColumns().stream()
+                  .map(
+                      (col) ->
+                          new ClusteringExpression(
+                              col.name(), Objects.requireNonNull(col.order()).name()))
+                  .collect(Collectors.toList());
+
+          final PrimaryKey primaryKey = new PrimaryKey(partitionKey, clusteringKey);
+          final int ttl = 0; // no way to get this without querying schema currently
+          final TableOptions tableOptions = new TableOptions(ttl, clusteringExpression);
+
+          return Response.ok(
+                  new TableResponse(
+                      tableMetadata.name(),
+                      keyspaceName,
+                      columnDefinitions,
+                      primaryKey,
+                      tableOptions))
               .build();
         });
   }
 
   @Timed
   @DELETE
-  @ApiOperation(value = "Delete a column", notes = "Delete a single column in a specific table.")
+  @ApiOperation(
+      value = "Delete a table",
+      notes = "Delete a single table in the specified keyspace.")
   @ApiResponses(
       value = {
         @ApiResponse(code = 204, message = "No Content"),
         @ApiResponse(code = 400, message = "Bad request", response = Error.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
         @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
         @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
       })
-  @Path("/{columnName}")
-  public Response deleteColumn(
+  @Path("/{tableName}")
+  public Response deleteTable(
       @ApiParam(
               value =
                   "The token returned from the authorization endpoint. Use this token in each request.",
@@ -300,9 +357,6 @@ public class ColumnResource {
       @ApiParam(value = "Name of the table to use for the request.", required = true)
           @PathParam("tableName")
           final String tableName,
-      @ApiParam(value = "Name of the column to use for the request.", required = true)
-          @PathParam("columnName")
-          final String columnName,
       @Context HttpServletRequest request) {
     return RequestHandler.handle(
         () -> {
@@ -314,80 +368,20 @@ public class ColumnResource {
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
                   tableName,
-                  Scope.ALTER,
+                  Scope.DROP,
                   SourceAPI.REST,
                   ResourceKind.TABLE);
 
           authenticatedDB
               .getDataStore()
               .queryBuilder()
-              .alter()
+              .drop()
               .table(keyspaceName, tableName)
-              .dropColumn(columnName)
               .build()
               .execute(ConsistencyLevel.LOCAL_QUORUM)
               .get();
 
-          return Response.status(Response.Status.NO_CONTENT).entity(new SuccessResponse()).build();
-        });
-  }
-
-  @Timed
-  @PUT
-  @ApiOperation(
-      value = "Update a column",
-      notes = "Update a single column in a specific table.",
-      response = SuccessResponse.class)
-  @ApiResponses(
-      value = {
-        @ApiResponse(code = 200, message = "OK", response = SuccessResponse.class),
-        @ApiResponse(code = 400, message = "Bad request", response = Error.class),
-        @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
-        @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
-        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
-        @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
-      })
-  @Path("/{columnName}")
-  public Response updateColumn(
-      @ApiParam(
-              value =
-                  "The token returned from the authorization endpoint. Use this token in each request.",
-              required = true)
-          @HeaderParam("X-Cassandra-Token")
-          String token,
-      @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
-          @PathParam("keyspaceName")
-          final String keyspaceName,
-      @ApiParam(value = "Name of the table to use for the request.", required = true)
-          @PathParam("tableName")
-          final String tableName,
-      @PathParam("columnName") final String columnName,
-      @ApiParam(value = "", required = true) @NotNull final ColumnUpdate columnUpdate,
-      @Context HttpServletRequest request) {
-    return RequestHandler.handle(
-        () -> {
-          AuthenticatedDB authenticatedDB =
-              db.getRestDataStoreForToken(token, getAllHeaders(request));
-
-          db.getAuthorizationService()
-              .authorizeSchemaWrite(
-                  authenticatedDB.getAuthenticationSubject(),
-                  keyspaceName,
-                  tableName,
-                  Scope.ALTER,
-                  SourceAPI.REST,
-                  ResourceKind.TABLE);
-
-          authenticatedDB
-              .getDataStore()
-              .queryBuilder()
-              .alter()
-              .table(keyspaceName, tableName)
-              .renameColumn(columnName, columnUpdate.getNewName())
-              .build()
-              .execute()
-              .get();
-          return Response.status(Response.Status.OK).entity(new SuccessResponse()).build();
+          return Response.status(Response.Status.NO_CONTENT).build();
         });
   }
 }

--- a/restapi/src/main/java/io/stargate/web/swagger/SwaggerUIResource.java
+++ b/restapi/src/main/java/io/stargate/web/swagger/SwaggerUIResource.java
@@ -33,8 +33,10 @@ public class SwaggerUIResource {
 
   private static final Logger logger = LoggerFactory.getLogger(SwaggerUIResource.class);
 
-  private static Pattern fileExtensionPattern =
+  private static final Pattern fileExtensionPattern =
       Pattern.compile("([^\\s]+(\\.(?i)(css|png|js|map|html))$)");
+
+  private static final Pattern bearerTokenPattern = Pattern.compile("^Bearer\\s");
 
   private Bundle bundle;
   private String indexFile;
@@ -90,7 +92,7 @@ public class SwaggerUIResource {
       token =
           Strings.isNullOrEmpty(bearerToken)
               ? bearerToken
-              : bearerToken.replaceFirst("^Bearer\\s", "");
+              : bearerTokenPattern.matcher(bearerToken).replaceFirst("");
     }
 
     // Using an HTML file with templated text that's been read in as a String. Yes,  we could use

--- a/restapi/src/test/java/io/stargate/web/resources/ColumnResourceTest.java
+++ b/restapi/src/test/java/io/stargate/web/resources/ColumnResourceTest.java
@@ -12,6 +12,7 @@ import io.stargate.db.schema.Column;
 import io.stargate.db.schema.ImmutableColumn;
 import io.stargate.db.schema.Table;
 import io.stargate.web.models.ColumnDefinition;
+import io.stargate.web.resources.v1.ColumnResource;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/restapi/src/test/java/io/stargate/web/resources/ConvertersTest.java
+++ b/restapi/src/test/java/io/stargate/web/resources/ConvertersTest.java
@@ -25,7 +25,7 @@ import io.stargate.db.schema.ImmutableUserDefinedType;
 import io.stargate.db.schema.ParameterizedType.TupleType;
 import io.stargate.db.schema.Table;
 import io.stargate.db.schema.UserDefinedType;
-import io.stargate.web.impl.Server;
+import io.stargate.web.impl.RestApiServer;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.InetAddress;
@@ -401,7 +401,7 @@ public class ConvertersTest {
 
   private static ObjectMapper testObjectMapper() {
     ObjectMapper mapper = new ObjectMapper();
-    Server.configureObjectMapper(mapper);
+    RestApiServer.configureObjectMapper(mapper);
     return mapper;
   }
 


### PR DESCRIPTION
**What this PR does**:

Minor rename patch to improve readability of `restapi` (which contains REST and Documents APIs):

* Move `v1` resources under specific `v1/` package similar to `v2`
* Rename generic `Server` as `RestApiServer`; `WebImpl` as `RestApiRunner`

**Which issue(s) this PR fixes**:
Fixes #1284

**Checklist**
- [x] Changes manually tested -- verified by CI that things still work (no functional changes)
- [ ] Automated Tests added/updated
- [x] Documentation added/updated -- one reference to renamed `RestApiServer`
