### PR TITLE
Fix #1287: clean up division between `DocumentDB` and `AuthenticatedDB`

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -133,6 +133,10 @@ public class DocumentDB {
     return authenticationSubject;
   }
 
+  public boolean supportsSAI() {
+    return dataStore.supportsSAI();
+  }
+
   public boolean treatBooleansAsNumeric() {
     return !dataStore.supportsSecondaryIndex();
   }
@@ -141,7 +145,7 @@ public class DocumentDB {
     return allColumns;
   }
 
-  public QueryBuilder builder() {
+  public QueryBuilder queryBuilder() {
     return dataStore.queryBuilder();
   }
 
@@ -149,8 +153,21 @@ public class DocumentDB {
     return dataStore.schema();
   }
 
+  public Table getTable(String keyspaceName, String table) {
+    Keyspace keyspace = getKeyspace(keyspaceName);
+    return (keyspace == null) ? null : keyspace.table(table);
+  }
+
+  public Keyspace getKeyspace(String keyspaceName) {
+    return dataStore.schema().keyspace(keyspaceName);
+  }
+
+  public Set<Keyspace> getKeyspaces() {
+    return dataStore.schema().keyspaces();
+  }
+
   public void writeJsonSchemaToCollection(String namespace, String collection, String schemaData) {
-    this.builder()
+    this.queryBuilder()
         .alter()
         .table(namespace, collection)
         .withComment(schemaData)

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/CollectionService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/CollectionService.java
@@ -8,14 +8,13 @@ import io.stargate.web.docsapi.exception.ErrorCode;
 import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
 import io.stargate.web.docsapi.models.CollectionUpgradeType;
 import io.stargate.web.docsapi.models.DocCollection;
-import io.stargate.web.resources.Db;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 public class CollectionService {
-  public DocCollection getCollectionInfo(Table table, Db db) {
-    if (db.getDataStore().supportsSAI()) {
+  public DocCollection getCollectionInfo(Table table, DocumentDB db) {
+    if (db.supportsSAI()) {
       List<Index> indexes = table.indexes();
       // If all secondary indexes are not SAI or there are no secondary indexes,
       // then an upgrade is available.

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/JsonSchemaHandler.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/JsonSchemaHandler.java
@@ -65,7 +65,7 @@ public class JsonSchemaHandler {
   }
 
   private String getRawJsonSchemaForCollection(DocumentDB db, String namespace, String collection) {
-    String comment = db.schema().keyspace(namespace).table(collection).comment();
+    String comment = db.getTable(namespace, collection).comment();
     return comment.isEmpty() ? null : comment;
   }
 


### PR DESCRIPTION
**What this PR does**:

As per linked issue, the goal here is to improve separation between logically distinct REST and Document APIs.
There is also smaller clean up wrt abstractions themselves, construction of DocumentDB, AuthenticatedDB by `Db` class.

**Which issue(s) this PR fixes**:
Fixes #1287

**Checklist**
- [x] Changes manually tested -- Should not change functionality, relying on CI (plus local sanity check)
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated

