### PR TITLE
closes #1280: all resources as singletons 

### DIFF
--- a/auth-api/src/main/java/io/stargate/auth/api/impl/Server.java
+++ b/auth-api/src/main/java/io/stargate/auth/api/impl/Server.java
@@ -96,6 +96,7 @@ public class Server extends Application<ApplicationConfiguration> {
 
     environment.jersey().register(ApiListingResource.class);
     environment.jersey().register(SwaggerSerializers.class);
+    environment.jersey().register(SwaggerUIResource.class);
 
     environment
         .jersey()
@@ -106,8 +107,6 @@ public class Server extends Application<ApplicationConfiguration> {
                 bind(FrameworkUtil.getBundle(AuthApiActivator.class)).to(Bundle.class);
               }
             });
-
-    environment.jersey().register(SwaggerUIResource.class);
 
     enableCors(environment);
 

--- a/auth-api/src/main/java/io/stargate/auth/api/resources/AuthResource.java
+++ b/auth-api/src/main/java/io/stargate/auth/api/resources/AuthResource.java
@@ -30,6 +30,7 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
@@ -49,6 +50,7 @@ import org.slf4j.LoggerFactory;
 @Path("/v1")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
+@Singleton
 public class AuthResource {
 
   private static final Logger logger = LoggerFactory.getLogger(AuthResource.class);

--- a/auth-api/src/main/java/io/stargate/auth/api/swagger/SwaggerUIResource.java
+++ b/auth-api/src/main/java/io/stargate/auth/api/swagger/SwaggerUIResource.java
@@ -13,6 +13,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
@@ -29,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 @Path("/swagger-ui")
 @Produces({MediaType.TEXT_HTML, "text/css", "image/png"})
+@Singleton
 public class SwaggerUIResource {
 
   private static final Logger logger = LoggerFactory.getLogger(SwaggerUIResource.class);

--- a/health-checker/src/main/java/io/stargate/health/CheckerResource.java
+++ b/health-checker/src/main/java/io/stargate/health/CheckerResource.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -28,6 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 @Path("/checker")
 @Produces(MediaType.TEXT_PLAIN)
+@Singleton
 public class CheckerResource {
 
   private static final Logger logger = LoggerFactory.getLogger(CheckerResource.class);

--- a/health-checker/src/main/java/io/stargate/health/PrometheusResource.java
+++ b/health-checker/src/main/java/io/stargate/health/PrometheusResource.java
@@ -17,6 +17,7 @@ package io.stargate.health;
 
 import io.stargate.core.metrics.api.MetricsScraper;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -28,6 +29,7 @@ import javax.ws.rs.core.Response;
  * /metrics</code> endpoint.
  */
 @Path("/metrics")
+@Singleton
 public class PrometheusResource {
 
   @Inject private MetricsScraper scraper;

--- a/restapi/src/main/java/io/stargate/web/resources/HealthResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/HealthResource.java
@@ -15,6 +15,7 @@
  */
 package io.stargate.web.resources;
 
+import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -23,6 +24,7 @@ import javax.ws.rs.core.Response;
 
 @Path("/")
 @Produces(MediaType.APPLICATION_JSON)
+@Singleton
 public class HealthResource {
 
   @GET

--- a/restapi/src/main/java/io/stargate/web/resources/v1/ColumnResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v1/ColumnResource.java
@@ -42,6 +42,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.DELETE;
@@ -63,6 +64,7 @@ import org.apache.cassandra.stargate.db.ConsistencyLevel;
     tags = {"schemas"})
 @Path("/v1/keyspaces/{keyspaceName}/tables/{tableName}/columns")
 @Produces(MediaType.APPLICATION_JSON)
+@Singleton
 public class ColumnResource {
 
   private Db db;

--- a/restapi/src/main/java/io/stargate/web/resources/v1/KeyspaceResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v1/KeyspaceResource.java
@@ -30,6 +30,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import java.util.List;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -45,6 +46,7 @@ import javax.ws.rs.core.Response;
     tags = {"schemas"})
 @Path("/v1/keyspaces")
 @Produces(MediaType.APPLICATION_JSON)
+@Singleton
 public class KeyspaceResource {
   @Inject private Db db;
 

--- a/restapi/src/main/java/io/stargate/web/resources/v1/RowResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v1/RowResource.java
@@ -66,6 +66,7 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.DELETE;
@@ -91,6 +92,7 @@ import org.slf4j.LoggerFactory;
     tags = {"data"})
 @Path("/v1/keyspaces/{keyspaceName}/tables/{tableName}/rows")
 @Produces(MediaType.APPLICATION_JSON)
+@Singleton
 public class RowResource {
 
   private static final Logger logger = LoggerFactory.getLogger(RowResource.class);

--- a/restapi/src/main/java/io/stargate/web/resources/v1/TableResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v1/TableResource.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -73,6 +74,7 @@ import org.apache.cassandra.stargate.db.ConsistencyLevel;
 @Path("/v1/keyspaces/{keyspaceName}/tables")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
+@Singleton
 public class TableResource {
   @Inject private Db db;
 

--- a/restapi/src/main/java/io/stargate/web/resources/v2/RowsResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/RowsResource.java
@@ -60,6 +60,7 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -83,6 +84,7 @@ import org.apache.cassandra.stargate.db.ConsistencyLevel;
     tags = {"data"})
 @Path("/v2/keyspaces/{keyspaceName}/{tableName}")
 @Produces(MediaType.APPLICATION_JSON)
+@Singleton
 public class RowsResource {
 
   @Inject private Db db;

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/ColumnsResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/ColumnsResource.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.DELETE;
@@ -65,6 +66,7 @@ import org.apache.cassandra.stargate.db.ConsistencyLevel;
     tags = {"schemas"})
 @Path("/v2/schemas/keyspaces/{keyspaceName}/tables/{tableName}/columns")
 @Produces(MediaType.APPLICATION_JSON)
+@Singleton
 public class ColumnsResource {
   @Inject private Db db;
 

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/IndexesResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/IndexesResource.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.DELETE;
@@ -72,6 +73,7 @@ import org.apache.cassandra.stargate.db.ConsistencyLevel;
     tags = {"schemas"})
 @Path("/v2/schemas/keyspaces/{keyspaceName}/tables/{tableName}/indexes")
 @Produces(MediaType.APPLICATION_JSON)
+@Singleton
 public class IndexesResource {
   @Inject private Db db;
 

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/KeyspacesResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/KeyspacesResource.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -63,6 +64,7 @@ import org.apache.cassandra.stargate.db.ConsistencyLevel;
     tags = {"schemas"})
 @Path("/v2/schemas/keyspaces")
 @Produces(MediaType.APPLICATION_JSON)
+@Singleton
 public class KeyspacesResource {
   @Inject private Db db;
 

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/TablesResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/TablesResource.java
@@ -52,6 +52,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.DELETE;
@@ -75,6 +76,7 @@ import org.apache.cassandra.stargate.db.ConsistencyLevel;
     tags = {"schemas"})
 @Path("/v2/schemas/keyspaces/{keyspaceName}/tables")
 @Produces(MediaType.APPLICATION_JSON)
+@Singleton
 public class TablesResource {
   @Inject private Db db;
 

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/UserDefinedTypesResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/UserDefinedTypesResource.java
@@ -54,6 +54,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -84,6 +85,7 @@ import org.javatuples.Pair;
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
 @Path("/v2/schemas/keyspaces/{keyspaceName}/types")
+@Singleton
 public class UserDefinedTypesResource {
 
   public static final String HEADER_TOKEN_AUTHENTICATION = "X-Cassandra-Token";

--- a/restapi/src/main/java/io/stargate/web/swagger/SwaggerUIResource.java
+++ b/restapi/src/main/java/io/stargate/web/swagger/SwaggerUIResource.java
@@ -13,6 +13,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
@@ -29,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 @Path("/swagger-ui")
 @Produces({MediaType.TEXT_HTML, "text/css", "image/png"})
+@Singleton
 public class SwaggerUIResource {
 
   private static final Logger logger = LoggerFactory.getLogger(SwaggerUIResource.class);


### PR DESCRIPTION
**What this PR does**:
Coming on top of the #1283, I did the same thing for all the other modules. GraphQL did not have the problem, as singleton resources are already defined.

**Which issue(s) this PR fixes**:
Fixes #1280

**Checklist**
- ~[ ] Changes manually tested~
- ~[ ] Automated Tests added/updated~
- ~[ ] Documentation added/updated~
