### PR TITLE
Adapt gRPC example to work with Astra

### DIFF
--- a/grpc-examples/src/main/java/io/stargate/grpcexample/GrpcClientExecuteQuery.java
+++ b/grpc-examples/src/main/java/io/stargate/grpcexample/GrpcClientExecuteQuery.java
@@ -52,7 +52,7 @@ public class GrpcClientExecuteQuery {
   //  "{$ASTRA_DB_ID}-{ASTRA_DB_REGION}.apps.astra.datastax.com";
 
   // change to false when running on Astra
-  private static final boolean LOCAL_RUN = false;
+  private static final boolean LOCAL_RUN = true;
 
   private static final int STARGATE_GRPC_PORT = 8090;
   // when running on astra

--- a/grpc-examples/src/main/java/io/stargate/grpcexample/GrpcClientExecuteQuery.java
+++ b/grpc-examples/src/main/java/io/stargate/grpcexample/GrpcClientExecuteQuery.java
@@ -194,6 +194,10 @@ public class GrpcClientExecuteQuery {
   }
 
   public ManagedChannel createChannel(String host, int port) {
-    return ManagedChannelBuilder.forAddress(host, port).build();
+    if (LOCAL_RUN) {
+      return ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
+    } else {
+      return ManagedChannelBuilder.forAddress(host, port).build();
+    }
   }
 }

--- a/grpc-examples/src/main/java/io/stargate/grpcexample/GrpcClientExecuteQuery.java
+++ b/grpc-examples/src/main/java/io/stargate/grpcexample/GrpcClientExecuteQuery.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
  *       (https://docs.datastax.com/en/astra/docs/manage-application-tokens.html).
  *   <li>Adapt the {@link GrpcClientExecuteQuery#STARGATE_HOST} according to the {@code
  *       "{$ASTRA_DB_ID}-{ASTRA_DB_REGION}.apps.astra.datastax.com"}.
- *   <li>Change the {@link GrpcClientExecuteQuery#LOCAL_RUN} to prevent new keyspace creation.
+ *   <li>Set the {@link GrpcClientExecuteQuery#LOCAL_RUN} to false to prevent new keyspace creation.
  *   <li>Change the {@link GrpcClientExecuteQuery#STARGATE_GRPC_PORT} to 443.
  *   <li>Change the {@link GrpcClientExecuteQuery#KS} to ASTRA_DB_KEYSPACE.
  * </ol>


### PR DESCRIPTION
**What this PR does**:
Adapts the `GrpcClientExecuteQueryAstra` to allow user to interact with the gRPC API on the astra cluster (not only local `Staragate`)

**Checklist**
- [x] Changes manually tested
- [x] Documentation added/updated
