### PR TITLE
closes #1293: correctly quote comment in create and alter table queries

### DIFF
--- a/persistence-api/src/main/java/io/stargate/db/query/builder/QueryBuilderImpl.java
+++ b/persistence-api/src/main/java/io/stargate/db/query/builder/QueryBuilderImpl.java
@@ -21,6 +21,7 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
+import com.datastax.oss.driver.internal.core.util.Strings;
 import com.datastax.oss.driver.shaded.guava.common.collect.Sets;
 import com.github.misberner.apcommons.util.AFModifier;
 import com.github.misberner.duzzt.annotations.DSLAction;
@@ -1020,7 +1021,8 @@ public class QueryBuilderImpl {
 
   private void addComment(WithAdder with) {
     if (comment != null) {
-      with.add().append(" comment = '").append(comment).append("'");
+      String quotedComment = Strings.quote(comment);
+      with.add().append(" comment = ").append(quotedComment);
     }
   }
 

--- a/persistence-api/src/test/java/io/stargate/db/query/builder/BuiltAlterTest.java
+++ b/persistence-api/src/test/java/io/stargate/db/query/builder/BuiltAlterTest.java
@@ -1,0 +1,27 @@
+package io.stargate.db.query.builder;
+
+import io.stargate.db.query.BoundDelete;
+import io.stargate.db.query.QueryType;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class BuiltAlterTest extends BuiltDMLTest<BoundDelete> {
+
+  BuiltAlterTest() {
+    super(QueryType.OTHER);
+  }
+
+  @Nested
+  class Table {
+
+    @Test
+    public void withComment() {
+      QueryBuilder builder = newBuilder();
+
+      BuiltQuery<?> query =
+          builder.alter().table(KS_NAME, "t1").withComment("Special Ivan's comment.").build();
+
+      assertBuiltQuery(query, "ALTER TABLE ks.t1 WITH comment = 'Special Ivan''s comment.'");
+    }
+  }
+}

--- a/persistence-api/src/test/java/io/stargate/db/query/builder/BuiltCreateTest.java
+++ b/persistence-api/src/test/java/io/stargate/db/query/builder/BuiltCreateTest.java
@@ -1,0 +1,35 @@
+package io.stargate.db.query.builder;
+
+import io.stargate.db.query.BoundDelete;
+import io.stargate.db.query.QueryType;
+import io.stargate.db.schema.Column;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class BuiltCreateTest extends BuiltDMLTest<BoundDelete> {
+
+  BuiltCreateTest() {
+    super(QueryType.OTHER);
+  }
+
+  @Nested
+  class Table {
+
+    @Test
+    public void withComment() {
+      QueryBuilder builder = newBuilder();
+
+      BuiltQuery<?> query =
+          builder
+              .create()
+              .table(KS_NAME, "new_table")
+              .column(Column.create("key", Column.Kind.PartitionKey, Column.Type.Text))
+              .withComment("Special Ivan's comment.")
+              .build();
+
+      assertBuiltQuery(
+          query,
+          "CREATE TABLE ks.new_table (key text, PRIMARY KEY ((key))) WITH comment = 'Special Ivan''s comment.'");
+    }
+  }
+}

--- a/testing/src/main/resources/schema.json
+++ b/testing/src/main/resources/schema.json
@@ -15,7 +15,8 @@
     "price": {
       "type": "number",
       "minimum": 0,
-      "exclusiveMinimum": true
+      "exclusiveMinimum": true,
+      "description": "Product's price"
     }
   },
   "required": ["id", "name", "price"]


### PR DESCRIPTION
**What this PR does**:

Correctly quotes the comment that might be used while building create and alter table queries.

It's kinda insane we don't have any tests for create & alter queries, keyspaces, tables, etc.. We need to add this and I will create a ticket.

**Which issue(s) this PR fixes**:

Fixes #1293 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- ~[ ] Documentation added/updated~
