### PR TITLE
Provide a flag to disable watching the bundles directory

### DIFF
--- a/starctl
+++ b/starctl
@@ -155,6 +155,10 @@ if [[ ${#STARGATE_ARGS[@]} -eq 0 ]]; then
     if [[ ! -z "$DISABLE_MBEAN_REGISTRATION" ]]; then
         STARGATE_ARGS+=("--disable-mbean-registration")
     fi
+
+    if [[ ! -z "$DISABLE_BUNDLES_WATCH" ]]; then
+        STARGATE_ARGS+=("--disable-bundles-watch"")
+    fi
 fi
 
 declare -a CMD=(java -server)

--- a/starctl
+++ b/starctl
@@ -157,7 +157,7 @@ if [[ ${#STARGATE_ARGS[@]} -eq 0 ]]; then
     fi
 
     if [[ ! -z "$DISABLE_BUNDLES_WATCH" ]]; then
-        STARGATE_ARGS+=("--disable-bundles-watch"")
+        STARGATE_ARGS+=("--disable-bundles-watch")
     fi
 fi
 

--- a/stargate-starter/src/main/java/io/stargate/starter/Starter.java
+++ b/stargate-starter/src/main/java/io/stargate/starter/Starter.java
@@ -237,7 +237,7 @@ public class Starter {
   @Option(
       name = {
         "--disable-bundles-watch",
-        "Whether watching the bundle directory for new jars load should be disabled"
+        "Whether watching the bundle directory for new jars to load should be disabled"
       })
   protected boolean disableBundlesWatch = false;
 


### PR DESCRIPTION


**What this PR does**:
This change adds a flag to optionally disable watching the bundle directory that allows for hot-reload of new jars and it will log an error instead of throwing an exception in the event there is a failure while watching the directory.


**Which issue(s) this PR fixes**:
Fixes #1286

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
