### PR TITLE
Fix #1301: encapsulate `AuthenticatedDB` better wrt DataStore

### DIFF
--- a/persistence-api/src/main/java/io/stargate/db/Persistence.java
+++ b/persistence-api/src/main/java/io/stargate/db/Persistence.java
@@ -31,7 +31,7 @@ import org.apache.cassandra.stargate.exceptions.AuthenticationException;
  * A persistence layer that can be queried.
  *
  * <p>This is the interface that stargate API extensions uses (either directly, or through the
- * higher level {@link DataStore} API which wraps a instance of this interface) to query the
+ * higher level {@link DataStore} API which wraps an instance of this interface) to query the
  * underlying store, and thus the one interface that persistence extensions must implement.
  */
 public interface Persistence {

--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -37,11 +37,12 @@ import org.slf4j.LoggerFactory;
 
 public class DocumentDB {
   private static final Logger logger = LoggerFactory.getLogger(DocumentDB.class);
-  private Boolean useLoggedBatches;
 
   private static final Splitter PATH_SPLITTER = Splitter.on(".");
 
-  final DataStore dataStore;
+  private final Boolean useLoggedBatches;
+
+  private final DataStore dataStore;
   private final AuthorizationService authorizationService;
   private final AuthenticationSubject authenticationSubject;
   private final QueryExecutor executor;

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/CollectionsResource.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/CollectionsResource.java
@@ -158,7 +158,8 @@ public class CollectionsResource {
         () -> {
           DocumentDB docDB = db.getDocDataStoreForToken(token, getAllHeaders(request));
 
-          db.getAuthorizationService()
+          docDB
+              .getAuthorizationService()
               .authorizeSchemaWrite(
                   docDB.getAuthenticationSubject(),
                   namespace,
@@ -211,7 +212,8 @@ public class CollectionsResource {
         () -> {
           DocumentDB docDB = db.getDocDataStoreForToken(token, getAllHeaders(request));
 
-          db.getAuthorizationService()
+          docDB
+              .getAuthorizationService()
               .authorizeSchemaWrite(
                   docDB.getAuthenticationSubject(),
                   namespace,
@@ -274,8 +276,8 @@ public class CollectionsResource {
     return RequestHandler.handle(
         () -> {
           DocumentDB docDB = db.getDocDataStoreForToken(token, getAllHeaders(servletRequest));
-
-          db.getAuthorizationService()
+          docDB
+              .getAuthorizationService()
               .authorizeSchemaWrite(
                   docDB.getAuthenticationSubject(),
                   namespace,

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/NamespacesResource.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/NamespacesResource.java
@@ -175,7 +175,8 @@ public class NamespacesResource {
     return RequestHandler.handle(
         () -> {
           DocumentDB docDB = db.getDocDataStoreForToken(token, getAllHeaders(request));
-          db.getAuthorizationService()
+          docDB
+              .getAuthorizationService()
               .authorizeSchemaRead(
                   docDB.getAuthenticationSubject(),
                   Collections.singletonList(namespaceName),

--- a/restapi/src/main/java/io/stargate/web/resources/AuthenticatedDB.java
+++ b/restapi/src/main/java/io/stargate/web/resources/AuthenticatedDB.java
@@ -60,6 +60,15 @@ public class AuthenticatedDB {
     return authenticationSubject;
   }
 
+  /**
+   * Method for trying to find and return all tables for given keyspace. Keyspace must exist for
+   * call to work; otherise {@link NotFoundException} will be thrown
+   *
+   * @param keyspaceName Name of keyspace to look for tables (must exist)
+   * @return A collection that contains all tables for given keyspace
+   * @throws NotFoundException If no keyspace with given keyspace exists in the underlying data
+   *     store
+   */
   public Collection<Table> getTables(String keyspaceName) {
     Keyspace keyspace = getKeyspace(keyspaceName);
     if (keyspace == null) {
@@ -69,6 +78,16 @@ public class AuthenticatedDB {
     return keyspace.tables();
   }
 
+  /**
+   * Method for trying to find specific table that exists in given keyspace. Keyspace must exist for
+   * call to work; otherise {@link NotFoundException} will be thrown
+   *
+   * @param keyspaceName Name of keyspace to look for tables (must exist)
+   * @param table Name of table to look for (must exist)
+   * @return Metadata for Table requested
+   * @throws NotFoundException If no keyspace with given keyspace exists in the underlying data
+   *     store, or if no table with specified name exists within that keyspace.
+   */
   public Table getTable(String keyspaceName, String table) {
     Keyspace keyspace = getKeyspace(keyspaceName);
     if (keyspace == null) {
@@ -82,19 +101,34 @@ public class AuthenticatedDB {
     return tableMetadata;
   }
 
+  /**
+   * Method for finding and returning metadata for all keyspaces for the underlying data store.
+   *
+   * @return A set of metadata for all keyspaces the underlying data store has.
+   */
   public Set<Keyspace> getKeyspaces() {
     return dataStore.schema().keyspaces();
   }
 
+  /**
+   * Method for trying to find and return metadata for given keyspace, if one exists; if none,
+   * {@code null} is returned.
+   *
+   * @param keyspaceName Name of keyspace to look for
+   * @return Metadata for keyspace requested if one exists; {@code null} otherwise.
+   */
   public Keyspace getKeyspace(String keyspaceName) {
     return dataStore.schema().keyspace(keyspaceName);
   }
 
   /**
-   * Retrieve user defined types definitions for a keyspace.
+   * Retrieve user defined types definitions for a keyspace. Keyspace must exist, otherwise a {@link
+   * NotFoundException} is thrown.
    *
    * @param keyspaceName existing keyspace name
-   * @return a collection of user defined types definitions
+   * @return a collection of user defined types definitions within specified keyspace
+   * @throws NotFoundException If no keyspace with given keyspace exists in the underlying data
+   *     store
    */
   public Collection<UserDefinedType> getTypes(String keyspaceName) {
     Keyspace keyspace = getKeyspace(keyspaceName);
@@ -107,9 +141,11 @@ public class AuthenticatedDB {
   /**
    * Retrieve user defined types definitions from its identifier in a keyspace.
    *
-   * @param keyspaceName existing keyspace name
-   * @param typeName identifier for the type
-   * @return a collection of user defined types definitions
+   * @param keyspaceName existing keyspace name (must exist)
+   * @param typeName identifier for the type (must exist)
+   * @return Metadat for the user defined type requested
+   * @throws NotFoundException If no keyspace with given keyspace exists in the underlying data
+   *     store, or if no user defined type with given name exists in that keyspace.
    */
   public UserDefinedType getType(String keyspaceName, String typeName) {
     Keyspace keyspace = getKeyspace(keyspaceName);
@@ -125,6 +161,12 @@ public class AuthenticatedDB {
     return typeMetadata;
   }
 
+  /**
+   * Accessor for getting a new {@link QueryBuilder} to use for constructing queries against
+   * underlying data store
+   *
+   * @return New {@link QueryBuilder} instance
+   */
   public QueryBuilder queryBuilder() {
     return dataStore.queryBuilder();
   }

--- a/restapi/src/main/java/io/stargate/web/resources/Converters.java
+++ b/restapi/src/main/java/io/stargate/web/resources/Converters.java
@@ -24,7 +24,6 @@ import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.Lists;
 import com.datastax.oss.driver.shaded.guava.common.collect.Maps;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.stargate.db.datastore.Row;
 import io.stargate.db.query.Modification.Operation;
@@ -73,14 +72,10 @@ import java.util.stream.Collectors;
 
 public class Converters {
 
-  private static final ObjectMapper mapper = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final Pattern UNQUOTED_IDENTIFIER = Pattern.compile("[a-z][a-z0-9_]*");
   private static final Pattern PATTERN_DOUBLE_QUOTE = Pattern.compile("\"", Pattern.LITERAL);
   private static final String ESCAPED_DOUBLE_QUOTE = Matcher.quoteReplacement("\"\"");
-
-  static {
-    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-  }
 
   public static Map<String, Object> row2Map(final Row row) {
     final Map<String, Object> map = new HashMap<>(row.columns().size());
@@ -131,7 +126,7 @@ public class Converters {
     if (cqlValue instanceof InetAddress) {
       return ((InetAddress) cqlValue).getHostAddress();
     }
-    if (cqlValue instanceof List || cqlValue instanceof Set) {
+    if (cqlValue instanceof Collection) {
       @SuppressWarnings("unchecked")
       Collection<Object> cqlCollection = (Collection<Object>) cqlValue;
       return cqlCollection.stream().map(Converters::toJsonValue).collect(Collectors.toList());
@@ -1028,7 +1023,7 @@ public class Converters {
    * @throws JsonProcessingException
    */
   public static String writeResponse(Object response) throws JsonProcessingException {
-    return mapper.writeValueAsString(response);
+    return OBJECT_MAPPER.writeValueAsString(response);
   }
 
   public static String maybeQuote(String text) {

--- a/restapi/src/main/java/io/stargate/web/resources/Db.java
+++ b/restapi/src/main/java/io/stargate/web/resources/Db.java
@@ -67,14 +67,6 @@ public class Db {
     this.config = config;
   }
 
-  public DataStore getDataStore() {
-    return this.dataStore;
-  }
-
-  public AuthorizationService getAuthorizationService() {
-    return authorizationService;
-  }
-
   private DocumentDB getDocDataStoreForTokenInternal(TokenAndHeaders tokenAndHeaders)
       throws UnauthorizedException {
     AuthenticationSubject authenticationSubject =
@@ -82,7 +74,7 @@ public class Db {
     return new DocumentDB(
         constructDataStore(authenticationSubject, tokenAndHeaders),
         authenticationSubject,
-        getAuthorizationService(),
+        authorizationService,
         config);
   }
 
@@ -91,7 +83,9 @@ public class Db {
     AuthenticationSubject authenticationSubject =
         authenticationService.validateToken(tokenAndHeaders.token, tokenAndHeaders.headers);
     return new AuthenticatedDB(
-        constructDataStore(authenticationSubject, tokenAndHeaders), authenticationSubject);
+        constructDataStore(authenticationSubject, tokenAndHeaders),
+        authenticationSubject,
+        authorizationService);
   }
 
   private DataStore constructDataStore(

--- a/restapi/src/main/java/io/stargate/web/resources/RequestHandler.java
+++ b/restapi/src/main/java/io/stargate/web/resources/RequestHandler.java
@@ -21,15 +21,12 @@ import io.stargate.web.models.Error;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import javax.ws.rs.NotFoundException;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.cassandra.stargate.exceptions.InvalidRequestException;
 import org.apache.cassandra.stargate.exceptions.OverloadedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Produces(MediaType.APPLICATION_JSON)
 public class RequestHandler {
   private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 

--- a/restapi/src/main/java/io/stargate/web/resources/v1/ColumnResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v1/ColumnResource.java
@@ -111,7 +111,8 @@ public class ColumnResource {
         () -> {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaRead(
                   authenticatedDB.getAuthenticationSubject(),
                   Collections.singletonList(keyspaceName),
@@ -196,7 +197,8 @@ public class ColumnResource {
                           keyspace, columnDefinition.getTypeDefinition()))
                   .build();
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -206,7 +208,6 @@ public class ColumnResource {
                   ResourceKind.TABLE);
 
           authenticatedDB
-              .getDataStore()
               .queryBuilder()
               .alter()
               .table(keyspaceName, tableName)
@@ -256,7 +257,8 @@ public class ColumnResource {
         () -> {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaRead(
                   authenticatedDB.getAuthenticationSubject(),
                   Collections.singletonList(keyspaceName),
@@ -314,7 +316,8 @@ public class ColumnResource {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -324,7 +327,6 @@ public class ColumnResource {
                   ResourceKind.TABLE);
 
           authenticatedDB
-              .getDataStore()
               .queryBuilder()
               .alter()
               .table(keyspaceName, tableName)
@@ -374,7 +376,8 @@ public class ColumnResource {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -384,7 +387,6 @@ public class ColumnResource {
                   ResourceKind.TABLE);
 
           authenticatedDB
-              .getDataStore()
               .queryBuilder()
               .alter()
               .table(keyspaceName, tableName)

--- a/restapi/src/main/java/io/stargate/web/resources/v1/KeyspaceResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v1/KeyspaceResource.java
@@ -82,8 +82,9 @@ public class KeyspaceResource {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
 
-          List<String> keyspaceNames = authenticatedDB.getDataStore().schema().keyspaceNames();
-          db.getAuthorizationService()
+          List<String> keyspaceNames = authenticatedDB.schema().keyspaceNames();
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaRead(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceNames,

--- a/restapi/src/main/java/io/stargate/web/resources/v1/RowResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v1/RowResource.java
@@ -144,7 +144,6 @@ public class RowResource {
 
           BoundQuery query =
               authenticatedDB
-                  .getDataStore()
                   .queryBuilder()
                   .select()
                   .from(keyspaceName, tableName)
@@ -155,13 +154,10 @@ public class RowResource {
                   .bind();
 
           final ResultSet r =
-              db.getAuthorizationService()
+              authenticatedDB
+                  .getAuthorizationService()
                   .authorizedDataRead(
-                      () ->
-                          authenticatedDB
-                              .getDataStore()
-                              .execute(query, ConsistencyLevel.LOCAL_QUORUM)
-                              .get(),
+                      () -> authenticatedDB.execute(query, ConsistencyLevel.LOCAL_QUORUM).get(),
                       authenticatedDB.getAuthenticationSubject(),
                       keyspaceName,
                       tableName,
@@ -226,13 +222,7 @@ public class RowResource {
               db.getRestDataStoreForToken(token, getAllHeaders(request));
 
           BoundQuery query =
-              authenticatedDB
-                  .getDataStore()
-                  .queryBuilder()
-                  .select()
-                  .from(keyspaceName, tableName)
-                  .build()
-                  .bind();
+              authenticatedDB.queryBuilder().select().from(keyspaceName, tableName).build().bind();
 
           // Using final variables here to satisfy lambda
           ByteBuffer finalPageState = pageState;
@@ -247,9 +237,10 @@ public class RowResource {
               };
 
           final ResultSet r =
-              db.getAuthorizationService()
+              authenticatedDB
+                  .getAuthorizationService()
                   .authorizedDataRead(
-                      () -> authenticatedDB.getDataStore().execute(query, parametersModifier).get(),
+                      () -> authenticatedDB.execute(query, parametersModifier).get(),
                       authenticatedDB.getAuthenticationSubject(),
                       keyspaceName,
                       tableName,
@@ -362,7 +353,6 @@ public class RowResource {
 
           BoundQuery query =
               authenticatedDB
-                  .getDataStore()
                   .queryBuilder()
                   .select()
                   .column(selectedColumns)
@@ -385,9 +375,10 @@ public class RowResource {
               };
 
           ResultSet r =
-              db.getAuthorizationService()
+              authenticatedDB
+                  .getAuthorizationService()
                   .authorizedDataRead(
-                      () -> authenticatedDB.getDataStore().execute(query, parametersModifier).get(),
+                      () -> authenticatedDB.execute(query, parametersModifier).get(),
                       authenticatedDB.getAuthenticationSubject(),
                       keyspaceName,
                       tableName,
@@ -456,14 +447,14 @@ public class RowResource {
 
           BoundQuery query =
               authenticatedDB
-                  .getDataStore()
                   .queryBuilder()
                   .insertInto(keyspaceName, tableName)
                   .value(values)
                   .build()
                   .bind();
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeDataWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -472,7 +463,7 @@ public class RowResource {
                   Scope.MODIFY,
                   SourceAPI.REST);
 
-          authenticatedDB.getDataStore().execute(query, ConsistencyLevel.LOCAL_QUORUM).get();
+          authenticatedDB.execute(query, ConsistencyLevel.LOCAL_QUORUM).get();
 
           return Response.status(Response.Status.CREATED).entity(new RowsResponse(true, 1)).build();
         });
@@ -517,7 +508,6 @@ public class RowResource {
 
           BoundQuery query =
               authenticatedDB
-                  .getDataStore()
                   .queryBuilder()
                   .delete()
                   .from(keyspaceName, tableName)
@@ -527,7 +517,8 @@ public class RowResource {
                   .build()
                   .bind();
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeDataWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -536,7 +527,7 @@ public class RowResource {
                   Scope.DELETE,
                   SourceAPI.REST);
 
-          authenticatedDB.getDataStore().execute(query, ConsistencyLevel.LOCAL_QUORUM).get();
+          authenticatedDB.execute(query, ConsistencyLevel.LOCAL_QUORUM).get();
 
           return Response.status(Response.Status.NO_CONTENT).entity(new SuccessResponse()).build();
         });
@@ -592,7 +583,6 @@ public class RowResource {
 
           BoundQuery query =
               authenticatedDB
-                  .getDataStore()
                   .queryBuilder()
                   .update(keyspaceName, tableName)
                   .value(changes)
@@ -600,7 +590,8 @@ public class RowResource {
                   .build()
                   .bind();
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeDataWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -609,7 +600,7 @@ public class RowResource {
                   Scope.MODIFY,
                   SourceAPI.REST);
 
-          authenticatedDB.getDataStore().execute(query, ConsistencyLevel.LOCAL_QUORUM).get();
+          authenticatedDB.execute(query, ConsistencyLevel.LOCAL_QUORUM).get();
 
           return Response.status(Response.Status.OK).entity(new SuccessResponse()).build();
         });

--- a/restapi/src/main/java/io/stargate/web/resources/v1/TableResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v1/TableResource.java
@@ -118,7 +118,8 @@ public class TableResource {
                   .map(Table::name)
                   .collect(Collectors.toList());
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaRead(
                   authenticatedDB.getAuthenticationSubject(),
                   Collections.singletonList(keyspaceName),
@@ -163,7 +164,7 @@ public class TableResource {
         () -> {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
-          Keyspace keyspace = authenticatedDB.getDataStore().schema().keyspace(keyspaceName);
+          Keyspace keyspace = authenticatedDB.getKeyspace(keyspaceName);
           if (keyspace == null) {
             return Response.status(Response.Status.BAD_REQUEST)
                 .entity(
@@ -215,7 +216,8 @@ public class TableResource {
             columns.add(Column.create(columnName, kind, type, order));
           }
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -230,7 +232,6 @@ public class TableResource {
           }
 
           authenticatedDB
-              .getDataStore()
               .queryBuilder()
               .create()
               .table(keyspaceName, tableName)
@@ -278,7 +279,8 @@ public class TableResource {
         () -> {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaRead(
                   authenticatedDB.getAuthenticationSubject(),
                   Collections.singletonList(keyspaceName),
@@ -365,7 +367,8 @@ public class TableResource {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -375,7 +378,6 @@ public class TableResource {
                   ResourceKind.TABLE);
 
           authenticatedDB
-              .getDataStore()
               .queryBuilder()
               .drop()
               .table(keyspaceName, tableName)

--- a/restapi/src/main/java/io/stargate/web/resources/v2/RowsResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/RowsResource.java
@@ -392,14 +392,14 @@ public class RowsResource {
 
           BoundQuery query =
               authenticatedDB
-                  .getDataStore()
                   .queryBuilder()
                   .insertInto(keyspaceName, tableName)
                   .value(values)
                   .build()
                   .bind();
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeDataWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -408,7 +408,7 @@ public class RowsResource {
                   Scope.MODIFY,
                   SourceAPI.REST);
 
-          authenticatedDB.getDataStore().execute(query, ConsistencyLevel.LOCAL_QUORUM).get();
+          authenticatedDB.execute(query, ConsistencyLevel.LOCAL_QUORUM).get();
 
           Map<String, Object> keys = new HashMap<>();
           for (Column col : table.primaryKeyColumns()) {
@@ -514,7 +514,6 @@ public class RowsResource {
 
           BoundQuery query =
               authenticatedDB
-                  .getDataStore()
                   .queryBuilder()
                   .delete()
                   .from(keyspaceName, tableName)
@@ -522,7 +521,8 @@ public class RowsResource {
                   .build()
                   .bind();
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeDataWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -531,7 +531,7 @@ public class RowsResource {
                   Scope.DELETE,
                   SourceAPI.REST);
 
-          authenticatedDB.getDataStore().execute(query, ConsistencyLevel.LOCAL_QUORUM).get();
+          authenticatedDB.execute(query, ConsistencyLevel.LOCAL_QUORUM).get();
           return Response.status(Response.Status.NO_CONTENT).build();
         });
   }
@@ -610,7 +610,6 @@ public class RowsResource {
 
     BoundQuery query =
         authenticatedDB
-            .getDataStore()
             .queryBuilder()
             .update(keyspaceName, tableName)
             .value(changes)
@@ -618,7 +617,8 @@ public class RowsResource {
             .build()
             .bind();
 
-    db.getAuthorizationService()
+    authenticatedDB
+        .getAuthorizationService()
         .authorizeDataWrite(
             authenticatedDB.getAuthenticationSubject(),
             keyspaceName,
@@ -627,7 +627,7 @@ public class RowsResource {
             Scope.MODIFY,
             SourceAPI.REST);
 
-    authenticatedDB.getDataStore().execute(query, ConsistencyLevel.LOCAL_QUORUM).get();
+    authenticatedDB.execute(query, ConsistencyLevel.LOCAL_QUORUM).get();
     Object response = raw ? requestBody : new ResponseWrapper(requestBody);
     return Response.status(Response.Status.OK).entity(Converters.writeResponse(response)).build();
   }
@@ -656,7 +656,6 @@ public class RowsResource {
 
     BoundQuery query =
         authenticatedDB
-            .getDataStore()
             .queryBuilder()
             .select()
             .column(columns)
@@ -677,9 +676,10 @@ public class RowsResource {
         };
 
     final ResultSet r =
-        db.getAuthorizationService()
+        authenticatedDB
+            .getAuthorizationService()
             .authorizedDataRead(
-                () -> authenticatedDB.getDataStore().execute(query, parametersModifier).get(),
+                () -> authenticatedDB.execute(query, parametersModifier).get(),
                 authenticatedDB.getAuthenticationSubject(),
                 tableMetadata.keyspace(),
                 tableMetadata.name(),

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/ColumnsResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/ColumnsResource.java
@@ -104,7 +104,8 @@ public class ColumnsResource {
         () -> {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaRead(
                   authenticatedDB.getAuthenticationSubject(),
                   Collections.singletonList(keyspaceName),
@@ -202,7 +203,8 @@ public class ColumnsResource {
 
           Column column = ImmutableColumn.builder().name(name).kind(kind).type(type).build();
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -212,7 +214,6 @@ public class ColumnsResource {
                   ResourceKind.TABLE);
 
           authenticatedDB
-              .getDataStore()
               .queryBuilder()
               .alter()
               .table(keyspaceName, tableName)
@@ -265,7 +266,8 @@ public class ColumnsResource {
         () -> {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaRead(
                   authenticatedDB.getAuthenticationSubject(),
                   Collections.singletonList(keyspaceName),
@@ -342,7 +344,8 @@ public class ColumnsResource {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -352,7 +355,6 @@ public class ColumnsResource {
                   ResourceKind.TABLE);
 
           authenticatedDB
-              .getDataStore()
               .queryBuilder()
               .alter()
               .table(keyspaceName, tableName)
@@ -399,7 +401,8 @@ public class ColumnsResource {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -409,7 +412,6 @@ public class ColumnsResource {
                   ResourceKind.TABLE);
 
           authenticatedDB
-              .getDataStore()
               .queryBuilder()
               .alter()
               .table(keyspaceName, tableName)

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/IndexesResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/IndexesResource.java
@@ -113,7 +113,8 @@ public class IndexesResource {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeDataRead(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -125,7 +126,6 @@ public class IndexesResource {
             List<Column> columns = tableMetadata.columns();
             BoundQuery query =
                 authenticatedDB
-                    .getDataStore()
                     .queryBuilder()
                     .select()
                     .column(columns)
@@ -136,13 +136,10 @@ public class IndexesResource {
                     .bind();
 
             final ResultSet r =
-                db.getAuthorizationService()
+                authenticatedDB
+                    .getAuthorizationService()
                     .authorizedDataRead(
-                        () ->
-                            authenticatedDB
-                                .getDataStore()
-                                .execute(query, ConsistencyLevel.LOCAL_QUORUM)
-                                .get(),
+                        () -> authenticatedDB.execute(query, ConsistencyLevel.LOCAL_QUORUM).get(),
                         authenticatedDB.getAuthenticationSubject(),
                         keyspaceName,
                         tableName,
@@ -199,7 +196,8 @@ public class IndexesResource {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -218,7 +216,7 @@ public class IndexesResource {
                 .build();
           }
 
-          Keyspace keyspace = authenticatedDB.getDataStore().schema().keyspace(keyspaceName);
+          Keyspace keyspace = authenticatedDB.getKeyspace(keyspaceName);
           if (keyspace == null) {
             return Response.status(Response.Status.NOT_FOUND)
                 .entity(
@@ -262,7 +260,6 @@ public class IndexesResource {
                   .build();
 
           authenticatedDB
-              .getDataStore()
               .queryBuilder()
               .create()
               .index(indexAdd.getName())
@@ -322,7 +319,8 @@ public class IndexesResource {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -331,7 +329,7 @@ public class IndexesResource {
                   SourceAPI.REST,
                   ResourceKind.INDEX);
 
-          Keyspace keyspace = authenticatedDB.getDataStore().schema().keyspace(keyspaceName);
+          Keyspace keyspace = authenticatedDB.getKeyspace(keyspaceName);
           if (keyspace == null) {
             return Response.status(Response.Status.NOT_FOUND)
                 .entity(
@@ -362,7 +360,6 @@ public class IndexesResource {
           }
 
           authenticatedDB
-              .getDataStore()
               .queryBuilder()
               .drop()
               .index(keyspaceName, indexName)

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/KeyspacesResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/KeyspacesResource.java
@@ -101,7 +101,8 @@ public class KeyspacesResource {
                   .map(k -> new Keyspace(k.name(), buildDatacenters(k)))
                   .collect(Collectors.toList());
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaRead(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaces.stream().map(Keyspace::getName).collect(Collectors.toList()),
@@ -148,7 +149,8 @@ public class KeyspacesResource {
         () -> {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaRead(
                   authenticatedDB.getAuthenticationSubject(),
                   Collections.singletonList(keyspaceName),
@@ -224,7 +226,8 @@ public class KeyspacesResource {
           Map<String, Object> requestBody = ResourceUtils.readJson(payload);
 
           String keyspaceName = (String) requestBody.get("name");
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -251,7 +254,6 @@ public class KeyspacesResource {
           }
 
           authenticatedDB
-              .getDataStore()
               .queryBuilder()
               .create()
               .keyspace(keyspaceName)
@@ -293,7 +295,8 @@ public class KeyspacesResource {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -303,7 +306,6 @@ public class KeyspacesResource {
                   ResourceKind.KEYSPACE);
 
           authenticatedDB
-              .getDataStore()
               .queryBuilder()
               .drop()
               .keyspace(keyspaceName)

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/TablesResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/TablesResource.java
@@ -117,7 +117,8 @@ public class TablesResource {
                   .map(this::getTable)
                   .collect(Collectors.toList());
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaRead(
                   authenticatedDB.getAuthenticationSubject(),
                   Collections.singletonList(keyspaceName),
@@ -166,7 +167,8 @@ public class TablesResource {
         () -> {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaRead(
                   authenticatedDB.getAuthenticationSubject(),
                   Collections.singletonList(keyspaceName),
@@ -214,7 +216,7 @@ public class TablesResource {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
 
-          Keyspace keyspace = authenticatedDB.getDataStore().schema().keyspace(keyspaceName);
+          Keyspace keyspace = authenticatedDB.getKeyspace(keyspaceName);
           if (keyspace == null) {
             return Response.status(Response.Status.BAD_REQUEST)
                 .entity(
@@ -232,7 +234,8 @@ public class TablesResource {
                 .build();
           }
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -286,7 +289,6 @@ public class TablesResource {
           }
 
           authenticatedDB
-              .getDataStore()
               .queryBuilder()
               .create()
               .table(keyspaceName, tableName)
@@ -339,7 +341,8 @@ public class TablesResource {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -368,7 +371,6 @@ public class TablesResource {
           }
 
           authenticatedDB
-              .getDataStore()
               .queryBuilder()
               .alter()
               .table(keyspaceName, tableName)
@@ -415,7 +417,8 @@ public class TablesResource {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -425,7 +428,6 @@ public class TablesResource {
                   ResourceKind.TABLE);
 
           authenticatedDB
-              .getDataStore()
               .queryBuilder()
               .drop()
               .table(keyspaceName, tableName)

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/UserDefinedTypesResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/UserDefinedTypesResource.java
@@ -162,7 +162,7 @@ public class UserDefinedTypesResource {
       String keyspaceName, String typeName, boolean raw, String token, HttpServletRequest request)
       throws UnauthorizedException, JsonProcessingException {
     AuthenticatedDB authenticatedDB = db.getRestDataStoreForToken(token, getAllHeaders(request));
-    Keyspace keyspace = authenticatedDB.getDataStore().schema().keyspace(keyspaceName);
+    Keyspace keyspace = authenticatedDB.getKeyspace(keyspaceName);
     if (keyspace == null) {
       return Response.status(Response.Status.BAD_REQUEST)
           .entity(
@@ -170,7 +170,8 @@ public class UserDefinedTypesResource {
           .build();
     }
 
-    db.getAuthorizationService()
+    authenticatedDB
+        .getAuthorizationService()
         .authorizeSchemaRead(
             authenticatedDB.getAuthenticationSubject(),
             Collections.singletonList(keyspaceName),
@@ -237,7 +238,7 @@ public class UserDefinedTypesResource {
         () -> {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
-          Keyspace keyspace = authenticatedDB.getDataStore().schema().keyspace(keyspaceName);
+          Keyspace keyspace = authenticatedDB.getKeyspace(keyspaceName);
 
           if (keyspace == null) {
             return Response.status(Response.Status.BAD_REQUEST)
@@ -263,7 +264,8 @@ public class UserDefinedTypesResource {
                 .build();
           }
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -289,7 +291,6 @@ public class UserDefinedTypesResource {
                   .build();
 
           authenticatedDB
-              .getDataStore()
               .queryBuilder()
               .create()
               .type(keyspaceName, udt)
@@ -336,7 +337,7 @@ public class UserDefinedTypesResource {
         () -> {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
-          Keyspace keyspace = authenticatedDB.getDataStore().schema().keyspace(keyspaceName);
+          Keyspace keyspace = authenticatedDB.getKeyspace(keyspaceName);
           if (keyspace == null) {
             return Response.status(Response.Status.BAD_REQUEST)
                 .entity(
@@ -345,7 +346,8 @@ public class UserDefinedTypesResource {
                 .build();
           }
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -355,7 +357,6 @@ public class UserDefinedTypesResource {
                   ResourceKind.TYPE);
 
           authenticatedDB
-              .getDataStore()
               .queryBuilder()
               .drop()
               .type(
@@ -397,7 +398,7 @@ public class UserDefinedTypesResource {
           AuthenticatedDB authenticatedDB =
               db.getRestDataStoreForToken(token, getAllHeaders(request));
 
-          Keyspace keyspace = authenticatedDB.getDataStore().schema().keyspace(keyspaceName);
+          Keyspace keyspace = authenticatedDB.getKeyspace(keyspaceName);
           if (keyspace == null) {
             return Response.status(Response.Status.BAD_REQUEST)
                 .entity(
@@ -415,7 +416,8 @@ public class UserDefinedTypesResource {
                 .build();
           }
 
-          db.getAuthorizationService()
+          authenticatedDB
+              .getAuthorizationService()
               .authorizeSchemaWrite(
                   authenticatedDB.getAuthenticationSubject(),
                   keyspaceName,
@@ -456,7 +458,6 @@ public class UserDefinedTypesResource {
     if (addFields != null && !addFields.isEmpty()) {
       List<Column> columns = getUdtColumns(keyspace, addFields);
       authenticatedDB
-          .getDataStore()
           .queryBuilder()
           .alter()
           .type(keyspace.name(), udt)
@@ -472,7 +473,6 @@ public class UserDefinedTypesResource {
               .map(r -> Pair.fromArray(new String[] {r.getFrom(), r.getTo()}))
               .collect(Collectors.toList());
       authenticatedDB
-          .getDataStore()
           .queryBuilder()
           .alter()
           .type(keyspace.name(), udt)

--- a/restapi/src/test/java/io/stargate/web/resources/ColumnResourceTest.java
+++ b/restapi/src/test/java/io/stargate/web/resources/ColumnResourceTest.java
@@ -44,7 +44,7 @@ class ColumnResourceTest {
 
     AuthenticatedDB authenticatedDB = mock(AuthenticatedDB.class);
     when(db.getRestDataStoreForToken("token", Collections.emptyMap())).thenReturn(authenticatedDB);
-    when(db.getAuthorizationService()).thenReturn(authorizationService);
+    when(authenticatedDB.getAuthorizationService()).thenReturn(authorizationService);
     when(authenticatedDB.getTable("keySpaceName", "tableName")).thenReturn(table);
     when(table.columns()).thenReturn(columns);
 


### PR DESCRIPTION
**What this PR does**:

Follows up on #1287 to further improve `AuthenticatedDB` abstraction; try to remove direct use of `Db` for anything other than creating `AuthenticatedDB` instances, and simplify call patterns to avoid using unnecessary chains like `getDataStore().queryBuilder()`. In other words make `AuthenticatedDB` more similar to `DocumentDB`, actually useful abstraction on top of DataStore.

Note: will likely follow-up with renaming of `Db`, as well as reconsidering how `getAuthorizationService()` / `getAuthenticationSubject()` should be handled.

**Which issue(s) this PR fixes**:
Fixes #1301

**Checklist**

- [x] Changes manually tested - no functional change so IT/CI should be enough
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
