### PR TITLE
Add value conversion methods for complex types

### DIFF
--- a/grpc-proto/pom.xml
+++ b/grpc-proto/pom.xml
@@ -23,6 +23,17 @@
       <artifactId>grpc-stub</artifactId>
       <version>${grpc.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/grpc-proto/src/main/java/io/stargate/grpc/Values.java
+++ b/grpc-proto/src/main/java/io/stargate/grpc/Values.java
@@ -22,11 +22,13 @@ import io.stargate.proto.QueryOuterClass.Inet;
 import io.stargate.proto.QueryOuterClass.UdtValue;
 import io.stargate.proto.QueryOuterClass.Uuid;
 import io.stargate.proto.QueryOuterClass.Value;
+import io.stargate.proto.QueryOuterClass.Value.InnerCase;
 import io.stargate.proto.QueryOuterClass.Value.Null;
 import io.stargate.proto.QueryOuterClass.Value.Unset;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -162,5 +164,144 @@ public class Values {
     return Value.newBuilder()
         .setCollection(Collection.newBuilder().addAllElements(values).build())
         .build();
+  }
+
+  public static boolean bool(Value value) {
+    if (value.getInnerCase() != InnerCase.BOOLEAN) {
+      throw new IllegalArgumentException("Expected boolean value");
+    }
+    return value.getBoolean();
+  }
+
+  public static int int_(Value value) {
+    if (value.getInnerCase() != InnerCase.INT) {
+      throw new IllegalArgumentException("Expected int value");
+    }
+    int intValue = (int) value.getInt();
+    if (intValue != value.getInt()) {
+      throw new IllegalArgumentException(
+          String.format("Valid range for int is %d to %d", Integer.MIN_VALUE, Integer.MAX_VALUE));
+    }
+    return intValue;
+  }
+
+  public static long bigint(Value value) {
+    if (value.getInnerCase() != InnerCase.INT) {
+      throw new IllegalArgumentException("Expected int value");
+    }
+    return value.getInt();
+  }
+
+  public static short smallint(Value value) {
+    if (value.getInnerCase() != InnerCase.INT) {
+      throw new IllegalArgumentException("Expected int value");
+    }
+    short shortValue = (short) value.getInt();
+    if (shortValue != value.getInt()) {
+      throw new IllegalArgumentException(
+          String.format("Valid range for int is %d to %d", Short.MIN_VALUE, Short.MAX_VALUE));
+    }
+    return shortValue;
+  }
+
+  public static byte tinyint(Value value) {
+    if (value.getInnerCase() != InnerCase.INT) {
+      throw new IllegalArgumentException("Expected int value");
+    }
+    byte byteValue = (byte) value.getInt();
+    if (byteValue != value.getInt()) {
+      throw new IllegalArgumentException(
+          String.format("Valid range for int is %d to %d", Byte.MIN_VALUE, Byte.MAX_VALUE));
+    }
+    return byteValue;
+  }
+
+  public static float float_(Value value) {
+    if (value.getInnerCase() != InnerCase.FLOAT) {
+      throw new IllegalArgumentException("Expected float value");
+    }
+    return value.getFloat();
+  }
+
+  public static double double_(Value value) {
+    if (value.getInnerCase() != InnerCase.DOUBLE) {
+      throw new IllegalArgumentException("Expected double value");
+    }
+    return value.getDouble();
+  }
+
+  public static ByteBuffer byteBuffer(Value value) {
+    if (value.getInnerCase() != InnerCase.BYTES) {
+      throw new IllegalArgumentException("Expected bytes value");
+    }
+    ByteBuffer bytes = ByteBuffer.allocate(value.getBytes().size());
+    value.getBytes().copyTo(bytes);
+    return bytes;
+  }
+
+  public static byte[] bytes(Value value) {
+    if (value.getInnerCase() != InnerCase.BYTES) {
+      throw new IllegalArgumentException("Expected bytes value");
+    }
+    return value.getBytes().toByteArray();
+  }
+
+  public static String string(Value value) {
+    if (value.getInnerCase() != InnerCase.STRING) {
+      throw new IllegalArgumentException("Expected string value");
+    }
+    return value.getString();
+  }
+
+  public static UUID uuid(Value value) {
+    if (value.getInnerCase() != InnerCase.UUID) {
+      throw new IllegalArgumentException("Expected uuid value");
+    }
+    ByteBuffer bytes = ByteBuffer.allocate(16);
+    value.getUuid().getValue().copyTo(bytes);
+    bytes.flip();
+    return new UUID(bytes.getLong(bytes.position()), bytes.getLong(bytes.position() + 8));
+  }
+
+  public static InetAddress inet(Value value) {
+    if (value.getInnerCase() != InnerCase.INET) {
+      throw new IllegalArgumentException("Expected inet value");
+    }
+    try {
+      return InetAddress.getByAddress(value.getInet().getValue().toByteArray());
+    } catch (UnknownHostException e) {
+      throw new IllegalArgumentException("Invalid bytes in inet value");
+    }
+  }
+
+  public static BigInteger varint(Value value) {
+    if (value.getInnerCase() != InnerCase.VARINT) {
+      throw new IllegalArgumentException("Expected varint value");
+    }
+    return new BigInteger(value.getVarint().getValue().toByteArray());
+  }
+
+  public static BigDecimal decimal(Value value) {
+    if (value.getInnerCase() != InnerCase.DECIMAL) {
+      throw new IllegalArgumentException("Expected decimal value");
+    }
+    return new BigDecimal(
+        new BigInteger(value.getDecimal().getValue().toByteArray()), value.getDecimal().getScale());
+  }
+
+  public static LocalDate date(Value value) {
+    if (value.getInnerCase() != InnerCase.DATE) {
+      throw new IllegalArgumentException("Expected date value");
+    }
+    int unsigned = value.getDate();
+    int signed = unsigned + Integer.MIN_VALUE;
+    return EPOCH.plusDays(signed);
+  }
+
+  public static LocalTime time(Value value) {
+    if (value.getInnerCase() != InnerCase.TIME) {
+      throw new IllegalArgumentException("Expected time value");
+    }
+    return LocalTime.ofNanoOfDay(value.getTime());
   }
 }

--- a/grpc-proto/src/test/java/ValuesTest.java
+++ b/grpc-proto/src/test/java/ValuesTest.java
@@ -1,0 +1,323 @@
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.stargate.grpc.Values;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class ValuesTest {
+
+  @Nested
+  class BoolTest {
+
+    @Test
+    public void encodeDecode() {
+      boolean expected = true;
+      assertThat(Values.bool(Values.of(expected))).isEqualTo(expected);
+    }
+
+    @Test
+    public void invalid() {
+      assertThatThrownBy(
+              () -> {
+                Values.bool(Values.NULL);
+              })
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  class IntTest {
+
+    @Test
+    public void encodeDecode() {
+      int expected = Integer.MAX_VALUE;
+      assertThat(Values.int_(Values.of(expected))).isEqualTo(expected);
+    }
+
+    @Test
+    public void invalid() {
+      assertThatThrownBy(
+              () -> {
+                Values.int_(Values.NULL);
+              })
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  class BigintTest {
+
+    @Test
+    public void encodeDecode() {
+      long expected = Long.MAX_VALUE;
+      assertThat(Values.bigint(Values.of(expected))).isEqualTo(expected);
+    }
+
+    @Test
+    public void invalid() {
+      assertThatThrownBy(
+              () -> {
+                Values.bigint(Values.NULL);
+              })
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  class SmallintTest {
+
+    @Test
+    public void encodeDecode() {
+      short expected = Short.MAX_VALUE;
+      assertThat(Values.smallint(Values.of(expected))).isEqualTo(expected);
+    }
+
+    @Test
+    public void invalid() {
+      assertThatThrownBy(
+              () -> {
+                Values.smallint(Values.NULL);
+              })
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  class TinyintTest {
+
+    @Test
+    public void encodeDecode() {
+      byte expected = Byte.MAX_VALUE;
+      assertThat(Values.tinyint(Values.of(expected))).isEqualTo(expected);
+    }
+
+    @Test
+    public void invalid() {
+      assertThatThrownBy(
+              () -> {
+                Values.tinyint(Values.NULL);
+              })
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  class FloatTest {
+
+    @Test
+    public void encodeDecode() {
+      float expected = Float.MAX_VALUE;
+      assertThat(Values.float_(Values.of(expected))).isEqualTo(expected);
+    }
+
+    @Test
+    public void invalid() {
+      assertThatThrownBy(
+              () -> {
+                Values.float_(Values.NULL);
+              })
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  class DoubleTest {
+
+    @Test
+    public void encodeDecode() {
+      double expected = Double.MAX_VALUE;
+      assertThat(Values.double_(Values.of(expected))).isEqualTo(expected);
+    }
+
+    @Test
+    public void invalid() {
+      assertThatThrownBy(
+              () -> {
+                Values.double_(Values.NULL);
+              })
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  class BytesTest {
+
+    @Test
+    public void encodeDecodeBytes() {
+      byte[] expected = new byte[] {1, 2, 3};
+      assertThat(Values.bytes(Values.of(expected))).isEqualTo(expected);
+    }
+
+    @Test
+    public void encodeDecodeByteBuffer() {
+      ByteBuffer expected = ByteBuffer.wrap(new byte[] {1, 2, 3});
+      assertThat(Values.byteBuffer(Values.of(expected))).isEqualTo(expected);
+    }
+
+    @Test
+    public void invalidBytes() {
+      assertThatThrownBy(
+              () -> {
+                Values.bytes(Values.NULL);
+              })
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void invalidByteBuffer() {
+      assertThatThrownBy(
+              () -> {
+                Values.byteBuffer(Values.NULL);
+              })
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  class StringTest {
+
+    @Test
+    public void encodeDecode() {
+      String expected = "abc";
+      assertThat(Values.string(Values.of(expected))).isEqualTo(expected);
+    }
+
+    @Test
+    public void invalid() {
+      assertThatThrownBy(
+              () -> {
+                Values.string(Values.NULL);
+              })
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  class UUIDTest {
+
+    @Test
+    public void encodeDecode() {
+      UUID expected = UUID.randomUUID();
+      assertThat(Values.uuid(Values.of(expected))).isEqualTo(expected);
+    }
+
+    @Test
+    public void invalid() {
+      assertThatThrownBy(
+              () -> {
+                Values.uuid(Values.NULL);
+              })
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  class InetTest {
+
+    @Test
+    public void encodeDecodeV4() throws UnknownHostException {
+      InetAddress expected = InetAddress.getByName("127.0.0.1");
+      assertThat(Values.inet(Values.of(expected))).isEqualTo(expected);
+    }
+
+    @Test
+    public void encodeDecodeV6() throws UnknownHostException {
+      InetAddress expected = InetAddress.getByName("2001:db8::8a2e:370:7334");
+      assertThat(Values.inet(Values.of(expected))).isEqualTo(expected);
+    }
+
+    @Test
+    public void invalid() {
+      assertThatThrownBy(
+              () -> {
+                Values.inet(Values.NULL);
+              })
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  public class VarintTest {
+
+    @Test
+    public void encodeDecode() {
+      BigInteger expected = new BigInteger("99999999999999999999999999999999999999");
+      assertThat(Values.varint(Values.of(expected))).isEqualTo(expected);
+    }
+
+    @Test
+    public void invalid() {
+      assertThatThrownBy(
+              () -> {
+                Values.varint(Values.NULL);
+              })
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  public class DecimalTest {
+
+    @Test
+    public void encodeDecode() {
+      BigDecimal expected = new BigDecimal("9999999999999.9999999999999999999999999");
+      assertThat(Values.decimal(Values.of(expected))).isEqualTo(expected);
+    }
+
+    @Test
+    public void invalid() {
+      assertThatThrownBy(
+              () -> {
+                Values.decimal(Values.NULL);
+              })
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  public class DateTest {
+
+    @Test
+    public void encodeDecode() {
+      LocalDate expected = LocalDate.now();
+      assertThat(Values.date(Values.of(expected))).isEqualTo(expected);
+    }
+
+    @Test
+    public void invalid() {
+      assertThatThrownBy(
+              () -> {
+                Values.date(Values.NULL);
+              })
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  public class TimeTest {
+
+    @Test
+    public void encodeDecode() {
+      LocalTime expected = LocalTime.now();
+      assertThat(Values.time(Values.of(expected))).isEqualTo(expected);
+    }
+
+    @Test
+    public void invalid() {
+      assertThatThrownBy(
+              () -> {
+                Values.time(Values.NULL);
+              })
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+}


### PR DESCRIPTION
Add methods to convert from `Value` to Java types.

Also, add value conversion methods for less complex types for
completeness.

This doesn't include collections, UDTs or tuples. That's a PR in itself.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**Checklist**
- [X ] Changes manually tested
- [X] Automated Tests added/updated
- [ ] Documentation added/updated
