### PR TITLE
(WIP) Fix #1309: split `Db` into separate factories, rename data access types

### DIFF
--- a/restapi/src/main/java/io/stargate/web/resources/v1/ColumnResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v1/ColumnResource.java
@@ -30,9 +30,9 @@ import io.stargate.web.models.ColumnDefinition;
 import io.stargate.web.models.ColumnUpdate;
 import io.stargate.web.models.Error;
 import io.stargate.web.models.SuccessResponse;
-import io.stargate.web.resources.AuthenticatedDB;
-import io.stargate.web.resources.Db;
 import io.stargate.web.resources.RequestHandler;
+import io.stargate.web.restapi.dao.RestDBAccess;
+import io.stargate.web.restapi.dao.RestDBAccessFactory;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -67,11 +67,11 @@ import org.apache.cassandra.stargate.db.ConsistencyLevel;
 @Singleton
 public class ColumnResource {
 
-  private Db db;
+  private RestDBAccessFactory dbFactory;
 
   @Inject
-  public ColumnResource(Db db) {
-    this.db = db;
+  public ColumnResource(RestDBAccessFactory db) {
+    this.dbFactory = db;
   }
 
   @Timed
@@ -109,18 +109,17 @@ public class ColumnResource {
       @Context HttpServletRequest request) {
     return RequestHandler.handle(
         () -> {
-          AuthenticatedDB authenticatedDB =
-              db.getRestDataStoreForToken(token, getAllHeaders(request));
-          authenticatedDB
+          RestDBAccess restDBAccess = dbFactory.getRestDBForToken(token, getAllHeaders(request));
+          restDBAccess
               .getAuthorizationService()
               .authorizeSchemaRead(
-                  authenticatedDB.getAuthenticationSubject(),
+                  restDBAccess.getAuthenticationSubject(),
                   Collections.singletonList(keyspaceName),
                   Collections.singletonList(tableName),
                   SourceAPI.REST,
                   ResourceKind.TABLE);
 
-          final Table tableMetadata = authenticatedDB.getTable(keyspaceName, tableName);
+          final Table tableMetadata = restDBAccess.getTable(keyspaceName, tableName);
 
           List<ColumnDefinition> collect =
               tableMetadata.columns().stream()
@@ -170,9 +169,8 @@ public class ColumnResource {
       @Context HttpServletRequest request) {
     return RequestHandler.handle(
         () -> {
-          AuthenticatedDB authenticatedDB =
-              db.getRestDataStoreForToken(token, getAllHeaders(request));
-          Keyspace keyspace = authenticatedDB.getKeyspace(keyspaceName);
+          RestDBAccess restDBAccess = dbFactory.getRestDBForToken(token, getAllHeaders(request));
+          Keyspace keyspace = restDBAccess.getKeyspace(keyspaceName);
           if (keyspace == null) {
             return Response.status(Response.Status.BAD_REQUEST)
                 .entity(
@@ -197,17 +195,17 @@ public class ColumnResource {
                           keyspace, columnDefinition.getTypeDefinition()))
                   .build();
 
-          authenticatedDB
+          restDBAccess
               .getAuthorizationService()
               .authorizeSchemaWrite(
-                  authenticatedDB.getAuthenticationSubject(),
+                  restDBAccess.getAuthenticationSubject(),
                   keyspaceName,
                   tableName,
                   Scope.ALTER,
                   SourceAPI.REST,
                   ResourceKind.TABLE);
 
-          authenticatedDB
+          restDBAccess
               .queryBuilder()
               .alter()
               .table(keyspaceName, tableName)
@@ -255,18 +253,17 @@ public class ColumnResource {
       @Context HttpServletRequest request) {
     return RequestHandler.handle(
         () -> {
-          AuthenticatedDB authenticatedDB =
-              db.getRestDataStoreForToken(token, getAllHeaders(request));
-          authenticatedDB
+          RestDBAccess restDBAccess = dbFactory.getRestDBForToken(token, getAllHeaders(request));
+          restDBAccess
               .getAuthorizationService()
               .authorizeSchemaRead(
-                  authenticatedDB.getAuthenticationSubject(),
+                  restDBAccess.getAuthenticationSubject(),
                   Collections.singletonList(keyspaceName),
                   Collections.singletonList(tableName),
                   SourceAPI.REST,
                   ResourceKind.TABLE);
 
-          final Table tableMetadata = authenticatedDB.getTable(keyspaceName, tableName);
+          final Table tableMetadata = restDBAccess.getTable(keyspaceName, tableName);
           final Column col = tableMetadata.column(columnName);
           if (col == null) {
             return Response.status(Response.Status.NOT_FOUND)
@@ -313,20 +310,19 @@ public class ColumnResource {
       @Context HttpServletRequest request) {
     return RequestHandler.handle(
         () -> {
-          AuthenticatedDB authenticatedDB =
-              db.getRestDataStoreForToken(token, getAllHeaders(request));
+          RestDBAccess restDBAccess = dbFactory.getRestDBForToken(token, getAllHeaders(request));
 
-          authenticatedDB
+          restDBAccess
               .getAuthorizationService()
               .authorizeSchemaWrite(
-                  authenticatedDB.getAuthenticationSubject(),
+                  restDBAccess.getAuthenticationSubject(),
                   keyspaceName,
                   tableName,
                   Scope.ALTER,
                   SourceAPI.REST,
                   ResourceKind.TABLE);
 
-          authenticatedDB
+          restDBAccess
               .queryBuilder()
               .alter()
               .table(keyspaceName, tableName)
@@ -373,20 +369,19 @@ public class ColumnResource {
       @Context HttpServletRequest request) {
     return RequestHandler.handle(
         () -> {
-          AuthenticatedDB authenticatedDB =
-              db.getRestDataStoreForToken(token, getAllHeaders(request));
+          RestDBAccess restDBAccess = dbFactory.getRestDBForToken(token, getAllHeaders(request));
 
-          authenticatedDB
+          restDBAccess
               .getAuthorizationService()
               .authorizeSchemaWrite(
-                  authenticatedDB.getAuthenticationSubject(),
+                  restDBAccess.getAuthenticationSubject(),
                   keyspaceName,
                   tableName,
                   Scope.ALTER,
                   SourceAPI.REST,
                   ResourceKind.TABLE);
 
-          authenticatedDB
+          restDBAccess
               .queryBuilder()
               .alter()
               .table(keyspaceName, tableName)

--- a/restapi/src/main/java/io/stargate/web/resources/v1/KeyspaceResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v1/KeyspaceResource.java
@@ -20,9 +20,9 @@ import static io.stargate.web.docsapi.resources.RequestToHeadersMapper.getAllHea
 import com.codahale.metrics.annotation.Timed;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.entity.ResourceKind;
-import io.stargate.web.resources.AuthenticatedDB;
-import io.stargate.web.resources.Db;
 import io.stargate.web.resources.RequestHandler;
+import io.stargate.web.restapi.dao.RestDBAccess;
+import io.stargate.web.restapi.dao.RestDBAccessFactory;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -48,7 +48,7 @@ import javax.ws.rs.core.Response;
 @Produces(MediaType.APPLICATION_JSON)
 @Singleton
 public class KeyspaceResource {
-  @Inject private Db db;
+  @Inject private RestDBAccessFactory dbFactory;
 
   @Timed
   @GET
@@ -79,14 +79,13 @@ public class KeyspaceResource {
       @Context HttpServletRequest request) {
     return RequestHandler.handle(
         () -> {
-          AuthenticatedDB authenticatedDB =
-              db.getRestDataStoreForToken(token, getAllHeaders(request));
+          RestDBAccess restDBAccess = dbFactory.getRestDBForToken(token, getAllHeaders(request));
 
-          List<String> keyspaceNames = authenticatedDB.schema().keyspaceNames();
-          authenticatedDB
+          List<String> keyspaceNames = restDBAccess.schema().keyspaceNames();
+          restDBAccess
               .getAuthorizationService()
               .authorizeSchemaRead(
-                  authenticatedDB.getAuthenticationSubject(),
+                  restDBAccess.getAuthenticationSubject(),
                   keyspaceNames,
                   null,
                   SourceAPI.REST,

--- a/restapi/src/main/java/io/stargate/web/resources/v2/schemas/ColumnsResource.java
+++ b/restapi/src/main/java/io/stargate/web/resources/v2/schemas/ColumnsResource.java
@@ -29,10 +29,10 @@ import io.stargate.db.schema.Table;
 import io.stargate.web.models.ColumnDefinition;
 import io.stargate.web.models.Error;
 import io.stargate.web.models.ResponseWrapper;
-import io.stargate.web.resources.AuthenticatedDB;
 import io.stargate.web.resources.Converters;
-import io.stargate.web.resources.Db;
 import io.stargate.web.resources.RequestHandler;
+import io.stargate.web.restapi.dao.RestDBAccess;
+import io.stargate.web.restapi.dao.RestDBAccessFactory;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -68,7 +68,7 @@ import org.apache.cassandra.stargate.db.ConsistencyLevel;
 @Produces(MediaType.APPLICATION_JSON)
 @Singleton
 public class ColumnsResource {
-  @Inject private Db db;
+  @Inject private RestDBAccessFactory dbFactory;
 
   @Timed
   @GET
@@ -102,12 +102,11 @@ public class ColumnsResource {
       @Context HttpServletRequest request) {
     return RequestHandler.handle(
         () -> {
-          AuthenticatedDB authenticatedDB =
-              db.getRestDataStoreForToken(token, getAllHeaders(request));
-          authenticatedDB
+          RestDBAccess restDBAccess = dbFactory.getRestDBForToken(token, getAllHeaders(request));
+          restDBAccess
               .getAuthorizationService()
               .authorizeSchemaRead(
-                  authenticatedDB.getAuthenticationSubject(),
+                  restDBAccess.getAuthenticationSubject(),
                   Collections.singletonList(keyspaceName),
                   Collections.singletonList(tableName),
                   SourceAPI.REST,
@@ -115,7 +114,7 @@ public class ColumnsResource {
 
           final Table tableMetadata;
           try {
-            tableMetadata = authenticatedDB.getTable(keyspaceName, tableName);
+            tableMetadata = restDBAccess.getTable(keyspaceName, tableName);
           } catch (Exception e) {
             return Response.status(Response.Status.BAD_REQUEST)
                 .entity(
@@ -174,9 +173,8 @@ public class ColumnsResource {
       @Context HttpServletRequest request) {
     return RequestHandler.handle(
         () -> {
-          AuthenticatedDB authenticatedDB =
-              db.getRestDataStoreForToken(token, getAllHeaders(request));
-          Keyspace keyspace = authenticatedDB.getKeyspace(keyspaceName);
+          RestDBAccess restDBAccess = dbFactory.getRestDBForToken(token, getAllHeaders(request));
+          Keyspace keyspace = restDBAccess.getKeyspace(keyspaceName);
           if (keyspace == null) {
             return Response.status(Response.Status.BAD_REQUEST)
                 .entity(
@@ -203,17 +201,17 @@ public class ColumnsResource {
 
           Column column = ImmutableColumn.builder().name(name).kind(kind).type(type).build();
 
-          authenticatedDB
+          restDBAccess
               .getAuthorizationService()
               .authorizeSchemaWrite(
-                  authenticatedDB.getAuthenticationSubject(),
+                  restDBAccess.getAuthenticationSubject(),
                   keyspaceName,
                   tableName,
                   Scope.ALTER,
                   SourceAPI.REST,
                   ResourceKind.TABLE);
 
-          authenticatedDB
+          restDBAccess
               .queryBuilder()
               .alter()
               .table(keyspaceName, tableName)
@@ -264,12 +262,11 @@ public class ColumnsResource {
       @Context HttpServletRequest request) {
     return RequestHandler.handle(
         () -> {
-          AuthenticatedDB authenticatedDB =
-              db.getRestDataStoreForToken(token, getAllHeaders(request));
-          authenticatedDB
+          RestDBAccess restDBAccess = dbFactory.getRestDBForToken(token, getAllHeaders(request));
+          restDBAccess
               .getAuthorizationService()
               .authorizeSchemaRead(
-                  authenticatedDB.getAuthenticationSubject(),
+                  restDBAccess.getAuthenticationSubject(),
                   Collections.singletonList(keyspaceName),
                   Collections.singletonList(tableName),
                   SourceAPI.REST,
@@ -277,7 +274,7 @@ public class ColumnsResource {
 
           final Table tableMetadata;
           try {
-            tableMetadata = authenticatedDB.getTable(keyspaceName, tableName);
+            tableMetadata = restDBAccess.getTable(keyspaceName, tableName);
           } catch (Exception e) {
             return Response.status(Response.Status.BAD_REQUEST)
                 .entity(
@@ -341,20 +338,19 @@ public class ColumnsResource {
       @Context HttpServletRequest request) {
     return RequestHandler.handle(
         () -> {
-          AuthenticatedDB authenticatedDB =
-              db.getRestDataStoreForToken(token, getAllHeaders(request));
+          RestDBAccess restDBAccess = dbFactory.getRestDBForToken(token, getAllHeaders(request));
 
-          authenticatedDB
+          restDBAccess
               .getAuthorizationService()
               .authorizeSchemaWrite(
-                  authenticatedDB.getAuthenticationSubject(),
+                  restDBAccess.getAuthenticationSubject(),
                   keyspaceName,
                   tableName,
                   Scope.ALTER,
                   SourceAPI.REST,
                   ResourceKind.TABLE);
 
-          authenticatedDB
+          restDBAccess
               .queryBuilder()
               .alter()
               .table(keyspaceName, tableName)
@@ -398,20 +394,19 @@ public class ColumnsResource {
       @Context HttpServletRequest request) {
     return RequestHandler.handle(
         () -> {
-          AuthenticatedDB authenticatedDB =
-              db.getRestDataStoreForToken(token, getAllHeaders(request));
+          RestDBAccess restDBAccess = dbFactory.getRestDBForToken(token, getAllHeaders(request));
 
-          authenticatedDB
+          restDBAccess
               .getAuthorizationService()
               .authorizeSchemaWrite(
-                  authenticatedDB.getAuthenticationSubject(),
+                  restDBAccess.getAuthenticationSubject(),
                   keyspaceName,
                   tableName,
                   Scope.ALTER,
                   SourceAPI.REST,
                   ResourceKind.TABLE);
 
-          authenticatedDB
+          restDBAccess
               .queryBuilder()
               .alter()
               .table(keyspaceName, tableName)

--- a/restapi/src/main/java/io/stargate/web/restapi/dao/RestDBAccess.java
+++ b/restapi/src/main/java/io/stargate/web/restapi/dao/RestDBAccess.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.stargate.web.resources;
+package io.stargate.web.restapi.dao;
 
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
@@ -34,16 +34,15 @@ import javax.ws.rs.NotFoundException;
 import org.apache.cassandra.stargate.db.ConsistencyLevel;
 
 /**
- * Data store abstraction used by Rest API: encapsulates authentication aspects along with
+ * Data access abstraction used by Rest API: encapsulates authentication aspects along with
  * underlying actual {@link DataStore}, offers some more convenience access.
  */
-public class AuthenticatedDB {
-
+public class RestDBAccess {
   private final DataStore dataStore;
   private final AuthenticationSubject authenticationSubject;
   private final AuthorizationService authorizationService;
 
-  public AuthenticatedDB(
+  public RestDBAccess(
       DataStore dataStore,
       AuthenticationSubject authenticationSubject,
       AuthorizationService authorizationService) {

--- a/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
@@ -10,8 +10,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.stargate.web.docsapi.service.DocsApiConfiguration;
 import io.stargate.web.docsapi.service.DocsSchemaChecker;
 import io.stargate.web.docsapi.service.DocumentService;
-import io.stargate.web.resources.AuthenticatedDB;
 import io.stargate.web.resources.Db;
+import io.stargate.web.restapi.dao.RestDBAccess;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -32,7 +32,7 @@ import org.mockito.quality.Strictness;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class DocumentResourceV2Test {
-  private final AuthenticatedDB authenticatedDBMock = mock(AuthenticatedDB.class);
+  private final RestDBAccess restDBAccessMock = mock(RestDBAccess.class);
   @InjectMocks private DocumentResourceV2 documentResourceV2;
   @Mock private DocumentService documentServiceMock;
   @Mock private Db dbFactoryMock;

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -156,7 +156,7 @@ public class DocumentServiceTest extends AbstractDataStoreTest {
 
   @BeforeEach
   void setup() throws UnauthorizedException {
-    when(dataStoreFactory.createInternal(any())).thenReturn(datastore());
+    //    when(dataStoreFactory.createInternal(any())).thenReturn(datastore());
     when(dataStoreFactory.create(any(), any())).thenReturn(datastore());
 
     db = new Db(authenticationService, authorizationService, dataStoreFactory, config);

--- a/restapi/src/test/java/io/stargate/web/resources/ColumnResourceTest.java
+++ b/restapi/src/test/java/io/stargate/web/resources/ColumnResourceTest.java
@@ -13,6 +13,8 @@ import io.stargate.db.schema.ImmutableColumn;
 import io.stargate.db.schema.Table;
 import io.stargate.web.models.ColumnDefinition;
 import io.stargate.web.resources.v1.ColumnResource;
+import io.stargate.web.restapi.dao.RestDBAccess;
+import io.stargate.web.restapi.dao.RestDBAccessFactory;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -24,7 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(DropwizardExtensionsSupport.class)
 class ColumnResourceTest {
 
-  private static final Db db = mock(Db.class);
+  private static final RestDBAccessFactory db = mock(RestDBAccessFactory.class);
 
   private static final ResourceExtension resource =
       ResourceExtension.builder().addResource(new ColumnResource(db)).build();
@@ -42,10 +44,10 @@ class ColumnResourceTest {
     Column column2 = ImmutableColumn.create("c2", Column.Kind.Regular, Column.Type.Int);
     List<Column> columns = Arrays.asList(column1, column2);
 
-    AuthenticatedDB authenticatedDB = mock(AuthenticatedDB.class);
-    when(db.getRestDataStoreForToken("token", Collections.emptyMap())).thenReturn(authenticatedDB);
-    when(authenticatedDB.getAuthorizationService()).thenReturn(authorizationService);
-    when(authenticatedDB.getTable("keySpaceName", "tableName")).thenReturn(table);
+    RestDBAccess restDBAccess = mock(RestDBAccess.class);
+    when(db.getRestDBForToken("token", Collections.emptyMap())).thenReturn(restDBAccess);
+    when(restDBAccess.getAuthorizationService()).thenReturn(authorizationService);
+    when(restDBAccess.getTable("keySpaceName", "tableName")).thenReturn(table);
     when(table.columns()).thenReturn(columns);
 
     List<ColumnDefinition> columnDefinitions =


### PR DESCRIPTION
(Work in Progress)

**What this PR does**:

Continuation of splitting of REST/Document APIs, improve naming.

**Which issue(s) this PR fixes**:
Fixes #1309

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
