### PR TITLE
Fix #1327: make `duzzt` dependency "provided" (6 fewer bundled jars)

### DIFF
--- a/persistence-api/pom.xml
+++ b/persistence-api/pom.xml
@@ -49,6 +49,7 @@
       <groupId>com.github.misberner.duzzt</groupId>
       <artifactId>duzzt-processor</artifactId>
       <version>0.0.2</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>javax.annotation</groupId>


### PR DESCRIPTION
**What this PR does**:

Changes scope of "Duzzt" processor "provided", to avoid adding 6 jars in bundle of `persistence-api`

**Which issue(s) this PR fixes**:
Fixes #1327

**Checklist**
- [x] Changes manually tested -- verified that 6 jars listed on https://github.com/misberner/duzzt README are no longer included (and were before change)
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
