### PR TITLE
Enable GraphQL schema-first by default

### DIFF
--- a/graphqlapi/src/main/java/io/stargate/graphql/GraphqlActivator.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/GraphqlActivator.java
@@ -42,7 +42,7 @@ public class GraphqlActivator extends BaseActivator {
   private static final String AUTH_IDENTIFIER =
       System.getProperty("stargate.auth_id", "AuthTableBasedService");
   private static final boolean ENABLE_GRAPHQL_FIRST =
-      Boolean.getBoolean("stargate.graphql_first.enabled");
+      Boolean.parseBoolean(System.getProperty("stargate.graphql_first.enabled", "true"));
   private static final boolean ENABLE_GRAPHQL_PLAYGROUND =
       !Boolean.getBoolean("stargate.graphql_playground.disabled");
 


### PR DESCRIPTION
**What this PR does**:

GraphQL schema-first is conditioned by `stargate.graphql_first.enabled`, which still defaults to `false`.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- ~~Automated Tests added/updated~~
- ~~Documentation added/updated~~
