### PR TITLE
Fix gRPC prepared cache invalidation approach #2

### DIFF
--- a/grpc/src/main/java/io/stargate/grpc/service/BatchHandler.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/BatchHandler.java
@@ -60,7 +60,7 @@ class BatchHandler extends MessageHandler<Batch, BatchHandler.BatchAndIdempotenc
   BatchHandler(
       Batch batch,
       Connection connection,
-      Cache<PrepareInfo, CompletionStage<Prepared>> preparedCache,
+      Cache<PrepareInfo, Prepared> preparedCache,
       Persistence persistence,
       StreamObserver<Response> responseObserver) {
     super(batch, connection, preparedCache, persistence, responseObserver);

--- a/grpc/src/main/java/io/stargate/grpc/service/GrpcService.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/GrpcService.java
@@ -20,15 +20,17 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import io.grpc.Context;
 import io.grpc.stub.StreamObserver;
 import io.stargate.core.metrics.api.Metrics;
+import io.stargate.db.EventListener;
 import io.stargate.db.Persistence;
 import io.stargate.db.Persistence.Connection;
 import io.stargate.db.Result;
 import io.stargate.db.Result.Prepared;
+import io.stargate.db.schema.Column;
 import io.stargate.proto.QueryOuterClass.Batch;
 import io.stargate.proto.QueryOuterClass.Query;
 import io.stargate.proto.QueryOuterClass.Response;
+import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nullable;
 import org.apache.cassandra.stargate.db.ConsistencyLevel;
@@ -42,8 +44,7 @@ public class GrpcService extends io.stargate.proto.StargateGrpc.StargateImplBase
   public static final ConsistencyLevel DEFAULT_SERIAL_CONSISTENCY = ConsistencyLevel.SERIAL;
 
   // TODO: Add a maximum size and add tuning options
-  private final Cache<PrepareInfo, CompletionStage<Prepared>> preparedCache =
-      Caffeine.newBuilder().build();
+  private final Cache<PrepareInfo, Prepared> preparedCache = Caffeine.newBuilder().build();
 
   private final Persistence persistence;
 
@@ -80,6 +81,8 @@ public class GrpcService extends io.stargate.proto.StargateGrpc.StargateImplBase
     this.executor = executor;
     this.schemaAgreementRetries = schemaAgreementRetries;
     assert this.metrics != null;
+
+    this.persistence.registerEventListener(new PreparedCacheInvalidatingEventListener());
   }
 
   @Override
@@ -117,6 +120,110 @@ public class GrpcService extends io.stargate.proto.StargateGrpc.StargateImplBase
 
     public boolean tracingIdIsEmpty() {
       return tracingId == null || tracingId.toString().isEmpty();
+    }
+  }
+
+  /**
+   * An event listener that invalidates the prepared cache when schema change event occur.
+   *
+   * <p>This is not as granular as it could be for functions/aggregates because it's not possible to
+   * know whether a prepared statement is using either of those with the information available in
+   * {@link Prepared}. It will also invalidate any query where the keyspace and/or table can not be
+   * determined, that is, queries with out bind parameters or result metadata.
+   */
+  private class PreparedCacheInvalidatingEventListener implements EventListener {
+    public void onCreateFunction(String keyspace, String function, List<String> argumentTypes) {
+      invalidateByKeyspace(keyspace);
+    }
+
+    public void onCreateAggregate(String keyspace, String aggregate, List<String> argumentTypes) {
+      invalidateByKeyspace(keyspace);
+    }
+
+    public void onAlterTable(String keyspace, String table) {
+      invalidateByTable(keyspace, table);
+    }
+
+    public void onAlterFunction(String keyspace, String function, List<String> argumentTypes) {
+      invalidateByKeyspace(keyspace);
+    }
+
+    public void onAlterAggregate(String keyspace, String aggregate, List<String> argumentTypes) {
+      invalidateByKeyspace(keyspace);
+    }
+
+    public void onDropKeyspace(String keyspace) {
+      invalidateByKeyspace(keyspace);
+    }
+
+    public void onDropTable(String keyspace, String table) {
+      invalidateByTable(keyspace, table);
+    }
+
+    public void onDropFunction(String keyspace, String function, List<String> argumentTypes) {
+      invalidateByKeyspace(keyspace);
+    }
+
+    public void onDropAggregate(String keyspace, String aggregate, List<String> argumentTypes) {
+      invalidateByKeyspace(keyspace);
+    }
+
+    /*
+     * Invalidates any prepared statement that matches the keyspace or where the keyspace cannot be
+     * determined.
+     */
+    private void invalidateByKeyspace(String keyspace) {
+      preparedCache
+          .asMap()
+          .forEach(
+              (info, prepared) -> {
+                int size = prepared.metadata.columns.size();
+                int resultSize = prepared.resultMetadata.columns.size();
+                boolean unableToDetermineKeyspace = size == 0 && resultSize == 0;
+                if (unableToDetermineKeyspace
+                    || (size > 0 && shouldInvalidate(prepared.metadata.columns.get(0), keyspace))
+                    || (resultSize > 0
+                        && shouldInvalidate(prepared.resultMetadata.columns.get(0), keyspace))) {
+                  preparedCache.invalidate(info);
+                }
+              });
+    }
+
+    /*
+     * Invalidates any prepared statement that matches the keyspace/table or where the
+     * keyspace/table cannot be determined.
+     */
+    private void invalidateByTable(String keyspace, String table) {
+      preparedCache
+          .asMap()
+          .forEach(
+              (info, prepared) -> {
+                int size = prepared.metadata.columns.size();
+                int resultSize = prepared.resultMetadata.columns.size();
+                boolean unableToDetermineTable = size == 0 && resultSize == 0;
+                if (unableToDetermineTable
+                    || (size > 0
+                        && shouldInvalidate(prepared.metadata.columns.get(0), keyspace, table))
+                    || (resultSize > 0
+                        && shouldInvalidate(
+                            prepared.resultMetadata.columns.get(0), keyspace, table))) {
+                  preparedCache.invalidate(info);
+                }
+              });
+    }
+
+    public boolean shouldInvalidate(Column column, String keyspaceToInvalidate) {
+      String keyspace = column.keyspace();
+      return keyspace == null || keyspace.equals(keyspaceToInvalidate);
+    }
+
+    public boolean shouldInvalidate(
+        Column column, String keyspaceToInvalidate, String tableToInvalidate) {
+      String keyspace = column.keyspace();
+      String table = column.table();
+      return keyspace == null
+          || table == null
+          || (keyspace.equals(keyspaceToInvalidate) && table.equals(tableToInvalidate));
     }
   }
 }

--- a/grpc/src/main/java/io/stargate/grpc/service/QueryHandler.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/QueryHandler.java
@@ -55,7 +55,7 @@ class QueryHandler extends MessageHandler<Query, Prepared> {
   QueryHandler(
       Query query,
       Connection connection,
-      Cache<PrepareInfo, CompletionStage<Prepared>> preparedCache,
+      Cache<PrepareInfo, Prepared> preparedCache,
       Persistence persistence,
       ScheduledExecutorService executor,
       int schemaAgreementRetries,

--- a/testing/src/main/java/io/stargate/it/grpc/ExecuteQueryTest.java
+++ b/testing/src/main/java/io/stargate/it/grpc/ExecuteQueryTest.java
@@ -216,4 +216,37 @@ public class ExecuteQueryTest extends GrpcIntegrationTest {
             cqlQuery("INSERT INTO test (k, v) VALUES ('a', 1)", queryParameters(keyspace)));
     assertThat(response).isNotNull();
   }
+
+  @Test
+  public void dropTableAndChangeType(@TestKeyspace CqlIdentifier keyspace) {
+    StargateBlockingStub stub = stubWithCallCredentials();
+
+    Response response;
+    response =
+        stub.executeQuery(
+            cqlQuery(
+                "CREATE TABLE IF NOT EXISTS drop_table_test(pk BIGINT PRIMARY KEY)",
+                queryParameters(keyspace)));
+    assertThat(response).isNotNull();
+
+    response =
+        stub.executeQuery(
+            cqlQuery("INSERT INTO drop_table_test(pk) VALUES(1)", queryParameters(keyspace)));
+    assertThat(response).isNotNull();
+
+    response = stub.executeQuery(cqlQuery("DROP TABLE drop_table_test", queryParameters(keyspace)));
+    assertThat(response).isNotNull();
+
+    response =
+        stub.executeQuery(
+            cqlQuery(
+                "CREATE TABLE IF NOT EXISTS drop_table_test(pk TEXT PRIMARY KEY)",
+                queryParameters(keyspace)));
+    assertThat(response).isNotNull();
+
+    response =
+        stub.executeQuery(
+            cqlQuery("INSERT INTO drop_table_test(pk) VALUES('1')", queryParameters(keyspace)));
+    assertThat(response).isNotNull();
+  }
 }


### PR DESCRIPTION
This approach fixes prepared cache validation by registering an
`EventListener` to invalidate external prepared cache whenever relevant
schema change event occur. This means that the cache can no longer be
asynchronous and will possibly suffer from a prepare stampede when the
same query is run many times simultaneously.

The drawback of this approach is the very rough invalidation of the
cache and complexity. The invalidation of the cache can be quite broad
i.e. if we're unable to determine the keyspace and/or table of a
prepared statement we have to invalidate it because we don't have enough
metadata to see if it's still valid or not.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [ ] ~Documentation added/updated~
