### PR TITLE
Fix #1342: remove trivial usage, dependency to slf4j/logback, by `authnz` to shrink jar/bundle by 95%

### DIFF
--- a/authnz/pom.xml
+++ b/authnz/pom.xml
@@ -15,23 +15,6 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>log4j-over-slf4j</artifactId>
-      <scope>runtime</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -51,7 +34,6 @@
               io.stargate.db.*,
               org.apache.cassandra.stargate,
               org.apache.cassandra.stargate.*,
-              org.javatuples,
             ]]></Import-Package>
             <Export-Package>io.stargate.auth,io.stargate.auth.entity</Export-Package>
             <Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>

--- a/authnz/src/main/java/io/stargate/auth/PlainTextTokenSaslNegotiator.java
+++ b/authnz/src/main/java/io/stargate/auth/PlainTextTokenSaslNegotiator.java
@@ -23,13 +23,8 @@ import io.stargate.db.Authenticator.SaslNegotiator;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.apache.cassandra.stargate.exceptions.AuthenticationException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public abstract class PlainTextTokenSaslNegotiator implements SaslNegotiator {
-
-  private static final Logger logger = LoggerFactory.getLogger(PlainTextTokenSaslNegotiator.class);
-
   static final byte NUL = 0;
 
   protected final AuthenticationService authentication;
@@ -86,7 +81,6 @@ public abstract class PlainTextTokenSaslNegotiator implements SaslNegotiator {
    * @throws AuthenticationException if either the authnId or password is null
    */
   public static Credentials decodeCredentials(byte[] bytes) throws AuthenticationException {
-    logger.trace("Decoding credentials from client token");
     byte[] user = null;
     byte[] pass = null;
     int end = bytes.length;


### PR DESCRIPTION
**What this PR does**:

Removes one trace-level logging statement, to get rid of slf4j/logback dependency which resulted in 700kB+ addition in otherwise tiny `authnz` bundle.

**Which issue(s) this PR fixes**:
Fixes #1342

**Checklist**
- [x] Changes manually tested -- verify with CI
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
