### PR TITLE
Add empty implementation for DSE search indexes (fixes #606)

### DIFF
--- a/persistence-dse-6.8/src/main/java/com/datastax/bdp/search/solr/Cql3SolrSecondaryIndex.java
+++ b/persistence-dse-6.8/src/main/java/com/datastax/bdp/search/solr/Cql3SolrSecondaryIndex.java
@@ -33,7 +33,7 @@ public class Cql3SolrSecondaryIndex implements Index {
 
   private final IndexMetadata indexMetadata;
 
-  public Cql3SolrSecondaryIndex(ColumnFamilyStore columnFamilyStore, IndexMetadata indexMetadata) {
+  public Cql3SolrSecondaryIndex(ColumnFamilyStore ignoredCfs, IndexMetadata indexMetadata) {
     this.indexMetadata = indexMetadata;
   }
 


### PR DESCRIPTION
**What this PR does**:

Adds an empty implementation as a placeholder for `Cql3SolrSecondaryIndex`. This avoids the ClassNotFoundException while parsing the schema. 

Example of a search query when connected directly to the DSE backend:
```
create table test.foo(k int primary key);
create search index on test.foo;

insert into test.foo(k) values (0);
select * from test.foo where solr_query = 'k: 0';

 k | solr_query
---+------------
 0 |       null
```

When connecting through Stargate, the query won't work: it requires ALLOW FILTERING, and once that gets added it returns no results.

**Which issue(s) this PR fixes**:
Fixes #606

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
