### PR TITLE
Add one missing piece wrt #1255 for config-store-yaml/Caffeine dependency

### DIFF
--- a/config-store-yaml/pom.xml
+++ b/config-store-yaml/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<parent>
+  <parent>
     <artifactId>stargate</artifactId>
     <groupId>io.stargate</groupId>
     <version>1.0.40-SNAPSHOT</version>
   </parent>
-	<modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
     <groupId>io.stargate.config.store.yaml</groupId>
-	<artifactId>config-store-yaml</artifactId>
-	<dependencies>
+    <artifactId>config-store-yaml</artifactId>
+    <dependencies>
       <!-- Stargate component dependencies -->
       <dependency>
         <groupId>io.stargate.config-store</groupId>
@@ -39,7 +39,6 @@
       <dependency>
         <groupId>com.github.ben-manes.caffeine</groupId>
         <artifactId>caffeine</artifactId>
-        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>


### PR DESCRIPTION
**What this PR does**:

Fixes issue with incomplete merge of earlier fix: Caffeine dependency was accidentally left as `provided`.
Seems like a merge problem of some kind as it passed CI earlier.

**Which issue(s) this PR fixes**:
Fixes #1255

**Checklist**
- [x] Changes manually tested -- use existing CI/IT (which failed for another PR due to this issue)
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
