### PR TITLE
Remove unused `Any` import from gRPC proto file

### DIFF
--- a/grpc-proto/proto/query.proto
+++ b/grpc-proto/proto/query.proto
@@ -15,7 +15,6 @@
  */
 syntax = "proto3";
 
-import "google/protobuf/any.proto";
 import "google/protobuf/wrappers.proto";
 
 option java_package = "io.stargate.proto";


### PR DESCRIPTION
**What this PR does**:

Removes a left over import from use of `Any`.

**Checklist**
- [X] Changes manually tested
