### PR TITLE
GraphQL CQL-first: handle null values for complex types (fixes #1347)

### DIFF
--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/DataTypeMapping.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/DataTypeMapping.java
@@ -40,6 +40,9 @@ class DataTypeMapping {
 
   /** Converts a value coming from the GraphQL runtime into a DB value. */
   static Object toDBValue(ColumnType type, Object graphQLValue, NameMapping nameMapping) {
+    if (graphQLValue == null) {
+      return null;
+    }
     if (type.isCollection()) {
       if (type.rawType() == Column.Type.List) {
         return convertCollection(type, graphQLValue, nameMapping, ArrayList::new);

--- a/testing/src/main/java/io/stargate/it/http/graphql/cqlfirst/TuplesTest.java
+++ b/testing/src/main/java/io/stargate/it/http/graphql/cqlfirst/TuplesTest.java
@@ -151,4 +151,33 @@ public class TuplesTest extends BaseOsgiIntegrationTest {
     assertThat(JsonPath.<Integer>read(response, "$.TuplesPk.values[0].id.item0")).isEqualTo(0);
     assertThat(JsonPath.<Integer>read(response, "$.TuplesPk.values[0].id.item1")).isEqualTo(1);
   }
+
+  @Test
+  public void shouldInsertNullTuple(@TestKeyspace CqlIdentifier keyspaceId) {
+    // When inserting a new row:
+    Map<String, Object> response =
+        CLIENT.executeDmlQuery(
+            keyspaceId,
+            "mutation {\n"
+                + "  insertTuples: insertTuplx65_s(value: {\n"
+                + "    id: \"792d0a56-bb46-4bc2-bc41-5f4a94a83da9\"\n"
+                + "    tuple1: null\n"
+                + "  }) {\n"
+                + "        applied\n"
+                + "    }\n"
+                + "}");
+    assertThat(JsonPath.<Boolean>read(response, "$.insertTuples.applied")).isTrue();
+
+    // Then the data can be read back:
+    String getQuery =
+        "{\n"
+            + "  Tuples: Tuplx65_s(value: { id: \"792d0a56-bb46-4bc2-bc41-5f4a94a83da9\"}) {\n"
+            + "    values {\n"
+            + "      tuple1 { item0 }\n"
+            + "    }\n"
+            + "  }\n"
+            + "}";
+    response = CLIENT.executeDmlQuery(keyspaceId, getQuery);
+    assertThat(JsonPath.<Object>read(response, "$.Tuples.values[0].tuple1")).isNull();
+  }
 }

--- a/testing/src/main/java/io/stargate/it/http/graphql/cqlfirst/UdtsTest.java
+++ b/testing/src/main/java/io/stargate/it/http/graphql/cqlfirst/UdtsTest.java
@@ -36,7 +36,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
     initQueries = {
       "CREATE TYPE IF NOT EXISTS \"B\"(i int)",
       "CREATE TYPE IF NOT EXISTS \"A\"(b frozen<\"B\">)",
-      "CREATE TABLE IF NOT EXISTS \"Udts\"(a frozen<\"A\"> PRIMARY KEY, bs list<frozen<\"B\">>)"
+      "CREATE TABLE IF NOT EXISTS \"Udts\"(a frozen<\"A\"> PRIMARY KEY, bs list<frozen<\"B\">>)",
+      "CREATE TABLE IF NOT EXISTS \"Udts2\"(k int PRIMARY KEY, a \"A\")"
     })
 public class UdtsTest extends BaseOsgiIntegrationTest {
 
@@ -78,5 +79,34 @@ public class UdtsTest extends BaseOsgiIntegrationTest {
     assertThat(JsonPath.<Integer>read(response, "$.Udts.values[0].a.b.i")).isEqualTo(1);
     assertThat(JsonPath.<Integer>read(response, "$.Udts.values[0].bs[0].i")).isEqualTo(2);
     assertThat(JsonPath.<Integer>read(response, "$.Udts.values[0].bs[1].i")).isEqualTo(3);
+  }
+
+  @Test
+  @DisplayName("Should insert null UDT")
+  public void nullUdtTest(@TestKeyspace CqlIdentifier keyspaceId) {
+    Map<String, Object> response =
+        CLIENT.executeDmlQuery(
+            keyspaceId,
+            "mutation {\n"
+                + "  insertUdts2(value: {\n"
+                + "    k: 1\n"
+                + "    a: null\n"
+                + "  }) {\n"
+                + "        applied\n"
+                + "    }\n"
+                + "}");
+    assertThat(JsonPath.<Boolean>read(response, "$.insertUdts2.applied")).isTrue();
+
+    response =
+        CLIENT.executeDmlQuery(
+            keyspaceId,
+            "{\n"
+                + "    Udts2(value: { k: 1 }) {\n"
+                + "        values {\n"
+                + "            a { b { i } }\n"
+                + "        }\n"
+                + "    }\n"
+                + "}");
+    assertThat(JsonPath.<Object>read(response, "$.Udts2.values[0].a")).isNull();
   }
 }


### PR DESCRIPTION
**What this PR does**:
Allow null input values for collections, tuples and UDTs in GraphQL requests.

**Which issue(s) this PR fixes**:
Fixes #1347

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
