### PR TITLE
(WIP) SGv2: use `QueryBuilder` for "getAllRows()"

### DIFF
--- a/sgv2-restapi/pom.xml
+++ b/sgv2-restapi/pom.xml
@@ -22,6 +22,13 @@
       <artifactId>core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.stargate.db</groupId>
+      <artifactId>persistence-api</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
     <!-- this should also bring transitively "io.grpc:grpc-netty-shaded"...
          but somehow does not seem to, despite being listed as a dep?!
       -->

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/util/SchemaNoPersistence.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/util/SchemaNoPersistence.java
@@ -6,7 +6,6 @@ import io.stargate.db.schema.Schema;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Bogus {@link Schema} implementation that we need for Stargate V2 as we do not have actual

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/util/SchemaNoPersistence.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/util/SchemaNoPersistence.java
@@ -1,0 +1,35 @@
+package io.stargate.sgv2.restsvc.util;
+
+import io.stargate.db.schema.ImmutableKeyspace;
+import io.stargate.db.schema.Keyspace;
+import io.stargate.db.schema.Schema;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Bogus {@link Schema} implementation that we need for Stargate V2 as we do not have actual
+ * Persistence implementation. This means that keyspace and table entities are constructed on-demand
+ * without validation for existence.
+ */
+public class SchemaNoPersistence extends Schema {
+  private static final Keyspace ANONYMOUS = ImmutableKeyspace.builder().name("<anonymous>").build();
+
+  @Override
+  public Set<Keyspace> keyspaces() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public Keyspace keyspace(String name) {
+    if (name == null) {
+      return ANONYMOUS;
+    }
+    return ImmutableKeyspace.builder().name(name).build();
+  }
+
+  public List<String> keyspaceNames() {
+    return keyspaces().stream().map(k -> k.name()).sorted().collect(Collectors.toList());
+  }
+}

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/util/SchemaNoPersistence.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/util/SchemaNoPersistence.java
@@ -11,11 +11,11 @@ import java.util.Set;
  * Bogus {@link Schema} implementation that we need for Stargate V2 as we do not have actual
  * Persistence implementation. This means that keyspace and table entities are constructed on-demand
  * without validation for existence.
+ *
+ * <p>NOTE: very much prototype level, unlikely to be used in this exact form for eventual Stargate
+ * V2.
  */
 public class SchemaNoPersistence extends Schema {
-  // NOTE: copied from the base class; intent not clear
-  private static final Keyspace ANONYMOUS = ImmutableKeyspace.builder().name("<anonymous>").build();
-
   @Override
   public Set<Keyspace> keyspaces() {
     return Collections.emptySet();
@@ -23,8 +23,9 @@ public class SchemaNoPersistence extends Schema {
 
   @Override
   public Keyspace keyspace(String name) {
-    if (name == null) {
-      return ANONYMOUS;
+    if ((name == null) || name.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Can not create a keyspace without non-null, non-empty \"name\"");
     }
     return ImmutableKeyspace.builder().name(name).build();
   }

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/util/SchemaNoPersistence.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/util/SchemaNoPersistence.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
  * without validation for existence.
  */
 public class SchemaNoPersistence extends Schema {
+  // NOTE: copied from the base class; intent not clear
   private static final Keyspace ANONYMOUS = ImmutableKeyspace.builder().name("<anonymous>").build();
 
   @Override
@@ -30,6 +31,6 @@ public class SchemaNoPersistence extends Schema {
   }
 
   public List<String> keyspaceNames() {
-    return keyspaces().stream().map(k -> k.name()).sorted().collect(Collectors.toList());
+    return Collections.emptyList();
   }
 }


### PR DESCRIPTION
**What this PR does**:

Minor change to use property `QueryBuilder` for constructing query for "getAllRows()"

**Which issue(s) this PR fixes**:
No issue filed

**Checklist**
- [x] Changes manually tested -- passes same integration tests as before.
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
