### PR TITLE
Add schema agreement check to persistence connection

### DIFF
--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/ExecuteMessage.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/ExecuteMessage.java
@@ -94,7 +94,7 @@ public class ExecuteMessage extends Message.Request {
         new BoundStatement(statementId, options.getValues(), options.getNames());
     CompletableFuture<? extends Result> future =
         persistenceConnection().execute(statement, makeParameters(options), queryStartNanoTime);
-    return SchemaAgreement.maybeWaitForAgreement(future, persistence())
+    return SchemaAgreement.maybeWaitForAgreement(future, persistenceConnection())
         .thenApply(ResultMessage::new);
   }
 

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/QueryMessage.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/QueryMessage.java
@@ -72,7 +72,7 @@ public class QueryMessage extends Message.Request {
     SimpleStatement statement = new SimpleStatement(query, options.getValues(), options.getNames());
     CompletableFuture<? extends Result> future =
         persistenceConnection().execute(statement, makeParameters(options), queryStartNanoTime);
-    return SchemaAgreement.maybeWaitForAgreement(future, persistence())
+    return SchemaAgreement.maybeWaitForAgreement(future, persistenceConnection())
         .thenApply(ResultMessage::new);
   }
 

--- a/grpc/src/main/java/io/stargate/grpc/service/QueryHandler.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/QueryHandler.java
@@ -198,7 +198,7 @@ class QueryHandler extends MessageHandler<Query, Prepared> {
 
   private void waitForSchemaAgreement(
       int remainingAttempts, CompletableFuture<Void> agreementFuture) {
-    if (persistence.isInSchemaAgreement()) {
+    if (connection.isInSchemaAgreement()) {
       agreementFuture.complete(null);
       return;
     }

--- a/grpc/src/test/java/io/stargate/grpc/service/SchemaAgreementTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/SchemaAgreementTest.java
@@ -40,7 +40,7 @@ public class SchemaAgreementTest extends BaseGrpcServiceTest {
   public void schemaAgreementSuccess() {
     // Given
     StargateGrpc.StargateBlockingStub stub = makeBlockingStub();
-    when(persistence.isInSchemaAgreement()).thenReturn(true);
+    when(connection.isInSchemaAgreement()).thenReturn(true);
     mockAnyQueryAsSchemaChange();
     when(persistence.newConnection()).thenReturn(connection);
     startServer(persistence);
@@ -57,7 +57,7 @@ public class SchemaAgreementTest extends BaseGrpcServiceTest {
   public void schemaAgreementFailure() {
     // Given
     StargateGrpc.StargateBlockingStub stub = makeBlockingStub();
-    when(persistence.isInSchemaAgreement()).thenReturn(false);
+    when(connection.isInSchemaAgreement()).thenReturn(false);
     mockAnyQueryAsSchemaChange();
     when(persistence.newConnection()).thenReturn(connection);
     startServer(persistence);

--- a/persistence-api/src/main/java/io/stargate/db/Persistence.java
+++ b/persistence-api/src/main/java/io/stargate/db/Persistence.java
@@ -80,8 +80,6 @@ public interface Persistence extends SchemaAgreementChecker {
    */
   ByteBuffer unsetValue();
 
-  boolean isInSchemaAgreement();
-
   /**
    * Returns <code>true</code> if the local schema agrees with all storage nodes, <code>false</code>
    * otherwise.

--- a/persistence-api/src/main/java/io/stargate/db/Persistence.java
+++ b/persistence-api/src/main/java/io/stargate/db/Persistence.java
@@ -15,7 +15,6 @@
  */
 package io.stargate.db;
 
-import com.datastax.oss.driver.shaded.guava.common.util.concurrent.Uninterruptibles;
 import io.stargate.db.datastore.DataStore;
 import io.stargate.db.schema.Schema;
 import io.stargate.db.schema.TableName;
@@ -24,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 import org.apache.cassandra.stargate.exceptions.AuthenticationException;
 
 /**
@@ -34,10 +32,7 @@ import org.apache.cassandra.stargate.exceptions.AuthenticationException;
  * higher level {@link DataStore} API which wraps an instance of this interface) to query the
  * underlying store, and thus the one interface that persistence extensions must implement.
  */
-public interface Persistence {
-
-  int SCHEMA_AGREEMENT_WAIT_RETRIES =
-      Integer.getInteger("stargate.persistence.schema.agreement.wait.retries", 900);
+public interface Persistence extends SchemaChecker {
 
   /** Name describing the persistence implementation. */
   String name();
@@ -105,20 +100,6 @@ public interface Persistence {
     return true;
   }
 
-  /** Wait for schema to agree across the cluster */
-  default void waitForSchemaAgreement() {
-    for (int count = 0; count < SCHEMA_AGREEMENT_WAIT_RETRIES; count++) {
-      if (isInSchemaAgreement()) {
-        return;
-      }
-      Uninterruptibles.sleepUninterruptibly(200, TimeUnit.MILLISECONDS);
-    }
-    throw new IllegalStateException(
-        "Failed to reach schema agreement after "
-            + (200 * SCHEMA_AGREEMENT_WAIT_RETRIES)
-            + " milliseconds.");
-  }
-
   /**
    * Returns <code>false</code>> if the persistence implementation cannot reasonably expect to reach
    * schema agreement with storage nodes assuming no external intervention.
@@ -155,7 +136,7 @@ public interface Persistence {
    * <p>It is through this object that a user can be logged in and that the persistence can be
    * queried.
    */
-  interface Connection {
+  interface Connection extends SchemaChecker {
 
     /** The underlying persistence on which this is a connection. */
     Persistence persistence();
@@ -252,5 +233,16 @@ public interface Persistence {
 
     /** Makes a new {@link RowDecorator} for the given table. */
     RowDecorator makeRowDecorator(TableName table);
+
+    /**
+     * Checks whether this coordinator in schema agreement with the other nodes in the cluster. This
+     * is the same as {@code Persistence#isInSchemaAgreement()}, except that it *may* consider other
+     * connection specific properties to determine whether schema is in agreement.
+     *
+     * @return true if schema is agreement; otherwise false.
+     */
+    default boolean isInSchemaAgreement() {
+      return persistence().isInSchemaAgreement();
+    }
   }
 }

--- a/persistence-api/src/main/java/io/stargate/db/Persistence.java
+++ b/persistence-api/src/main/java/io/stargate/db/Persistence.java
@@ -32,7 +32,7 @@ import org.apache.cassandra.stargate.exceptions.AuthenticationException;
  * higher level {@link DataStore} API which wraps an instance of this interface) to query the
  * underlying store, and thus the one interface that persistence extensions must implement.
  */
-public interface Persistence extends SchemaChecker {
+public interface Persistence extends SchemaAgreementChecker {
 
   /** Name describing the persistence implementation. */
   String name();
@@ -136,7 +136,7 @@ public interface Persistence extends SchemaChecker {
    * <p>It is through this object that a user can be logged in and that the persistence can be
    * queried.
    */
-  interface Connection extends SchemaChecker {
+  interface Connection extends SchemaAgreementChecker {
 
     /** The underlying persistence on which this is a connection. */
     Persistence persistence();

--- a/persistence-api/src/main/java/io/stargate/db/RateLimitingPersistence.java
+++ b/persistence-api/src/main/java/io/stargate/db/RateLimitingPersistence.java
@@ -101,11 +101,6 @@ public class RateLimitingPersistence implements Persistence {
   }
 
   @Override
-  public void waitForSchemaAgreement() {
-    persistence.waitForSchemaAgreement();
-  }
-
-  @Override
   public Map<String, List<String>> cqlSupportedOptions() {
     return persistence.cqlSupportedOptions();
   }

--- a/persistence-api/src/main/java/io/stargate/db/SchemaAgreementChecker.java
+++ b/persistence-api/src/main/java/io/stargate/db/SchemaAgreementChecker.java
@@ -4,7 +4,7 @@ import com.datastax.oss.driver.shaded.guava.common.util.concurrent.Uninterruptib
 import java.util.concurrent.TimeUnit;
 
 /** A persistence object that checks whether it's in schema agreement. */
-public interface SchemaChecker {
+public interface SchemaAgreementChecker {
   int SCHEMA_AGREEMENT_WAIT_RETRIES =
       Integer.getInteger("stargate.persistence.schema.agreement.wait.retries", 900);
 

--- a/persistence-api/src/main/java/io/stargate/db/SchemaChecker.java
+++ b/persistence-api/src/main/java/io/stargate/db/SchemaChecker.java
@@ -1,0 +1,31 @@
+package io.stargate.db;
+
+import com.datastax.oss.driver.shaded.guava.common.util.concurrent.Uninterruptibles;
+import java.util.concurrent.TimeUnit;
+
+/** A persistence object that checks whether it's in schema agreement. */
+public interface SchemaChecker {
+  int SCHEMA_AGREEMENT_WAIT_RETRIES =
+      Integer.getInteger("stargate.persistence.schema.agreement.wait.retries", 900);
+
+  /**
+   * Checks whether this coordinator in schema agreement with the other nodes in the cluster.
+   *
+   * @return true if schema is agreement; otherwise false.
+   */
+  boolean isInSchemaAgreement();
+
+  /** Wait for schema to agree across the cluster */
+  default void waitForSchemaAgreement() {
+    for (int count = 0; count < SCHEMA_AGREEMENT_WAIT_RETRIES; count++) {
+      if (isInSchemaAgreement()) {
+        return;
+      }
+      Uninterruptibles.sleepUninterruptibly(200, TimeUnit.MILLISECONDS);
+    }
+    throw new IllegalStateException(
+        "Failed to reach schema agreement after "
+            + (200 * SCHEMA_AGREEMENT_WAIT_RETRIES)
+            + " milliseconds.");
+  }
+}

--- a/persistence-api/src/main/java/io/stargate/db/datastore/PersistenceBackedDataStore.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/PersistenceBackedDataStore.java
@@ -201,7 +201,7 @@ public class PersistenceBackedDataStore implements DataStore {
 
   @Override
   public boolean isInSchemaAgreement() {
-    return persistence().isInSchemaAgreement();
+    return connection.isInSchemaAgreement();
   }
 
   @Override

--- a/persistence-api/src/main/java/io/stargate/db/datastore/PersistenceBackedDataStore.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/PersistenceBackedDataStore.java
@@ -221,7 +221,7 @@ public class PersistenceBackedDataStore implements DataStore {
 
   @Override
   public void waitForSchemaAgreement() {
-    persistence().waitForSchemaAgreement();
+    connection.waitForSchemaAgreement();
   }
 
   @Override

--- a/persistence-api/src/main/java/io/stargate/db/datastore/PersistenceBackedResultSet.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/PersistenceBackedResultSet.java
@@ -79,7 +79,7 @@ class PersistenceBackedResultSet implements ResultSet {
       case Prepared:
         throw new AssertionError("Shouldn't get a 'Prepared' result when executing a statement");
       case SchemaChange:
-        connection.persistence().waitForSchemaAgreement();
+        connection.waitForSchemaAgreement();
         return ResultSet.empty(true);
       case Void: // fallthrough on purpose
       case SetKeyspace:

--- a/persistence-test/src/main/java/io/stargate/it/PersistenceTest.java
+++ b/persistence-test/src/main/java/io/stargate/it/PersistenceTest.java
@@ -1666,7 +1666,7 @@ public abstract class PersistenceTest {
     execute(conn, "USE " + ks.cqlName());
     execute(conn, "CREATE TABLE t (k int PRIMARY KEY)");
 
-    persistence().waitForSchemaAgreement();
+    conn.waitForSchemaAgreement();
 
     // TTLs have a hard cap to 20 years, so we can't pass a bigger one that that or it will hard
     // throw rather than warn (and cap the TTL).


### PR DESCRIPTION
This adds a more granular level of checking for schema agreement. If the
underlying persistence implementation supports per-client schema this
allows for other custom, client-level properties to be accounted for
when checking the schema.

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [X] Documentation added/updated (added javadoc comments)
