### PR TITLE
Fix #1404: add/expose "byte[]" methods; remove legacy (broken) base64 handling workaround

### DIFF
--- a/core/src/main/java/io/stargate/core/util/ByteBufferUtils.java
+++ b/core/src/main/java/io/stargate/core/util/ByteBufferUtils.java
@@ -44,30 +44,15 @@ public class ByteBufferUtils {
   }
 
   public static ByteBuffer fromBase64UrlParam(String base64) {
-    // TODO: remove support for legacy use cases when they are no longer relevant
-    if (isLegacyEncodedBase64String(base64)) {
-      // Fix legacy strings that got broken by decoding `+` at HTTP level
-      base64 = base64.replace(' ', '+');
-      // Use the decoder compatible with the encoder previously used for URL params
-      return ByteBuffer.wrap(Base64.getDecoder().decode(base64));
-    }
-
+    // As per PR #1405 (and earlier issue #1041), special handling no longer needed
+    /*    if (base64.chars().anyMatch(c -> c == '/' || c == '+' || c == ' ')) {
+    Fix legacy strings that got broken by decoding `+` at HTTP level
+         base64 = base64.replace(' ', '+');
+         // Use the decoder compatible with the encoder previously used for URL params
+         return ByteBuffer.wrap(Base64.getDecoder().decode(base64));
+       }
+    */
     return ByteBuffer.wrap(Base64.getUrlDecoder().decode(base64));
-  }
-
-  private static boolean isLegacyEncodedBase64String(String base64) {
-    // From
-    // https://cowtowncoder.medium.com/measuring-string-indexofany-string-performance-java-fecb9eb473fa
-    // use the fastest (and simple) method here (since commons-lang3 not yet a dependency)
-    for (int i = 0, len = base64.length(); i < len; ++i) {
-      switch (base64.charAt(i)) {
-        case '/':
-        case '+':
-        case ' ':
-          return true;
-      }
-    }
-    return false;
   }
 
   /**

--- a/core/src/main/java/io/stargate/core/util/ByteBufferUtils.java
+++ b/core/src/main/java/io/stargate/core/util/ByteBufferUtils.java
@@ -24,7 +24,11 @@ public class ByteBufferUtils {
   private ByteBufferUtils() {}
 
   public static String toBase64(ByteBuffer buffer) {
-    return Base64.getEncoder().encodeToString(getArray(buffer));
+    return toBase64(getArray(buffer));
+  }
+
+  public static String toBase64(byte[] bytes) {
+    return Base64.getEncoder().encodeToString(bytes);
   }
 
   public static ByteBuffer fromBase64(String base64) {
@@ -32,12 +36,16 @@ public class ByteBufferUtils {
   }
 
   public static String toBase64ForUrl(ByteBuffer buffer) {
-    return Base64.getUrlEncoder().encodeToString(getArray(buffer));
+    return toBase64ForUrl(getArray(buffer));
+  }
+
+  public static String toBase64ForUrl(byte[] bytes) {
+    return Base64.getUrlEncoder().encodeToString(bytes);
   }
 
   public static ByteBuffer fromBase64UrlParam(String base64) {
     // TODO: remove support for legacy use cases when they are no longer relevant
-    if (base64.chars().anyMatch(c -> c == '/' || c == '+' || c == ' ')) {
+    if (isLegacyEncodedBase64String(base64)) {
       // Fix legacy strings that got broken by decoding `+` at HTTP level
       base64 = base64.replace(' ', '+');
       // Use the decoder compatible with the encoder previously used for URL params
@@ -45,6 +53,21 @@ public class ByteBufferUtils {
     }
 
     return ByteBuffer.wrap(Base64.getUrlDecoder().decode(base64));
+  }
+
+  private static boolean isLegacyEncodedBase64String(String base64) {
+    // From
+    // https://cowtowncoder.medium.com/measuring-string-indexofany-string-performance-java-fecb9eb473fa
+    // use the fastest (and simple) method here (since commons-lang3 not yet a dependency)
+    for (int i = 0, len = base64.length(); i < len; ++i) {
+      switch (base64.charAt(i)) {
+        case '/':
+        case '+':
+        case ' ':
+          return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/core/src/test/java/io/stargate/core/util/ByteBufferUtilsTest.java
+++ b/core/src/test/java/io/stargate/core/util/ByteBufferUtilsTest.java
@@ -36,6 +36,8 @@ class ByteBufferUtilsTest {
     }
   }
 
+  // Tests for earlier issue #1041, obsoleted by PR #1405:
+  /*
   @Test
   void testLegacyUrlParameterDecoding() {
     assertThat(fromBase64UrlParam("g/A=").array()).isEqualTo(new byte[] {-125, -16});
@@ -47,4 +49,5 @@ class ByteBufferUtilsTest {
     // validate the decoding of base64 strings where `+` got replaced by ` ` at the HTTP level
     assertThat(fromBase64UrlParam("y A=").array()).isEqualTo(new byte[] {-53, -32});
   }
+  */
 }


### PR DESCRIPTION
**What this PR does**:

* Adds and exposes 2 methods that accept `byte[]` (over just `ByteBuffer`) since functionality exists and is useful for use cases that do not use `ByteBuffer`s
* Optimizes check for legacy URLs (used heavily for PagingState handling) (see issue for details -- significant perf penalty for existing Streams-based impl)

**Which issue(s) this PR fixes**:
Fixes #1404 

**Checklist**
- [x] Changes manually tested -- verified that commenting out parts of new check would fail tests
- [x] Automated Tests added/updated -- relies on existing unit tests
- [ ] Documentation added/updated
