### PR TITLE
WIP: use placeholder-INSERT for "addRow()" instead of as-JSON

### DIFF
--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/JsonToProtoValueConverter.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/JsonToProtoValueConverter.java
@@ -2,14 +2,17 @@ package io.stargate.sgv2.restsvc.grpc;
 
 import io.stargate.grpc.Values;
 import io.stargate.proto.QueryOuterClass;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 
+/**
+ * Helper class for converting "natural" Java object types (such as ones bound by Jackson when
+ * target is {@code java.lang.Object}) into matching gRPC {@link QueryOuterClass.Value} types.
+ *
+ * <p>NOTE: current implementation is incomplete and may not prove useful without additional schema
+ * information.
+ */
 public class JsonToProtoValueConverter {
-  public static QueryOuterClass.Value NULL =
-      QueryOuterClass.Value.newBuilder()
-          .setNull(QueryOuterClass.Value.Null.newBuilder().build())
-          .build();
-
   private JsonToProtoValueConverter() {}
 
   public static QueryOuterClass.Value protoValueFor(Object javaValue) {
@@ -28,6 +31,15 @@ public class JsonToProtoValueConverter {
       }
       if (javaValue instanceof BigInteger) {
         return Values.of((BigInteger) javaValue);
+      }
+      if (javaValue instanceof Double) {
+        return Values.of((Double) javaValue);
+      }
+      if (javaValue instanceof Float) {
+        return Values.of((Float) javaValue);
+      }
+      if (javaValue instanceof BigDecimal) {
+        return Values.of((BigDecimal) javaValue);
       }
     }
     if (javaValue instanceof Boolean) {

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/JsonToProtoValueConverter.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/JsonToProtoValueConverter.java
@@ -1,0 +1,38 @@
+package io.stargate.sgv2.restsvc.grpc;
+
+import io.stargate.grpc.Values;
+import io.stargate.proto.QueryOuterClass;
+import java.math.BigInteger;
+
+public class JsonToProtoValueConverter {
+  public static QueryOuterClass.Value NULL =
+      QueryOuterClass.Value.newBuilder()
+          .setNull(QueryOuterClass.Value.Null.newBuilder().build())
+          .build();
+
+  private JsonToProtoValueConverter() {}
+
+  public static QueryOuterClass.Value protoValueFor(Object javaValue) {
+    if (javaValue == null) {
+      return Values.NULL;
+    }
+    if (javaValue instanceof String) {
+      return Values.of((String) javaValue);
+    }
+    if (javaValue instanceof Number) {
+      if (javaValue instanceof Long) {
+        return Values.of((Long) javaValue);
+      }
+      if (javaValue instanceof Integer) {
+        return Values.of((Integer) javaValue);
+      }
+      if (javaValue instanceof BigInteger) {
+        return Values.of((BigInteger) javaValue);
+      }
+    }
+    if (javaValue instanceof Boolean) {
+      return Values.of((Boolean) javaValue);
+    }
+    throw new IllegalArgumentException("Unsupported Java type: " + javaValue.getClass().getName());
+  }
+}

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/ResourceBase.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/ResourceBase.java
@@ -1,10 +1,15 @@
 package io.stargate.sgv2.restsvc.resources;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.BytesValue;
 import io.stargate.proto.QueryOuterClass;
 import io.stargate.sgv2.restsvc.models.RestServiceError;
+import java.io.IOException;
 import java.util.Base64;
+import java.util.Map;
 import javax.ws.rs.core.Response;
 
 /**
@@ -12,6 +17,8 @@ import javax.ws.rs.core.Response;
  * specific place.
  */
 public abstract class ResourceBase {
+  protected static final ObjectMapper JSON_MAPPER = new JsonMapper();
+  protected static final ObjectReader MAP_READER = JSON_MAPPER.readerFor(Map.class);
 
   // // // Helper methods for Response construction
 
@@ -25,6 +32,16 @@ public abstract class ResourceBase {
 
   protected static Response.ResponseBuilder jaxrsResponse(Response.Status status) {
     return Response.status(status);
+  }
+
+  protected static Response.ResponseBuilder jaxrsServiceError(Response.Status status, String msg) {
+    return Response.status(status).entity(new RestServiceError(msg, status.getStatusCode()));
+  }
+
+  // // // Helper methods for JSON decoding
+
+  protected static Map<String, Object> parseJsonAsMap(String jsonString) throws IOException {
+    return MAP_READER.readValue(jsonString);
   }
 
   // // // Helper methods for gRPC type manipulation


### PR DESCRIPTION
**What this PR does**:

Changes kind of CQL query send to gRPC for adding row: used "as JSON" binding; now slices values from JSON payload into specific columns.
Intent was to improve handling -- JSON payload only works for scalars, but not Lists, Maps etc -- but turns out it won't really improve situation much immediately as specific values do not convert (UUID not coerced from String, unlike with JSON).

But we can work on conversion on gRPC side most likely; or, if and when we get schema-awareness use that.

**Which issue(s) this PR fixes**:

No issue filed.

**Checklist**
- [x] Changes manually tested -- use existing Integration tests (for v2.0.0)
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
