### PR TITLE
Fix parameterized keyspace regression in the gRPC API

### DIFF
--- a/grpc/src/main/java/io/stargate/grpc/service/QueryHandler.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/QueryHandler.java
@@ -71,10 +71,7 @@ class QueryHandler extends MessageHandler<Query, Prepared> {
 
   @Override
   protected CompletionStage<Prepared> prepare() {
-    QueryParameters queryParameters = message.getParameters();
-    return prepare(
-        message.getCql(),
-        queryParameters.hasKeyspace() ? queryParameters.getKeyspace().getValue() : null);
+    return prepare(message.getCql(), decoratedKeyspace);
   }
 
   @Override


### PR DESCRIPTION
This fixes a regression where the decorated keyspace is not properly
passed when a query is prepared.

**Checklist**
- [X] Changes manually tested