### PR TITLE
Centralize logging

### DIFF
--- a/auth-api/pom.xml
+++ b/auth-api/pom.xml
@@ -146,8 +146,6 @@
                             org.slf4j,
                             org.slf4j.helpers,
                             org.slf4j.spi,
-                            !ch.qos.logback.classic.*,
-                            !ch.qos.logback.core.*,
                             !io.dropwizard.logging,
                             io.stargate.core,
                             org.osgi.framework,

--- a/auth-api/pom.xml
+++ b/auth-api/pom.xml
@@ -52,14 +52,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-logging</artifactId>
     </dependency>
@@ -151,9 +143,9 @@
             <Bundle-Activator>io.stargate.auth.api.AuthApiActivator</Bundle-Activator>
             <Embed-Transitive>true</Embed-Transitive>
             <Import-Package><![CDATA[
-                            !org.slf4j,
-                            !org.slf4j.helpers,
-                            !org.slf4j.spi,
+                            org.slf4j,
+                            org.slf4j.helpers,
+                            org.slf4j.spi,
                             !ch.qos.logback.classic.*,
                             !ch.qos.logback.core.*,
                             !io.dropwizard.logging,

--- a/auth-jwt-service/pom.xml
+++ b/auth-jwt-service/pom.xml
@@ -26,15 +26,6 @@
       <artifactId>json</artifactId>
       <version>20190722</version>
     </dependency>
-
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
@@ -78,6 +69,9 @@
             <Bundle-SymbolicName>io.stargate.auth.jwt</Bundle-SymbolicName>
             <Bundle-Activator>io.stargate.auth.jwt.AuthJWTServiceActivator</Bundle-Activator>
             <Import-Package><![CDATA[
+              org.slf4j,
+              org.slf4j.helpers,
+              org.slf4j.spi,
               org.osgi.framework,
               io.stargate.core.*,
               io.stargate.auth,

--- a/auth-jwt-service/pom.xml
+++ b/auth-jwt-service/pom.xml
@@ -27,15 +27,6 @@
       <version>20190722</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>log4j-over-slf4j</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
       <version>9.0.1</version>

--- a/auth-table-based-service/pom.xml
+++ b/auth-table-based-service/pom.xml
@@ -43,16 +43,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -93,6 +86,9 @@
             <Bundle-SymbolicName>io.stargate.auth.table</Bundle-SymbolicName>
             <Bundle-Activator>io.stargate.auth.table.AuthTableBasedServiceActivator</Bundle-Activator>
             <Import-Package><![CDATA[
+              org.slf4j,
+              org.slf4j.helpers,
+              org.slf4j.spi,
               org.osgi.framework,
               io.stargate.core.*,
               io.stargate.auth,

--- a/auth-table-based-service/pom.xml
+++ b/auth-table-based-service/pom.xml
@@ -43,16 +43,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>log4j-over-slf4j</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mindrot</groupId>
       <artifactId>jbcrypt</artifactId>
       <version>0.4</version>

--- a/authnz/pom.xml
+++ b/authnz/pom.xml
@@ -29,6 +29,9 @@
             </Bundle-Description>
             <Bundle-SymbolicName>io.stargate.auth</Bundle-SymbolicName>
             <Import-Package><![CDATA[
+              org.slf4j,
+              org.slf4j.helpers,
+              org.slf4j.spi,
               org.osgi.framework,
               io.stargate.db,
               io.stargate.db.*,

--- a/config-store-yaml/pom.xml
+++ b/config-store-yaml/pom.xml
@@ -24,14 +24,6 @@
       </dependency>
       <!-- 3rd party dependencies -->
       <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-core</artifactId>
-      </dependency>
-      <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
         <version>2.11.4</version>
@@ -79,6 +71,9 @@
 						<Bundle-SymbolicName>io.stargate.config.store.yaml</Bundle-SymbolicName>
 						<Bundle-Activator>io.stargate.config.store.yaml.ConfigStoreActivator</Bundle-Activator>
 						<Import-Package><![CDATA[
+                                        org.slf4j,
+                                        org.slf4j.helpers,
+                                        org.slf4j.spi,
                                         org.osgi.framework,
                                         io.stargate.config.store.api,
                                         io.stargate.core.*,

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -12,6 +12,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
@@ -80,11 +81,35 @@
                           org.osgi.framework,
                           org.osgi.util.tracker,
                         ]]></Import-Package>
+                        <!--
+                        This is exports `org.slf4j` APIs so that this is the only instance of slf4j
+                        initialized. Otherwise, each bundle will re-initialize their own instance
+                        in each bundle. This is fine when using stateless appenders, but this causes
+                        unpredictable results when using stateful appenders such as
+                        `ch.qos.logback.core.rolling.RollingFileAppender`.
+
+                        Ideally, this would not export `ch.qos.logback` APIs; however, the
+                        persistence backends include dependencies (`cassandra-all` and `dse-db`)
+                        that use logback APIs directly e.g. calling
+                        `org.slf4j.LoggerFactory.getLogger(...)` and casting it to a logback
+                        `ch.qos.logback.classic.Logger`. This results in casting errors without
+                        exporting these APIs. Only the persistence backends import these.
+
+                        If it can be helped, no other bundle should include any or use logback
+                        dependencies. Instead they should stick to using slf4j APIs.
+                        -->
                         <Export-Package><![CDATA[
                           io.stargate.core.*,
                           com.codahale.metrics,
                           com.codahale.metrics.*,
-                          io.micrometer.core.*
+                          io.micrometer.core.*,
+                          org.slf4j,
+                          org.slf4j.event,
+                          org.slf4j.helpers,
+                          org.slf4j.spi,
+                          ch.qos.logback.classic,
+                          ch.qos.logback.classic.helpers,
+                          ch.qos.logback.classic.spi,
                         ]]></Export-Package>
                         <Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -12,7 +12,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>

--- a/cql/pom.xml
+++ b/cql/pom.xml
@@ -122,6 +122,9 @@
             <Bundle-Activator>io.stargate.cql.CqlActivator</Bundle-Activator>
             <!-- TODO [doug] do this the right way https://baptiste-wicht.com/posts/2010/03/bundle-non-osgi-dependencies-maven.html -->
             <Import-Package><![CDATA[
+                            org.slf4j,
+                            org.slf4j.helpers,
+                            org.slf4j.spi,
                             org.osgi.framework,
                             io.stargate.core.*,
                             io.stargate.auth,

--- a/graphqlapi/pom.xml
+++ b/graphqlapi/pom.xml
@@ -113,11 +113,6 @@
       <version>3.27.0-GA</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt</artifactId>
       <version>0.9.1</version>

--- a/graphqlapi/pom.xml
+++ b/graphqlapi/pom.xml
@@ -115,19 +115,12 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt</artifactId>
       <version>0.9.1</version>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>
@@ -173,6 +166,9 @@
             <Bundle-Activator>io.stargate.graphql.GraphqlActivator</Bundle-Activator>
             <Embed-Transitive>true</Embed-Transitive>
             <Import-Package><![CDATA[
+                            org.slf4j,
+                            org.slf4j.helpers,
+                            org.slf4j.spi,
                             org.osgi.framework,
                             io.stargate.db.*,
                             org.apache.cassandra.stargate,

--- a/grpc/pom.xml
+++ b/grpc/pom.xml
@@ -114,6 +114,9 @@
             <Bundle-SymbolicName>io.stargate.grpc</Bundle-SymbolicName>
             <Bundle-Activator>io.stargate.grpc.GrpcActivator</Bundle-Activator>
             <Import-Package><![CDATA[
+                            org.slf4j,
+                            org.slf4j.helpers,
+                            org.slf4j.spi,
                             org.osgi.framework,
                             io.stargate.core.*,
                             io.stargate.auth,

--- a/grpc/pom.xml
+++ b/grpc/pom.xml
@@ -60,10 +60,6 @@
       <artifactId>micrometer-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
     </dependency>

--- a/health-checker/pom.xml
+++ b/health-checker/pom.xml
@@ -78,14 +78,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
       <scope>provided</scope>
@@ -134,6 +126,9 @@
             <Bundle-Activator>io.stargate.health.HealthCheckerActivator</Bundle-Activator>
             <Embed-Transitive>true</Embed-Transitive>
             <Import-Package><![CDATA[
+              org.slf4j,
+              org.slf4j.helpers,
+              org.slf4j.spi,
               org.osgi.framework,
               com.codahale.metrics,
               com.codahale.metrics.*,

--- a/persistence-api/pom.xml
+++ b/persistence-api/pom.xml
@@ -106,6 +106,9 @@
             <Bundle-SymbolicName>io.stargate.db</Bundle-SymbolicName>
             <Bundle-Activator>io.stargate.db.DbActivator</Bundle-Activator>
             <Import-Package><![CDATA[
+              org.slf4j,
+              org.slf4j.helpers,
+              org.slf4j.spi,
               org.osgi.framework,
               io.stargate.core.*,
               io.micrometer.core.*

--- a/persistence-cassandra-3.11/pom.xml
+++ b/persistence-cassandra-3.11/pom.xml
@@ -212,6 +212,13 @@
             <Bundle-SymbolicName>io.stargate.db.cassandra_3_11</Bundle-SymbolicName>
             <Bundle-Activator>io.stargate.db.cassandra.Cassandra311PersistenceActivator</Bundle-Activator>
             <Import-Package><![CDATA[
+                            org.slf4j,
+                            org.slf4j.event,
+                            org.slf4j.helpers,
+                            org.slf4j.spi,
+                            ch.qos.logback.classic,
+                            ch.qos.logback.classic.helpers,
+                            ch.qos.logback.classic.spi,
                             org.osgi.framework,
                             io.stargate.core.*,
                             io.stargate.auth.*,

--- a/persistence-cassandra-4.0/pom.xml
+++ b/persistence-cassandra-4.0/pom.xml
@@ -223,6 +223,12 @@
             <Bundle-SymbolicName>io.stargate.db.cassandra_4_0</Bundle-SymbolicName>
             <Bundle-Activator>io.stargate.db.cassandra.Cassandra40PersistenceActivator</Bundle-Activator>
             <Import-Package><![CDATA[
+              org.slf4j,
+              org.slf4j.helpers,
+              org.slf4j.spi,
+              ch.qos.logback.classic,
+              ch.qos.logback.classic.helpers,
+              ch.qos.logback.classic.spi,
               org.osgi.framework,
               io.stargate.core.*,
               io.stargate.auth.*,

--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -311,6 +311,12 @@
             <Bundle-SymbolicName>io.stargate.db.dse</Bundle-SymbolicName>
             <Bundle-Activator>io.stargate.db.dse.DsePersistenceActivator</Bundle-Activator>
             <Import-Package><![CDATA[
+              org.slf4j,
+              org.slf4j.helpers,
+              org.slf4j.spi,
+              ch.qos.logback.classic,
+              ch.qos.logback.classic.helpers,
+              ch.qos.logback.classic.spi,
               org.osgi.framework,
               io.stargate.core.*,
               io.stargate.auth.*,

--- a/rate-limiting-global/pom.xml
+++ b/rate-limiting-global/pom.xml
@@ -35,6 +35,9 @@
             <Bundle-SymbolicName>io.stargate.db.limiter.global</Bundle-SymbolicName>
             <Bundle-Activator>io.stargate.db.limiter.global.GlobalRateLimitingActivator</Bundle-Activator>
             <Import-Package><![CDATA[
+              org.slf4j,
+              org.slf4j.helpers,
+              org.slf4j.spi,
               org.osgi.framework,
               io.stargate.core.*,
               io.stargate.db,

--- a/restapi/pom.xml
+++ b/restapi/pom.xml
@@ -93,14 +93,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-logging</artifactId>
     </dependency>
@@ -233,6 +225,9 @@
             <Bundle-Activator>io.stargate.web.impl.RestApiActivator</Bundle-Activator>
             <Embed-Transitive>true</Embed-Transitive>
             <Import-Package><![CDATA[
+                            org.slf4j,
+                            org.slf4j.helpers,
+                            org.slf4j.spi,
                             org.osgi.framework,
                             io.stargate.auth,
                             io.stargate.auth.*,

--- a/stargate-lib/logback.xml
+++ b/stargate-lib/logback.xml
@@ -1,14 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration scan="true" scanPeriod="60 seconds">
   <jmxConfigurator/>
+
+  <appender name="SYSTEMLOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>INFO</level>
+    </filter>
+    <file>log/system.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <!-- rollover daily -->
+      <fileNamePattern>log/system.log.%d{yyyy-MM-dd}.%i.zip</fileNamePattern>
+      <!-- each file should be at most 50MB, keep 7 days worth of history, but at most 5GB -->
+      <maxFileSize>50MB</maxFileSize>
+      <maxHistory>7</maxHistory>
+      <totalSizeCap>5GB</totalSizeCap>
+    </rollingPolicy>
+    <encoder>
+      <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- DEBUGLOG rolling file appender to debug.log (all levels) -->
+
+  <appender name="DEBUGLOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>log/debug.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <!-- rollover daily -->
+      <fileNamePattern>log/debug.log.%d{yyyy-MM-dd}.%i.zip</fileNamePattern>
+      <!-- each file should be at most 50MB, keep 7 days worth of history, but at most 5GB -->
+      <maxFileSize>50MB</maxFileSize>
+      <maxHistory>7</maxHistory>
+      <totalSizeCap>5GB</totalSizeCap>
+    </rollingPolicy>
+    <encoder>
+      <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="ASYNCDEBUGLOG" class="ch.qos.logback.classic.AsyncAppender">
+    <queueSize>1024</queueSize>
+    <discardingThreshold>0</discardingThreshold>
+    <includeCallerData>true</includeCallerData>
+    <appender-ref ref="DEBUGLOG" />
+  </appender>
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern>
     </encoder>
   </appender>
+
   <root level="${stargate.logging.level.root:-INFO}">
-    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="SYSTEMLOG" />
+    <appender-ref ref="STDOUT" />
+    <appender-ref ref="ASYNCDEBUGLOG" /> <!-- Comment this line to disable debug.log -->
   </root>
+
   <logger name="org.apache.cassandra" level="${stargate.logging.level.cassandra:-INFO}"/>
   <logger name="com.datastax.bdp.db" level="${stargate.logging.level.dse:-INFO}"/>
   <logger name="io.stargate.web" level="${stargate.logging.level.web:-INFO}"/>

--- a/testing-services/pom.xml
+++ b/testing-services/pom.xml
@@ -10,11 +10,6 @@
   <artifactId>testing-services</artifactId>
   <dependencies>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>io.stargate.auth</groupId>
       <artifactId>authnz</artifactId>
       <version>${project.version}</version>

--- a/testing-services/pom.xml
+++ b/testing-services/pom.xml
@@ -12,14 +12,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.stargate.auth</groupId>
@@ -54,6 +47,9 @@
             <Bundle-Activator>io.stargate.testing.TestingServicesActivator</Bundle-Activator>
             <Embed-Transitive>true</Embed-Transitive>
             <Import-Package><![CDATA[
+              org.slf4j,
+              org.slf4j.helpers,
+              org.slf4j.spi,
               org.osgi.framework,
               io.stargate.auth.*,
               io.stargate.core.*,

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -43,6 +43,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -41,11 +41,6 @@
       <version>1.3</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
     </dependency>


### PR DESCRIPTION
**What this PR does**:

In the previous setup each bundle initialized slf4j (and in turn,
initialized logback). This causes issues when using stateful appenders,
more specifically `ch.qos.logback.core.rolling.RollingFileAppender`.
Each bundle initialized its own copy of the appenders causing issues
with rolling over the log files.

This centralizes logging initialization to the `core` bundle which
exports the slf4j APIs. This results in the `core` bundle initializing
logback once and sharing a single instance of the appenders and
log configuration with all other bundles.

**Checklist**
- [X] Changes manually tested
- [x] Automated Tests added/updated
