### PR TITLE
closes #1220: fixed document store when having empty string json keys

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocsShredder.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocsShredder.java
@@ -12,6 +12,7 @@ import io.stargate.web.docsapi.service.util.DocsApiUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import javax.inject.Inject;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.jsfr.json.JsonSurfer;
@@ -173,10 +174,15 @@ public class DocsShredder {
       String key,
       boolean patching,
       boolean numericBooleans) {
+    // the converter can not handle empty field names, thus add manually
     String bracketedPath = DocsApiUtils.convertJsonToBracketedPath(parsingContext.getJsonPath());
-    Map<String, Object> bindMap = DocsApiUtils.newBindMap(path, config.getMaxDepth());
+    if (Objects.equals("", parsingContext.getCurrentFieldName())) {
+      bracketedPath += "['']";
+    }
 
+    Map<String, Object> bindMap = DocsApiUtils.newBindMap(path, config.getMaxDepth());
     bindMap.put("key", key);
+
     String leaf = null;
     int i = path.size();
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/JsonConverter.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/JsonConverter.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import javax.inject.Inject;
 
 public class JsonConverter {
@@ -97,7 +98,7 @@ public class JsonConverter {
       for (int i = 0; i < maxDepth; i++) {
         String p = row.getString("p" + i);
         String nextP = i < maxDepth - 1 ? row.getString("p" + (i + 1)) : "";
-        boolean endOfPath = nextP.equals("");
+        boolean endOfPath = nextP.equals("") && Objects.equals(p, rowLeaf);
         boolean isArray = p.startsWith("[");
         boolean nextIsArray = nextP.startsWith("[");
 

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/JsonConverterTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/JsonConverterTest.java
@@ -453,7 +453,7 @@ public class JsonConverterTest {
     data2.put("p2", "");
     data2.put("p3", "");
     data2.put("text_value", "initial");
-    data2.put("leaf", "a");
+    data2.put("leaf", "[0]");
 
     Map<String, Object> data3 = new HashMap<>();
 
@@ -464,7 +464,7 @@ public class JsonConverterTest {
     data3.put("p2", "[0]");
     data3.put("dbl_value", 1.23);
     data3.put("p3", "");
-    data3.put("leaf", "a");
+    data3.put("leaf", "[0]");
 
     Map<String, Object> data4 = new HashMap<>();
 

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -760,6 +760,17 @@ public abstract class BaseDocumentApiV2Test extends BaseIntegrationTest {
   }
 
   @Test
+  public void testJsonEmptyKey() throws IOException {
+    String json = "{\"\": \"value\", \"nested\": {\"\": \"value\"}}";
+
+    Response resp = RestUtils.postRaw(authToken, collectionPath, json, 201);
+    String docLocation = resp.header("location");
+    String r = RestUtils.get(authToken, docLocation + "?raw=true", 200);
+
+    assertThat(OBJECT_MAPPER.readTree(r)).isEqualTo(OBJECT_MAPPER.readTree(json));
+  }
+
+  @Test
   public void testWriteManyDocs() throws IOException {
     // Create documents using multiExample that creates random ID's
     URL url = Resources.getResource("multiExample.json");


### PR DESCRIPTION
**What this PR does**:
Fixes the #1220, the empty key is valid in JSON. However, we were not storing this correctly and we had `leaf=null`, which would lead to the errors when getting the document. The `JsonConverter` also needed to be updated as it was not counting for this situation. `JsonConverterTest` was also wrong, as leaves were not correctly set in two rows.

Note that atm search with wildcard will not match the empty keys. This will be fixed in a separate issue and PR. Problem is that once we have a wildcard we are doing a search with `pX > ''` which in this case would not match the row with empty string key.

**@EricBorczuk Although this looks small, please let me know if there are any other implications as this is heavily affecting the current doc saving structure. Maybe I should have gone for the empty key marker better?**

**Which issue(s) this PR fixes**:
Fixes #1220

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Create follow-up issue  
- [x] ~Documentation added/updated~

