### PR TITLE
closes #1388: improved channel handling in the gRPC integration tests

### DIFF
--- a/testing/src/main/java/io/stargate/it/grpc/TracingQueryTest.java
+++ b/testing/src/main/java/io/stargate/it/grpc/TracingQueryTest.java
@@ -207,12 +207,15 @@ public class TracingQueryTest extends GrpcIntegrationTest {
     assertThat(traces.getStartedAt()).isGreaterThan(0);
     assertThat(traces.getId()).isNotNull();
 
-    assertThat(traces.getEventsList()).isNotEmpty();
-    QueryOuterClass.Traces.Event event = traces.getEvents(0);
-
-    assertThat(event.getActivity()).isNotEmpty();
-    assertThat(event.getSourceElapsed()).isGreaterThan(0);
-    assertThat(event.getThread()).isNotEmpty();
-    assertThat(event.getSource()).isNotEmpty();
+    assertThat(traces.getEventsList())
+        .isNotEmpty()
+        .allSatisfy(
+            event -> {
+              assertThat(event.getEventId()).isNotEmpty();
+              assertThat(event.getActivity()).isNotEmpty();
+              assertThat(event.getThread()).isNotEmpty();
+              assertThat(event.getSource()).isNotEmpty();
+              assertThat(event.getSourceElapsed()).isGreaterThanOrEqualTo(0);
+            });
   }
 }


### PR DESCRIPTION
**What this PR does**:
Hopefully fixes the annoying `io.stargate.it.grpc.TracingQueryTest` that fails almost every second time on the DSE builds.. The stacktrace in the #1388 shows that `ManagedChannel` was not properly shutdown:

```
Step #4 - "dse-6.8": Nov 18, 2021 8:10:26 PM io.grpc.internal.ManagedChannelOrphanWrapper$ManagedChannelReference cleanQueue
Step #4 - "dse-6.8": SEVERE: *~*~*~ Channel ManagedChannelImpl{logId=177, target=127.0.2.37:8090} was not shutdown properly!!! ~*~*~*
Step #4 - "dse-6.8":     Make sure to call shutdown()/shutdownNow() and wait until awaitTermination() returns true.
```

* Added proper shutdown in the after tests
* Moved init and cleanup to before all and after all, I think there is no reason to create and shutdown channel before/after each tests. This will also speed up the tests..

**UPDATE**: Test was still failing after first fix, it turns out that `source_elapsed` can be zero and test was wrong (see https://docs.datastax.com/en/dse/6.7/cql/cql/cql_reference/cqlsh_commands/cqlshTracing.html#cqlshTracing__tracing-sequential-scan)

**Which issue(s) this PR fixes**:
Fixes #1388
