### PR TITLE
Tiny improvements to REST/getTable IT checks to avoid passing with no columns

### DIFF
--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -303,6 +303,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
     assertThat(table.getKeyspace()).isEqualTo("system");
     assertThat(table.getName()).isEqualTo("local");
     assertThat(table.getColumnDefinitions()).isNotNull();
+    assertThat(table.getColumnDefinitions()).isNotEmpty();
   }
 
   @Test
@@ -317,6 +318,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
     assertThat(table.getKeyspace()).isEqualTo("system");
     assertThat(table.getName()).isEqualTo("local");
     assertThat(table.getColumnDefinitions()).isNotNull();
+    assertThat(table.getColumnDefinitions()).isNotEmpty();
   }
 
   @Test
@@ -335,6 +337,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
     assertThat(table.getKeyspace()).isEqualTo(keyspaceName);
     assertThat(table.getName()).isEqualTo(tableName);
     assertThat(table.getColumnDefinitions()).isNotNull();
+    assertThat(table.getColumnDefinitions()).isNotEmpty();
     ColumnDefinition columnDefinition =
         table.getColumnDefinitions().stream()
             .filter(c -> c.getName().equals("col1"))
@@ -343,6 +346,9 @@ public class RestApiv2Test extends BaseIntegrationTest {
     assertThat(columnDefinition)
         .usingRecursiveComparison()
         .isEqualTo(new ColumnDefinition("col1", "frozen<map<date, varchar>>", false));
+
+    // but also check we seem to have right number of columns as well
+    assertThat(table.getColumnDefinitions()).hasSize(4);
   }
 
   @Test


### PR DESCRIPTION
**What this PR does**:

Adds checks for REST API integration test, "getTable()" method, to avoid false pass if no column definitions returned.
Problem found with SGv2 prototyping.

**Which issue(s) this PR fixes**:
No issue filed

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
