### PR TITLE
check connection getPrepare before executing the prepare

### DIFF
--- a/persistence-api/src/main/java/io/stargate/db/datastore/PersistenceBackedDataStore.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/PersistenceBackedDataStore.java
@@ -17,6 +17,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
@@ -78,8 +79,18 @@ public class PersistenceBackedDataStore implements DataStore {
 
   @Override
   public <B extends BoundQuery> CompletableFuture<Query<B>> prepare(Query<B> query) {
-    return connection
-        .prepare(query.queryStringForPreparation(), parameters())
+    String queryToPrepare = query.queryStringForPreparation();
+
+    // check first in the connection cache
+    return Optional.ofNullable(connection.getPrepared(queryToPrepare, parameters()))
+
+        // if so finalize
+        .map(CompletableFuture::completedFuture)
+
+        // otherwise, go and prepare
+        .orElseGet(() -> connection.prepare(queryToPrepare, parameters()))
+
+        // then apply transformation to the BoundQuery
         .thenApply(prepared -> query.withPreparedId(prepared.statementId));
   }
 


### PR DESCRIPTION
**What this PR does**:

I ported over the changes to preparing of the statement that @mpenick implemented in the `grpc`, basically calling first `Connection#getPrepared`.. Change is relatively small, but the effect can be big. I need the confirmation that this is working for all the prepare queries and that there are no negative side effects. 

I did perf test this locally with Document API on DSE and C4. The effect on DSE seems to be bigger and we have app. 20% throughput gain for the light-weight searches where preparation plays a role. In the complex search cases we execute way too many queries and thus preparation is not actually an overhead so I don't see much improvement there. For C4 there is a small improvement as well.

I want to perf test the CRUD scenarios as well. I guess the biggest win should be seen in the read a document queries, as there we have 1 prepare + 1 execute, so here the effect can be the biggest.

I will try to organize and summarize perf results in a comment below.

**Which issue(s) this PR fixes**:
/

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
