### PR TITLE
increase initial page size for `$or` search in docs api

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolver.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolver.java
@@ -116,8 +116,8 @@ public class OrExpressionDocumentsResolver implements DocumentsResolver {
               // if we have evaluate on missing then we have single query, so go for the
               // getStoragePageSize
               // otherwise the page size for each query should be requested page size + 1
-              // since we are doing an order merge of the results to preserve sorting
-              // we can not fetch less document
+              // since we are doing in order merge of the results to preserve sorting
+              // we can not fetch fewer document
               int pageSize =
                   evaluateOnMissing
                       ? config.getApproximateStoragePageSize(paginator.docPageSize)

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolver.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolver.java
@@ -115,11 +115,13 @@ public class OrExpressionDocumentsResolver implements DocumentsResolver {
               // execute them all by respecting the paging state
               // if we have evaluate on missing then we have single query, so go for the
               // getStoragePageSize
-              // otherwise determine the page size for each query based on the requested docs
+              // otherwise the page size for each query should be requested page size + 1
+              // since we are doing an order merge of the results to preserve sorting
+              // we can not fetch less document
               int pageSize =
                   evaluateOnMissing
                       ? config.getApproximateStoragePageSize(paginator.docPageSize)
-                      : determinePageSize(paginator.docPageSize, boundQueries.size());
+                      : paginator.docPageSize + 1;
               return queryExecutor.queryDocs(
                   boundQueries, pageSize, true, paginator.getCurrentDbPageState(), context);
             })
@@ -138,15 +140,6 @@ public class OrExpressionDocumentsResolver implements DocumentsResolver {
               rules.put(FilterExpression.EXPR_TYPE, new RawDocumentEvalRule(doc));
               return EvalEngine.evaluate(expression, rules);
             });
-  }
-
-  // page size in the queries executed is determined by slicing the number of requested documents
-  // and queries
-  // for example, having 20 docs requested with 3 OR queries would make it 6
-  // this is to level out the pressure of finding the documents and favor queries that are taken
-  // into account first
-  private int determinePageSize(int docPageSize, int numberOfQueries) {
-    return Math.max(2, Math.floorDiv(docPageSize, numberOfQueries));
   }
 
   private String[] columnsForQuery(AbstractSearchQueryBuilder queryBuilder, int maxDepth) {

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolverTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolverTest.java
@@ -111,7 +111,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
                   "field",
                   "",
                   "query-value")
-              .withPageSize(5)
+              .withPageSize(pageSize + 1)
               .returning(Collections.singletonList(ImmutableMap.of("key", "1")));
 
       ValidatingDataStore.QueryAssert query2Assert =
@@ -122,7 +122,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
                   "field",
                   "",
                   1d)
-              .withPageSize(5)
+              .withPageSize(pageSize + 1)
               .returning(Collections.singletonList(ImmutableMap.of("key", "1")));
 
       Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
@@ -260,7 +260,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
                   "field",
                   "",
                   "query-value")
-              .withPageSize(2)
+              .withPageSize(pageSize + 1)
               .returningNothing();
 
       ValidatingDataStore.QueryAssert query2Assert =
@@ -271,7 +271,7 @@ class OrExpressionDocumentsResolverTest extends AbstractDataStoreTest {
                   "field",
                   "",
                   1d)
-              .withPageSize(2)
+              .withPageSize(pageSize + 1)
               .returningNothing();
 
       Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);


### PR DESCRIPTION
**What this PR does**:
Minor improvement for the `$or` based search in the document API. Since we are merging in order fashon we need the inital page size in all queries to be at least the requested page size. Until now, we always had one extra hop to the database. 

Improvements: 

```
httpdocsapisearchbasic_default_mainor.result-success.Mean                    7.2% faster
httpdocsapisearchbasic_default_mainor.result-success.99.000ptile             0.3% faster

httpdocsapisearchbasic_default_mainorsinglematch.result-success.Mean         8.8% faster
httpdocsapisearchbasic_default_mainorsinglematch.result-success.99.000ptile  6.7% faster
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
