### PR TITLE
refactored shredding of json payload

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/service/JsonDocumentShredder.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/JsonDocumentShredder.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.web.docsapi.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.stargate.web.docsapi.exception.ErrorCode;
+import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
+import io.stargate.web.docsapi.service.query.DocsApiConstants;
+import io.stargate.web.docsapi.service.util.DocsApiUtils;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+import javax.inject.Inject;
+
+public class JsonDocumentShredder {
+
+  @Inject private DocsApiConfiguration config;
+
+  @Inject private ObjectMapper objectMapper;
+
+  public JsonDocumentShredder(DocsApiConfiguration config, ObjectMapper objectMapper) {
+    this.config = config;
+    this.objectMapper = objectMapper;
+  }
+
+  public List<JsonShreddedRow> shred(
+      String payload, String documentId, List<String> subDocumentPath, boolean numericBooleans) {
+    try {
+      JsonNode node = objectMapper.readTree(payload);
+      return shred(node, documentId, subDocumentPath, numericBooleans);
+    } catch (JsonProcessingException e) {
+      throw new ErrorCodeRuntimeException(
+          ErrorCode.DOCS_API_INVALID_JSON_VALUE,
+          "Malformed JSON object found during shredding.",
+          e);
+    }
+  }
+
+  public List<JsonShreddedRow> shred(
+      JsonNode node, String documentId, List<String> subDocumentPath, boolean numericBooleans) {
+    Supplier<ImmutableJsonShreddedRow.Builder> rowBuilder =
+        () ->
+            ImmutableJsonShreddedRow.builder()
+                .key(documentId)
+                .maxDepth(config.getMaxDepth())
+                .addAllPath(subDocumentPath); // TODO should we also convert these parts with escape
+
+    List<JsonShreddedRow> result = new ArrayList<>();
+    processNode(node, rowBuilder, numericBooleans, result);
+    return result;
+  }
+
+  private void processNode(
+      JsonNode node,
+      Supplier<ImmutableJsonShreddedRow.Builder> rowBuilder,
+      boolean numericBooleans,
+      List<JsonShreddedRow> result) {
+    if (node.isArray()) {
+      processArrayNode(node, rowBuilder, numericBooleans, result);
+    } else if (node.isObject()) {
+      processObjectNode(node, rowBuilder, numericBooleans, result);
+    } else {
+      processValueNode(node, rowBuilder, numericBooleans, result);
+    }
+  }
+
+  private void processArrayNode(
+      JsonNode node,
+      Supplier<ImmutableJsonShreddedRow.Builder> rowBuilder,
+      boolean numericBooleans,
+      List<JsonShreddedRow> result) {
+    // empty array, simply create a reference to empty node and return
+    if (node.isEmpty()) {
+      ImmutableJsonShreddedRow row =
+          rowBuilder.get().stringValue(DocsApiConstants.EMPTY_ARRAY_MARKER).build();
+      result.add(row);
+      return;
+    }
+
+    // otherwise, iterate all nodes
+    int idx = 0;
+    for (JsonNode inner : node) {
+      // make sure we didn't exceed the maximum array length
+      if (idx >= config.getMaxArrayLength()) {
+        throw new ErrorCodeRuntimeException(ErrorCode.DOCS_API_GENERAL_ARRAY_LENGTH_EXCEEDED);
+      }
+
+      // convert the array index into path
+      // then create new next row builder
+      String arrayPath = "[" + DocsApiUtils.leftPadTo6(String.valueOf(idx)) + "]";
+      Supplier<ImmutableJsonShreddedRow.Builder> nextRowBuilder =
+          () -> rowBuilder.get().addPath(arrayPath);
+
+      // process inner node and increase the index
+      processNode(inner, nextRowBuilder, numericBooleans, result);
+      idx++;
+    }
+  }
+
+  private void processObjectNode(
+      JsonNode node,
+      Supplier<ImmutableJsonShreddedRow.Builder> rowBuilder,
+      boolean numericBooleans,
+      List<JsonShreddedRow> result) {
+    // empty object, simply create a reference to empty node and return
+    if (node.isEmpty()) {
+      ImmutableJsonShreddedRow row =
+          rowBuilder.get().stringValue(DocsApiConstants.EMPTY_OBJECT_MARKER).build();
+      result.add(row);
+      return;
+    }
+
+    node.fields()
+        .forEachRemaining(
+            field -> {
+              // TODO is this still valid
+              //  ErrorCode.DOCS_API_GENERAL_INVALID_FIELD_NAME
+
+              // escape the field path
+              // then create new next row builder
+              String fieldPath = DocsApiUtils.convertEscapedCharacters(field.getKey());
+              Supplier<ImmutableJsonShreddedRow.Builder> nextRowBuilder =
+                  () -> rowBuilder.get().addPath(fieldPath);
+
+              // process inner node and increase the index
+              processNode(field.getValue(), nextRowBuilder, numericBooleans, result);
+            });
+  }
+
+  private void processValueNode(
+      JsonNode node,
+      Supplier<ImmutableJsonShreddedRow.Builder> rowBuilder,
+      boolean numericBooleans,
+      List<JsonShreddedRow> result) {
+    ImmutableJsonShreddedRow.Builder builder = rowBuilder.get();
+
+    // depending on the value type set values
+    if (node.isBoolean()) {
+      builder.booleanValue(convertToBackendBooleanValue(node.asBoolean(), numericBooleans));
+    } else if (node.isNumber()) {
+      builder.doubleValue(node.asDouble());
+    } else if (!node.isNull()) {
+      builder.stringValue(node.asText());
+    }
+
+    // build and add to the results
+    ImmutableJsonShreddedRow row = builder.build();
+    result.add(row);
+  }
+
+  private Object convertToBackendBooleanValue(boolean value, boolean numericBooleans) {
+    if (numericBooleans) {
+      return value ? 1 : 0;
+    }
+    return value;
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/JsonDocumentShredder.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/JsonDocumentShredder.java
@@ -56,6 +56,10 @@ public class JsonDocumentShredder {
 
   public List<JsonShreddedRow> shred(
       JsonNode node, String documentId, List<String> subDocumentPath, boolean numericBooleans) {
+    // check if this is a valid root node
+    if (subDocumentPath.isEmpty()) {
+      checkRoot(node);
+    }
 
     // sub-paths escaped
     List<String> subPathsEscaped =
@@ -73,6 +77,22 @@ public class JsonDocumentShredder {
     List<JsonShreddedRow> result = new ArrayList<>();
     processNode(node, rowBuilder, numericBooleans, result);
     return result;
+  }
+
+  private void checkRoot(JsonNode root) {
+    // empty object and arrays not allowed
+    if (root.isContainerNode() && root.isEmpty()) {
+      String msg =
+          "Updating a key with just an empty object or an empty array is not allowed. Hint: update the parent path with a defined object instead.";
+      throw new ErrorCodeRuntimeException(ErrorCode.DOCS_API_PUT_PAYLOAD_INVALID, msg);
+    }
+
+    // scalars not allowed
+    if (root.isValueNode()) {
+      String msg =
+          "Updating a key with just a JSON primitive is not allowed. Hint: update the parent path with a defined object instead.";
+      throw new ErrorCodeRuntimeException(ErrorCode.DOCS_API_PUT_PAYLOAD_INVALID, msg);
+    }
   }
 
   private void processNode(

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/JsonDocumentShredder.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/JsonDocumentShredder.java
@@ -41,11 +41,10 @@ public class JsonDocumentShredder {
     this.objectMapper = objectMapper;
   }
 
-  public List<JsonShreddedRow> shred(
-      String payload, String documentId, List<String> subDocumentPath) {
+  public List<JsonShreddedRow> shred(String payload, List<String> subDocumentPath) {
     try {
       JsonNode node = objectMapper.readTree(payload);
-      return shred(node, documentId, subDocumentPath);
+      return shred(node, subDocumentPath);
     } catch (JsonProcessingException e) {
       throw new ErrorCodeRuntimeException(
           ErrorCode.DOCS_API_INVALID_JSON_VALUE,
@@ -54,8 +53,7 @@ public class JsonDocumentShredder {
     }
   }
 
-  public List<JsonShreddedRow> shred(
-      JsonNode node, String documentId, List<String> subDocumentPath) {
+  public List<JsonShreddedRow> shred(JsonNode node, List<String> subDocumentPath) {
     // check if this is a valid root node
     if (subDocumentPath.isEmpty()) {
       checkRoot(node);
@@ -70,7 +68,6 @@ public class JsonDocumentShredder {
     Supplier<ImmutableJsonShreddedRow.Builder> rowBuilder =
         () ->
             ImmutableJsonShreddedRow.builder()
-                .key(documentId)
                 .maxDepth(config.getMaxDepth())
                 .addAllPath(subPathsEscaped);
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/JsonShreddedRow.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/JsonShreddedRow.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.web.docsapi.service;
+
+import io.stargate.web.docsapi.exception.ErrorCode;
+import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface JsonShreddedRow {
+
+  // TODO Convert to abstract class, hide?
+
+  @Value.Check
+  default void validate() {
+    if (getPath().size() > getMaxDepth()) {
+      throw new ErrorCodeRuntimeException(ErrorCode.DOCS_API_GENERAL_DEPTH_EXCEEDED);
+    }
+  }
+
+  String getKey();
+
+  int getMaxDepth();
+
+  List<String> getPath();
+
+  // leaf is always actually the last path we have
+  default String getLeaf() {
+    List<String> path = getPath();
+    if (path != null && !path.isEmpty()) {
+      return path.get(path.size() - 1);
+    } else {
+      return null; // TODO is this fine? what do we return as leaf for empty objects and empty
+      // arrays
+    }
+  }
+
+  @Nullable
+  String getStringValue();
+
+  @Nullable
+  Double getDoubleValue();
+
+  // booleans can be int or bools
+  @Nullable
+  Object getBooleanValue();
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/JsonShreddedRow.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/JsonShreddedRow.java
@@ -47,8 +47,7 @@ public interface JsonShreddedRow {
     if (path != null && !path.isEmpty()) {
       return path.get(path.size() - 1);
     } else {
-      return null; // TODO is this fine? what do we return as leaf for empty objects and empty
-      // arrays
+      throw new IllegalStateException("Shredded row does not contain a single path.");
     }
   }
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/JsonShreddedRow.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/JsonShreddedRow.java
@@ -57,7 +57,7 @@ public interface JsonShreddedRow {
   @Nullable
   Double getDoubleValue();
 
-  // booleans can be int or bools
+  // booleans can be int or bools, storage should handle
   @Nullable
-  Object getBooleanValue();
+  Boolean getBooleanValue();
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/JsonShreddedRow.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/JsonShreddedRow.java
@@ -35,8 +35,6 @@ public interface JsonShreddedRow {
     }
   }
 
-  String getKey();
-
   int getMaxDepth();
 
   List<String> getPath();

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/JsonDocumentShredderTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/JsonDocumentShredderTest.java
@@ -66,7 +66,7 @@ class JsonDocumentShredderTest {
       JsonNode payload = objectMapper.readTree("22");
 
       List<JsonShreddedRow> result =
-          shredder.shred(payload, key, Collections.singletonList("field"), false);
+          shredder.shred(payload, key, Collections.singletonList("field"));
 
       assertThat(result)
           .singleElement()
@@ -87,7 +87,7 @@ class JsonDocumentShredderTest {
       JsonNode payload = objectMapper.readTree("22");
 
       Throwable result =
-          catchThrowable(() -> shredder.shred(payload, key, Collections.emptyList(), false));
+          catchThrowable(() -> shredder.shred(payload, key, Collections.emptyList()));
 
       assertThat(result)
           .isInstanceOf(ErrorCodeRuntimeException.class)
@@ -99,7 +99,7 @@ class JsonDocumentShredderTest {
       String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload = objectMapper.createObjectNode().put("field", "text");
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList(), false);
+      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList());
 
       assertThat(result)
           .singleElement()
@@ -119,7 +119,7 @@ class JsonDocumentShredderTest {
       String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload = objectMapper.createObjectNode().put("field", 22);
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList(), false);
+      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList());
 
       assertThat(result)
           .singleElement()
@@ -139,7 +139,7 @@ class JsonDocumentShredderTest {
       String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload = objectMapper.createObjectNode().put("field", true);
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList(), false);
+      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList());
 
       assertThat(result)
           .singleElement()
@@ -155,31 +155,11 @@ class JsonDocumentShredderTest {
     }
 
     @Test
-    public void simpleObjectBooleanValueNumeric() {
-      String key = RandomStringUtils.randomAlphanumeric(16);
-      ObjectNode payload = objectMapper.createObjectNode().put("field", true);
-
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList(), true);
-
-      assertThat(result)
-          .singleElement()
-          .satisfies(
-              row -> {
-                assertThat(row.getKey()).isEqualTo(key);
-                assertThat(row.getPath()).containsExactly("field");
-                assertThat(row.getLeaf()).isEqualTo("field");
-                assertThat(row.getStringValue()).isNull();
-                assertThat(row.getDoubleValue()).isNull();
-                assertThat(row.getBooleanValue()).isEqualTo(1);
-              });
-    }
-
-    @Test
     public void simpleObjectNullValue() {
       String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload = objectMapper.createObjectNode().putNull("field");
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList(), false);
+      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList());
 
       assertThat(result)
           .singleElement()
@@ -200,7 +180,7 @@ class JsonDocumentShredderTest {
       ObjectNode payload = objectMapper.createObjectNode();
 
       List<JsonShreddedRow> result =
-          shredder.shred(payload, key, Collections.singletonList("path"), false);
+          shredder.shred(payload, key, Collections.singletonList("path"));
 
       assertThat(result)
           .singleElement()
@@ -221,7 +201,7 @@ class JsonDocumentShredderTest {
       ObjectNode payload = objectMapper.createObjectNode();
 
       Throwable result =
-          catchThrowable(() -> shredder.shred(payload, key, Collections.emptyList(), false));
+          catchThrowable(() -> shredder.shred(payload, key, Collections.emptyList()));
 
       assertThat(result)
           .isInstanceOf(ErrorCodeRuntimeException.class)
@@ -234,7 +214,7 @@ class JsonDocumentShredderTest {
       ObjectNode payload =
           objectMapper.createObjectNode().set("field", objectMapper.createObjectNode());
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList(), false);
+      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList());
 
       assertThat(result)
           .singleElement()
@@ -258,7 +238,7 @@ class JsonDocumentShredderTest {
       payload.set("n1", n1);
       payload.set("n2", n2);
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList(), false);
+      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList());
 
       assertThat(result)
           .hasSize(2)
@@ -288,7 +268,7 @@ class JsonDocumentShredderTest {
       ArrayNode payload = objectMapper.createArrayNode();
 
       List<JsonShreddedRow> result =
-          shredder.shred(payload, key, Collections.singletonList("path"), false);
+          shredder.shred(payload, key, Collections.singletonList("path"));
 
       assertThat(result)
           .singleElement()
@@ -309,7 +289,7 @@ class JsonDocumentShredderTest {
       ArrayNode payload = objectMapper.createArrayNode();
 
       Throwable result =
-          catchThrowable(() -> shredder.shred(payload, key, Collections.emptyList(), false));
+          catchThrowable(() -> shredder.shred(payload, key, Collections.emptyList()));
 
       assertThat(result)
           .isInstanceOf(ErrorCodeRuntimeException.class)
@@ -322,7 +302,7 @@ class JsonDocumentShredderTest {
       ObjectNode payload =
           objectMapper.createObjectNode().set("field", objectMapper.createArrayNode());
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList(), false);
+      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList());
 
       assertThat(result)
           .singleElement()
@@ -345,7 +325,7 @@ class JsonDocumentShredderTest {
               .createObjectNode()
               .set("field", objectMapper.createArrayNode().add("first").add("second"));
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList(), false);
+      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList());
 
       assertThat(result)
           .hasSize(2)
@@ -378,7 +358,7 @@ class JsonDocumentShredderTest {
               .set("field", objectMapper.createArrayNode().add("first").add("second").add("third"));
 
       Throwable result =
-          catchThrowable(() -> shredder.shred(payload, key, Collections.emptyList(), false));
+          catchThrowable(() -> shredder.shred(payload, key, Collections.emptyList()));
 
       assertThat(result)
           .isInstanceOf(ErrorCodeRuntimeException.class)
@@ -391,7 +371,7 @@ class JsonDocumentShredderTest {
       String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload = objectMapper.createObjectNode().put("period\\.", "text");
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList(), false);
+      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList());
 
       assertThat(result)
           .singleElement()
@@ -412,7 +392,7 @@ class JsonDocumentShredderTest {
       ObjectNode payload = objectMapper.createObjectNode().put("period.", "text");
 
       Throwable result =
-          catchThrowable(() -> shredder.shred(payload, key, Collections.emptyList(), false));
+          catchThrowable(() -> shredder.shred(payload, key, Collections.emptyList()));
 
       assertThat(result)
           .isInstanceOf(ErrorCodeRuntimeException.class)
@@ -424,8 +404,7 @@ class JsonDocumentShredderTest {
       String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload = objectMapper.createObjectNode().put("field", "text");
 
-      List<JsonShreddedRow> result =
-          shredder.shred(payload, key, Arrays.asList("one", "two"), false);
+      List<JsonShreddedRow> result = shredder.shred(payload, key, Arrays.asList("one", "two"));
 
       assertThat(result)
           .singleElement()
@@ -445,7 +424,7 @@ class JsonDocumentShredderTest {
       String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload = objectMapper.createObjectNode().put("field", "text");
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Arrays.asList("one\\\\."), false);
+      List<JsonShreddedRow> result = shredder.shred(payload, key, Arrays.asList("one\\\\."));
 
       assertThat(result)
           .singleElement()
@@ -466,8 +445,7 @@ class JsonDocumentShredderTest {
       ObjectNode payload = objectMapper.createObjectNode().put("field", "text");
 
       Throwable result =
-          catchThrowable(
-              () -> shredder.shred(payload, key, Arrays.asList("one", "two", "three"), false));
+          catchThrowable(() -> shredder.shred(payload, key, Arrays.asList("one", "two", "three")));
 
       assertThat(result)
           .isInstanceOf(ErrorCodeRuntimeException.class)

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/JsonDocumentShredderTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/JsonDocumentShredderTest.java
@@ -57,7 +57,7 @@ class JsonDocumentShredderTest {
   }
 
   @Nested
-  public class Shred {
+  class Shred {
 
     @Test
     public void primitive() throws JsonProcessingException {
@@ -371,24 +371,6 @@ class JsonDocumentShredderTest {
           .satisfies(
               row -> {
                 assertThat(row.getPath()).containsExactly("one", "two", "field");
-                assertThat(row.getLeaf()).isEqualTo("field");
-                assertThat(row.getStringValue()).isEqualTo("text");
-                assertThat(row.getDoubleValue()).isNull();
-                assertThat(row.getBooleanValue()).isNull();
-              });
-    }
-
-    @Test
-    public void withEscapedPrependPath() {
-      ObjectNode payload = objectMapper.createObjectNode().put("field", "text");
-
-      List<JsonShreddedRow> result = shredder.shred(payload, Arrays.asList("one\\\\."));
-
-      assertThat(result)
-          .singleElement()
-          .satisfies(
-              row -> {
-                assertThat(row.getPath()).containsExactly("one\\.", "field");
                 assertThat(row.getLeaf()).isEqualTo("field");
                 assertThat(row.getStringValue()).isEqualTo("text");
                 assertThat(row.getDoubleValue()).isNull();

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/JsonDocumentShredderTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/JsonDocumentShredderTest.java
@@ -65,19 +65,33 @@ class JsonDocumentShredderTest {
       String key = RandomStringUtils.randomAlphanumeric(16);
       JsonNode payload = objectMapper.readTree("22");
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList(), false);
+      List<JsonShreddedRow> result =
+          shredder.shred(payload, key, Collections.singletonList("field"), false);
 
       assertThat(result)
           .singleElement()
           .satisfies(
               row -> {
                 assertThat(row.getKey()).isEqualTo(key);
-                assertThat(row.getPath()).isEmpty();
-                assertThat(row.getLeaf()).isNull();
+                assertThat(row.getPath()).containsExactly("field");
+                assertThat(row.getLeaf()).isEqualTo("field");
                 assertThat(row.getStringValue()).isNull();
                 assertThat(row.getDoubleValue()).isEqualTo(22d);
                 assertThat(row.getBooleanValue()).isNull();
               });
+    }
+
+    @Test
+    public void primitiveRoot() throws JsonProcessingException {
+      String key = RandomStringUtils.randomAlphanumeric(16);
+      JsonNode payload = objectMapper.readTree("22");
+
+      Throwable result =
+          catchThrowable(() -> shredder.shred(payload, key, Collections.emptyList(), false));
+
+      assertThat(result)
+          .isInstanceOf(ErrorCodeRuntimeException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_PUT_PAYLOAD_INVALID);
     }
 
     @Test
@@ -185,19 +199,33 @@ class JsonDocumentShredderTest {
       String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload = objectMapper.createObjectNode();
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList(), false);
+      List<JsonShreddedRow> result =
+          shredder.shred(payload, key, Collections.singletonList("path"), false);
 
       assertThat(result)
           .singleElement()
           .satisfies(
               row -> {
                 assertThat(row.getKey()).isEqualTo(key);
-                assertThat(row.getPath()).isEmpty();
-                assertThat(row.getLeaf()).isNull();
+                assertThat(row.getPath()).containsExactly("path");
+                assertThat(row.getLeaf()).isEqualTo("path");
                 assertThat(row.getStringValue()).isEqualTo(DocsApiConstants.EMPTY_OBJECT_MARKER);
                 assertThat(row.getDoubleValue()).isNull();
                 assertThat(row.getBooleanValue()).isNull();
               });
+    }
+
+    @Test
+    public void emptyObjectRoot() {
+      String key = RandomStringUtils.randomAlphanumeric(16);
+      ObjectNode payload = objectMapper.createObjectNode();
+
+      Throwable result =
+          catchThrowable(() -> shredder.shred(payload, key, Collections.emptyList(), false));
+
+      assertThat(result)
+          .isInstanceOf(ErrorCodeRuntimeException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_PUT_PAYLOAD_INVALID);
     }
 
     @Test
@@ -259,19 +287,33 @@ class JsonDocumentShredderTest {
       String key = RandomStringUtils.randomAlphanumeric(16);
       ArrayNode payload = objectMapper.createArrayNode();
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList(), false);
+      List<JsonShreddedRow> result =
+          shredder.shred(payload, key, Collections.singletonList("path"), false);
 
       assertThat(result)
           .singleElement()
           .satisfies(
               row -> {
                 assertThat(row.getKey()).isEqualTo(key);
-                assertThat(row.getPath()).isEmpty();
-                assertThat(row.getLeaf()).isNull();
+                assertThat(row.getPath()).containsExactly("path");
+                assertThat(row.getLeaf()).isEqualTo("path");
                 assertThat(row.getStringValue()).isEqualTo(DocsApiConstants.EMPTY_ARRAY_MARKER);
                 assertThat(row.getDoubleValue()).isNull();
                 assertThat(row.getBooleanValue()).isNull();
               });
+    }
+
+    @Test
+    public void emptyArrayRoot() {
+      String key = RandomStringUtils.randomAlphanumeric(16);
+      ArrayNode payload = objectMapper.createArrayNode();
+
+      Throwable result =
+          catchThrowable(() -> shredder.shred(payload, key, Collections.emptyList(), false));
+
+      assertThat(result)
+          .isInstanceOf(ErrorCodeRuntimeException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_PUT_PAYLOAD_INVALID);
     }
 
     @Test

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/JsonDocumentShredderTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/JsonDocumentShredderTest.java
@@ -32,7 +32,6 @@ import io.stargate.web.docsapi.service.query.DocsApiConstants;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -62,17 +61,14 @@ class JsonDocumentShredderTest {
 
     @Test
     public void primitive() throws JsonProcessingException {
-      String key = RandomStringUtils.randomAlphanumeric(16);
       JsonNode payload = objectMapper.readTree("22");
 
-      List<JsonShreddedRow> result =
-          shredder.shred(payload, key, Collections.singletonList("field"));
+      List<JsonShreddedRow> result = shredder.shred(payload, Collections.singletonList("field"));
 
       assertThat(result)
           .singleElement()
           .satisfies(
               row -> {
-                assertThat(row.getKey()).isEqualTo(key);
                 assertThat(row.getPath()).containsExactly("field");
                 assertThat(row.getLeaf()).isEqualTo("field");
                 assertThat(row.getStringValue()).isNull();
@@ -83,11 +79,9 @@ class JsonDocumentShredderTest {
 
     @Test
     public void primitiveRoot() throws JsonProcessingException {
-      String key = RandomStringUtils.randomAlphanumeric(16);
       JsonNode payload = objectMapper.readTree("22");
 
-      Throwable result =
-          catchThrowable(() -> shredder.shred(payload, key, Collections.emptyList()));
+      Throwable result = catchThrowable(() -> shredder.shred(payload, Collections.emptyList()));
 
       assertThat(result)
           .isInstanceOf(ErrorCodeRuntimeException.class)
@@ -96,16 +90,14 @@ class JsonDocumentShredderTest {
 
     @Test
     public void simpleObjectStringValue() {
-      String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload = objectMapper.createObjectNode().put("field", "text");
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList());
+      List<JsonShreddedRow> result = shredder.shred(payload, Collections.emptyList());
 
       assertThat(result)
           .singleElement()
           .satisfies(
               row -> {
-                assertThat(row.getKey()).isEqualTo(key);
                 assertThat(row.getPath()).containsExactly("field");
                 assertThat(row.getLeaf()).isEqualTo("field");
                 assertThat(row.getStringValue()).isEqualTo("text");
@@ -116,16 +108,14 @@ class JsonDocumentShredderTest {
 
     @Test
     public void simpleObjectNumericValue() {
-      String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload = objectMapper.createObjectNode().put("field", 22);
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList());
+      List<JsonShreddedRow> result = shredder.shred(payload, Collections.emptyList());
 
       assertThat(result)
           .singleElement()
           .satisfies(
               row -> {
-                assertThat(row.getKey()).isEqualTo(key);
                 assertThat(row.getPath()).containsExactly("field");
                 assertThat(row.getLeaf()).isEqualTo("field");
                 assertThat(row.getStringValue()).isNull();
@@ -136,16 +126,14 @@ class JsonDocumentShredderTest {
 
     @Test
     public void simpleObjectBooleanValue() {
-      String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload = objectMapper.createObjectNode().put("field", true);
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList());
+      List<JsonShreddedRow> result = shredder.shred(payload, Collections.emptyList());
 
       assertThat(result)
           .singleElement()
           .satisfies(
               row -> {
-                assertThat(row.getKey()).isEqualTo(key);
                 assertThat(row.getPath()).containsExactly("field");
                 assertThat(row.getLeaf()).isEqualTo("field");
                 assertThat(row.getStringValue()).isNull();
@@ -156,16 +144,14 @@ class JsonDocumentShredderTest {
 
     @Test
     public void simpleObjectNullValue() {
-      String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload = objectMapper.createObjectNode().putNull("field");
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList());
+      List<JsonShreddedRow> result = shredder.shred(payload, Collections.emptyList());
 
       assertThat(result)
           .singleElement()
           .satisfies(
               row -> {
-                assertThat(row.getKey()).isEqualTo(key);
                 assertThat(row.getPath()).containsExactly("field");
                 assertThat(row.getLeaf()).isEqualTo("field");
                 assertThat(row.getStringValue()).isNull();
@@ -176,17 +162,14 @@ class JsonDocumentShredderTest {
 
     @Test
     public void emptyObject() {
-      String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload = objectMapper.createObjectNode();
 
-      List<JsonShreddedRow> result =
-          shredder.shred(payload, key, Collections.singletonList("path"));
+      List<JsonShreddedRow> result = shredder.shred(payload, Collections.singletonList("path"));
 
       assertThat(result)
           .singleElement()
           .satisfies(
               row -> {
-                assertThat(row.getKey()).isEqualTo(key);
                 assertThat(row.getPath()).containsExactly("path");
                 assertThat(row.getLeaf()).isEqualTo("path");
                 assertThat(row.getStringValue()).isEqualTo(DocsApiConstants.EMPTY_OBJECT_MARKER);
@@ -197,11 +180,9 @@ class JsonDocumentShredderTest {
 
     @Test
     public void emptyObjectRoot() {
-      String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload = objectMapper.createObjectNode();
 
-      Throwable result =
-          catchThrowable(() -> shredder.shred(payload, key, Collections.emptyList()));
+      Throwable result = catchThrowable(() -> shredder.shred(payload, Collections.emptyList()));
 
       assertThat(result)
           .isInstanceOf(ErrorCodeRuntimeException.class)
@@ -210,17 +191,15 @@ class JsonDocumentShredderTest {
 
     @Test
     public void withEmptyObject() {
-      String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload =
           objectMapper.createObjectNode().set("field", objectMapper.createObjectNode());
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList());
+      List<JsonShreddedRow> result = shredder.shred(payload, Collections.emptyList());
 
       assertThat(result)
           .singleElement()
           .satisfies(
               row -> {
-                assertThat(row.getKey()).isEqualTo(key);
                 assertThat(row.getPath()).containsExactly("field");
                 assertThat(row.getLeaf()).isEqualTo("field");
                 assertThat(row.getStringValue()).isEqualTo(DocsApiConstants.EMPTY_OBJECT_MARKER);
@@ -231,20 +210,18 @@ class JsonDocumentShredderTest {
 
     @Test
     public void withNestedObject() {
-      String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode n1 = objectMapper.createObjectNode().put("key1", "value1");
       ObjectNode n2 = objectMapper.createObjectNode().put("key2", 44.22d);
       ObjectNode payload = objectMapper.createObjectNode();
       payload.set("n1", n1);
       payload.set("n2", n2);
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList());
+      List<JsonShreddedRow> result = shredder.shred(payload, Collections.emptyList());
 
       assertThat(result)
           .hasSize(2)
           .anySatisfy(
               row -> {
-                assertThat(row.getKey()).isEqualTo(key);
                 assertThat(row.getPath()).containsExactly("n1", "key1");
                 assertThat(row.getLeaf()).isEqualTo("key1");
                 assertThat(row.getStringValue()).isEqualTo("value1");
@@ -253,7 +230,6 @@ class JsonDocumentShredderTest {
               })
           .anySatisfy(
               row -> {
-                assertThat(row.getKey()).isEqualTo(key);
                 assertThat(row.getPath()).containsExactly("n2", "key2");
                 assertThat(row.getLeaf()).isEqualTo("key2");
                 assertThat(row.getStringValue()).isNull();
@@ -264,17 +240,14 @@ class JsonDocumentShredderTest {
 
     @Test
     public void emptyArray() {
-      String key = RandomStringUtils.randomAlphanumeric(16);
       ArrayNode payload = objectMapper.createArrayNode();
 
-      List<JsonShreddedRow> result =
-          shredder.shred(payload, key, Collections.singletonList("path"));
+      List<JsonShreddedRow> result = shredder.shred(payload, Collections.singletonList("path"));
 
       assertThat(result)
           .singleElement()
           .satisfies(
               row -> {
-                assertThat(row.getKey()).isEqualTo(key);
                 assertThat(row.getPath()).containsExactly("path");
                 assertThat(row.getLeaf()).isEqualTo("path");
                 assertThat(row.getStringValue()).isEqualTo(DocsApiConstants.EMPTY_ARRAY_MARKER);
@@ -285,11 +258,9 @@ class JsonDocumentShredderTest {
 
     @Test
     public void emptyArrayRoot() {
-      String key = RandomStringUtils.randomAlphanumeric(16);
       ArrayNode payload = objectMapper.createArrayNode();
 
-      Throwable result =
-          catchThrowable(() -> shredder.shred(payload, key, Collections.emptyList()));
+      Throwable result = catchThrowable(() -> shredder.shred(payload, Collections.emptyList()));
 
       assertThat(result)
           .isInstanceOf(ErrorCodeRuntimeException.class)
@@ -298,17 +269,15 @@ class JsonDocumentShredderTest {
 
     @Test
     public void withEmptyArray() {
-      String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload =
           objectMapper.createObjectNode().set("field", objectMapper.createArrayNode());
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList());
+      List<JsonShreddedRow> result = shredder.shred(payload, Collections.emptyList());
 
       assertThat(result)
           .singleElement()
           .satisfies(
               row -> {
-                assertThat(row.getKey()).isEqualTo(key);
                 assertThat(row.getPath()).containsExactly("field");
                 assertThat(row.getLeaf()).isEqualTo("field");
                 assertThat(row.getStringValue()).isEqualTo(DocsApiConstants.EMPTY_ARRAY_MARKER);
@@ -319,19 +288,17 @@ class JsonDocumentShredderTest {
 
     @Test
     public void withArrayElements() {
-      String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload =
           objectMapper
               .createObjectNode()
               .set("field", objectMapper.createArrayNode().add("first").add("second"));
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList());
+      List<JsonShreddedRow> result = shredder.shred(payload, Collections.emptyList());
 
       assertThat(result)
           .hasSize(2)
           .anySatisfy(
               row -> {
-                assertThat(row.getKey()).isEqualTo(key);
                 assertThat(row.getPath()).containsExactly("field", "[000000]");
                 assertThat(row.getLeaf()).isEqualTo("[000000]");
                 assertThat(row.getStringValue()).isEqualTo("first");
@@ -340,7 +307,6 @@ class JsonDocumentShredderTest {
               })
           .anySatisfy(
               row -> {
-                assertThat(row.getKey()).isEqualTo(key);
                 assertThat(row.getPath()).containsExactly("field", "[000001]");
                 assertThat(row.getLeaf()).isEqualTo("[000001]");
                 assertThat(row.getStringValue()).isEqualTo("second");
@@ -351,14 +317,13 @@ class JsonDocumentShredderTest {
 
     @Test
     public void withArrayOverflow() {
-      String key = RandomStringUtils.randomAlphanumeric(16);
+
       ObjectNode payload =
           objectMapper
               .createObjectNode()
               .set("field", objectMapper.createArrayNode().add("first").add("second").add("third"));
 
-      Throwable result =
-          catchThrowable(() -> shredder.shred(payload, key, Collections.emptyList()));
+      Throwable result = catchThrowable(() -> shredder.shred(payload, Collections.emptyList()));
 
       assertThat(result)
           .isInstanceOf(ErrorCodeRuntimeException.class)
@@ -368,16 +333,14 @@ class JsonDocumentShredderTest {
 
     @Test
     public void withEscapedFields() {
-      String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload = objectMapper.createObjectNode().put("period\\.", "text");
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Collections.emptyList());
+      List<JsonShreddedRow> result = shredder.shred(payload, Collections.emptyList());
 
       assertThat(result)
           .singleElement()
           .satisfies(
               row -> {
-                assertThat(row.getKey()).isEqualTo(key);
                 assertThat(row.getPath()).containsExactly("period.");
                 assertThat(row.getLeaf()).isEqualTo("period.");
                 assertThat(row.getStringValue()).isEqualTo("text");
@@ -388,11 +351,9 @@ class JsonDocumentShredderTest {
 
     @Test
     public void withInvalidFields() {
-      String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload = objectMapper.createObjectNode().put("period.", "text");
 
-      Throwable result =
-          catchThrowable(() -> shredder.shred(payload, key, Collections.emptyList()));
+      Throwable result = catchThrowable(() -> shredder.shred(payload, Collections.emptyList()));
 
       assertThat(result)
           .isInstanceOf(ErrorCodeRuntimeException.class)
@@ -401,16 +362,14 @@ class JsonDocumentShredderTest {
 
     @Test
     public void withPrependPath() {
-      String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload = objectMapper.createObjectNode().put("field", "text");
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Arrays.asList("one", "two"));
+      List<JsonShreddedRow> result = shredder.shred(payload, Arrays.asList("one", "two"));
 
       assertThat(result)
           .singleElement()
           .satisfies(
               row -> {
-                assertThat(row.getKey()).isEqualTo(key);
                 assertThat(row.getPath()).containsExactly("one", "two", "field");
                 assertThat(row.getLeaf()).isEqualTo("field");
                 assertThat(row.getStringValue()).isEqualTo("text");
@@ -421,16 +380,14 @@ class JsonDocumentShredderTest {
 
     @Test
     public void withEscapedPrependPath() {
-      String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload = objectMapper.createObjectNode().put("field", "text");
 
-      List<JsonShreddedRow> result = shredder.shred(payload, key, Arrays.asList("one\\\\."));
+      List<JsonShreddedRow> result = shredder.shred(payload, Arrays.asList("one\\\\."));
 
       assertThat(result)
           .singleElement()
           .satisfies(
               row -> {
-                assertThat(row.getKey()).isEqualTo(key);
                 assertThat(row.getPath()).containsExactly("one\\.", "field");
                 assertThat(row.getLeaf()).isEqualTo("field");
                 assertThat(row.getStringValue()).isEqualTo("text");
@@ -441,11 +398,10 @@ class JsonDocumentShredderTest {
 
     @Test
     public void maxDepthExceeded() {
-      String key = RandomStringUtils.randomAlphanumeric(16);
       ObjectNode payload = objectMapper.createObjectNode().put("field", "text");
 
       Throwable result =
-          catchThrowable(() -> shredder.shred(payload, key, Arrays.asList("one", "two", "three")));
+          catchThrowable(() -> shredder.shred(payload, Arrays.asList("one", "two", "three")));
 
       assertThat(result)
           .isInstanceOf(ErrorCodeRuntimeException.class)


### PR DESCRIPTION
**What this PR does**:
Provides simpler and more efficient document shredding based on the recursion. Operate only against the JsonNode and returns results in a minimal concrete class representation of shredding. The idea is that we add later on `JsonShreddedRow#bind(Query inserQuery)` and easily bind values based on the object state.

Open questions:

1. What should be the leaf & path values in case of empty objects and empty arrays?
2. Do we support primitives and what should be the leaf & path values if we do?
3. Should we escape also the prepend path? (seems this is not done at the moment)
4. Is the `ErrorCode.DOCS_API_GENERAL_INVALID_FIELD_NAME` still valid and when it should be thrown?

**Which issue(s) this PR fixes**:
None.

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
