### PR TITLE
(WIP) Sgv2 #1435: Add createTable()

### DIFF
--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/BridgeProtoTypeTranslator.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/BridgeProtoTypeTranslator.java
@@ -1,6 +1,12 @@
 package io.stargate.sgv2.restsvc.grpc;
 
 import io.stargate.proto.QueryOuterClass;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -8,17 +14,28 @@ import java.util.stream.Collectors;
  * Bridge/gRPC when describing things like column types.
  */
 public class BridgeProtoTypeTranslator {
-  public static String fromProtoToCqlType(QueryOuterClass.TypeSpec type) {
+  private static final EnumMap<QueryOuterClass.TypeSpec.Basic, String> simpleBridgeToCqlTypes =
+      CqlAndProtoTypesHelper.simpleBridgeToCqlTypes;
+
+  /**
+   * Method for constructing CQL type definition String like {@code map<string, uuid>} from
+   * Bridge/gRPC {@code TypeSpec}: type definition String should be something that may be included
+   * directly in a CQL statement
+   *
+   * @param type Bridge/gRPC type specification of type type
+   * @return Valid CQL type definition String that matches given type specification
+   */
+  public static String cqlTypeFromBridgeTypeSpec(QueryOuterClass.TypeSpec type) {
     boolean frozen;
     String desc;
 
     switch (type.getSpecCase()) {
       case BASIC:
-        return basicProtoToCqlType(type.getBasic());
+        return basicBridgeToCqlType(type.getBasic());
       case LIST:
         {
           QueryOuterClass.TypeSpec.List listType = type.getList();
-          desc = "list<" + fromProtoToCqlType(listType.getElement()) + ">";
+          desc = "list<" + cqlTypeFromBridgeTypeSpec(listType.getElement()) + ">";
           frozen = listType.getFrozen();
           break;
         }
@@ -27,9 +44,9 @@ public class BridgeProtoTypeTranslator {
           QueryOuterClass.TypeSpec.Map mapType = type.getMap();
           desc =
               "map<"
-                  + fromProtoToCqlType(mapType.getKey())
+                  + cqlTypeFromBridgeTypeSpec(mapType.getKey())
                   + ", "
-                  + fromProtoToCqlType(mapType.getValue())
+                  + cqlTypeFromBridgeTypeSpec(mapType.getValue())
                   + ">";
           frozen = mapType.getFrozen();
           break;
@@ -37,7 +54,7 @@ public class BridgeProtoTypeTranslator {
       case SET:
         {
           QueryOuterClass.TypeSpec.Set setType = type.getSet();
-          desc = "set<" + fromProtoToCqlType(setType.getElement()) + ">";
+          desc = "set<" + cqlTypeFromBridgeTypeSpec(setType.getElement()) + ">";
           frozen = setType.getFrozen();
           break;
         }
@@ -46,7 +63,7 @@ public class BridgeProtoTypeTranslator {
           QueryOuterClass.TypeSpec.Tuple tupleType = type.getTuple();
           String types =
               tupleType.getElementsList().stream()
-                  .map(elem -> fromProtoToCqlType(elem))
+                  .map(elem -> cqlTypeFromBridgeTypeSpec(elem))
                   .collect(Collectors.joining(", "));
           desc = "tuple<" + types + ">";
           frozen = false;
@@ -69,14 +86,344 @@ public class BridgeProtoTypeTranslator {
     return desc;
   }
 
-  private static String basicProtoToCqlType(QueryOuterClass.TypeSpec.Basic type) {
-    switch (type) {
-        // special cases first, if any
+  private static String basicBridgeToCqlType(QueryOuterClass.TypeSpec.Basic type) {
+    // For now we should have full mapping available:
+    String cqlBasicType = simpleBridgeToCqlTypes.get(type);
+    if (cqlBasicType == null) {
+      throw new IllegalArgumentException("Unrecognized TypeSpec.Basic: " + type.name());
+    }
+    return cqlBasicType;
+  }
 
-        // and then default: lower-case of enum itself
-        // NOTE: could be optimized by map lookup if we care
-      default:
-        return type.name().toLowerCase();
+  /**
+   * Method for constructing valid Bridge/gRPC {@code TypeSpec} given a valid CQL type description
+   * String.
+   *
+   * @param cqlTypeDescription Valid CQL type description String (like {code String} or {@code
+   *     map<string, uuid>}.
+   * @return Valid {@code TypeSpec} that defines same type as the given CQL type description.
+   */
+  public static QueryOuterClass.TypeSpec cqlTypeFromBridgeTypeSpec(String cqlTypeDescription) {
+    return fromCqlDefinitionOf(cqlTypeDescription);
+  }
+
+  // Copied from SGv1 'Column'
+  public static QueryOuterClass.TypeSpec fromCqlDefinitionOf(String cqlType) {
+    cqlType = cqlType.trim();
+    if (cqlType.isEmpty()) {
+      throw new IllegalArgumentException("Invalid empty cql type name");
+    }
+    return CqlTypeParser.parse(cqlType, false);
+  }
+
+  /*
+  /////////////////////////////////////////////////////////////////////////
+  // Helper classes
+  /////////////////////////////////////////////////////////////////////////
+   */
+
+  private static class CqlAndProtoTypesHelper {
+    public static final EnumMap<QueryOuterClass.TypeSpec.Basic, String> simpleBridgeToCqlTypes;
+    public static final Map<String, QueryOuterClass.TypeSpec> simpleCqlToBridgeTypes;
+
+    static {
+      simpleBridgeToCqlTypes = new EnumMap<>(QueryOuterClass.TypeSpec.Basic.class);
+      simpleCqlToBridgeTypes = new LinkedHashMap<>();
+      for (QueryOuterClass.TypeSpec.Basic basicType : QueryOuterClass.TypeSpec.Basic.values()) {
+        // At least for now, there is full 1-to-1 mapping between enum upper-case name, matching
+        // lower-case CQL type name
+        final String cqlTypeName = basicType.name().toLowerCase();
+        simpleBridgeToCqlTypes.put(basicType, cqlTypeName);
+        simpleCqlToBridgeTypes.put(
+            cqlTypeName, QueryOuterClass.TypeSpec.newBuilder().setBasic(basicType).build());
+      }
+    }
+  }
+
+  // Lifted from "DataTypeCqlNameParser" of DataStax OSS Java driver
+  private static class CqlTypeParser {
+    private static final Map<String, QueryOuterClass.TypeSpec> simpleCqlToBridgeTypes =
+        CqlAndProtoTypesHelper.simpleCqlToBridgeTypes;
+
+    public static QueryOuterClass.TypeSpec parse(String toParse, boolean frozen) {
+      if (toParse.startsWith("'")) {
+        throw new IllegalArgumentException("Custom types are not supported");
+      }
+      CqlTypeScanner scanner = new CqlTypeScanner(toParse, 0);
+      String type = scanner.parseTypeName();
+
+      QueryOuterClass.TypeSpec nativeType =
+          simpleCqlToBridgeTypes.get(type.toLowerCase(Locale.ROOT));
+      if (nativeType != null) {
+        return nativeType;
+      }
+
+      if (scanner.isEOS()) {
+        // No parameters => it's a UDT
+        return QueryOuterClass.TypeSpec.newBuilder().setUdt(udtType(type, frozen)).build();
+      }
+
+      List<String> parameters = scanner.parseTypeParameters();
+      if (type.equalsIgnoreCase("list")) {
+        if (parameters.size() != 1) {
+          throw new IllegalArgumentException(
+              String.format("Expecting single parameter for list, got %s", parameters));
+        }
+        QueryOuterClass.TypeSpec elementType = parse(parameters.get(0), false);
+        return QueryOuterClass.TypeSpec.newBuilder().setList(listType(elementType, frozen)).build();
+      }
+
+      if (type.equalsIgnoreCase("set")) {
+        if (parameters.size() != 1) {
+          throw new IllegalArgumentException(
+              String.format("Expecting single parameter for set, got %s", parameters));
+        }
+        QueryOuterClass.TypeSpec elementType = parse(parameters.get(0), false);
+        return QueryOuterClass.TypeSpec.newBuilder().setSet(setType(elementType, frozen)).build();
+      }
+
+      if (type.equalsIgnoreCase("map")) {
+        if (parameters.size() != 2) {
+          throw new IllegalArgumentException(
+              String.format("Expecting two parameters for map, got %s", parameters));
+        }
+        QueryOuterClass.TypeSpec keyType = parse(parameters.get(0), false);
+        QueryOuterClass.TypeSpec valueType = parse(parameters.get(1), false);
+        return QueryOuterClass.TypeSpec.newBuilder()
+            .setMap(mapType(keyType, valueType, frozen))
+            .build();
+      }
+
+      if (type.equalsIgnoreCase("frozen")) {
+        if (parameters.size() != 1) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "Expecting single parameter for frozen keyword, got %d: %s",
+                  parameters.size(), parameters));
+        }
+        return parse(parameters.get(0), true);
+      }
+
+      if (type.equalsIgnoreCase("tuple")) {
+        if (parameters.isEmpty()) {
+          throw new IllegalArgumentException(
+              "Expecting at least one parameter for tuple, got none");
+        }
+        List<QueryOuterClass.TypeSpec> componentTypes = new ArrayList<>();
+        for (String rawType : parameters) {
+          componentTypes.add(parse(rawType, false));
+        }
+        return QueryOuterClass.TypeSpec.newBuilder().setTuple(tupleType(componentTypes)).build();
+      }
+
+      throw new IllegalArgumentException("Could not parse type name '" + toParse + "'");
+    }
+
+    private static QueryOuterClass.TypeSpec.List listType(
+        QueryOuterClass.TypeSpec element, boolean frozen) {
+      return QueryOuterClass.TypeSpec.List.newBuilder()
+          .setFrozen(frozen)
+          .setElement(element)
+          .build();
+    }
+
+    private static QueryOuterClass.TypeSpec.Map mapType(
+        QueryOuterClass.TypeSpec keyType, QueryOuterClass.TypeSpec valueType, boolean frozen) {
+      return QueryOuterClass.TypeSpec.Map.newBuilder()
+          .setFrozen(frozen)
+          .setKey(keyType)
+          .setValue(valueType)
+          .build();
+    }
+
+    private static QueryOuterClass.TypeSpec.Set setType(
+        QueryOuterClass.TypeSpec element, boolean frozen) {
+      return QueryOuterClass.TypeSpec.Set.newBuilder()
+          .setFrozen(frozen)
+          .setElement(element)
+          .build();
+    }
+
+    private static QueryOuterClass.TypeSpec.Tuple tupleType(
+        List<QueryOuterClass.TypeSpec> elementTypes) {
+      QueryOuterClass.TypeSpec.Tuple.Builder b = QueryOuterClass.TypeSpec.Tuple.newBuilder();
+      for (QueryOuterClass.TypeSpec type : elementTypes) {
+        b.addElements(type);
+      }
+      return b.build();
+    }
+
+    private static QueryOuterClass.TypeSpec.Udt udtType(String name, boolean frozen) {
+      return QueryOuterClass.TypeSpec.Udt.newBuilder().setName(name).setFrozen(frozen).build();
+    }
+  }
+
+  private static class CqlTypeScanner {
+    private final String str;
+    private int idx;
+
+    CqlTypeScanner(String str, int idx) {
+      this.str = str;
+      this.idx = idx;
+    }
+
+    String parseTypeName() {
+      idx = skipSpaces(str, idx);
+      return readNextIdentifier();
+    }
+
+    List<String> parseTypeParameters() {
+      List<String> list = new ArrayList<>();
+
+      if (isEOS()) {
+        return list;
+      }
+
+      skipBlankAndComma();
+
+      if (str.charAt(idx) != '<') {
+        throw new IllegalStateException();
+      }
+
+      ++idx; // skipping '<'
+
+      while (skipBlankAndComma()) {
+        if (str.charAt(idx) == '>') {
+          ++idx;
+          return list;
+        }
+
+        String name = parseTypeName();
+        String args = readRawTypeParameters();
+        list.add(name + args);
+      }
+      throw new IllegalArgumentException(
+          String.format(
+              "Syntax error parsing '%s' at char %d: unexpected end of string", str, idx));
+    }
+
+    // left idx positioned on the character stopping the read
+    private String readNextIdentifier() {
+      int startIdx = idx;
+      if (str.charAt(startIdx) == '"') { // case-sensitive name included in double quotes
+        ++idx;
+        // read until closing quote.
+        while (!isEOS()) {
+          boolean atQuote = str.charAt(idx) == '"';
+          ++idx;
+          if (atQuote) {
+            // if the next character is also a quote, this is an escaped quote, continue reading,
+            // otherwise stop.
+            if (!isEOS() && str.charAt(idx) == '"') {
+              ++idx;
+            } else {
+              break;
+            }
+          }
+        }
+      } else if (str.charAt(startIdx) == '\'') { // custom type name included in single quotes
+        ++idx;
+        // read until closing quote.
+        while (!isEOS() && str.charAt(idx++) != '\'') {
+          /* loop */
+        }
+      } else {
+        while (!isEOS() && (isCqlIdentifierChar(str.charAt(idx)) || str.charAt(idx) == '"')) {
+          ++idx;
+        }
+      }
+      return str.substring(startIdx, idx);
+    }
+
+    // Assumes we have just read a type name and read its potential arguments blindly. I.e. it
+    // assumes that either parsing is done or that we're on a '<' and this reads everything up until
+    // the corresponding closing '>'. It returns everything read, including the enclosing brackets.
+    private String readRawTypeParameters() {
+      idx = skipSpaces(str, idx);
+
+      if (isEOS() || str.charAt(idx) == '>' || str.charAt(idx) == ',') {
+        return "";
+      }
+
+      if (str.charAt(idx) != '<') {
+        throw new IllegalStateException(
+            String.format(
+                "Expecting char %d of %s to be '<' but '%c' found", idx, str, str.charAt(idx)));
+      }
+
+      int i = idx;
+      int open = 1;
+      boolean inQuotes = false;
+      while (open > 0) {
+        ++idx;
+
+        if (isEOS()) {
+          throw new IllegalStateException("Non closed angle brackets");
+        }
+
+        // Only parse for '<' and '>' characters if not within a quoted identifier.
+        // Note we don't need to handle escaped quotes ("") in type names here, because they just
+        // cause inQuotes to flip to false and immediately back to true
+        if (!inQuotes) {
+          if (str.charAt(idx) == '"') {
+            inQuotes = true;
+          } else if (str.charAt(idx) == '<') {
+            open++;
+          } else if (str.charAt(idx) == '>') {
+            open--;
+          }
+        } else if (str.charAt(idx) == '"') {
+          inQuotes = false;
+        }
+      }
+      // we've stopped at the last closing ')' so move past that
+      ++idx;
+      return str.substring(i, idx);
+    }
+
+    // skip all blank and at best one comma, return true if there not EOS
+    private boolean skipBlankAndComma() {
+      boolean commaFound = false;
+      while (!isEOS()) {
+        int c = str.charAt(idx);
+        if (c == ',') {
+          if (commaFound) {
+            return true;
+          } else {
+            commaFound = true;
+          }
+        } else if (!isBlank(c)) {
+          return true;
+        }
+        ++idx;
+      }
+      return false;
+    }
+
+    private boolean isEOS() {
+      return idx >= str.length();
+    }
+
+    // // // Methods from "ParseUtils":
+
+    private static int skipSpaces(String toParse, int idx) {
+      while (idx < toParse.length() && isBlank(toParse.charAt(idx))) ++idx;
+      return idx;
+    }
+
+    private static boolean isBlank(int c) {
+      return c == ' ' || c == '\t' || c == '\n';
+    }
+
+    public static boolean isCqlIdentifierChar(int c) {
+      return (c >= '0' && c <= '9')
+          || (c >= 'a' && c <= 'z')
+          || (c >= 'A' && c <= 'Z')
+          || c == '-'
+          || c == '+'
+          || c == '.'
+          || c == '_'
+          || c == '&';
     }
   }
 }

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/BridgeSchemaClient.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/BridgeSchemaClient.java
@@ -1,5 +1,6 @@
 package io.stargate.sgv2.restsvc.grpc;
 
+import io.stargate.proto.QueryOuterClass;
 import io.stargate.proto.Schema;
 import io.stargate.proto.StargateGrpc;
 import java.util.List;
@@ -17,6 +18,12 @@ public class BridgeSchemaClient {
 
   public static BridgeSchemaClient create(StargateGrpc.StargateBlockingStub blockingStub) {
     return new BridgeSchemaClient(blockingStub);
+  }
+
+  public QueryOuterClass.Response createTable(Schema.CqlTableCreate request) {
+    // !!! TODO: error handling to expose proper failure downstream
+    final QueryOuterClass.Response resp = blockingStub.createTable(request);
+    return resp;
   }
 
   public Schema.CqlTable findTable(String keyspace, String tableName) {

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2ColumnDefinition.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2ColumnDefinition.java
@@ -19,8 +19,8 @@ public class Sgv2ColumnDefinition {
       @JsonProperty("name") final String name,
       @JsonProperty("typeDefinition") final String typeDefinition,
       @JsonProperty("static") final boolean isStatic) {
-    this.name = name;
-    this.typeDefinition = typeDefinition;
+    this.name = (name == null) ? "" : name;
+    this.typeDefinition = (typeDefinition == null) ? "" : typeDefinition;
     this.isStatic = isStatic;
   }
 

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2Table.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2Table.java
@@ -28,8 +28,9 @@ public class Sgv2Table {
       @JsonProperty("tableOptions") final TableOptions tableOptions) {
     this.name = name;
     this.keyspace = keyspace;
-    this.columnDefinitions = columnDefinitions;
-    this.primaryKey = primaryKey;
+    this.columnDefinitions =
+        (columnDefinitions == null) ? Collections.emptyList() : columnDefinitions;
+    this.primaryKey = (primaryKey == null) ? new PrimaryKey() : primaryKey;
     this.tableOptions = tableOptions;
   }
 
@@ -109,6 +110,14 @@ public class Sgv2Table {
     public void setClusteringKey(List<String> clusteringKey) {
       this.clusteringKey = clusteringKey;
     }
+
+    public boolean hasPartitionKey(String key) {
+      return (partitionKey != null) && partitionKey.contains(key);
+    }
+
+    public boolean hasClusteringKey(String key) {
+      return (clusteringKey != null) && clusteringKey.contains(key);
+    }
   }
 
   // copy of SGv1 TableOptions
@@ -128,7 +137,7 @@ public class Sgv2Table {
     }
 
     public TableOptions() {
-      this(null, Collections.emptyList());
+      this(null, null);
     }
 
     @ApiModelProperty(
@@ -178,6 +187,14 @@ public class Sgv2Table {
     @ApiModelProperty(required = true, value = "The clustering order", allowableValues = "asc,desc")
     public String getOrder() {
       return order;
+    }
+
+    public boolean hasOrderAsc() {
+      return VALUE_ASC.equals(order);
+    }
+
+    public boolean hasOrderDesc() {
+      return VALUE_DESC.equals(order);
     }
   }
 }

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2Table.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2Table.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 // Note: copy from SGv1 TableResponse
@@ -124,6 +125,10 @@ public class Sgv2Table {
             final List<ClusteringExpression> clusteringExpression) {
       this.defaultTimeToLive = defaultTimeToLive;
       this.clusteringExpression = clusteringExpression;
+    }
+
+    public TableOptions() {
+      this(null, Collections.emptyList());
     }
 
     @ApiModelProperty(

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2TableAddRequest.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2TableAddRequest.java
@@ -1,6 +1,7 @@
 package io.stargate.sgv2.restsvc.models;
 
 import io.swagger.annotations.ApiModelProperty;
+import java.util.Collections;
 import java.util.List;
 import javax.validation.constraints.NotNull;
 
@@ -64,5 +65,17 @@ public class Sgv2TableAddRequest {
 
   public void setTableOptions(Sgv2Table.TableOptions tableOptions) {
     this.tableOptions = tableOptions;
+  }
+
+  // // // Convenience access
+
+  public List<Sgv2Table.ClusteringExpression> findClusteringExpressions() {
+    if (tableOptions != null) {
+      List<Sgv2Table.ClusteringExpression> clustering = tableOptions.getClusteringExpression();
+      if (clustering != null) {
+        return clustering;
+      }
+    }
+    return Collections.emptyList();
   }
 }

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2TableAddRequest.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2TableAddRequest.java
@@ -1,0 +1,68 @@
+package io.stargate.sgv2.restsvc.models;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.List;
+import javax.validation.constraints.NotNull;
+
+// Copied from SGv1 "TableAdd"
+public class Sgv2TableAddRequest {
+  @NotNull private String name;
+  @NotNull private Sgv2Table.PrimaryKey primaryKey;
+  @NotNull private List<Sgv2ColumnDefinition> columnDefinitions;
+
+  boolean ifNotExists = false;
+
+  Sgv2Table.TableOptions tableOptions = new Sgv2Table.TableOptions();
+
+  @ApiModelProperty(required = true, value = "The name of the table to add.")
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @ApiModelProperty(
+      value =
+          "Determines whether to create a new table if a table with the same name exists. Attempting to create an existing table returns an error unless this option is true.")
+  public boolean getIfNotExists() {
+    return ifNotExists;
+  }
+
+  public void setIfNotExists(boolean ifNotExists) {
+    this.ifNotExists = ifNotExists;
+  }
+
+  @ApiModelProperty(
+      required = true,
+      value =
+          "The primary key definition of the table, consisting of partition and clustering keys.")
+  public Sgv2Table.PrimaryKey getPrimaryKey() {
+    return primaryKey;
+  }
+
+  public void setPrimaryKey(Sgv2Table.PrimaryKey primaryKey) {
+    this.primaryKey = primaryKey;
+  }
+
+  @ApiModelProperty(
+      required = true,
+      value = "Definition of columns that belong to the table to be added.")
+  public List<Sgv2ColumnDefinition> getColumnDefinitions() {
+    return columnDefinitions;
+  }
+
+  public void setColumnDefinitions(List<Sgv2ColumnDefinition> columnDefinitions) {
+    this.columnDefinitions = columnDefinitions;
+  }
+
+  @ApiModelProperty(value = "The set of table options to apply to the table when creating.")
+  public Sgv2Table.TableOptions getTableOptions() {
+    return tableOptions;
+  }
+
+  public void setTableOptions(Sgv2Table.TableOptions tableOptions) {
+    this.tableOptions = tableOptions;
+  }
+}

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2TablesResource.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2TablesResource.java
@@ -208,6 +208,7 @@ public class Sgv2TablesResource extends ResourceBase {
               Schema.CqlTableCreate.newBuilder()
                   .setKeyspaceName(keyspaceName)
                   .setTable(table2table(tableAdd))
+                  .setIfNotExists(tableAdd.getIfNotExists())
                   .build();
           BridgeSchemaClient.create(blockingStub).createTable(addTable);
           return jaxrsResponse(Response.Status.CREATED)
@@ -341,7 +342,9 @@ public class Sgv2TablesResource extends ResourceBase {
 
   private Sgv2ColumnDefinition column2column(QueryOuterClass.ColumnSpec column, boolean isStatic) {
     return new Sgv2ColumnDefinition(
-        column.getName(), BridgeProtoTypeTranslator.fromProtoToCqlType(column.getType()), isStatic);
+        column.getName(),
+        BridgeProtoTypeTranslator.cqlTypeFromBridgeTypeSpec(column.getType()),
+        isStatic);
   }
 
   private List<Sgv2Table.ClusteringExpression> clustering2clustering(

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2TablesResource.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2TablesResource.java
@@ -193,11 +193,11 @@ public class Sgv2TablesResource extends ResourceBase {
       return invalidTokenFailure();
     }
     if (isStringEmpty(keyspaceName)) {
-      return jaxrsBadRequestError("keyspaceName must be non-empty").build();
+      return jaxrsBadRequestError("keyspaceName must be provided").build();
     }
     final String tableName = tableAdd.getName();
     if (isStringEmpty(keyspaceName)) {
-      return jaxrsBadRequestError("Table name must be non-empty").build();
+      return jaxrsBadRequestError("table name must be provided").build();
     }
     final StargateGrpc.StargateBlockingStub blockingStub =
         grpcFactory.constructBlockingStub().withCallCredentials(new StargateBearerToken(token));
@@ -324,10 +324,10 @@ public class Sgv2TablesResource extends ResourceBase {
                   BridgeProtoTypeTranslator.cqlTypeFromBridgeTypeSpec(
                       columnDef.getTypeDefinition()))
               .build();
-      if (primaryKeys.hasClusteringKey(columnName)) {
-        b.addClusteringKeyColumns(column);
-      } else if (primaryKeys.hasClusteringKey(columnName)) {
+      if (primaryKeys.hasPartitionKey(columnName)) {
         b.addPartitionKeyColumns(column);
+      } else if (primaryKeys.hasClusteringKey(columnName)) {
+        b.addClusteringKeyColumns(column);
       } else if (columnDef.getIsStatic()) {
         b.addStaticColumns(column);
       } else {

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -370,7 +370,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
   @Test
   public void createTable() throws IOException {
     createKeyspace(keyspaceName);
-    createTable(keyspaceName, tableName);
+    createTable(keyspaceName, tableName, restUrlBase);
 
     String body =
         RestUtils.get(
@@ -383,7 +383,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
     TableResponse table = objectMapper.readValue(body, TableResponse.class);
     assertThat(table.getKeyspace()).isEqualTo(keyspaceName);
     assertThat(table.getName()).isEqualTo(tableName);
-    assertThat(table.getColumnDefinitions()).isNotNull();
+    assertThat(table.getColumnDefinitions()).isNotNull().isNotEmpty().hasSize(4);
   }
 
   @Test
@@ -2822,6 +2822,12 @@ public class RestApiv2Test extends BaseIntegrationTest {
   }
 
   private void createTable(String keyspaceName, String tableName) throws IOException {
+    // !!! TODO: change to SGv2 when done
+    createTable(keyspaceName, tableName, legacyRestUrlBase);
+  }
+
+  private void createTable(String keyspaceName, String tableName, String urlBase)
+      throws IOException {
     TableAdd tableAdd = new TableAdd();
     tableAdd.setName(tableName);
 
@@ -2841,7 +2847,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
     // TODO: change to restUrlBase after new REST service implements table creation
     RestUtils.post(
         authToken,
-        String.format("%s/v2/schemas/keyspaces/%s/tables", legacyRestUrlBase, keyspaceName),
+        String.format("%s/v2/schemas/keyspaces/%s/tables", urlBase, keyspaceName),
         objectMapper.writeValueAsString(tableAdd),
         HttpStatus.SC_CREATED);
   }
@@ -2962,7 +2968,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
 
   private void createKeyspace(String keyspaceName) throws IOException {
     // TODO: change to restUrlBase after new REST service implements keyspace creation
-    createKeyspace(keyspaceName, legacyRestUrlBase);
+    createKeyspace(keyspaceName, restUrlBase);
   }
 
   private void createKeyspace(String keyspaceName, String urlBaseToUse) throws IOException {

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -2822,8 +2822,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
   }
 
   private void createTable(String keyspaceName, String tableName) throws IOException {
-    // !!! TODO: change to SGv2 when done
-    createTable(keyspaceName, tableName, legacyRestUrlBase);
+    createTable(keyspaceName, tableName, restUrlBase);
   }
 
   private void createTable(String keyspaceName, String tableName, String urlBase)
@@ -2872,11 +2871,10 @@ public class RestApiv2Test extends BaseIntegrationTest {
     }
     tableAdd.setPrimaryKey(primaryKey);
 
-    // TODO: change to restUrlBase after new REST service implements table creation
     String body =
         RestUtils.post(
             authToken,
-            String.format("%s/v2/schemas/keyspaces/%s/tables", legacyRestUrlBase, keyspaceName),
+            String.format("%s/v2/schemas/keyspaces/%s/tables", restUrlBase, keyspaceName),
             objectMapper.writeValueAsString(tableAdd),
             HttpStatus.SC_CREATED);
 
@@ -2902,10 +2900,9 @@ public class RestApiv2Test extends BaseIntegrationTest {
     primaryKey.setPartitionKey(Collections.singletonList("pk0"));
     tableAdd.setPrimaryKey(primaryKey);
 
-    // TODO: change to restUrlBase after new REST service implements table creation
     RestUtils.post(
         authToken,
-        String.format("%s/v2/schemas/keyspaces/%s/tables", legacyRestUrlBase, keyspaceName),
+        String.format("%s/v2/schemas/keyspaces/%s/tables", restUrlBase, keyspaceName),
         objectMapper.writeValueAsString(tableAdd),
         HttpStatus.SC_CREATED);
   }
@@ -2929,10 +2926,9 @@ public class RestApiv2Test extends BaseIntegrationTest {
     primaryKey.setClusteringKey(Collections.singletonList("expense_id"));
     tableAdd.setPrimaryKey(primaryKey);
 
-    // TODO: change to restUrlBase after new REST service implements table creation
     RestUtils.post(
         authToken,
-        String.format("%s/v2/schemas/keyspaces/%s/tables", legacyRestUrlBase, keyspaceName),
+        String.format("%s/v2/schemas/keyspaces/%s/tables", restUrlBase, keyspaceName),
         objectMapper.writeValueAsString(tableAdd),
         HttpStatus.SC_CREATED);
   }
@@ -2958,10 +2954,9 @@ public class RestApiv2Test extends BaseIntegrationTest {
     primaryKey.setClusteringKey(Arrays.asList("ck0", "ck1"));
     tableAdd.setPrimaryKey(primaryKey);
 
-    // TODO: change to restUrlBase after new REST service implements table creation
     RestUtils.post(
         authToken,
-        String.format("%s/v2/schemas/keyspaces/%s/tables", legacyRestUrlBase, keyspaceName),
+        String.format("%s/v2/schemas/keyspaces/%s/tables", restUrlBase, keyspaceName),
         objectMapper.writeValueAsString(tableAdd),
         HttpStatus.SC_CREATED);
   }
@@ -2993,10 +2988,9 @@ public class RestApiv2Test extends BaseIntegrationTest {
       }
       insertedRows.add(rowMap);
 
-      // TODO: change to restUrlBase after new REST service implements insert operation
       RestUtils.post(
           authToken,
-          String.format("%s/v2/keyspaces/%s/%s", legacyRestUrlBase, keyspaceName, tableName),
+          String.format("%s/v2/keyspaces/%s/%s", restUrlBase, keyspaceName, tableName),
           objectMapper.writeValueAsString(rowMap),
           HttpStatus.SC_CREATED);
     }
@@ -3007,16 +3001,17 @@ public class RestApiv2Test extends BaseIntegrationTest {
     createKeyspace(keyspaceName);
     createTableWithClustering(keyspaceName, tableName);
 
+    final String restUrlForInserts = restUrlBase;
+
     String rowIdentifier = "1";
     Map<String, String> row = new HashMap<>();
     row.put("id", rowIdentifier);
     row.put("firstname", "John");
     row.put("expense_id", "1");
 
-    // TODO: change to restUrlBase after new REST service implements insert operation
     RestUtils.post(
         authToken,
-        String.format("%s/v2/keyspaces/%s/%s", legacyRestUrlBase, keyspaceName, tableName),
+        String.format("%s/v2/keyspaces/%s/%s", restUrlForInserts, keyspaceName, tableName),
         objectMapper.writeValueAsString(row),
         HttpStatus.SC_CREATED);
 
@@ -3025,10 +3020,9 @@ public class RestApiv2Test extends BaseIntegrationTest {
     row.put("firstname", "John");
     row.put("expense_id", "2");
 
-    // TODO: change to restUrlBase after new REST service implements insert operation
     RestUtils.post(
         authToken,
-        String.format("%s/v2/keyspaces/%s/%s", legacyRestUrlBase, keyspaceName, tableName),
+        String.format("%s/v2/keyspaces/%s/%s", restUrlForInserts, keyspaceName, tableName),
         objectMapper.writeValueAsString(row),
         HttpStatus.SC_CREATED);
 
@@ -3037,10 +3031,9 @@ public class RestApiv2Test extends BaseIntegrationTest {
     row.put("firstname", "Jane");
     row.put("expense_id", "1");
 
-    // TODO: change to restUrlBase after new REST service implements insert operation
     RestUtils.post(
         authToken,
-        String.format("%s/v2/keyspaces/%s/%s", legacyRestUrlBase, keyspaceName, tableName),
+        String.format("%s/v2/keyspaces/%s/%s", restUrlForInserts, keyspaceName, tableName),
         objectMapper.writeValueAsString(row),
         HttpStatus.SC_CREATED);
 
@@ -3049,10 +3042,9 @@ public class RestApiv2Test extends BaseIntegrationTest {
     row.put("firstname", "Jane");
     row.put("expense_id", "1");
 
-    // TODO: change to restUrlBase after new REST service implements insert operation
     RestUtils.post(
         authToken,
-        String.format("%s/v2/keyspaces/%s/%s", legacyRestUrlBase, keyspaceName, tableName),
+        String.format("%s/v2/keyspaces/%s/%s", restUrlForInserts, keyspaceName, tableName),
         objectMapper.writeValueAsString(row),
         HttpStatus.SC_CREATED);
 
@@ -3063,6 +3055,8 @@ public class RestApiv2Test extends BaseIntegrationTest {
     createKeyspace(keyspaceName);
     createTableWithMixedClustering(keyspaceName, tableName);
 
+    final String restUrlForInserts = restUrlBase;
+
     Map<String, String> row = new HashMap<>();
     row.put("pk0", "1");
     row.put("pk1", "one");
@@ -3071,10 +3065,9 @@ public class RestApiv2Test extends BaseIntegrationTest {
     row.put("ck1", "foo");
     row.put("v", "9");
 
-    // TODO: change to restUrlBase after new REST service implements insert operation
     RestUtils.post(
         authToken,
-        String.format("%s/v2/keyspaces/%s/%s", legacyRestUrlBase, keyspaceName, tableName),
+        String.format("%s/v2/keyspaces/%s/%s", restUrlForInserts, keyspaceName, tableName),
         objectMapper.writeValueAsString(row),
         HttpStatus.SC_CREATED);
 
@@ -3086,10 +3079,9 @@ public class RestApiv2Test extends BaseIntegrationTest {
     row.put("ck1", "foo");
     row.put("v", "19");
 
-    // TODO: change to restUrlBase after new REST service implements insert operation
     RestUtils.post(
         authToken,
-        String.format("%s/v2/keyspaces/%s/%s", legacyRestUrlBase, keyspaceName, tableName),
+        String.format("%s/v2/keyspaces/%s/%s", restUrlForInserts, keyspaceName, tableName),
         objectMapper.writeValueAsString(row),
         HttpStatus.SC_CREATED);
 
@@ -3101,10 +3093,9 @@ public class RestApiv2Test extends BaseIntegrationTest {
     row.put("ck1", "bar");
     row.put("v", "18");
 
-    // TODO: change to restUrlBase after new REST service implements insert operation
     RestUtils.post(
         authToken,
-        String.format("%s/v2/keyspaces/%s/%s", legacyRestUrlBase, keyspaceName, tableName),
+        String.format("%s/v2/keyspaces/%s/%s", restUrlForInserts, keyspaceName, tableName),
         objectMapper.writeValueAsString(row),
         HttpStatus.SC_CREATED);
   }

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -369,7 +369,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
 
   @Test
   public void createTable() throws IOException {
-    createKeyspace(keyspaceName);
+    createKeyspace(keyspaceName, restUrlBase);
     createTable(keyspaceName, tableName, restUrlBase);
 
     String body =


### PR DESCRIPTION
**What this PR does**:

Implements "createTable" for Tables Resource using SGv2 mechanism (going via gRPC bridge).

For some reason there seem to be issues in conjunction with keyspace creation on tests.

**Which issue(s) this PR fixes**:
Fixes #1435

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
