### PR TITLE
Fix #1444 by changing swagger annotated response type to correct one

### DIFF
--- a/restapi/src/main/java/io/stargate/web/restapi/resources/v1/TableResource.java
+++ b/restapi/src/main/java/io/stargate/web/restapi/resources/v1/TableResource.java
@@ -236,10 +236,10 @@ public class TableResource {
   @ApiOperation(
       value = "Return a table",
       notes = "Retrieve data for a single table in a specific keyspace.",
-      response = Table.class)
+      response = TableResponse.class)
   @ApiResponses(
       value = {
-        @ApiResponse(code = 200, message = "OK", response = Table.class),
+        @ApiResponse(code = 200, message = "OK", response = TableResponse.class),
         @ApiResponse(code = 400, message = "Bad request", response = ApiError.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = ApiError.class),
         @ApiResponse(code = 403, message = "Forbidden", response = ApiError.class),

--- a/restapi/src/main/java/io/stargate/web/restapi/resources/v2/schemas/TablesResource.java
+++ b/restapi/src/main/java/io/stargate/web/restapi/resources/v2/schemas/TablesResource.java
@@ -134,10 +134,10 @@ public class TablesResource {
   @ApiOperation(
       value = "Get a table",
       notes = "Retrieve data for a single table in a specific keyspace.",
-      response = Table.class)
+      response = TableResponse.class)
   @ApiResponses(
       value = {
-        @ApiResponse(code = 200, message = "OK", response = Table.class),
+        @ApiResponse(code = 200, message = "OK", response = TableResponse.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = ApiError.class),
         @ApiResponse(code = 404, message = "Not Found", response = ApiError.class),
         @ApiResponse(code = 500, message = "Internal server error", response = ApiError.class)


### PR DESCRIPTION
**What this PR does**:

Changes successful response type form `Table` to `TableResponse` for "getOneTable()" REST v1/v2 endpoints -- this is the type actually returned. Will fix Swagger-generated documentation

**Which issue(s) this PR fixes**:
Fixes #1444

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
