### PR TITLE
Add string-only QueryBuilder

### DIFF
--- a/persistence-api/src/main/java/io/stargate/db/query/builder/QueryBuilderImpl.java
+++ b/persistence-api/src/main/java/io/stargate/db/query/builder/QueryBuilderImpl.java
@@ -15,12 +15,6 @@
  */
 package io.stargate.db.query.builder;
 
-import static com.datastax.oss.driver.shaded.guava.common.base.Preconditions.checkArgument;
-import static io.stargate.db.query.BindMarker.markerFor;
-import static java.lang.String.format;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
-
 import com.datastax.oss.driver.internal.core.util.Strings;
 import com.datastax.oss.driver.shaded.guava.common.collect.Sets;
 import com.github.misberner.apcommons.util.AFModifier;
@@ -58,6 +52,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.javatuples.Pair;
+
+import static com.datastax.oss.driver.shaded.guava.common.base.Preconditions.checkArgument;
+import static io.stargate.db.query.BindMarker.markerFor;
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 
 /** Convenience builder for creating queries. */
 @GenerateEmbeddedDSL(

--- a/persistence-api/src/main/java/io/stargate/db/query/builder/QueryBuilderImpl.java
+++ b/persistence-api/src/main/java/io/stargate/db/query/builder/QueryBuilderImpl.java
@@ -15,6 +15,12 @@
  */
 package io.stargate.db.query.builder;
 
+import static com.datastax.oss.driver.shaded.guava.common.base.Preconditions.checkArgument;
+import static io.stargate.db.query.BindMarker.markerFor;
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
 import com.datastax.oss.driver.internal.core.util.Strings;
 import com.datastax.oss.driver.shaded.guava.common.collect.Sets;
 import com.github.misberner.apcommons.util.AFModifier;
@@ -52,12 +58,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.javatuples.Pair;
-
-import static com.datastax.oss.driver.shaded.guava.common.base.Preconditions.checkArgument;
-import static io.stargate.db.query.BindMarker.markerFor;
-import static java.lang.String.format;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
 
 /** Convenience builder for creating queries. */
 @GenerateEmbeddedDSL(

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,7 @@
         <module>graphqlapi</module>
         <module>restapi</module>
         <module>sgv2-restapi</module>
+        <module>sgv2-service-common</module>
         <module>auth-api</module>
         <module>authnz</module>
         <module>auth-table-based-service</module>
@@ -176,6 +177,7 @@
         <module>graphqlapi</module>
         <module>restapi</module>
         <module>sgv2-restapi</module>
+        <module>sgv2-service-common</module>
         <module>auth-api</module>
         <module>authnz</module>
         <module>auth-table-based-service</module>

--- a/sgv2-service-common/pom.xml
+++ b/sgv2-service-common/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.stargate</groupId>
+        <artifactId>stargate</artifactId>
+        <version>1.0.44-SNAPSHOT</version>
+    </parent>
+    <artifactId>sgv2-service-common</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>com.github.misberner.duzzt</groupId>
+            <artifactId>duzzt-processor</artifactId>
+            <version>0.0.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.immutables</groupId>
+            <artifactId>value</artifactId>
+            <version>2.8.8</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/sgv2-service-common/pom.xml
+++ b/sgv2-service-common/pom.xml
@@ -26,6 +26,7 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <version>3.0.2</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/ColumnUtils.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/ColumnUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright DataStax, Inc. and/or The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.common.cql;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ColumnUtils {
+
+  private static final Pattern PATTERN_DOUBLE_QUOTE = Pattern.compile("\"", Pattern.LITERAL);
+  private static final String ESCAPED_DOUBLE_QUOTE = Matcher.quoteReplacement("\"\"");
+  private static final Pattern UNQUOTED_IDENTIFIER = Pattern.compile("[a-z][a-z0-9_]*");
+
+  /**
+   * Given the raw (as stored internally) text of an identifier, return its CQL representation. That
+   * is, unless the text is full lowercase and use only characters allowed in unquoted identifiers,
+   * the result is double-quoted.
+   */
+  public static String maybeQuote(String text) {
+    if (UNQUOTED_IDENTIFIER.matcher(text).matches() && !ReservedKeywords.isReserved(text)) {
+      return text;
+    }
+    return '"' + PATTERN_DOUBLE_QUOTE.matcher(text).replaceAll(ESCAPED_DOUBLE_QUOTE) + '"';
+  }
+}

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/ReservedKeywords.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/ReservedKeywords.java
@@ -16,86 +16,86 @@
 package io.stargate.sgv2.common.cql;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
 
 public final class ReservedKeywords {
-  private static final String[] reservedKeywords =
-      new String[] {
-        "SELECT",
-        "FROM",
-        "WHERE",
-        "AND",
-        "ENTRIES",
-        "FULL",
-        "INSERT",
-        "UPDATE",
-        "WITH",
-        "LIMIT",
-        "USING",
-        "USE",
-        "SET",
-        "BEGIN",
-        "UNLOGGED",
-        "BATCH",
-        "APPLY",
-        "TRUNCATE",
-        "DELETE",
-        "IN",
-        "CREATE",
-        "KEYSPACE",
-        "SCHEMA",
-        "COLUMNFAMILY",
-        "TABLE",
-        "MATERIALIZED",
-        "VIEW",
-        "INDEX",
-        "ON",
-        "TO",
-        "DROP",
-        "PRIMARY",
-        "INTO",
-        "ALTER",
-        "RENAME",
-        "ADD",
-        "ORDER",
-        "BY",
-        "ASC",
-        "DESC",
-        "ALLOW",
-        "IF",
-        "IS",
-        "GRANT",
-        "OF",
-        "REVOKE",
-        "MODIFY",
-        "AUTHORIZE",
-        "DESCRIBE",
-        "EXECUTE",
-        "NORECURSIVE",
-        "TOKEN",
-        "NULL",
-        "NOT",
-        "NAN",
-        "INFINITY",
-        "OR",
-        "REPLACE",
-        "DEFAULT",
-        "UNSET",
-        "MBEAN",
-        "MBEANS",
-        "FOR",
-        "RESTRICT",
-        "UNRESTRICT"
-      };
 
-  private static final Set<String> reservedSet =
-      new CopyOnWriteArraySet<>(Arrays.asList(reservedKeywords));
+  private static final Set<String> KEYWORDS =
+      Collections.unmodifiableSet(
+          new HashSet<>(
+              Arrays.asList(
+                  "SELECT",
+                  "FROM",
+                  "WHERE",
+                  "AND",
+                  "ENTRIES",
+                  "FULL",
+                  "INSERT",
+                  "UPDATE",
+                  "WITH",
+                  "LIMIT",
+                  "USING",
+                  "USE",
+                  "SET",
+                  "BEGIN",
+                  "UNLOGGED",
+                  "BATCH",
+                  "APPLY",
+                  "TRUNCATE",
+                  "DELETE",
+                  "IN",
+                  "CREATE",
+                  "KEYSPACE",
+                  "SCHEMA",
+                  "COLUMNFAMILY",
+                  "TABLE",
+                  "MATERIALIZED",
+                  "VIEW",
+                  "INDEX",
+                  "ON",
+                  "TO",
+                  "DROP",
+                  "PRIMARY",
+                  "INTO",
+                  "ALTER",
+                  "RENAME",
+                  "ADD",
+                  "ORDER",
+                  "BY",
+                  "ASC",
+                  "DESC",
+                  "ALLOW",
+                  "IF",
+                  "IS",
+                  "GRANT",
+                  "OF",
+                  "REVOKE",
+                  "MODIFY",
+                  "AUTHORIZE",
+                  "DESCRIBE",
+                  "EXECUTE",
+                  "NORECURSIVE",
+                  "TOKEN",
+                  "NULL",
+                  "NOT",
+                  "NAN",
+                  "INFINITY",
+                  "OR",
+                  "REPLACE",
+                  "DEFAULT",
+                  "UNSET",
+                  "MBEAN",
+                  "MBEANS",
+                  "FOR",
+                  "RESTRICT",
+                  "UNRESTRICT")));
+
+  public static boolean isReserved(String text) {
+    return KEYWORDS.contains(text.toUpperCase());
+  }
 
   /** This class must not be instantiated as it only contains static methods. */
   private ReservedKeywords() {}
-
-  public static boolean isReserved(String text) {
-    return reservedSet.contains(text.toUpperCase());
-  }
 }

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/ReservedKeywords.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/ReservedKeywords.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.common.cql;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+public final class ReservedKeywords {
+  private static final String[] reservedKeywords =
+      new String[] {
+        "SELECT",
+        "FROM",
+        "WHERE",
+        "AND",
+        "ENTRIES",
+        "FULL",
+        "INSERT",
+        "UPDATE",
+        "WITH",
+        "LIMIT",
+        "USING",
+        "USE",
+        "SET",
+        "BEGIN",
+        "UNLOGGED",
+        "BATCH",
+        "APPLY",
+        "TRUNCATE",
+        "DELETE",
+        "IN",
+        "CREATE",
+        "KEYSPACE",
+        "SCHEMA",
+        "COLUMNFAMILY",
+        "TABLE",
+        "MATERIALIZED",
+        "VIEW",
+        "INDEX",
+        "ON",
+        "TO",
+        "DROP",
+        "PRIMARY",
+        "INTO",
+        "ALTER",
+        "RENAME",
+        "ADD",
+        "ORDER",
+        "BY",
+        "ASC",
+        "DESC",
+        "ALLOW",
+        "IF",
+        "IS",
+        "GRANT",
+        "OF",
+        "REVOKE",
+        "MODIFY",
+        "AUTHORIZE",
+        "DESCRIBE",
+        "EXECUTE",
+        "NORECURSIVE",
+        "TOKEN",
+        "NULL",
+        "NOT",
+        "NAN",
+        "INFINITY",
+        "OR",
+        "REPLACE",
+        "DEFAULT",
+        "UNSET",
+        "MBEAN",
+        "MBEANS",
+        "FOR",
+        "RESTRICT",
+        "UNRESTRICT"
+      };
+
+  private static final Set<String> reservedSet =
+      new CopyOnWriteArraySet<>(Arrays.asList(reservedKeywords));
+
+  /** This class must not be instantiated as it only contains static methods. */
+  private ReservedKeywords() {}
+
+  public static boolean isReserved(String text) {
+    return reservedSet.contains(text.toUpperCase());
+  }
+}

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/Strings.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/Strings.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright DataStax, Inc. and/or The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.common.cql;
+
+public class Strings {
+  /**
+   * Quote the given string; single quotes are escaped. If the given string is null, this method
+   * returns a quoted empty string ({@code ''}).
+   *
+   * @param value The value to quote.
+   * @return The quoted string.
+   */
+  public static String quote(String value) {
+    return quote(value, '\'');
+  }
+
+  /**
+   * Quotes text and escapes any existing quotes in the text. {@code String.replace()} is a bit too
+   * inefficient (see JAVA-67, JAVA-1262).
+   *
+   * @param text The text.
+   * @param quoteChar The character to use as a quote.
+   * @return The text with surrounded in quotes with all existing quotes escaped with (i.e. '
+   *     becomes '')
+   */
+  private static String quote(String text, char quoteChar) {
+    if (text == null || text.isEmpty()) return emptyQuoted(quoteChar);
+
+    int nbMatch = 0;
+    int start = -1;
+    do {
+      start = text.indexOf(quoteChar, start + 1);
+      if (start != -1) ++nbMatch;
+    } while (start != -1);
+
+    // no quotes found that need to be escaped, simply surround in quotes and return.
+    if (nbMatch == 0) return quoteChar + text + quoteChar;
+
+    // 2 for beginning and end quotes.
+    // length for original text
+    // nbMatch for escape characters to add to quotes to be escaped.
+    int newLength = 2 + text.length() + nbMatch;
+    char[] result = new char[newLength];
+    result[0] = quoteChar;
+    result[newLength - 1] = quoteChar;
+    int newIdx = 1;
+    for (int i = 0; i < text.length(); i++) {
+      char c = text.charAt(i);
+      if (c == quoteChar) {
+        // escape quote with another occurrence.
+        result[newIdx++] = c;
+        result[newIdx++] = c;
+      } else {
+        result[newIdx++] = c;
+      }
+    }
+    return new String(result);
+  }
+
+  /**
+   * @param quoteChar " or '
+   * @return A quoted empty string.
+   */
+  private static String emptyQuoted(char quoteChar) {
+    // don't handle non quote characters, this is done so that these are interned and don't create
+    // repeated empty quoted strings.
+    assert quoteChar == '"' || quoteChar == '\'';
+    if (quoteChar == '"') return "\"\"";
+    else return "''";
+  }
+}

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/BuiltCondition.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/BuiltCondition.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright DataStax, Inc. and/or The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.common.cql.builder;
+
+import io.stargate.sgv2.common.cql.ColumnUtils;
+import java.util.Optional;
+import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Style;
+import org.immutables.value.Value.Style.ImplementationVisibility;
+
+@Immutable
+@Style(visibility = ImplementationVisibility.PACKAGE)
+public interface BuiltCondition {
+  LHS lhs();
+
+  Predicate predicate();
+
+  Value<?> value();
+
+  static BuiltCondition of(String columnName, Predicate predicate, Object value) {
+    return of(LHS.column(columnName), predicate, Value.of(value));
+  }
+
+  static BuiltCondition ofMarker(String columnName, Predicate predicate) {
+    return of(LHS.column(columnName), predicate, Value.marker());
+  }
+
+  static BuiltCondition of(LHS lhs, Predicate predicate, Value<?> value) {
+    return ImmutableBuiltCondition.builder().lhs(lhs).predicate(predicate).value(value).build();
+  }
+
+  /**
+   * Represents the left hand side of a condition.
+   *
+   * <p>This is usually a column name, but technically can be:
+   *
+   * <ul>
+   *   <li>a column name ("c = ...")
+   *   <li>a specific element in a map column ("c[v] = ...")
+   *   <li>a tuple of column name ("(c, d, e) = ...")
+   *   <li>the token of a tuple of column name ("TOKEN(c, d, e) = ...")
+   * </ul>
+   */
+  abstract class LHS {
+    public static LHS column(String columnName) {
+      return new ColumnName(columnName);
+    }
+
+    public static LHS mapAccess(String columnName, Object key) {
+      return new MapElement(columnName, Value.of(key));
+    }
+
+    public static LHS mapAccess(String columnName) {
+      return new MapElement(columnName, Value.marker());
+    }
+
+    public static LHS columnTuple(String... columnNames) {
+      // Not yet needed, but we should add it someday
+      throw new UnsupportedOperationException();
+    }
+
+    public static LHS token(String... columnNames) {
+      // Not yet needed, but we should add it someday
+      throw new UnsupportedOperationException();
+    }
+
+    abstract void appendToBuilder(StringBuilder builder);
+
+    abstract String columnName();
+
+    Optional<Value<?>> value() {
+      return Optional.empty();
+    }
+
+    boolean isColumnName() {
+      return false;
+    }
+
+    boolean isMapAccess() {
+      return false;
+    }
+
+    static final class ColumnName extends LHS {
+      private final String columnName;
+
+      private ColumnName(String columnName) {
+        this.columnName = columnName;
+      }
+
+      @Override
+      String columnName() {
+        return columnName;
+      }
+
+      @Override
+      boolean isColumnName() {
+        return true;
+      }
+
+      @Override
+      void appendToBuilder(StringBuilder builder) {
+        builder.append(ColumnUtils.maybeQuote(columnName));
+      }
+    }
+
+    static final class MapElement extends LHS {
+      private final String columnName;
+      private final Value<?> keyValue;
+
+      private MapElement(String columnName, Value<?> keyValue) {
+        this.columnName = columnName;
+        this.keyValue = keyValue;
+      }
+
+      @Override
+      String columnName() {
+        return columnName;
+      }
+
+      Value<?> keyValue() {
+        return keyValue;
+      }
+
+      @Override
+      Optional<Value<?>> value() {
+        return Optional.of(keyValue);
+      }
+
+      @Override
+      void appendToBuilder(StringBuilder builder) {
+        builder
+            .append(ColumnUtils.maybeQuote(columnName))
+            .append('[')
+            .append(QueryBuilderImpl.formatValue(keyValue))
+            .append(']');
+      }
+
+      @Override
+      boolean isMapAccess() {
+        return true;
+      }
+    }
+  }
+}

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/CollectionIndexingType.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/CollectionIndexingType.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright DataStax, Inc. and/or The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.common.cql.builder;
+
+public enum CollectionIndexingType {
+  KEYS,
+  VALUES,
+  ENTRIES,
+  FULL,
+}

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Column.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Column.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright DataStax, Inc. and/or The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.common.cql.builder;
+
+import io.stargate.sgv2.common.cql.ColumnUtils;
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+@Immutable(prehash = true)
+public interface Column {
+  String name();
+
+  /** TODO do we ever need a more structured representation? */
+  @Nullable
+  String type();
+
+  @Nullable
+  Kind kind();
+
+  @Nullable
+  Order order();
+
+  @Value.Lazy
+  default String cqlName() {
+    return ColumnUtils.maybeQuote(name());
+  }
+
+  static Column reference(String name) {
+    return ImmutableColumn.builder().name(name).build();
+  }
+
+  enum Kind {
+    PARTITION_KEY,
+    CLUSTERING,
+    REGULAR,
+    STATIC,
+  }
+
+  enum Order {
+    ASC,
+    DESC,
+  }
+}

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/ConcreteValue.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/ConcreteValue.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright DataStax, Inc. and/or The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.common.cql.builder;
+
+class ConcreteValue<T> implements Value<T> {
+
+  private final T value;
+
+  public ConcreteValue(T value) {
+    this.value = value;
+  }
+
+  @Override
+  public boolean isMarker() {
+    return false;
+  }
+
+  @Override
+  public T get() {
+    return value;
+  }
+}

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Marker.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Marker.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc. and/or The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.common.cql.builder;
+
+class Marker<T> implements Value<T> {
+
+  @Override
+  public boolean isMarker() {
+    return true;
+  }
+
+  @Override
+  public T get() {
+    throw new UnsupportedOperationException("Cannot get the value of a marker");
+  }
+}

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Predicate.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Predicate.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright DataStax, Inc. and/or The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.common.cql.builder;
+
+public enum Predicate {
+  EQ("="),
+  NEQ("!="),
+  LT("<"),
+  GT(">"),
+  LTE("<="),
+  GTE(">="),
+  IN("IN"),
+  CONTAINS("CONTAINS"),
+  CONTAINS_KEY("CONTAINS KEY"),
+  ;
+
+  private final String cql;
+
+  Predicate(String cql) {
+    this.cql = cql;
+  }
+
+  @Override
+  public String toString() {
+    return cql;
+  }
+}

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/QueryBuilderImpl.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/QueryBuilderImpl.java
@@ -1,0 +1,1375 @@
+/*
+ * Copyright DataStax, Inc. and/or The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.common.cql.builder;
+
+import static java.lang.String.format;
+
+import com.github.misberner.apcommons.util.AFModifier;
+import com.github.misberner.duzzt.annotations.DSLAction;
+import com.github.misberner.duzzt.annotations.GenerateEmbeddedDSL;
+import com.github.misberner.duzzt.annotations.SubExpr;
+import io.stargate.sgv2.common.cql.ColumnUtils;
+import io.stargate.sgv2.common.cql.Strings;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/** Convenience builder for creating queries. */
+@GenerateEmbeddedDSL(
+    modifier = AFModifier.DEFAULT,
+    autoVarArgs = false,
+    name = "QueryBuilder",
+    syntax = "(<keyspace>|<table>|<insert>|<update>|<delete>|<select>|<index>|<type>) build",
+    where = {
+      @SubExpr(
+          name = "keyspace",
+          definedAs = "<keyspaceCreate> | <keyspaceAlter> | (drop keyspace ifExists?)"),
+      @SubExpr(
+          name = "keyspaceCreate",
+          definedAs = "(create keyspace ifNotExists? withReplication andDurableWrites?)"),
+      @SubExpr(
+          name = "keyspaceAlter",
+          definedAs = "(alter keyspace (withReplication andDurableWrites?)?)"),
+      @SubExpr(
+          name = "table",
+          definedAs =
+              "(create table ifNotExists? column+ withComment? withDefaultTTL?) | (alter table (((addColumn+)? | (dropColumn+)? | (renameColumn+)?) | (withComment? withDefaultTTL?))) | (drop table ifExists?) | (truncate table)"),
+      @SubExpr(
+          name = "type",
+          definedAs =
+              "(create type ifNotExists? column+) | (drop type ifExists?) | (alter type (addColumn+ | renameColumn+))"),
+      @SubExpr(name = "insert", definedAs = "insertInto value+ ifNotExists? ttl? timestamp?"),
+      @SubExpr(name = "update", definedAs = "update ttl? timestamp? value+ where+ ifs* ifExists?"),
+      @SubExpr(name = "delete", definedAs = "delete column* from timestamp? where+ ifs* ifExists?"),
+      @SubExpr(
+          name = "select",
+          definedAs =
+              "select star? column* function* ((count|min|max|avg|sum|writeTimeColumn) as?)* "
+                  + "from (where* perPartitionLimit? limit? groupBy* orderBy*) allowFiltering?"),
+      @SubExpr(
+          name = "index",
+          definedAs =
+              "(drop ((materializedView|index) ifExists?)) | (create ((materializedView ifNotExists? asSelect (column+) from withComment?)"
+                  + " | (index ifNotExists? on column (indexKeys|indexValues|indexEntries|indexFull|indexingType)? (custom options?)?)))"),
+    })
+public class QueryBuilderImpl {
+
+  private boolean isCreate;
+  private boolean isAlter;
+  private boolean isInsert;
+  private boolean isUpdate;
+  private boolean isDelete;
+  private boolean isSelect;
+  private boolean isDrop;
+  private boolean isKeyspace;
+  private boolean isTable;
+  private boolean isMaterializedView;
+  private boolean isType;
+  private boolean isIndex;
+  private boolean isTruncate;
+  private CollectionIndexingType indexingType;
+
+  private String keyspaceName;
+  private String tableName;
+  private String indexName;
+  private String typeName;
+
+  private final List<Column> createColumns = new ArrayList<>();
+
+  private final List<Column> addColumns = new ArrayList<>();
+  private final List<String> dropColumns = new ArrayList<>();
+  private final Map<String, String> columnRenames = new LinkedHashMap<>();
+
+  /**
+   * The modifications made for a DML query (for INSERT, this will include modifications for the
+   * primary key columns, but for UPDATE those will be part of the WHERE clause; note that for
+   * DELETE, nothing will be populated by the builder since {@link #selection} and {@link #wheres}
+   * are used instead).
+   */
+  private final List<ValueModifier> dmlModifications = new ArrayList<>();
+
+  /** Column names for a SELECT or DELETE. */
+  private final List<String> selection = new ArrayList<>();
+
+  private final List<FunctionCall> functionCalls = new ArrayList<>();
+
+  /** The where conditions for a SELECT or UPDATE. */
+  private final List<BuiltCondition> wheres = new ArrayList<>();
+
+  /** The IFs conditions for a conditional UPDATE or DELETE. */
+  private final List<BuiltCondition> ifs = new ArrayList<>();
+
+  private Value<Integer> limit;
+  private Value<Integer> perPartitionLimit;
+  private final List<String> groupBys = new ArrayList<>();
+  private final Map<String, Column.Order> orders = new LinkedHashMap<>();
+
+  private Replication replication;
+  private boolean ifNotExists;
+  private boolean ifExists;
+  private Boolean durableWrites;
+  private String comment;
+  private Integer defaultTTL;
+  private String indexCreateColumn;
+  private String customIndexClass;
+  private Map<String, String> customIndexOptions;
+  private Value<Integer> ttl;
+  private Value<Long> timestamp;
+  private boolean allowFiltering;
+
+  @DSLAction
+  public void create() {
+    isCreate = true;
+  }
+
+  @DSLAction
+  public void alter() {
+    isAlter = true;
+  }
+
+  @DSLAction
+  public void drop() {
+    isDrop = true;
+  }
+
+  @DSLAction
+  public void truncate() {
+    isTruncate = true;
+  }
+
+  @DSLAction
+  public void keyspace(String keyspace) {
+    this.keyspaceName = keyspace;
+    this.isKeyspace = true;
+  }
+
+  @DSLAction
+  public void table(String keyspace, String table) {
+    this.keyspaceName = keyspace;
+    table(table);
+  }
+
+  @DSLAction
+  public void table(String table) {
+    this.tableName = table;
+    this.isTable = true;
+  }
+
+  @DSLAction
+  public void withReplication(Replication replication) {
+    this.replication = replication;
+  }
+
+  @DSLAction
+  public void andDurableWrites(boolean durableWrites) {
+    this.durableWrites = durableWrites;
+  }
+
+  @DSLAction
+  public void ifNotExists() {
+    ifNotExists(true);
+  }
+
+  public void ifNotExists(boolean ifNotExists) {
+    this.ifNotExists = ifNotExists;
+  }
+
+  @DSLAction
+  public void ifExists() {
+    ifExists(true);
+  }
+
+  public void ifExists(boolean ifExists) {
+    this.ifExists = ifExists;
+  }
+
+  @DSLAction
+  public void withComment(String comment) {
+    this.comment = comment;
+  }
+
+  @DSLAction
+  public void withDefaultTTL(int defaultTTL) {
+    this.defaultTTL = defaultTTL;
+  }
+
+  @DSLAction
+  public void column(String column) {
+    if (isCreate) {
+      if (isTable || isType) {
+        throw invalid("Column '%s' type must be specified for a table or type creation");
+      } else if (isMaterializedView) {
+        createColumns.add(Column.reference(column));
+      } else if (isIndex) {
+        indexCreateColumn = column;
+      } else {
+        // We should haven't other case where this can be called ...
+        throw new AssertionError("This shouldn't have been called");
+      }
+    } else if (isSelect || isDelete) {
+      selection.add(column);
+    } else {
+      // We should haven't other case where this can be called ...
+      throw new AssertionError("This shouldn't have been called");
+    }
+  }
+
+  public void column(String... columns) {
+    for (String c : columns) {
+      column(c);
+    }
+  }
+
+  public void column(Column column) {
+    if (isCreate) {
+      if ((isTable || isType) && column.type() == null) {
+        throw invalid("Column '%s' type must be specified for a table or type creation");
+      }
+      createColumns.add(column);
+    } else {
+      column(column.name());
+    }
+  }
+
+  public void column(Collection<Column> columns) {
+    for (Column c : columns) {
+      column(c);
+    }
+  }
+
+  @DSLAction
+  public void column(String column, String type, Column.Kind kind) {
+    column(ImmutableColumn.builder().name(column).type(type).kind(kind).build());
+  }
+
+  @DSLAction
+  public void column(String column, String type, Column.Kind kind, Column.Order order) {
+    column(ImmutableColumn.builder().name(column).type(type).kind(kind).order(order).build());
+  }
+
+  @DSLAction
+  public void column(String column, Column.Kind kind) {
+    column(ImmutableColumn.builder().name(column).kind(kind).build());
+  }
+
+  @DSLAction
+  public void column(String column, Column.Kind kind, Column.Order order) {
+    column(ImmutableColumn.builder().name(column).kind(kind).order(order).build());
+  }
+
+  @DSLAction
+  public void column(String column, String type) {
+    column(column, type, Column.Kind.REGULAR);
+  }
+
+  public void as(String alias) {
+    if (functionCalls.isEmpty()) {
+      throw new IllegalStateException(
+          "The as() method cannot be called without a preceding function call.");
+    }
+    // the alias is set for the last function call
+    FunctionCall functionCall = functionCalls.get(functionCalls.size() - 1);
+    functionCall.setAlias(alias);
+  }
+
+  public void writeTimeColumn(String columnName) {
+    functionCalls.add(FunctionCall.writeTime(columnName));
+  }
+
+  public void writeTimeColumn(Column columnName) {
+    writeTimeColumn(columnName.name());
+  }
+
+  public void count(String columnName) {
+    functionCalls.add(FunctionCall.count(columnName));
+  }
+
+  public void count(Column columnName) {
+    count(columnName.name());
+  }
+
+  public void max(String maxColumnName) {
+    functionCalls.add(FunctionCall.max(maxColumnName));
+  }
+
+  public void max(Column maxColumnName) {
+    max(maxColumnName.name());
+  }
+
+  public void min(String minColumnName) {
+    functionCalls.add(FunctionCall.min(minColumnName));
+  }
+
+  public void min(Column minColumnName) {
+    min(minColumnName.name());
+  }
+
+  public void sum(String sumColumnName) {
+    functionCalls.add(FunctionCall.sum(sumColumnName));
+  }
+
+  public void sum(Column sumColumnName) {
+    sum(sumColumnName.name());
+  }
+
+  public void avg(String avgColumnName) {
+    functionCalls.add(FunctionCall.avg(avgColumnName));
+  }
+
+  public void avg(Column avgColumnName) {
+    avg(avgColumnName.name());
+  }
+
+  public void function(Collection<FunctionCall> calls) {
+    functionCalls.addAll(calls);
+  }
+
+  public void star() {
+    if (!this.selection.isEmpty()) {
+      throw invalid("Cannot use * when other columns are selected");
+    }
+  }
+
+  @DSLAction
+  public void addColumn(String column, String type) {
+    addColumn(ImmutableColumn.builder().name(column).type(type).kind(Column.Kind.REGULAR).build());
+  }
+
+  public void addColumn(Column column) {
+    addColumns.add(column);
+  }
+
+  public void addColumn(Collection<Column> columns) {
+    for (Column column : columns) {
+      addColumn(column);
+    }
+  }
+
+  @DSLAction
+  public void dropColumn(String column) {
+    dropColumns.add(column);
+  }
+
+  public void dropColumn(Collection<String> columns) {
+    for (String column : columns) {
+      dropColumn(column);
+    }
+  }
+
+  public void dropColumn(Column column) {
+    dropColumn(column.name());
+  }
+
+  @DSLAction
+  public void renameColumn(String from, String to) {
+    columnRenames.put(from, to);
+  }
+
+  public void renameColumn(Map<String, String> columnRenames) {
+    this.columnRenames.putAll(columnRenames);
+  }
+
+  @DSLAction
+  public void insertInto(String keyspace, String table) {
+    this.keyspaceName = keyspace;
+    this.tableName = table;
+    this.isInsert = true;
+  }
+
+  public void insertInto(String table) {
+    insertInto(null, table);
+  }
+
+  @DSLAction
+  public void update(String keyspace, String table) {
+    this.keyspaceName = keyspace;
+    this.tableName = table;
+    this.isUpdate = true;
+  }
+
+  public void update(String table) {
+    update(null, table);
+  }
+
+  @DSLAction
+  public void delete() {
+    this.isDelete = true;
+  }
+
+  @DSLAction
+  public void select() {
+    this.isSelect = true;
+  }
+
+  @DSLAction
+  public void from(String keyspace, String table) {
+    this.keyspaceName = keyspace;
+    from(table);
+  }
+
+  @DSLAction
+  public void from(String table) {
+    this.tableName = table;
+  }
+
+  @DSLAction
+  public void value(String column, Object value) {
+    value(ValueModifier.set(column, value));
+  }
+
+  @DSLAction
+  public void value(String column) {
+    value(ValueModifier.marker(column));
+  }
+
+  public void value(Column column) {
+    value(column.name());
+  }
+
+  public void value(Column column, Object value) {
+    value(column.name(), value);
+  }
+
+  public void value(ValueModifier modifier) {
+    if (isInsert && (modifier.target().fieldName() != null || modifier.target().mapKey() != null)) {
+      throw invalid("Can't reference fields or map elements in INSERT queries");
+    }
+    dmlModifications.add(modifier);
+  }
+
+  public void value(Collection<ValueModifier> setters) {
+    for (ValueModifier setter : setters) {
+      value(setter);
+    }
+  }
+
+  public void where(Column column, Predicate predicate, Object value) {
+    where(column.name(), predicate, value);
+  }
+
+  public void where(Column column, Predicate predicate) {
+    where(column.name(), predicate);
+  }
+
+  public void where(String columnName, Predicate predicate, Object value) {
+    where(BuiltCondition.of(columnName, predicate, value));
+  }
+
+  public void where(String columnName, Predicate predicate) {
+    where(BuiltCondition.ofMarker(columnName, predicate));
+  }
+
+  public void where(BuiltCondition where) {
+    wheres.add(where);
+  }
+
+  @DSLAction(autoVarArgs = false)
+  public void where(Collection<? extends BuiltCondition> where) {
+    for (BuiltCondition condition : where) {
+      where(condition);
+    }
+  }
+
+  public void ifs(String columnName, Predicate predicate, Object value) {
+    ifs(BuiltCondition.of(columnName, predicate, value));
+  }
+
+  public void ifs(String columnName, Predicate predicate) {
+    ifs(BuiltCondition.ofMarker(columnName, predicate));
+  }
+
+  public void ifs(BuiltCondition condition) {
+    ifs.add(condition);
+  }
+
+  @DSLAction(autoVarArgs = false)
+  public void ifs(Collection<? extends BuiltCondition> conditions) {
+    for (BuiltCondition condition : conditions) {
+      ifs(condition);
+    }
+  }
+
+  @DSLAction
+  public void materializedView(String keyspace, String name) {
+    this.keyspaceName = keyspace;
+    materializedView(name);
+  }
+
+  @DSLAction
+  public void materializedView(String name) {
+    // Note that we use the index to store the MV name, because the table variable will be used
+    // to store the base table name.
+    this.indexName = name;
+    this.isMaterializedView = true;
+  }
+
+  @DSLAction
+  public void asSelect() {
+    // This method is just so the builder flows better
+  }
+
+  @DSLAction
+  public void on(String keyspace, String table) {
+    this.keyspaceName = keyspace;
+    on(table);
+  }
+
+  @DSLAction
+  public void on(String table) {
+    this.tableName = table;
+  }
+
+  @DSLAction
+  public void index(String index) {
+    this.indexName = index;
+    this.isIndex = true;
+  }
+
+  @DSLAction
+  public void index() {
+    index(null);
+  }
+
+  @DSLAction
+  public void index(String keyspace, String index) {
+    this.keyspaceName = keyspace;
+    index(index);
+  }
+
+  @DSLAction
+  public void indexingType(CollectionIndexingType indexingType) {
+    this.indexingType = indexingType;
+  }
+
+  @DSLAction
+  public void indexKeys() {
+    indexingType(CollectionIndexingType.KEYS);
+  }
+
+  @DSLAction
+  public void indexValues() {
+    indexingType(CollectionIndexingType.VALUES);
+  }
+
+  @DSLAction
+  public void indexEntries() {
+    indexingType(CollectionIndexingType.ENTRIES);
+  }
+
+  @DSLAction
+  public void indexFull() {
+    indexingType(CollectionIndexingType.FULL);
+  }
+
+  @DSLAction
+  public void custom(String customIndexClass) {
+    this.customIndexClass = customIndexClass;
+  }
+
+  @DSLAction
+  public void custom(String customIndexClass, Map<String, String> customIndexOptions) {
+    custom(customIndexClass);
+    this.customIndexOptions = customIndexOptions;
+  }
+
+  @DSLAction
+  public void options(Map<String, String> customIndexOptions) {
+    this.customIndexOptions = customIndexOptions;
+  }
+
+  @DSLAction
+  public void type(String keyspace, String typeName) {
+    this.keyspaceName = keyspace;
+    this.typeName = typeName;
+    this.isType = true;
+  }
+
+  @DSLAction
+  public void limit() {
+    this.limit = Value.marker();
+  }
+
+  @DSLAction
+  public void limit(Integer limit) {
+    if (limit != null) {
+      this.limit = Value.of(limit);
+    }
+  }
+
+  @DSLAction
+  public void perPartitionLimit() {
+    this.perPartitionLimit = Value.marker();
+  }
+
+  @DSLAction
+  public void perPartitionLimit(Integer limit) {
+    if (limit != null) {
+      this.perPartitionLimit = Value.of(limit);
+    }
+  }
+
+  @DSLAction
+  public void groupBy(String name) {
+    groupBys.add(name);
+  }
+
+  @DSLAction
+  public void groupBy(Iterable<String> columns) {
+    columns.forEach(this::groupBy);
+  }
+
+  public void orderBy(Column column, Column.Order order) {
+    orderBy(column.name(), order);
+  }
+
+  public void orderBy(String column, Column.Order order) {
+    this.orders.put(column, order);
+  }
+
+  public void orderBy(Map<String, Column.Order> orders) {
+    this.orders.clear();
+    this.orders.putAll(orders);
+  }
+
+  public void allowFiltering() {
+    this.allowFiltering = true;
+  }
+
+  public void allowFiltering(boolean allowFiltering) {
+    this.allowFiltering = allowFiltering;
+  }
+
+  @DSLAction
+  public void ttl() {
+    this.ttl = Value.marker();
+  }
+
+  @DSLAction
+  public void ttl(Integer ttl) {
+    if (ttl != null) {
+      this.ttl = Value.of(ttl);
+    }
+  }
+
+  @DSLAction
+  public void timestamp() {
+    this.timestamp = Value.marker();
+  }
+
+  @DSLAction
+  public void timestamp(Long timestamp) {
+    if (timestamp != null) {
+      this.timestamp = Value.of(timestamp);
+    }
+  }
+
+  @DSLAction
+  public String build() {
+    if (isKeyspace && isCreate) {
+      return createKeyspace();
+    }
+    if (isKeyspace && isAlter) {
+      return alterKeyspace();
+    }
+    if (isKeyspace && isDrop) {
+      return dropKeyspace();
+    }
+
+    if (isTable && isCreate) {
+      return createTable();
+    }
+    if (isTable && isAlter) {
+      return alterTable();
+    }
+    if (isTable && isDrop) {
+      return dropTable();
+    }
+    if (isTable && isTruncate) {
+      return truncateTable();
+    }
+
+    if (isIndex && isCreate) {
+      return createIndex();
+    }
+    if (isIndex && isDrop) {
+      return dropIndex();
+    }
+
+    if (isMaterializedView && isCreate) {
+      return createMaterializedView();
+    }
+    if (isMaterializedView && isDrop) {
+      return dropMaterializedView();
+    }
+
+    if (isType && isCreate) {
+      return createType();
+    }
+    if (isType && isDrop) {
+      return dropType();
+    }
+    if (isType && isAlter) {
+      if (!columnRenames.isEmpty()) {
+        return renameTypeColumns();
+      }
+      return alterType();
+    }
+
+    if (isInsert) {
+      return insertQuery();
+    }
+    if (isUpdate) {
+      return updateQuery();
+    }
+    if (isDelete) {
+      return deleteQuery();
+    }
+    if (isSelect) {
+      return selectQuery();
+    }
+
+    throw new AssertionError("Unknown query type");
+  }
+
+  private static IllegalArgumentException invalid(String format, Object... args) {
+    return new IllegalArgumentException(format(format, args));
+  }
+
+  private static String cqlName(String name) {
+    return ColumnUtils.maybeQuote(name);
+  }
+
+  private static class WithAdder {
+    private final StringBuilder builder;
+    private boolean withAdded;
+
+    private WithAdder(StringBuilder builder) {
+      this.builder = builder;
+    }
+
+    private StringBuilder add() {
+      if (!withAdded) {
+        builder.append(" WITH");
+        withAdded = true;
+      } else {
+        builder.append(" AND");
+      }
+      return builder;
+    }
+  }
+
+  private String createKeyspace() {
+    StringBuilder query = new StringBuilder("CREATE KEYSPACE ");
+    String ksName = cqlName(keyspaceName);
+    if (ifNotExists) {
+      query.append("IF NOT EXISTS ");
+    }
+    query.append(ksName);
+
+    query.append(" WITH replication = ").append(replication);
+    if (durableWrites != null) {
+      query.append(" AND durable_writes = ").append(durableWrites);
+    }
+
+    return query.toString();
+  }
+
+  private String alterKeyspace() {
+    StringBuilder query = new StringBuilder("ALTER KEYSPACE ").append(cqlName(keyspaceName));
+
+    WithAdder with = new WithAdder(query);
+    if (replication != null) {
+      with.add().append(" replication = ").append(replication);
+    }
+    if (durableWrites != null) {
+      with.add().append(" durable_writes = ").append(durableWrites);
+    }
+
+    return query.toString();
+  }
+
+  private String dropKeyspace() {
+    StringBuilder query = new StringBuilder("DROP KEYSPACE ");
+    if (ifExists) {
+      query.append("IF EXISTS ");
+    }
+    query.append(cqlName(keyspaceName));
+
+    return query.toString();
+  }
+
+  private void addPrimaryKey(StringBuilder query, List<Column> columns, String name) {
+    if (columns.stream()
+        .noneMatch(c -> c.kind() == Column.Kind.valueOf(Column.Kind.PARTITION_KEY.name()))) {
+      throw invalid(
+          "At least one partition key must be specified for table or materialized view '%s' %s",
+          name, Arrays.deepToString(columns.toArray()));
+    }
+    query
+        .append("PRIMARY KEY ((")
+        .append(
+            columns.stream()
+                .filter(c -> c.kind() == Column.Kind.PARTITION_KEY)
+                .map(Column::cqlName)
+                .collect(Collectors.joining(", ")))
+        .append(")");
+    if (columns.stream().anyMatch(c -> c.kind() == Column.Kind.CLUSTERING)) {
+      query.append(", ");
+    }
+    query
+        .append(
+            columns.stream()
+                .filter(c -> c.kind() == Column.Kind.CLUSTERING)
+                .map(Column::cqlName)
+                .collect(Collectors.joining(", ")))
+        .append(")");
+  }
+
+  private void addClusteringOrder(WithAdder with, List<Column> columns) {
+    if (columns.stream().anyMatch(c -> c.kind() == Column.Kind.CLUSTERING && c.order() != null)) {
+      StringBuilder query = with.add();
+      query.append(" CLUSTERING ORDER BY (");
+      query.append(
+          columns.stream()
+              .filter(c -> c.kind() == Column.Kind.CLUSTERING)
+              .map(c -> c.cqlName() + " " + c.order().name().toUpperCase())
+              .collect(Collectors.joining(", ")));
+      query.append(")");
+    }
+  }
+
+  private void addComment(WithAdder with) {
+    if (comment != null) {
+      String quotedComment = Strings.quote(comment);
+      with.add().append(" comment = ").append(quotedComment);
+    }
+  }
+
+  private void addDefaultTTL(WithAdder with) {
+    if (defaultTTL != null) {
+      with.add().append(" default_time_to_live = ").append(defaultTTL);
+    }
+  }
+
+  private String maybeQualify(String elementName) {
+    if (keyspaceName == null) {
+      return cqlName(elementName);
+    } else {
+      return cqlName(keyspaceName) + '.' + cqlName(elementName);
+    }
+  }
+
+  private String createTable() {
+    StringBuilder query = new StringBuilder("CREATE TABLE ");
+    if (ifNotExists) {
+      query.append("IF NOT EXISTS ");
+    }
+    query
+        .append(maybeQualify(tableName))
+        .append(" (")
+        .append(
+            createColumns.stream()
+                .map(
+                    c ->
+                        c.cqlName()
+                            + " "
+                            + c.type()
+                            + (c.kind() == Column.Kind.STATIC ? " STATIC" : ""))
+                .collect(Collectors.joining(", ")))
+        .append(", ");
+    addPrimaryKey(query, createColumns, tableName);
+    query.append(")");
+
+    WithAdder with = new WithAdder(query);
+    addClusteringOrder(with, createColumns);
+    addComment(with);
+    addDefaultTTL(with);
+
+    return query.toString();
+  }
+
+  private String alterTable() {
+    StringBuilder query = new StringBuilder("ALTER TABLE ").append(maybeQualify(tableName));
+
+    if (!addColumns.isEmpty()) {
+      query.append(" ADD (");
+      query.append(
+          addColumns.stream()
+              .map(
+                  c ->
+                      c.cqlName()
+                          + " "
+                          + c.type()
+                          + (c.kind() == Column.Kind.STATIC ? " STATIC" : ""))
+              .collect(Collectors.joining(", ")));
+      query.append(")");
+    }
+    if (!dropColumns.isEmpty()) {
+      query.append(" DROP (");
+      query.append(
+          dropColumns.stream().map(QueryBuilderImpl::cqlName).collect(Collectors.joining(", ")));
+      query.append(")");
+    }
+    if (!columnRenames.isEmpty()) {
+      query.append(" RENAME ");
+      boolean isFirst = true;
+      for (Map.Entry<String, String> rename : columnRenames.entrySet()) {
+        if (isFirst) isFirst = false;
+        else query.append(" AND ");
+        query.append(cqlName(rename.getKey())).append(" TO ").append(cqlName(rename.getValue()));
+      }
+    }
+    WithAdder with = new WithAdder(query);
+    addComment(with);
+    addDefaultTTL(with);
+    return query.toString();
+  }
+
+  private String dropTable() {
+    StringBuilder query = new StringBuilder("DROP TABLE ");
+    if (ifExists) {
+      query.append("IF EXISTS ");
+    }
+    query.append(maybeQualify(tableName));
+    return query.toString();
+  }
+
+  private String truncateTable() {
+    return "TRUNCATE " + maybeQualify(tableName);
+  }
+
+  private String createIndex() {
+    StringBuilder query = new StringBuilder("CREATE");
+    if (customIndexClass != null) {
+      query.append(" CUSTOM");
+    }
+    query.append(" INDEX");
+    if (ifNotExists) {
+      query.append(" IF NOT EXISTS");
+    }
+    if (indexName != null) {
+      query.append(" ").append(cqlName(indexName));
+    }
+    query.append(" ON ").append(maybeQualify(tableName)).append(" (");
+    if (indexingType == null) {
+      query.append(cqlName(indexCreateColumn));
+    } else {
+      switch (indexingType) {
+        case KEYS:
+          query.append("KEYS(");
+          break;
+        case VALUES:
+          query.append("VALUES(");
+          break;
+        case ENTRIES:
+          query.append("ENTRIES(");
+          break;
+        case FULL:
+          query.append("FULL(");
+          break;
+        default:
+          throw new AssertionError("Unhandled indexing type " + indexingType);
+      }
+      query.append(cqlName(indexCreateColumn)).append(")");
+    }
+    query.append(")");
+    if (customIndexClass != null) {
+      query.append(" USING").append(format(" '%s'", customIndexClass));
+      if (customIndexOptions != null && !customIndexOptions.isEmpty()) {
+        query.append(
+            customIndexOptions.entrySet().stream()
+                .map(e -> format("'%s': '%s'", e.getKey(), e.getValue()))
+                .collect(Collectors.joining(", ", " WITH OPTIONS = { ", " }")));
+      }
+    }
+    return query.toString();
+  }
+
+  private String dropIndex() {
+    StringBuilder query = new StringBuilder("DROP INDEX ");
+    if (ifExists) {
+      query.append("IF EXISTS ");
+    }
+    query.append(maybeQualify(indexName));
+    return query.toString();
+  }
+
+  private String createMaterializedView() {
+    StringBuilder query = new StringBuilder("CREATE MATERIALIZED VIEW ");
+    if (ifNotExists) {
+      query.append("IF NOT EXISTS ");
+    }
+    query
+        .append(maybeQualify(indexName))
+        .append(" AS SELECT ")
+        .append(createColumns.stream().map(Column::cqlName).collect(Collectors.joining(", ")))
+        .append(" FROM ")
+        .append(maybeQualify(tableName))
+        .append(" WHERE ")
+        .append(
+            createColumns.stream()
+                .map(c -> c.cqlName() + " IS NOT NULL")
+                .collect(Collectors.joining(" AND ")))
+        .append(" ");
+    addPrimaryKey(query, createColumns, indexName);
+    WithAdder with = new WithAdder(query);
+    addClusteringOrder(with, createColumns);
+    addComment(with);
+    addDefaultTTL(with);
+
+    return query.toString();
+  }
+
+  private String dropMaterializedView() {
+    StringBuilder query = new StringBuilder("DROP MATERIALIZED VIEW ");
+    if (ifExists) {
+      query.append("IF EXISTS ");
+    }
+    query.append(maybeQualify(indexName));
+    return query.toString();
+  }
+
+  private String createType() {
+    StringBuilder query = new StringBuilder("CREATE TYPE ");
+    if (ifNotExists) {
+      query.append("IF NOT EXISTS ");
+    }
+    query
+        .append(maybeQualify(typeName))
+        .append(
+            createColumns.stream()
+                .map(c -> c.cqlName() + " " + c.type())
+                .collect(Collectors.joining(", ")));
+    return query.toString();
+  }
+
+  private String renameTypeColumns() {
+    return "ALTER TYPE "
+        + maybeQualify(typeName)
+        + " RENAME "
+        + columnRenames.entrySet().stream()
+            .map(e -> e.getKey() + " TO " + e.getValue())
+            .collect(Collectors.joining(" AND "));
+  }
+
+  private String dropType() {
+    StringBuilder query = new StringBuilder("DROP TYPE ");
+    if (ifExists) {
+      query.append("IF EXISTS ");
+    }
+    query.append(maybeQualify(typeName));
+    return query.toString();
+  }
+
+  private String alterType() {
+    assert !addColumns.isEmpty();
+    return "ALTER TYPE "
+        + maybeQualify(typeName)
+        + " ADD "
+        + addColumns.stream()
+            .map(c -> c.cqlName() + " " + c.type())
+            .collect(Collectors.joining(", "));
+  }
+
+  private String insertQuery() {
+    StringBuilder query =
+        new StringBuilder("INSERT INTO ")
+            .append(maybeQualify(tableName))
+            .append("(")
+            .append(
+                dmlModifications.stream()
+                    .map(m -> cqlName(m.target().columnName()))
+                    .collect(Collectors.joining(",")))
+            .append(") VALUES (")
+            .append(
+                dmlModifications.stream()
+                    .map(m -> formatValue(m.value()))
+                    .collect(Collectors.joining(",")))
+            .append(")");
+    if (ifNotExists) {
+      query.append(" IF NOT EXISTS");
+    }
+    addUsingClause(query);
+
+    return query.toString();
+  }
+
+  static String formatValue(Value<?> value) {
+    if (value instanceof Marker) {
+      return "?";
+    } else if (value instanceof ConcreteValue) {
+      Object v = ((ConcreteValue<?>) value).get();
+      if (v instanceof CharSequence) {
+        return Strings.quote(v.toString());
+      } else {
+        // This works for simple values. We assume that this will be good enough for our needs.
+        return v.toString();
+      }
+    } else {
+      throw new AssertionError("Unexpected value type " + value.getClass().getName());
+    }
+  }
+
+  private void addUsingClause(StringBuilder builder) {
+    String prefix = " USING ";
+    if (ttl != null) {
+      builder.append(prefix).append("TTL ").append(formatValue(ttl));
+      prefix = " AND ";
+    }
+    if (timestamp != null) {
+      builder.append(prefix).append("TIMESTAMP ").append(formatValue(timestamp));
+    }
+  }
+
+  private String formatModifier(ValueModifier modifier) {
+    StringBuilder builder = new StringBuilder();
+
+    String columnName = modifier.target().columnName();
+    String fieldName = modifier.target().fieldName();
+    Value<?> mapKey = modifier.target().mapKey();
+
+    String targetString;
+    if (fieldName != null) {
+      targetString = cqlName(columnName) + '.' + cqlName(fieldName);
+    } else if (mapKey != null) {
+      targetString = cqlName(columnName) + '[' + formatValue(mapKey) + ']';
+    } else {
+      targetString = cqlName(columnName);
+    }
+
+    builder
+        .append(targetString)
+        .append(operationStr(modifier.operation()))
+        .append(formatValue(modifier.value()));
+    // Unfortunately, prepend cannot be expressed with a concise operator and we have to add to it
+    if (modifier.operation() == ValueModifier.Operation.PREPEND) {
+      builder.append("+").append(targetString);
+    }
+
+    return builder.toString();
+  }
+
+  private String operationStr(ValueModifier.Operation operation) {
+    switch (operation) {
+      case PREPEND: // fallthrough on purpose
+      case SET:
+        return "=";
+      case APPEND: // fallthrough on purpose
+      case INCREMENT:
+        return "+=";
+      case REMOVE:
+        return "-=";
+      default:
+        throw new UnsupportedOperationException();
+    }
+  }
+
+  private String updateQuery() {
+    StringBuilder builder = new StringBuilder("UPDATE ").append(maybeQualify(tableName));
+    addUsingClause(builder);
+    builder
+        .append(" SET ")
+        .append(
+            dmlModifications.stream().map(this::formatModifier).collect(Collectors.joining(",")));
+    appendWheres(builder);
+    appendIfs(builder);
+    return builder.toString();
+  }
+
+  private void appendWheres(StringBuilder builder) {
+    appendConditions(this.wheres, " WHERE ", builder);
+  }
+
+  private void appendIfs(StringBuilder builder) {
+    appendConditions(this.ifs, " IF ", builder);
+  }
+
+  private void appendConditions(
+      List<BuiltCondition> conditions, String initialPrefix, StringBuilder builder) {
+    String prefix = initialPrefix;
+    if (ifExists) {
+      builder.append(prefix).append("EXISTS");
+      prefix = " AND ";
+    }
+    for (BuiltCondition condition : conditions) {
+      builder.append(prefix);
+      condition.lhs().appendToBuilder(builder);
+      builder
+          .append(" ")
+          .append(condition.predicate().toString())
+          .append(" ")
+          .append(formatValue(condition.value()));
+      prefix = " AND ";
+    }
+  }
+
+  private String deleteQuery() {
+    StringBuilder builder =
+        new StringBuilder("DELETE ")
+            .append(
+                selection.stream().map(QueryBuilderImpl::cqlName).collect(Collectors.joining(",")))
+            .append(" FROM ")
+            .append(maybeQualify(tableName));
+    addUsingClause(builder);
+    appendWheres(builder);
+    appendIfs(builder);
+    return builder.toString();
+  }
+
+  protected String selectQuery() {
+    StringBuilder builder = new StringBuilder("SELECT ");
+    if (selection.isEmpty() && functionCalls.isEmpty()) {
+      builder.append('*');
+    } else {
+      builder.append(
+          Stream.concat(
+                  selection.stream().map(QueryBuilderImpl::cqlName),
+                  functionCalls.stream().map(QueryBuilderImpl::formatFunctionCall))
+              .collect(Collectors.joining(",")));
+    }
+    builder.append(" FROM ").append(maybeQualify(tableName));
+
+    appendWheres(builder);
+
+    if (!groupBys.isEmpty()) {
+      builder
+          .append(" GROUP BY ")
+          .append(
+              groupBys.stream().map(QueryBuilderImpl::cqlName).collect(Collectors.joining(",")));
+    }
+
+    if (!orders.isEmpty()) {
+      builder
+          .append(" ORDER BY ")
+          .append(
+              orders.entrySet().stream()
+                  .map(e -> cqlName(e.getKey()) + " " + e.getValue().name())
+                  .collect(Collectors.joining(", ")));
+    }
+
+    if (perPartitionLimit != null) {
+      builder.append(" PER PARTITION LIMIT ").append(formatValue(perPartitionLimit));
+    }
+
+    if (limit != null) {
+      builder.append(" LIMIT ").append(formatValue(perPartitionLimit));
+    }
+
+    if (allowFiltering) {
+      builder.append(" ALLOW FILTERING");
+    }
+
+    return builder.toString();
+  }
+
+  private static String formatFunctionCall(FunctionCall functionCall) {
+    StringBuilder builder = new StringBuilder();
+    builder
+        .append(functionCall.getFunctionName())
+        .append('(')
+        .append(cqlName(functionCall.getColumnName()))
+        .append(')');
+    if (functionCall.getAlias() != null) {
+      builder.append(" AS ").append(cqlName(functionCall.getAlias()));
+    }
+    return builder.toString();
+  }
+
+  public static class FunctionCall {
+    final String columnName;
+    String alias;
+    final String functionName;
+
+    private FunctionCall(String columnName, String alias, String functionName) {
+      this.columnName = columnName;
+      this.alias = alias;
+      this.functionName = functionName;
+    }
+
+    public static FunctionCall function(String name, String alias, String functionName) {
+      return new FunctionCall(name, alias, functionName);
+    }
+
+    public static FunctionCall count(String columnName) {
+      return count(columnName, null);
+    }
+
+    public static FunctionCall count(String columnName, String alias) {
+      return function(columnName, alias, "COUNT");
+    }
+
+    public static FunctionCall max(String columnName) {
+      return max(columnName, null);
+    }
+
+    public static FunctionCall max(String columnName, String alias) {
+      return function(columnName, alias, "MAX");
+    }
+
+    public static FunctionCall min(String columnName) {
+      return min(columnName, null);
+    }
+
+    public static FunctionCall min(String columnName, String alias) {
+      return function(columnName, alias, "MIN");
+    }
+
+    public static FunctionCall avg(String columnName) {
+      return avg(columnName, null);
+    }
+
+    public static FunctionCall avg(String columnName, String alias) {
+      return function(columnName, alias, "AVG");
+    }
+
+    public static FunctionCall sum(String columnName) {
+      return sum(columnName, null);
+    }
+
+    public static FunctionCall sum(String columnName, String alias) {
+      return function(columnName, alias, "SUM");
+    }
+
+    public static FunctionCall writeTime(String columnName) {
+      return writeTime(columnName, null);
+    }
+
+    public static FunctionCall writeTime(String columnName, String alias) {
+      return function(columnName, alias, "WRITETIME");
+    }
+
+    public void setAlias(String alias) {
+      this.alias = alias;
+    }
+
+    public String getColumnName() {
+      return columnName;
+    }
+
+    public String getFunctionName() {
+      return functionName;
+    }
+
+    public String getAlias() {
+      return alias;
+    }
+  }
+}

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Replication.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Replication.java
@@ -39,7 +39,7 @@ public class Replication {
   public static Replication networkTopologyStrategy(
       Map<String, Integer> dataCenterReplicationFactors) {
     StringBuilder sb = new StringBuilder();
-    sb.append("{ 'class' : 'NetworkTopologyStrategy'");
+    sb.append("{ 'class': 'NetworkTopologyStrategy'");
     for (Map.Entry<String, Integer> entry : dataCenterReplicationFactors.entrySet()) {
       String dcName = entry.getKey();
       int dcReplication = entry.getValue();

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Replication.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Replication.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright DataStax, Inc. and/or The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.common.cql.builder;
+
+import static java.lang.String.format;
+
+import java.util.Map;
+
+/**
+ * Represents a keyspace replication string.
+ *
+ * <p>So something like "{ 'class': 'SimpleStrategy', 'replication_factor': 1}".
+ */
+public class Replication {
+  private final String replication;
+
+  private Replication(String replication) {
+    this.replication = replication;
+  }
+
+  public static Replication simpleStrategy(int replicationFactor) {
+    return new Replication(
+        format("{ 'class': 'SimpleStrategy', 'replication_factor': %d }", replicationFactor));
+  }
+
+  public static Replication networkTopologyStrategy(
+      Map<String, Integer> dataCenterReplicationFactors) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{ 'class' : 'NetworkTopologyStrategy'");
+    for (Map.Entry<String, Integer> entry : dataCenterReplicationFactors.entrySet()) {
+      String dcName = entry.getKey();
+      int dcReplication = entry.getValue();
+      sb.append(", '").append(dcName).append("': ").append(dcReplication);
+    }
+    sb.append(" }");
+    return new Replication(sb.toString());
+  }
+
+  @Override
+  public String toString() {
+    return replication;
+  }
+}

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Value.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Value.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright DataStax, Inc. and/or The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.common.cql.builder;
+
+public interface Value<T> {
+
+  static <T> Value<T> marker() {
+    return new Marker<>();
+  }
+
+  static <T> Value<T> of(T value) {
+    return new ConcreteValue<>(value);
+  }
+
+  boolean isMarker();
+
+  T get();
+}

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/ValueModifier.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/ValueModifier.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright DataStax, Inc. and/or The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.common.cql.builder;
+
+import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Style;
+
+@Immutable
+@Style(visibility = Style.ImplementationVisibility.PACKAGE)
+public interface ValueModifier {
+  Target target();
+
+  Operation operation();
+
+  Value<?> value();
+
+  static ValueModifier set(String columnName, Object value) {
+    return of(Target.column(columnName), Operation.SET, Value.of(value));
+  }
+
+  static ValueModifier marker(String columnName) {
+    return of(Target.column(columnName), Operation.SET, Value.marker());
+  }
+
+  static ValueModifier of(Target target, Operation operation, Value<?> value) {
+    return ImmutableValueModifier.builder()
+        .target(target)
+        .operation(operation)
+        .value(value)
+        .build();
+  }
+
+  enum Operation {
+    SET,
+    INCREMENT,
+    APPEND,
+    PREPEND,
+    REMOVE,
+  }
+
+  @Immutable
+  @Style(visibility = Style.ImplementationVisibility.PACKAGE)
+  interface Target {
+    String columnName();
+
+    /** only set for UDT field access */
+    String fieldName();
+
+    /** only set for map value access */
+    Value<?> mapKey();
+
+    static Target column(String columnName) {
+      return ImmutableTarget.builder().columnName(columnName).build();
+    }
+
+    static Target field(String columnName, String fieldName) {
+      return ImmutableTarget.builder().columnName(columnName).fieldName(fieldName).build();
+    }
+
+    static Target mapValue(String columnName, Value<?> mapKey) {
+      return ImmutableTarget.builder().columnName(columnName).mapKey(mapKey).build();
+    }
+  }
+}

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/ValueModifier.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/ValueModifier.java
@@ -15,6 +15,7 @@
  */
 package io.stargate.sgv2.common.cql.builder;
 
+import javax.annotation.Nullable;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
 
@@ -57,9 +58,11 @@ public interface ValueModifier {
     String columnName();
 
     /** only set for UDT field access */
+    @Nullable
     String fieldName();
 
     /** only set for map value access */
+    @Nullable
     Value<?> mapKey();
 
     static Target column(String columnName) {

--- a/sgv2-service-common/src/test/java/io/stargate/sgv2/common/cql/ColumnUtilsTest.java
+++ b/sgv2-service-common/src/test/java/io/stargate/sgv2/common/cql/ColumnUtilsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright DataStax, Inc. and/or The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.common.cql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ColumnUtilsTest {
+
+  @Test
+  @DisplayName("Should quote CQL identifier if needed")
+  public void maybeQuote() {
+    assertThat(ColumnUtils.maybeQuote("foo")).isEqualTo("foo");
+    // Mixed case:
+    assertThat(ColumnUtils.maybeQuote("Foo")).isEqualTo("\"Foo\"");
+    // Special characters:
+    assertThat(ColumnUtils.maybeQuote("foo bar")).isEqualTo("\"foo bar\"");
+    // Reserved keywords:
+    assertThat(ColumnUtils.maybeQuote("table")).isEqualTo("\"table\"");
+    // If we quote, existing quotes must be escaped:
+    assertThat(ColumnUtils.maybeQuote("a\"a")).isEqualTo("\"a\"\"a\"");
+  }
+}

--- a/sgv2-service-common/src/test/java/io/stargate/sgv2/common/cql/builder/QueryBuilderTest.java
+++ b/sgv2-service-common/src/test/java/io/stargate/sgv2/common/cql/builder/QueryBuilderTest.java
@@ -18,6 +18,7 @@ package io.stargate.sgv2.common.cql.builder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import java.util.LinkedHashMap;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -59,6 +60,22 @@ public class QueryBuilderTest {
               .build(),
           "CREATE KEYSPACE IF NOT EXISTS ks "
               + "WITH replication = { 'class': 'SimpleStrategy', 'replication_factor': 1 }"),
+      arguments(
+          new QueryBuilder()
+              .create()
+              .keyspace("ks")
+              .ifNotExists()
+              .withReplication(
+                  Replication.networkTopologyStrategy(
+                      new LinkedHashMap<String, Integer>() {
+                        {
+                          put("dc1", 3);
+                          put("dc2", 4);
+                        }
+                      }))
+              .build(),
+          "CREATE KEYSPACE IF NOT EXISTS ks "
+              + "WITH replication = { 'class': 'NetworkTopologyStrategy', 'dc1': 3, 'dc2': 4 }"),
       arguments(
           new QueryBuilder()
               .alter()

--- a/sgv2-service-common/src/test/java/io/stargate/sgv2/common/cql/builder/QueryBuilderTest.java
+++ b/sgv2-service-common/src/test/java/io/stargate/sgv2/common/cql/builder/QueryBuilderTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright DataStax, Inc. and/or The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.common.cql.builder;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class QueryBuilderTest {
+
+  @ParameterizedTest
+  @MethodSource("sampleQueries")
+  @DisplayName("Should generate expected CQL string")
+  public void generateCql(String actualCql, String expectedCql) {
+    assertThat(actualCql).isEqualTo(expectedCql);
+  }
+
+  public static Arguments[] sampleQueries() {
+    return new Arguments[] {
+      arguments(
+          new QueryBuilder()
+              .create()
+              .keyspace("ks")
+              .withReplication(Replication.simpleStrategy(1))
+              .build(),
+          "CREATE KEYSPACE ks "
+              + "WITH replication = { 'class': 'SimpleStrategy', 'replication_factor': 1 }"),
+      arguments(
+          new QueryBuilder()
+              .create()
+              .keyspace("Ks")
+              .withReplication(Replication.simpleStrategy(1))
+              .build(),
+          "CREATE KEYSPACE \"Ks\" "
+              + "WITH replication = { 'class': 'SimpleStrategy', 'replication_factor': 1 }"),
+      arguments(
+          new QueryBuilder()
+              .create()
+              .keyspace("ks")
+              .ifNotExists()
+              .withReplication(Replication.simpleStrategy(1))
+              .build(),
+          "CREATE KEYSPACE IF NOT EXISTS ks "
+              + "WITH replication = { 'class': 'SimpleStrategy', 'replication_factor': 1 }"),
+      arguments(
+          new QueryBuilder()
+              .alter()
+              .keyspace("ks")
+              .withReplication(Replication.simpleStrategy(1))
+              .build(),
+          "ALTER KEYSPACE ks "
+              + "WITH replication = { 'class': 'SimpleStrategy', 'replication_factor': 1 }"),
+      arguments(
+          new QueryBuilder()
+              .alter()
+              .keyspace("ks")
+              .withReplication(Replication.simpleStrategy(1))
+              .andDurableWrites(false)
+              .build(),
+          "ALTER KEYSPACE ks "
+              + "WITH replication = { 'class': 'SimpleStrategy', 'replication_factor': 1 } "
+              + "AND durable_writes = false"),
+      arguments(new QueryBuilder().drop().keyspace("ks").build(), "DROP KEYSPACE ks"),
+      arguments(
+          new QueryBuilder().drop().keyspace("ks").ifExists().build(),
+          "DROP KEYSPACE IF EXISTS ks"),
+      arguments(
+          new QueryBuilder()
+              .create()
+              .table("ks", "tbl")
+              .column("k", "int", Column.Kind.PARTITION_KEY)
+              .build(),
+          "CREATE TABLE ks.tbl (k int, PRIMARY KEY ((k)))"),
+      arguments(
+          new QueryBuilder()
+              .create()
+              .table("Ks", "Tbl")
+              .column("k", "int", Column.Kind.PARTITION_KEY)
+              .build(),
+          "CREATE TABLE \"Ks\".\"Tbl\" (k int, PRIMARY KEY ((k)))"),
+      arguments(
+          new QueryBuilder()
+              .create()
+              .table("tbl")
+              .column("k", "int", Column.Kind.PARTITION_KEY)
+              .build(),
+          "CREATE TABLE tbl (k int, PRIMARY KEY ((k)))"),
+      arguments(
+          new QueryBuilder()
+              .create()
+              .table("ks", "tbl")
+              .ifNotExists()
+              .column("k", "int", Column.Kind.PARTITION_KEY)
+              .build(),
+          "CREATE TABLE IF NOT EXISTS ks.tbl (k int, PRIMARY KEY ((k)))"),
+      arguments(
+          new QueryBuilder()
+              .create()
+              .table("ks", "tbl")
+              .ifNotExists()
+              .column("k", "int", Column.Kind.PARTITION_KEY)
+              .column("cc", "text", Column.Kind.CLUSTERING, Column.Order.DESC)
+              .column("v", "int")
+              .column("s", "int", Column.Kind.STATIC)
+              .build(),
+          "CREATE TABLE IF NOT EXISTS ks.tbl "
+              + "(k int, cc text, v int, s int STATIC, PRIMARY KEY ((k), cc)) "
+              + "WITH CLUSTERING ORDER BY (cc DESC)"),
+      arguments(
+          new QueryBuilder()
+              .create()
+              .table("ks", "tbl")
+              .column("k", "int", Column.Kind.PARTITION_KEY)
+              .withComment("'test' comment")
+              .withDefaultTTL(3600)
+              .build(),
+          "CREATE TABLE ks.tbl (k int, PRIMARY KEY ((k))) "
+              + "WITH comment = '''test'' comment' "
+              + "AND default_time_to_live = 3600"),
+      arguments(
+          new QueryBuilder()
+              .alter()
+              .table("ks", "tbl")
+              .addColumn("c", "int")
+              .addColumn("d", "int")
+              .build(),
+          "ALTER TABLE ks.tbl ADD (c int, d int)"),
+      arguments(
+          new QueryBuilder().alter().table("ks", "tbl").dropColumn("c").dropColumn("d").build(),
+          "ALTER TABLE ks.tbl DROP (c, d)"),
+      arguments(
+          new QueryBuilder()
+              .alter()
+              .table("ks", "tbl")
+              .renameColumn("c", "c2")
+              .renameColumn("d", "d2")
+              .build(),
+          "ALTER TABLE ks.tbl RENAME c TO c2 AND d TO d2"),
+      arguments(new QueryBuilder().drop().table("ks", "tbl").build(), "DROP TABLE ks.tbl"),
+      arguments(
+          new QueryBuilder().drop().table("ks", "tbl").ifExists().build(),
+          "DROP TABLE IF EXISTS ks.tbl"),
+      arguments(new QueryBuilder().truncate().table("ks", "tbl").build(), "TRUNCATE ks.tbl"),
+      arguments(
+          new QueryBuilder().create().index().on("ks", "tbl").column("c").build(),
+          "CREATE INDEX ON ks.tbl (c)"),
+      arguments(
+          new QueryBuilder().create().index("idx").on("ks", "tbl").column("c").build(),
+          "CREATE INDEX idx ON ks.tbl (c)"),
+      arguments(
+          new QueryBuilder()
+              .create()
+              .index("idx")
+              .ifNotExists()
+              .on("ks", "tbl")
+              .column("c")
+              .build(),
+          "CREATE INDEX IF NOT EXISTS idx ON ks.tbl (c)"),
+      arguments(
+          new QueryBuilder().create().index().on("ks", "tbl").column("c").indexEntries().build(),
+          "CREATE INDEX ON ks.tbl (ENTRIES(c))"),
+      arguments(
+          new QueryBuilder().create().index().on("ks", "tbl").column("c").indexFull().build(),
+          "CREATE INDEX ON ks.tbl (FULL(c))"),
+      arguments(
+          new QueryBuilder().create().index().on("ks", "tbl").column("c").indexKeys().build(),
+          "CREATE INDEX ON ks.tbl (KEYS(c))"),
+      arguments(
+          new QueryBuilder().create().index().on("ks", "tbl").column("c").indexValues().build(),
+          "CREATE INDEX ON ks.tbl (VALUES(c))"),
+      arguments(
+          new QueryBuilder()
+              .create()
+              .index()
+              .on("ks", "tbl")
+              .column("c")
+              .custom("IndexClass")
+              .build(),
+          "CREATE CUSTOM INDEX ON ks.tbl (c) USING 'IndexClass'"),
+      arguments(
+          new QueryBuilder().drop().index("idx").ifExists().build(), "DROP INDEX IF EXISTS idx"),
+      arguments(new QueryBuilder().drop().index("ks", "idx").build(), "DROP INDEX ks.idx"),
+    };
+  }
+}


### PR DESCRIPTION
Clone the persistence API's `QueryBuilder`, but the new version only produces plain query strings. This would be used by v2 services to generate the CQL queries they'll send to the bridge (if we go with a plain CQL approach). In the current REST prototype this is done with the Java driver's query builder, but we want to avoid pulling that dependency.

Notes:
* this duplicates everything. I didn't make any attempt to reuse code, because I think the persistence query builder won't exist anymore in the target v2 architecture.
* I duplicated the DSL as-is. There are things I might have done differently, but I don't want to restart everything from scratch.
* column types are passed as raw strings. This will work for our current needs with the REST API, we can introduce a more structured representation later if needed.