### PR TITLE
Upgrade swagger-ui dependency from 3.35.0 to the latest 3.x, 3.52.5.

### DIFF
--- a/auth-api/pom.xml
+++ b/auth-api/pom.xml
@@ -11,7 +11,6 @@
   <artifactId>auth-api</artifactId>
   <properties>
     <osgi.bundle.version>${project.version}</osgi.bundle.version>
-    <swagger-ui.version>3.35.0</swagger-ui.version>
   </properties>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
     <immutables.version>2.5.6</immutables.version>
     <grpc.version>1.42.1</grpc.version>
     <caffeine.version>2.9.2</caffeine.version>
+    <swagger-ui.version>3.52.5</swagger-ui.version>
   </properties>
   <dependencies>
     <!-- Basic OSGi dependency, provided by container -->

--- a/restapi/pom.xml
+++ b/restapi/pom.xml
@@ -11,7 +11,6 @@
   <artifactId>restapi</artifactId>
   <properties>
     <osgi.bundle.version>${project.version}</osgi.bundle.version>
-    <swagger-ui.version>3.35.0</swagger-ui.version>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
**What this PR does**:

Upgrade "swagger-ui" dependency from 3.35.0 (latest at the time Stargate project started) to 3.52.5, latest 3.x version currently available.

**Which issue(s) this PR fixes**:
No issue filed here.

**Checklist**
- [x] Changes manually tested -- verified behavior wrt resolving of cross-server references
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
