### PR TITLE
avoid going to props every time for supportsSecondaryIndex

### DIFF
--- a/persistence-api/src/main/java/io/stargate/db/Persistence.java
+++ b/persistence-api/src/main/java/io/stargate/db/Persistence.java
@@ -34,6 +34,9 @@ import org.apache.cassandra.stargate.exceptions.AuthenticationException;
  */
 public interface Persistence extends SchemaAgreementChecker {
 
+  boolean SUPPORTS_SECONDARY_INDEX =
+      Boolean.parseBoolean(System.getProperty("stargate.persistence.2i.support.default", "true"));
+
   /** Name describing the persistence implementation. */
   String name();
 
@@ -87,8 +90,7 @@ public interface Persistence extends SchemaAgreementChecker {
   boolean isInSchemaAgreementWithStorage();
 
   default boolean supportsSecondaryIndex() {
-    return Boolean.parseBoolean(
-        System.getProperty("stargate.persistence.2i.support.default", "true"));
+    return SUPPORTS_SECONDARY_INDEX;
   }
 
   /** Returns true if the persistence backend supports Storage Attached Indexes. */


### PR DESCRIPTION
**What this PR does**:
Avoids going to the system props every time when `Persistence#supportsSecondaryIndex` is called. We call this quite often in the docs API due to the number boolean storage check. Thus, under heavy load we create here unnecessary contention point, as the `Hashtable` is synchronized..

I guess this property was not meant to be changed over time. Thus, a small fix.

![image](https://user-images.githubusercontent.com/10600041/144879780-ace30fc7-7189-45b7-95e0-3bba064f605f.png)


**Checklist**
- [x] Changes manually tested
- ~Automated Tests added/updated~
- ~Documentation added/updated~
