### PR TITLE
gRPC: Set "host" header to ":authority" pseudo-header value

### DIFF
--- a/grpc/src/main/java/io/stargate/grpc/service/interceptors/NewConnectionInterceptor.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/interceptors/NewConnectionInterceptor.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.concurrent.CompletionException;
 import javax.annotation.Nullable;
 import org.apache.cassandra.stargate.exceptions.UnhandledClientException;
-import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/grpc/src/main/java/io/stargate/grpc/service/interceptors/NewConnectionInterceptor.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/interceptors/NewConnectionInterceptor.java
@@ -81,6 +81,11 @@ public class NewConnectionInterceptor implements ServerInterceptor {
       }
 
       Map<String, String> stringHeaders = convertAndFilterHeaders(headers);
+
+      // Some authentication service and persistence implementations depend on the "host" header
+      // being set. HTTP/2 uses the ":authority" pseudo-header for this purpose and the
+      // `grpc-netty-shaded` implementation will move the "host" header into the ":authority" value:
+      // https://github.com/grpc/grpc-java/commit/122b3b2f7cf2b50fe0a0cebc55a84133441a4348
       stringHeaders.put("host", call.getAuthority());
 
       RequestInfo info =

--- a/grpc/src/main/java/io/stargate/grpc/service/interceptors/NewConnectionInterceptor.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/interceptors/NewConnectionInterceptor.java
@@ -88,7 +88,7 @@ public class NewConnectionInterceptor implements ServerInterceptor {
       // https://github.com/grpc/grpc-java/commit/122b3b2f7cf2b50fe0a0cebc55a84133441a4348
       String authority = call.getAuthority();
       if (authority != null && !authority.isEmpty()) {
-        stringHeaders.put("host", call.getAuthority());
+        stringHeaders.put("host", authority);
       }
 
       RequestInfo info =

--- a/grpc/src/main/java/io/stargate/grpc/service/interceptors/NewConnectionInterceptor.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/interceptors/NewConnectionInterceptor.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.concurrent.CompletionException;
 import javax.annotation.Nullable;
 import org.apache.cassandra.stargate.exceptions.UnhandledClientException;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,7 +87,10 @@ public class NewConnectionInterceptor implements ServerInterceptor {
       // being set. HTTP/2 uses the ":authority" pseudo-header for this purpose and the
       // `grpc-netty-shaded` implementation will move the "host" header into the ":authority" value:
       // https://github.com/grpc/grpc-java/commit/122b3b2f7cf2b50fe0a0cebc55a84133441a4348
-      stringHeaders.put("host", call.getAuthority());
+      String authority = call.getAuthority();
+      if (authority != null && !authority.isEmpty()) {
+        stringHeaders.put("host", call.getAuthority());
+      }
 
       RequestInfo info =
           ImmutableRequestInfo.builder()

--- a/grpc/src/test/java/io/stargate/grpc/service/interceptors/NewConnectionInterceptorTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/interceptors/NewConnectionInterceptorTest.java
@@ -179,4 +179,47 @@ public class NewConnectionInterceptorTest {
     verify(authenticationService, times(1)).validateToken(anyString(), any(Map.class));
     verify(next, never()).startCall(any(ServerCall.class), any(Metadata.class));
   }
+
+  @Test
+  public void setHostHeaderUsingAuthorityPseudoHeader() throws UnauthorizedException {
+    AuthenticatedUser authenticatedUser = mock(AuthenticatedUser.class);
+    when(authenticatedUser.name()).thenReturn("abc");
+
+    AuthenticationSubject authenticationSubject = mock(AuthenticationSubject.class);
+    when(authenticationSubject.asUser()).thenReturn(authenticatedUser);
+
+    AuthenticationService authenticationService = mock(AuthenticationService.class);
+    when(authenticationService.validateToken(anyString(), any(Map.class)))
+        .then(
+            invocation -> {
+              Map<String, String> headers = invocation.getArgument(1, Map.class);
+              assertThat(headers).containsEntry("host", "example.com");
+              return authenticationSubject;
+            });
+
+    Connection connection = mock(Connection.class);
+    when(connection.loggedUser()).thenReturn(Optional.of(authenticatedUser));
+
+    Persistence persistence = mock(Persistence.class);
+    when(persistence.newConnection(any())).thenReturn(connection);
+
+    ServerCallHandler next = mock(ServerCallHandler.class);
+    ServerCall call = mock(ServerCall.class);
+
+    when(call.getAuthority()).thenReturn("example.com");
+
+    Attributes attributes =
+        Attributes.newBuilder()
+            .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, new InetSocketAddress(8090))
+            .build();
+    when(call.getAttributes()).thenReturn(attributes);
+
+    Metadata metadata = new Metadata();
+    metadata.put(NewConnectionInterceptor.TOKEN_KEY, "someToken");
+    NewConnectionInterceptor interceptor =
+        new NewConnectionInterceptor(persistence, authenticationService);
+    interceptor.interceptCall(call, metadata, next);
+
+    verify(authenticationService, times(1)).validateToken(anyString(), any(Map.class));
+  }
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

When `grpc-netty-shaded` was upgraded to `1.42.1` it included this change:

https://github.com/grpc/grpc-java/commit/122b3b2f7cf2b50fe0a0cebc55a84133441a4348

That change removes the "host" header from the request header metadata.
The problem is internal authentication and other persistence-level
logic depend on the "host" header being present.

This patch sets the internal "host" header using the ":authority"
pseudo-header value.

Additionally, this adds logging to the unhandled error path when an
exception is thrown while creating a new connection.

**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [ ] ~Documentation added/updated~
