### PR TITLE
add support to v2 REST API for additional types

### DIFF
--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/FromProtoValueCodecs.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/FromProtoValueCodecs.java
@@ -4,10 +4,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.uuid.impl.UUIDUtil;
-import com.google.protobuf.ByteString;
+import io.stargate.grpc.Values;
 import io.stargate.proto.QueryOuterClass;
 import java.math.BigDecimal;
-import java.nio.ByteBuffer;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -219,16 +218,7 @@ public class FromProtoValueCodecs {
     }
 
     private BigDecimal convertProtoValue(QueryOuterClass.Value value) {
-      QueryOuterClass.Decimal decimal = value.getDecimal();
-      ByteString bi = decimal.getValue();
-      int scale = decimal.getScale();
-      byte[] bibytes = bi.toByteArray();
-
-      ByteBuffer bytes = ByteBuffer.allocate(4 + bibytes.length);
-      bytes.putInt(scale);
-      bytes.put(bibytes);
-      bytes.rewind();
-      return new BigDecimal(bytes.asCharBuffer().array());
+      return Values.decimal(value);
     }
   }
 

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/FromProtoValueCodecs.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/FromProtoValueCodecs.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.uuid.impl.UUIDUtil;
 import io.stargate.grpc.Values;
 import io.stargate.proto.QueryOuterClass;
-import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -209,16 +208,12 @@ public class FromProtoValueCodecs {
   protected static final class DecimalCodec extends FromProtoValueCodec {
     @Override
     public Object fromProtoValue(QueryOuterClass.Value value) {
-      return convertProtoValue(value);
+      return Values.decimal(value);
     }
 
     @Override
     public JsonNode jsonNodeFrom(QueryOuterClass.Value value) {
-      return jsonNodeFactory.numberNode(convertProtoValue(value));
-    }
-
-    private BigDecimal convertProtoValue(QueryOuterClass.Value value) {
-      return Values.decimal(value);
+      return jsonNodeFactory.numberNode(Values.decimal(value));
     }
   }
 

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/FromProtoValueCodecs.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/FromProtoValueCodecs.java
@@ -24,6 +24,7 @@ public class FromProtoValueCodecs {
   private static final IntCodec CODEC_INT = new IntCodec();
   private static final LongCodec CODEC_LONG = new LongCodec();
   private static final ShortCodec CODEC_SHORT = new ShortCodec();
+  private static final DoubleCodec CODEC_DOUBLE = new DoubleCodec();
   private static final DecimalCodec CODEC_DECIMAL = new DecimalCodec();
 
   private static final TextCodec CODEC_TEXT = new TextCodec();
@@ -93,6 +94,8 @@ public class FromProtoValueCodecs {
         return CODEC_SHORT;
       case TINYINT:
         return CODEC_BYTE;
+      case DOUBLE:
+        return CODEC_DOUBLE;
       case DECIMAL:
         return CODEC_DECIMAL;
 
@@ -107,8 +110,6 @@ public class FromProtoValueCodecs {
       case BLOB:
         break;
       case COUNTER:
-        break;
-      case DOUBLE:
         break;
       case FLOAT:
         break;
@@ -188,6 +189,18 @@ public class FromProtoValueCodecs {
     @Override
     public JsonNode jsonNodeFrom(QueryOuterClass.Value value) {
       return jsonNodeFactory.numberNode(value.getInt());
+    }
+  }
+
+  protected static final class DoubleCodec extends FromProtoValueCodec {
+    @Override
+    public Object fromProtoValue(QueryOuterClass.Value value) {
+      return value.getDouble();
+    }
+
+    @Override
+    public JsonNode jsonNodeFrom(QueryOuterClass.Value value) {
+      return jsonNodeFactory.numberNode(value.getDouble());
     }
   }
 

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/FromProtoValueCodecs.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/FromProtoValueCodecs.java
@@ -83,6 +83,7 @@ public class FromProtoValueCodecs {
 
         // Supported Scalars: numeric
       case BIGINT:
+      case TIMESTAMP:
         return CODEC_LONG;
       case INT:
         return CODEC_INT;
@@ -108,8 +109,6 @@ public class FromProtoValueCodecs {
       case DOUBLE:
         break;
       case FLOAT:
-        break;
-      case TIMESTAMP:
         break;
       case VARINT:
         break;

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/ToProtoValueCodecs.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/ToProtoValueCodecs.java
@@ -12,6 +12,7 @@ public class ToProtoValueCodecs {
   protected static final BooleanCodec CODEC_BOOLEAN = new BooleanCodec();
   protected static final TextCodec CODEC_TEXT = new TextCodec();
   protected static final IntCodec CODEC_INT = new IntCodec();
+  protected static final DoubleCodec CODEC_DOUBLE = new DoubleCodec();
   protected static final DecimalCodec CODEC_DECIMAL = new DecimalCodec();
   protected static final LongCodec CODEC_LONG = new LongCodec("LONG");
   protected static final LongCodec CODEC_COUNTER = new LongCodec("COUNTER");
@@ -79,6 +80,8 @@ public class ToProtoValueCodecs {
         return CODEC_COUNTER; // actually same as LONG
       case TIMESTAMP:
         return CODEC_TIMESTAMP; // represented as LONG
+      case DOUBLE:
+        return CODEC_DOUBLE;
       case DECIMAL:
         return CODEC_DECIMAL;
 
@@ -89,8 +92,6 @@ public class ToProtoValueCodecs {
 
         // And then not-yet-implemented ones:
       case BLOB:
-        break;
-      case DOUBLE:
         break;
       case FLOAT:
         break;
@@ -279,6 +280,32 @@ public class ToProtoValueCodecs {
     public QueryOuterClass.Value protoValueFromStringified(String value) {
       try {
         return Values.of(Long.valueOf(value));
+      } catch (IllegalArgumentException e) {
+        return invalidStringValue(value);
+      }
+    }
+  }
+
+  protected static final class DoubleCodec extends ToProtoCodecBase {
+    public DoubleCodec() {
+      super("TypeSpec.Basic.DOUBLE");
+    }
+
+    @Override
+    public QueryOuterClass.Value protoValueFromStrictlyTyped(Object value) {
+      if (value instanceof Double) {
+        return Values.of((Double) value);
+      } else if (value instanceof Number) {
+        // !!! TODO: bounds checks
+        return Values.of(((Number) value).doubleValue());
+      }
+      return cannotCoerce(value);
+    }
+
+    @Override
+    public QueryOuterClass.Value protoValueFromStringified(String value) {
+      try {
+        return Values.of(Double.valueOf(value));
       } catch (IllegalArgumentException e) {
         return invalidStringValue(value);
       }

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/ToProtoValueCodecs.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/ToProtoValueCodecs.java
@@ -13,6 +13,7 @@ public class ToProtoValueCodecs {
   protected static final IntCodec CODEC_INT = new IntCodec();
   protected static final LongCodec CODEC_LONG = new LongCodec("LONG");
   protected static final LongCodec CODEC_COUNTER = new LongCodec("COUNTER");
+  protected static final LongCodec CODEC_TIMESTAMP = new LongCodec("TIMESTAMP");
 
   // Same codecs for UUIDs but for error messages need to create different instances
   protected static final UUIDCodec CODEC_UUID = new UUIDCodec("UUID");
@@ -74,6 +75,8 @@ public class ToProtoValueCodecs {
         return CODEC_INT;
       case COUNTER:
         return CODEC_COUNTER; // actually same as LONG
+      case TIMESTAMP:
+        return CODEC_TIMESTAMP; // represented as LONG
 
       case UUID:
         return CODEC_UUID;
@@ -88,8 +91,6 @@ public class ToProtoValueCodecs {
       case DOUBLE:
         break;
       case FLOAT:
-        break;
-      case TIMESTAMP:
         break;
       case VARINT:
         break;

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -2843,6 +2843,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
     columnDefinitions.add(new ColumnDefinition("est_unit_cost", "decimal"));
     columnDefinitions.add(new ColumnDefinition("est_unit_cost_updated", "timestamp"));
     columnDefinitions.add(new ColumnDefinition("inspection_notes", "text"));
+    columnDefinitions.add(new ColumnDefinition("mean_failure_time_hours", "double"));
     tableAdd.setColumnDefinitions(columnDefinitions);
 
     PrimaryKey primaryKey = new PrimaryKey();
@@ -2876,6 +2877,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
     row.put("est_unit_cost", "599.99");
     row.put("est_unit_cost_updated", timestamp);
     row.put("inspection_notes", "working");
+    row.put("mean_failure_time_hours", "29111.595");
 
     RestUtils.post(
         authToken,
@@ -2896,6 +2898,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
     row2.put("est_unit_cost", 38.95);
     row2.put("est_unit_cost_updated", timestamp2);
     row2.put("inspection_notes", "frayed cable");
+    row2.put("mean_failure_time_hours", 5917321.12334);
 
     RestUtils.post(
         authToken,

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -2852,14 +2852,14 @@ public class RestApiv2Test extends BaseIntegrationTest {
 
     // create table
     String body =
-            RestUtils.post(
-                    authToken,
-                    String.format("%s/v2/schemas/keyspaces/%s/tables", restUrlBase, keyspaceName),
-                    objectMapper.writeValueAsString(tableAdd),
-                    HttpStatus.SC_CREATED);
+        RestUtils.post(
+            authToken,
+            String.format("%s/v2/schemas/keyspaces/%s/tables", restUrlBase, keyspaceName),
+            objectMapper.writeValueAsString(tableAdd),
+            HttpStatus.SC_CREATED);
 
     TableResponse tableResponse =
-            objectMapper.readValue(body, new TypeReference<TableResponse>() {});
+        objectMapper.readValue(body, new TypeReference<TableResponse>() {});
     assertThat(tableResponse.getName()).isEqualTo(tableName);
 
     // insert a row
@@ -2878,26 +2878,27 @@ public class RestApiv2Test extends BaseIntegrationTest {
     row.put("inspection_notes", "working");
 
     RestUtils.post(
-            authToken,
-            String.format("%s/v2/keyspaces/%s/%s", restUrlBase, keyspaceName, tableName),
-            objectMapper.writeValueAsString(row),
-            HttpStatus.SC_CREATED);
+        authToken,
+        String.format("%s/v2/keyspaces/%s/%s", restUrlBase, keyspaceName, tableName),
+        objectMapper.writeValueAsString(row),
+        HttpStatus.SC_CREATED);
 
     // retrieve the row by ID
-    String whereClause = String.format(
+    String whereClause =
+        String.format(
             "{\"hour_created\":{\"$eq\":\"%s\"},\"serial_number\":{\"$eq\":[\"%s\"]}}",
             timestamp, serialNumber);
 
     body =
-            RestUtils.get(
-                    authToken,
-                    String.format(
-                            "%s/v2/keyspaces/%s/%s?where=%s",
-                            restUrlBase, keyspaceName, tableName, whereClause),
-                    HttpStatus.SC_OK);
+        RestUtils.get(
+            authToken,
+            String.format(
+                "%s/v2/keyspaces/%s/%s?where=%s",
+                restUrlBase, keyspaceName, tableName, whereClause),
+            HttpStatus.SC_OK);
 
     ListOfMapsGetResponseWrapper getResponseWrapper =
-            LIST_OF_MAPS_GETRESPONSE_READER.readValue(body);
+        LIST_OF_MAPS_GETRESPONSE_READER.readValue(body);
     List<Map<String, Object>> data = getResponseWrapper.getData();
     assertThat(data.get(0).get("hour_created")).isEqualTo(timestamp);
     assertThat(data.get(0).get("serial_number")).isEqualTo(serialNumber);
@@ -2918,11 +2919,10 @@ public class RestApiv2Test extends BaseIntegrationTest {
     row2.put("inspection_notes", "frayed cable");
 
     RestUtils.post(
-            authToken,
-            String.format("%s/v2/keyspaces/%s/%s", restUrlBase, keyspaceName, tableName),
-            objectMapper.writeValueAsString(row2),
-            HttpStatus.SC_CREATED);
-
+        authToken,
+        String.format("%s/v2/keyspaces/%s/%s", restUrlBase, keyspaceName, tableName),
+        objectMapper.writeValueAsString(row2),
+        HttpStatus.SC_CREATED);
   }
 
   private void createTable(String keyspaceName, String tableName) throws IOException {

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -2840,7 +2840,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
     columnDefinitions.add(new ColumnDefinition("created_at", "timestamp"));
     columnDefinitions.add(new ColumnDefinition("last_inspected_at", "timestamp"));
     columnDefinitions.add(new ColumnDefinition("times_inspected", "int"));
-    // columnDefinitions.add(new ColumnDefinition("est_unit_cost", "decimal"));
+    columnDefinitions.add(new ColumnDefinition("est_unit_cost", "decimal"));
     columnDefinitions.add(new ColumnDefinition("est_unit_cost_updated", "timestamp"));
     columnDefinitions.add(new ColumnDefinition("inspection_notes", "text"));
     tableAdd.setColumnDefinitions(columnDefinitions);
@@ -2873,7 +2873,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
     row.put("part_number", "DEF456");
     row.put("last_inspected_at", timestamp);
     row.put("times_inspected", "2");
-    // row.put("est_unit_cost", "599.99");
+    row.put("est_unit_cost", "599.99");
     row.put("est_unit_cost_updated", timestamp);
     row.put("inspection_notes", "working");
 
@@ -2893,7 +2893,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
     row2.put("part_number", "QRS246");
     row2.put("last_inspected_at", timestamp2);
     row2.put("times_inspected", 5);
-    // row2.put("est_unit_cost", 38.95);
+    row2.put("est_unit_cost", 38.95);
     row2.put("est_unit_cost_updated", timestamp2);
     row2.put("inspection_notes", "frayed cable");
 


### PR DESCRIPTION
Adding support for additional types referenced in performance testing - decimal, double, timestamp. See for example NoSQLBench http tests here: https://github.com/nosqlbench/nosqlbench/tree/main/driver-http/src/main/resources/activities/baselines