### PR TITLE
Add support for "order-by" feature of get-all-rows/get-row-by-pk

### DIFF
--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/ResourceBase.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/ResourceBase.java
@@ -1,5 +1,6 @@
 package io.stargate.sgv2.restsvc.resources;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.json.JsonMapper;
@@ -61,6 +62,10 @@ public abstract class ResourceBase {
 
   protected static Map<String, Object> parseJsonAsMap(String jsonString) throws IOException {
     return MAP_READER.readValue(jsonString);
+  }
+
+  protected static JsonNode parseJsonAsNode(String jsonString) throws IOException {
+    return JSON_MAPPER.readTree(jsonString);
   }
 
   // // // Helper methods for Bridge/gRPC query construction

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/Sgv2RowsResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/Sgv2RowsResourceImpl.java
@@ -75,7 +75,6 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
       return jaxrsBadRequestError(e.getMessage()).build();
     }
 
-    // To bind path/key parameters, need converter; and for that we need table metadata:
     Schema.CqlTable tableDef =
         BridgeSchemaClient.create(blockingStub).findTable(keyspaceName, tableName);
     final ToProtoConverter toProtoConverter = findProtoConverter(tableDef);

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/Sgv2RowsResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/Sgv2RowsResourceImpl.java
@@ -1,5 +1,6 @@
 package io.stargate.sgv2.restsvc.resources;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.stargate.grpc.StargateBearerToken;
 import io.stargate.proto.QueryOuterClass;
 import io.stargate.proto.Schema;
@@ -18,6 +19,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -62,7 +65,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
       final int pageSizeParam,
       final String pageStateParam,
       final boolean raw,
-      final String sort,
+      final String sortJson,
       final HttpServletRequest request) {
     if (isAuthTokenInvalid(token)) {
       return invalidTokenFailure();
@@ -81,7 +84,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
       final int pageSizeParam,
       final String pageStateParam,
       final boolean raw,
-      final String sort,
+      final String sortJson,
       final HttpServletRequest request) {
     if (isAuthTokenInvalid(token)) {
       return invalidTokenFailure();
@@ -89,6 +92,13 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
     List<Column> columns = isStringEmpty(fields) ? Collections.emptyList() : splitColumns(fields);
     final StargateGrpc.StargateBlockingStub blockingStub =
         grpcFactory.constructBlockingStub().withCallCredentials(new StargateBearerToken(token));
+
+    Map<String, Column.Order> sortOrder;
+    try {
+      sortOrder = decodeSortOrder(sortJson);
+    } catch (IllegalArgumentException e) {
+      return jaxrsBadRequestError(e.getMessage()).build();
+    }
 
     // To bind path/key parameters, need converter; and for that we need table metadata:
     Schema.CqlTable tableDef =
@@ -98,7 +108,14 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
 
     final String cql =
         buildGetRowsByPKCQL(
-            keyspaceName, tableName, path, columns, tableDef, valuesBuilder, toProtoConverter);
+            keyspaceName,
+            tableName,
+            path,
+            columns,
+            sortOrder,
+            tableDef,
+            valuesBuilder,
+            toProtoConverter);
     logger.info("getRows(): try to call backend with CQL of '{}'", cql);
 
     return fetchRows(blockingStub, pageSizeParam, pageStateParam, raw, cql, valuesBuilder);
@@ -113,22 +130,36 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
       final int pageSizeParam,
       final String pageStateParam,
       final boolean raw,
-      final String sort,
+      final String sortJson,
       final HttpServletRequest request) {
     if (isAuthTokenInvalid(token)) {
       return invalidTokenFailure();
     }
     List<Column> columns = isStringEmpty(fields) ? Collections.emptyList() : splitColumns(fields);
-    final String cql;
-
-    if (columns.isEmpty()) {
-      cql = new QueryBuilder().select().star().from(keyspaceName, tableName).build();
-    } else {
-      cql = new QueryBuilder().select().column(columns).from(keyspaceName, tableName).build();
+    Map<String, Column.Order> sortOrder;
+    try {
+      sortOrder = decodeSortOrder(sortJson);
+    } catch (IllegalArgumentException e) {
+      return jaxrsBadRequestError(e.getMessage()).build();
     }
-
-    logger.info("getAllRows(): try to call backend with CQL of '{}'", cql);
-
+    final String cql;
+    if (columns.isEmpty()) {
+      cql =
+          new QueryBuilder()
+              .select()
+              .star()
+              .from(keyspaceName, tableName)
+              .orderBy(sortOrder)
+              .build();
+    } else {
+      cql =
+          new QueryBuilder()
+              .select()
+              .column(columns)
+              .from(keyspaceName, tableName)
+              .orderBy(sortOrder)
+              .build();
+    }
     final StargateGrpc.StargateBlockingStub blockingStub =
         grpcFactory.constructBlockingStub().withCallCredentials(new StargateBearerToken(token));
     return fetchRows(blockingStub, pageSizeParam, pageStateParam, raw, cql, null);
@@ -323,6 +354,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
       String tableName,
       List<PathSegment> pkValues,
       List<Column> columns,
+      Map<String, Column.Order> sortOrder,
       Schema.CqlTable tableDef,
       QueryOuterClass.Values.Builder valuesBuilder,
       ToProtoConverter toProtoConverter) {
@@ -344,6 +376,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
           .star()
           .from(keyspaceName, tableName)
           .where(whereConditions)
+          .orderBy(sortOrder)
           .build();
     }
     return new QueryBuilder()
@@ -351,6 +384,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
         .column(columns)
         .from(keyspaceName, tableName)
         .where(whereConditions)
+        .orderBy(sortOrder)
         .build();
   }
 
@@ -470,6 +504,36 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
   // Helper methods for Structural/nested/scalar conversions
   /////////////////////////////////////////////////////////////////////////
    */
+
+  private Map<String, Column.Order> decodeSortOrder(String sortOrderJson) {
+    if (isStringEmpty(sortOrderJson)) {
+      return Collections.emptyMap();
+    }
+    JsonNode root;
+    try {
+      root = parseJsonAsNode(sortOrderJson);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Invalid 'sort' argument, not valid JSON (%s): %s", sortOrderJson, e.getMessage()));
+    }
+    if (!root.isObject()) {
+      throw new IllegalArgumentException(
+          String.format("Invalid 'sort' argument, not JSON Object (%s)", sortOrderJson));
+    }
+    if (root.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    Map<String, Column.Order> order = new LinkedHashMap<>();
+    Iterator<Map.Entry<String, JsonNode>> it = root.fields();
+    while (it.hasNext()) {
+      Map.Entry<String, JsonNode> entry = it.next();
+      String value = entry.getValue().asText();
+      order.put(entry.getKey(), "desc".equals(value) ? Column.Order.DESC : Column.Order.ASC);
+    }
+    return order;
+  }
 
   private Set<String> findCounterNames(Schema.CqlTable tableDef) {
     // Only need to check static and regular columns; primary keys cannot be Counters.


### PR DESCRIPTION
**What this PR does**:

Adds suport for `sort` query parameter in SGv2/REST get endpoints.

**Which issue(s) this PR fixes**:

SGv2/REST rows endpoint has so far ignored `sort` parameter for get methods; this PR adds support.

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated -- 2 more ITs now pass
- [ ] Documentation added/updated
