### PR TITLE
remove reflection usage from the request hot path in C4

### DIFF
--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Cassandra40Persistence.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Cassandra40Persistence.java
@@ -440,8 +440,7 @@ public class Cassandra40Persistence
             }
             request.setCustomPayload(parameters.customPayload().orElse(null));
 
-            Message.Response response =
-                ReflectionUtils.execute(request, queryState, queryStartNanoTime);
+            Message.Response response = request.execute(queryState, queryStartNanoTime);
 
             // There is only 2 types of response that can come out: either a ResultMessage (which
             // itself can of different kind), or an ErrorMessage.
@@ -458,7 +457,8 @@ public class Cassandra40Persistence
                 (T)
                     Conversion.toResult(
                         (ResultMessage) response,
-                        Conversion.toInternal(parameters.protocolVersion()));
+                        Conversion.toInternal(parameters.protocolVersion()),
+                        parameters.tracingRequested());
             return result;
           },
           parameters.protocolVersion().isGreaterOrEqualTo(ProtocolVersion.V4));

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
@@ -438,8 +438,18 @@ public class Conversion {
 
   public static Result toResult(
       ResultMessage resultMessage, org.apache.cassandra.transport.ProtocolVersion version) {
-    return toResultInternal(resultMessage, version)
-        .setTracingId(ReflectionUtils.getTracingId(resultMessage));
+    return toResult(resultMessage, version, true);
+  }
+
+  public static Result toResult(
+      ResultMessage resultMessage,
+      org.apache.cassandra.transport.ProtocolVersion version,
+      boolean includeTracingInfo) {
+    Result result = toResultInternal(resultMessage, version);
+    if (includeTracingInfo) {
+      result.setTracingId(ReflectionUtils.getTracingId(resultMessage));
+    }
+    return result;
   }
 
   private static Result toResultInternal(

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/ReflectionUtils.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/ReflectionUtils.java
@@ -6,22 +6,17 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.UUID;
 import org.apache.cassandra.cql3.QueryOptions;
-import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.transport.Message.Request;
 import org.apache.cassandra.transport.Message.Response;
 
 class ReflectionUtils {
 
-  private static final Method requestExecute;
   private static final Method requestSetTracingRequested;
   private static final Method responseGetTracingId;
   private static final Constructor<? extends QueryOptions> optionsWithNamesCtor;
 
   static {
     try {
-      requestExecute = Request.class.getDeclaredMethod("execute", QueryState.class, long.class);
-      requestExecute.setAccessible(true);
-
       requestSetTracingRequested = Request.class.getDeclaredMethod("setTracingRequested");
       requestSetTracingRequested.setAccessible(true);
 
@@ -82,10 +77,6 @@ class ReflectionUtils {
         throw new RuntimeException(cause);
       }
     }
-  }
-
-  static Response execute(Request request, QueryState queryState, long queryStartNanoTime) {
-    return invoke(requestExecute, request, queryState, queryStartNanoTime);
   }
 
   static void setTracingRequested(Request request) {


### PR DESCRIPTION
**What this PR does**:

Decreases the usage of the reflection in the `persistence-cassandra-4.0`. I see no reason the `execute` should be called with the reflection.. In addition, reading tracing info should not be done always..

**Which issue(s) this PR fixes**:
No isse.

**Checklist**
Should not require any test changes.
