### PR TITLE
Fix #1483: refactor SGv2 Tables, Keyspaces resource to use api/impl division

### DIFF
--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/impl/RestServiceServer.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/impl/RestServiceServer.java
@@ -36,7 +36,7 @@ import io.stargate.sgv2.restsvc.resources.Sgv2RowsResourceImpl;
 import io.stargate.sgv2.restsvc.resources.SwaggerUIResource;
 import io.stargate.sgv2.restsvc.resources.schemas.Sgv2ColumnsResourceImpl;
 import io.stargate.sgv2.restsvc.resources.schemas.Sgv2IndexesResourceImpl;
-import io.stargate.sgv2.restsvc.resources.schemas.Sgv2KeyspacesResource;
+import io.stargate.sgv2.restsvc.resources.schemas.Sgv2KeyspacesResourceImpl;
 import io.stargate.sgv2.restsvc.resources.schemas.Sgv2TablesResource;
 import io.swagger.config.ScannerFactory;
 import io.swagger.jaxrs.config.BeanConfig;
@@ -123,7 +123,7 @@ public class RestServiceServer extends Application<RestServiceServerConfiguratio
 
     // Schema endpoints
     environment.jersey().register(Sgv2ColumnsResourceImpl.class);
-    environment.jersey().register(Sgv2KeyspacesResource.class);
+    environment.jersey().register(Sgv2KeyspacesResourceImpl.class);
     environment.jersey().register(Sgv2TablesResource.class);
     environment.jersey().register(Sgv2IndexesResourceImpl.class);
 

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/impl/RestServiceServer.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/impl/RestServiceServer.java
@@ -37,7 +37,7 @@ import io.stargate.sgv2.restsvc.resources.SwaggerUIResource;
 import io.stargate.sgv2.restsvc.resources.schemas.Sgv2ColumnsResourceImpl;
 import io.stargate.sgv2.restsvc.resources.schemas.Sgv2IndexesResourceImpl;
 import io.stargate.sgv2.restsvc.resources.schemas.Sgv2KeyspacesResourceImpl;
-import io.stargate.sgv2.restsvc.resources.schemas.Sgv2TablesResource;
+import io.stargate.sgv2.restsvc.resources.schemas.Sgv2TablesResourceImpl;
 import io.swagger.config.ScannerFactory;
 import io.swagger.jaxrs.config.BeanConfig;
 import io.swagger.jaxrs.config.DefaultJaxrsScanner;
@@ -124,7 +124,7 @@ public class RestServiceServer extends Application<RestServiceServerConfiguratio
     // Schema endpoints
     environment.jersey().register(Sgv2ColumnsResourceImpl.class);
     environment.jersey().register(Sgv2KeyspacesResourceImpl.class);
-    environment.jersey().register(Sgv2TablesResource.class);
+    environment.jersey().register(Sgv2TablesResourceImpl.class);
     environment.jersey().register(Sgv2IndexesResourceImpl.class);
 
     // Swagger endpoints

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/ResourceBase.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/ResourceBase.java
@@ -113,6 +113,20 @@ public abstract class ResourceBase {
 
   // // // Helper methods for input validation
 
+  protected static void requireNonEmptyKeyspace(String keyspaceName) {
+    if (isStringEmpty(keyspaceName)) {
+      throw new WebApplicationException(
+          "keyspaceName must be provided", Response.Status.BAD_REQUEST);
+    }
+  }
+
+  protected static void requireNonEmptyKeyspaceAndTable(String keyspaceName, String tableName) {
+    requireNonEmptyKeyspace(keyspaceName);
+    if (isStringEmpty(tableName)) {
+      throw new WebApplicationException("table name must be provided", Response.Status.BAD_REQUEST);
+    }
+  }
+
   protected static final boolean isStringEmpty(String str) {
     return (str == null) || str.isEmpty();
   }

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/Sgv2RowsResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/Sgv2RowsResourceImpl.java
@@ -64,6 +64,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
       final boolean raw,
       final String sortJson,
       final HttpServletRequest request) {
+    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     if (isStringEmpty(where)) {
       throw new WebApplicationException("where parameter is required", Status.BAD_REQUEST);
     }
@@ -98,6 +99,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
       final boolean raw,
       final String sortJson,
       final HttpServletRequest request) {
+    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     final List<Column> columns =
         isStringEmpty(fields) ? Collections.emptyList() : splitColumns(fields);
     final Map<String, Column.Order> sortOrder;
@@ -139,6 +141,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
       final boolean raw,
       final String sortJson,
       final HttpServletRequest request) {
+    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     List<Column> columns = isStringEmpty(fields) ? Collections.emptyList() : splitColumns(fields);
     Map<String, Column.Order> sortOrder;
     try {
@@ -174,6 +177,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
       final String tableName,
       final String payloadAsString,
       final HttpServletRequest request) {
+    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     Map<String, Object> payloadMap;
     try {
       payloadMap = parseJsonAsMap(payloadAsString);
@@ -226,6 +230,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
       final String tableName,
       final List<PathSegment> path,
       HttpServletRequest request) {
+    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     // To bind path/key parameters, need converter; and for that we need table metadata:
     Schema.CqlTable tableDef =
         BridgeSchemaClient.create(blockingStub).findTable(keyspaceName, tableName);
@@ -268,6 +273,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
       final boolean raw,
       final String payloadAsString,
       final HttpServletRequest request) {
+    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     Map<String, Object> payloadMap;
     try {
       payloadMap = parseJsonAsMap(payloadAsString);

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2ColumnsResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2ColumnsResourceImpl.java
@@ -39,13 +39,7 @@ public class Sgv2ColumnsResourceImpl extends ResourceBase implements Sgv2Columns
       String tableName,
       boolean raw,
       HttpServletRequest request) {
-    if (isStringEmpty(keyspaceName)) {
-      throw new WebApplicationException(
-          "keyspaceName must be provided", Response.Status.BAD_REQUEST);
-    }
-    if (isStringEmpty(tableName)) {
-      throw new WebApplicationException("table name must be provided", Response.Status.BAD_REQUEST);
-    }
+    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     return callWithTable(
         blockingStub,
         keyspaceName,
@@ -64,13 +58,7 @@ public class Sgv2ColumnsResourceImpl extends ResourceBase implements Sgv2Columns
       String tableName,
       Sgv2ColumnDefinition columnDefinition,
       HttpServletRequest request) {
-    if (isStringEmpty(keyspaceName)) {
-      throw new WebApplicationException(
-          "keyspaceName must be provided", Response.Status.BAD_REQUEST);
-    }
-    if (isStringEmpty(tableName)) {
-      throw new WebApplicationException("table name must be provided", Response.Status.BAD_REQUEST);
-    }
+    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     final String columnName = columnDefinition.getName();
     if (isStringEmpty(tableName)) {
       throw new WebApplicationException("columnName must be provided", Response.Status.BAD_REQUEST);
@@ -114,13 +102,7 @@ public class Sgv2ColumnsResourceImpl extends ResourceBase implements Sgv2Columns
       String columnName,
       boolean raw,
       HttpServletRequest request) {
-    if (isStringEmpty(keyspaceName)) {
-      throw new WebApplicationException(
-          "keyspaceName must be provided", Response.Status.BAD_REQUEST);
-    }
-    if (isStringEmpty(tableName)) {
-      throw new WebApplicationException("table name must be provided", Response.Status.BAD_REQUEST);
-    }
+    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     if (isStringEmpty(columnName)) {
       throw new WebApplicationException("columnName must be provided", Response.Status.BAD_REQUEST);
     }
@@ -148,13 +130,7 @@ public class Sgv2ColumnsResourceImpl extends ResourceBase implements Sgv2Columns
       String columnName,
       Sgv2ColumnDefinition columnUpdate,
       HttpServletRequest request) {
-    if (isStringEmpty(keyspaceName)) {
-      throw new WebApplicationException(
-          "keyspaceName must be provided", Response.Status.BAD_REQUEST);
-    }
-    if (isStringEmpty(tableName)) {
-      throw new WebApplicationException("table name must be provided", Response.Status.BAD_REQUEST);
-    }
+    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     if (isStringEmpty(columnName)) {
       throw new WebApplicationException("columnName must be provided", Response.Status.BAD_REQUEST);
     }
@@ -197,13 +173,7 @@ public class Sgv2ColumnsResourceImpl extends ResourceBase implements Sgv2Columns
       String tableName,
       String columnName,
       HttpServletRequest request) {
-    if (isStringEmpty(keyspaceName)) {
-      throw new WebApplicationException(
-          "keyspaceName must be provided", Response.Status.BAD_REQUEST);
-    }
-    if (isStringEmpty(tableName)) {
-      throw new WebApplicationException("table name must be provided", Response.Status.BAD_REQUEST);
-    }
+    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     if (isStringEmpty(columnName)) {
       throw new WebApplicationException("columnName must be provided", Response.Status.BAD_REQUEST);
     }

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2KeyspacesResourceApi.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2KeyspacesResourceApi.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.restsvc.resources.schemas;
+
+import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.stargate.proto.StargateGrpc;
+import io.stargate.sgv2.restsvc.models.RestServiceError;
+import io.stargate.sgv2.restsvc.models.Sgv2Keyspace;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Api(
+    produces = MediaType.APPLICATION_JSON,
+    consumes = MediaType.APPLICATION_JSON,
+    tags = {"schemas"})
+@ApiImplicitParams({
+  @ApiImplicitParam(
+      name = "X-Cassandra-Token",
+      paramType = "header",
+      value = "The token returned from the authorization endpoint. Use this token in each request.",
+      required = true)
+})
+public interface Sgv2KeyspacesResourceApi {
+  @Timed
+  @GET
+  @ApiOperation(
+      value = "Get all keyspaces",
+      notes = "Retrieve all available keyspaces.",
+      response = Sgv2Keyspace.class,
+      responseContainer = "List")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 200, message = "OK", response = Sgv2Keyspace.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = RestServiceError.class),
+        @ApiResponse(
+            code = 500,
+            message = "Internal server error",
+            response = RestServiceError.class)
+      })
+  Response getAllKeyspaces(
+      @Context StargateGrpc.StargateBlockingStub blockingStub,
+      @ApiParam(value = "Unwrap results", defaultValue = "false") @QueryParam("raw")
+          final boolean raw,
+      @Context HttpServletRequest request);
+
+  @Timed
+  @GET
+  @ApiOperation(
+      value = "Get a keyspace",
+      notes = "Return a single keyspace specification.",
+      response = Sgv2Keyspace.class)
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 200, message = "OK", response = Sgv2Keyspace.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = RestServiceError.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = RestServiceError.class),
+        @ApiResponse(code = 404, message = "Not Found", response = RestServiceError.class),
+        @ApiResponse(
+            code = 500,
+            message = "Internal server error",
+            response = RestServiceError.class)
+      })
+  @Path("/{keyspaceName}")
+  Response getOneKeyspace(
+      @Context StargateGrpc.StargateBlockingStub blockingStub,
+      @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
+          @PathParam("keyspaceName")
+          final String keyspaceName,
+      @ApiParam(value = "Unwrap results", defaultValue = "false") @QueryParam("raw")
+          final boolean raw,
+      @Context HttpServletRequest request);
+
+  @Timed
+  @POST
+  @ApiOperation(
+      value = "Create a keyspace",
+      notes = "Create a new keyspace.",
+      response = Map.class,
+      code = 201)
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 201, message = "Created", response = Map.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = RestServiceError.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = RestServiceError.class),
+        @ApiResponse(code = 409, message = "Conflict", response = RestServiceError.class),
+        @ApiResponse(
+            code = 500,
+            message = "Internal server error",
+            response = RestServiceError.class)
+      })
+  Response createKeyspace(
+      @Context StargateGrpc.StargateBlockingStub blockingStub,
+      @ApiParam(
+              value =
+                  "A map representing a keyspace with SimpleStrategy or NetworkTopologyStrategy with default replicas of 1 and 3 respectively \n"
+                      + "Simple:\n"
+                      + "```json\n"
+                      + "{ \"name\": \"killrvideo\", \"replicas\": 1}\n"
+                      + "````\n"
+                      + "Network Topology:\n"
+                      + "```json\n"
+                      + "{\n"
+                      + "  \"name\": \"killrvideo\",\n"
+                      + "   \"datacenters\":\n"
+                      + "      [\n"
+                      + "         { \"name\": \"dc1\", \"replicas\": 3 },\n"
+                      + "         { \"name\": \"dc2\", \"replicas\": 3 },\n"
+                      + "      ],\n"
+                      + "}\n"
+                      + "```")
+          JsonNode payload,
+      @Context HttpServletRequest request);
+
+  @Timed
+  @DELETE
+  @ApiOperation(value = "Delete a keyspace", notes = "Delete a single keyspace.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 204, message = "No Content"),
+        @ApiResponse(code = 401, message = "Unauthorized", response = RestServiceError.class),
+        @ApiResponse(
+            code = 500,
+            message = "Internal server error",
+            response = RestServiceError.class)
+      })
+  @Path("/{keyspaceName}")
+  Response deleteKeyspace(
+      @Context StargateGrpc.StargateBlockingStub blockingStub,
+      @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
+          @PathParam("keyspaceName")
+          final String keyspaceName,
+      @Context HttpServletRequest request);
+}

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2KeyspacesResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2KeyspacesResourceImpl.java
@@ -15,7 +15,6 @@
  */
 package io.stargate.sgv2.restsvc.resources.schemas;
 
-import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -27,18 +26,10 @@ import io.stargate.sgv2.common.cql.builder.QueryBuilder;
 import io.stargate.sgv2.common.cql.builder.Replication;
 import io.stargate.sgv2.restsvc.grpc.BridgeProtoValueConverters;
 import io.stargate.sgv2.restsvc.grpc.FromProtoConverter;
-import io.stargate.sgv2.restsvc.models.RestServiceError;
 import io.stargate.sgv2.restsvc.models.Sgv2Keyspace;
 import io.stargate.sgv2.restsvc.models.Sgv2RESTResponse;
 import io.stargate.sgv2.restsvc.resources.CreateGrpcStub;
 import io.stargate.sgv2.restsvc.resources.ResourceBase;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -46,39 +37,20 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Api(
-    produces = MediaType.APPLICATION_JSON,
-    consumes = MediaType.APPLICATION_JSON,
-    tags = {"schemas"})
-@ApiImplicitParams({
-  @ApiImplicitParam(
-      name = "X-Cassandra-Token",
-      paramType = "header",
-      value = "The token returned from the authorization endpoint. Use this token in each request.",
-      required = true)
-})
 @Path("/v2/schemas/keyspaces")
 @Produces(MediaType.APPLICATION_JSON)
 @Singleton
 @CreateGrpcStub
-public class Sgv2KeyspacesResource extends ResourceBase {
-  private static final String DC_META_ENTRY_CLASS = "class";
-
+public class Sgv2KeyspacesResourceImpl extends ResourceBase implements Sgv2KeyspacesResourceApi {
   // Singleton resource so no need to be static
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -86,27 +58,11 @@ public class Sgv2KeyspacesResource extends ResourceBase {
 
   private static final SchemaBuilderHelper schemaBuilder = new SchemaBuilderHelper(JSON_MAPPER);
 
-  @Timed
-  @GET
-  @ApiOperation(
-      value = "Get all keyspaces",
-      notes = "Retrieve all available keyspaces.",
-      response = Sgv2Keyspace.class,
-      responseContainer = "List")
-  @ApiResponses(
-      value = {
-        @ApiResponse(code = 200, message = "OK", response = Sgv2Keyspace.class),
-        @ApiResponse(code = 401, message = "Unauthorized", response = RestServiceError.class),
-        @ApiResponse(
-            code = 500,
-            message = "Internal server error",
-            response = RestServiceError.class)
-      })
+  @Override
   public Response getAllKeyspaces(
-      @Context StargateGrpc.StargateBlockingStub blockingStub,
-      @ApiParam(value = "Unwrap results", defaultValue = "false") @QueryParam("raw")
-          final boolean raw,
-      @Context HttpServletRequest request) {
+      final StargateGrpc.StargateBlockingStub blockingStub,
+      final boolean raw,
+      final HttpServletRequest request) {
     QueryOuterClass.QueryParameters.Builder paramsB = QueryOuterClass.QueryParameters.newBuilder();
 
     String cql =
@@ -116,8 +72,6 @@ public class Sgv2KeyspacesResource extends ResourceBase {
             .column("replication")
             .from("system_schema", "keyspaces")
             .build();
-
-    logger.info("getAllKeyspaces, cql = " + cql);
 
     QueryOuterClass.Query query =
         QueryOuterClass.Query.newBuilder().setParameters(paramsB.build()).setCql(cql).build();
@@ -134,32 +88,12 @@ public class Sgv2KeyspacesResource extends ResourceBase {
     return Response.status(Status.OK).entity(payload).build();
   }
 
-  @Timed
-  @GET
-  @ApiOperation(
-      value = "Get a keyspace",
-      notes = "Return a single keyspace specification.",
-      response = Sgv2Keyspace.class)
-  @ApiResponses(
-      value = {
-        @ApiResponse(code = 200, message = "OK", response = Sgv2Keyspace.class),
-        @ApiResponse(code = 400, message = "Bad Request", response = RestServiceError.class),
-        @ApiResponse(code = 401, message = "Unauthorized", response = RestServiceError.class),
-        @ApiResponse(code = 404, message = "Not Found", response = RestServiceError.class),
-        @ApiResponse(
-            code = 500,
-            message = "Internal server error",
-            response = RestServiceError.class)
-      })
-  @Path("/{keyspaceName}")
+  @Override
   public Response getOneKeyspace(
-      @Context StargateGrpc.StargateBlockingStub blockingStub,
-      @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
-          @PathParam("keyspaceName")
-          final String keyspaceName,
-      @ApiParam(value = "Unwrap results", defaultValue = "false") @QueryParam("raw")
-          final boolean raw,
-      @Context HttpServletRequest request) {
+      final StargateGrpc.StargateBlockingStub blockingStub,
+      final String keyspaceName,
+      final boolean raw,
+      final HttpServletRequest request) {
     QueryOuterClass.QueryParameters.Builder paramsB = QueryOuterClass.QueryParameters.newBuilder();
 
     String cql =
@@ -189,46 +123,11 @@ public class Sgv2KeyspacesResource extends ResourceBase {
     return Response.status(Status.OK).entity(payload).build();
   }
 
-  @Timed
-  @POST
-  @ApiOperation(
-      value = "Create a keyspace",
-      notes = "Create a new keyspace.",
-      response = Map.class,
-      code = 201)
-  @ApiResponses(
-      value = {
-        @ApiResponse(code = 201, message = "Created", response = Map.class),
-        @ApiResponse(code = 400, message = "Bad Request", response = RestServiceError.class),
-        @ApiResponse(code = 401, message = "Unauthorized", response = RestServiceError.class),
-        @ApiResponse(code = 409, message = "Conflict", response = RestServiceError.class),
-        @ApiResponse(
-            code = 500,
-            message = "Internal server error",
-            response = RestServiceError.class)
-      })
+  @Override
   public Response createKeyspace(
-      @Context StargateGrpc.StargateBlockingStub blockingStub,
-      @ApiParam(
-              value =
-                  "A map representing a keyspace with SimpleStrategy or NetworkTopologyStrategy with default replicas of 1 and 3 respectively \n"
-                      + "Simple:\n"
-                      + "```json\n"
-                      + "{ \"name\": \"killrvideo\", \"replicas\": 1}\n"
-                      + "````\n"
-                      + "Network Topology:\n"
-                      + "```json\n"
-                      + "{\n"
-                      + "  \"name\": \"killrvideo\",\n"
-                      + "   \"datacenters\":\n"
-                      + "      [\n"
-                      + "         { \"name\": \"dc1\", \"replicas\": 3 },\n"
-                      + "         { \"name\": \"dc2\", \"replicas\": 3 },\n"
-                      + "      ],\n"
-                      + "}\n"
-                      + "```")
-          JsonNode payload,
-      @Context HttpServletRequest request) {
+      final StargateGrpc.StargateBlockingStub blockingStub,
+      final JsonNode payload,
+      final HttpServletRequest request) {
     SchemaBuilderHelper.KeyspaceCreateDefinition ksCreateDef;
     try {
       ksCreateDef = schemaBuilder.readKeyspaceCreateDefinition(payload);
@@ -255,8 +154,6 @@ public class Sgv2KeyspacesResource extends ResourceBase {
               .build();
     }
 
-    logger.info("Sending CREATE KEYSPACE with cql: [" + cql + "]");
-
     QueryOuterClass.Query query = QueryOuterClass.Query.newBuilder().setCql(cql).build();
     QueryOuterClass.Response grpcResponse = blockingStub.executeQuery(query);
 
@@ -266,25 +163,11 @@ public class Sgv2KeyspacesResource extends ResourceBase {
     return Response.status(Status.CREATED).entity(responsePayload).build();
   }
 
-  @Timed
-  @DELETE
-  @ApiOperation(value = "Delete a keyspace", notes = "Delete a single keyspace.")
-  @ApiResponses(
-      value = {
-        @ApiResponse(code = 204, message = "No Content"),
-        @ApiResponse(code = 401, message = "Unauthorized", response = RestServiceError.class),
-        @ApiResponse(
-            code = 500,
-            message = "Internal server error",
-            response = RestServiceError.class)
-      })
-  @Path("/{keyspaceName}")
+  @Override
   public Response deleteKeyspace(
-      @Context StargateGrpc.StargateBlockingStub blockingStub,
-      @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
-          @PathParam("keyspaceName")
-          final String keyspaceName,
-      @Context HttpServletRequest request) {
+      final StargateGrpc.StargateBlockingStub blockingStub,
+      final String keyspaceName,
+      final HttpServletRequest request) {
     String cql = new QueryBuilder().drop().keyspace(keyspaceName).ifExists().build();
     QueryOuterClass.Query query = QueryOuterClass.Query.newBuilder().setCql(cql).build();
     /*QueryOuterClass.Response grpcResponse =*/ blockingStub.executeQuery(query);
@@ -332,7 +215,7 @@ public class Sgv2KeyspacesResource extends ResourceBase {
       final String dcName = entry.getKey();
       // Datacenters are exposed as Map/Object entries from key to replica count,
       // plus at least one meta-entry ("class") for replication strategy
-      if (DC_META_ENTRY_CLASS.equals(dcName)) {
+      if ("class".equals(dcName)) {
         continue;
       }
       ks.addDatacenter(dcName, entry.getValue().asInt(0));

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2TablesResourceApi.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2TablesResourceApi.java
@@ -1,0 +1,177 @@
+package io.stargate.sgv2.restsvc.resources.schemas;
+
+import com.codahale.metrics.annotation.Timed;
+import io.stargate.proto.StargateGrpc;
+import io.stargate.sgv2.restsvc.models.RestServiceError;
+import io.stargate.sgv2.restsvc.models.Sgv2Table;
+import io.stargate.sgv2.restsvc.models.Sgv2TableAddRequest;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Api(
+    produces = MediaType.APPLICATION_JSON,
+    consumes = MediaType.APPLICATION_JSON,
+    tags = {"schemas"})
+@ApiImplicitParams({
+  @ApiImplicitParam(
+      name = "X-Cassandra-Token",
+      paramType = "header",
+      value = "The token returned from the authorization endpoint. Use this token in each request.",
+      required = true)
+})
+public interface Sgv2TablesResourceApi {
+  @Timed
+  @GET
+  @ApiOperation(
+      value = "Get all tables",
+      notes = "Retrieve all tables in a specific keyspace.",
+      response = Sgv2Table.class,
+      responseContainer = "List")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 200, message = "OK", response = Sgv2Table.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = RestServiceError.class),
+        @ApiResponse(code = 404, message = "Not Found", response = RestServiceError.class),
+        @ApiResponse(
+            code = 500,
+            message = "Internal server error",
+            response = RestServiceError.class)
+      })
+  Response getAllTables(
+      @Context StargateGrpc.StargateBlockingStub blockingStub,
+      @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
+          @PathParam("keyspaceName")
+          final String keyspaceName,
+      @ApiParam(value = "Unwrap results", defaultValue = "false") @QueryParam("raw")
+          final boolean raw,
+      @Context HttpServletRequest request);
+
+  @Timed
+  @GET
+  @ApiOperation(
+      value = "Get a table",
+      notes = "Retrieve data for a single table in a specific keyspace.",
+      response = Sgv2Table.class)
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 200, message = "OK", response = Sgv2Table.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = RestServiceError.class),
+        @ApiResponse(code = 404, message = "Not Found", response = RestServiceError.class),
+        @ApiResponse(
+            code = 500,
+            message = "Internal server error",
+            response = RestServiceError.class)
+      })
+  @Path("/{tableName}")
+  Response getOneTable(
+      @Context StargateGrpc.StargateBlockingStub blockingStub,
+      @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
+          @PathParam("keyspaceName")
+          final String keyspaceName,
+      @ApiParam(value = "Name of the table to use for the request.", required = true)
+          @PathParam("tableName")
+          final String tableName,
+      @ApiParam(value = "Unwrap results", defaultValue = "false") @QueryParam("raw")
+          final boolean raw,
+      @Context HttpServletRequest request);
+
+  @Timed
+  @POST
+  @ApiOperation(
+      value = "Create a table",
+      notes = "Add a table in a specific keyspace.",
+      response = Map.class,
+      code = 201)
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 201, message = "Created", response = Map.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = RestServiceError.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = RestServiceError.class),
+        @ApiResponse(code = 409, message = "Conflict", response = RestServiceError.class),
+        @ApiResponse(
+            code = 500,
+            message = "Internal server error",
+            response = RestServiceError.class)
+      })
+  Response createTable(
+      @Context StargateGrpc.StargateBlockingStub blockingStub,
+      @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
+          @PathParam("keyspaceName")
+          final String keyspaceName,
+      @ApiParam(required = true) @NotNull final Sgv2TableAddRequest tableAdd,
+      @Context HttpServletRequest request);
+
+  @Timed
+  @PUT
+  @ApiOperation(
+      value = "Replace a table definition",
+      notes = "Update a single table definition, except for columns, in a keyspace.",
+      response = Map.class)
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 200, message = "resource updated", response = Map.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = RestServiceError.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = RestServiceError.class),
+        @ApiResponse(code = 404, message = "Not Found", response = RestServiceError.class),
+        @ApiResponse(code = 409, message = "Conflict", response = RestServiceError.class),
+        @ApiResponse(
+            code = 500,
+            message = "Internal server error",
+            response = RestServiceError.class)
+      })
+  @Path("/{tableName}")
+  Response updateTable(
+      @Context StargateGrpc.StargateBlockingStub blockingStub,
+      @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
+          @PathParam("keyspaceName")
+          final String keyspaceName,
+      @ApiParam(value = "Name of the table to use for the request.", required = true)
+          @PathParam("tableName")
+          final String tableName,
+      @ApiParam(value = "table name", required = true) @NotNull
+          final Sgv2TableAddRequest tableUpdate,
+      @Context HttpServletRequest request);
+
+  @Timed
+  @DELETE
+  @ApiOperation(
+      value = "Delete a table",
+      notes = "Delete a single table in the specified keyspace.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 204, message = "No Content"),
+        @ApiResponse(code = 401, message = "Unauthorized", response = RestServiceError.class),
+        @ApiResponse(
+            code = 500,
+            message = "Internal server error",
+            response = RestServiceError.class)
+      })
+  @Path("/{tableName}")
+  Response deleteTable(
+      @Context StargateGrpc.StargateBlockingStub blockingStub,
+      @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
+          @PathParam("keyspaceName")
+          final String keyspaceName,
+      @ApiParam(value = "Name of the table to use for the request.", required = true)
+          @PathParam("tableName")
+          final String tableName,
+      @Context HttpServletRequest request);
+}


### PR DESCRIPTION
**What this PR does**:

Refactors SGv2 `TablesResource`, `KeyspacesResource` to have api/impl division similar to other resources.

**Which issue(s) this PR fixes**:
Fixes #1483

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated -- uses existing IT tests to verify against regression
- [ ] Documentation added/updated
