### PR TITLE
write documents with the new shredding and writer

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/ReactiveDocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/ReactiveDocumentResourceV2.java
@@ -3,6 +3,7 @@ package io.stargate.web.docsapi.resources;
 import static io.stargate.web.docsapi.resources.RequestToHeadersMapper.getAllHeaders;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.functions.Function;
 import io.stargate.auth.UnauthorizedException;
@@ -27,9 +28,13 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.ResponseHeader;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -42,6 +47,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -55,6 +61,8 @@ import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import org.glassfish.jersey.server.ManagedAsync;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Path("/v2/namespaces/{namespace-id: [a-zA-Z_0-9]+}")
 @Api(
@@ -64,6 +72,8 @@ import org.glassfish.jersey.server.ManagedAsync;
 @Produces(MediaType.APPLICATION_JSON)
 @Singleton
 public class ReactiveDocumentResourceV2 {
+
+  private static final Logger logger = LoggerFactory.getLogger(ReactiveDocumentResourceV2.class);
 
   private static final String WHERE_DESCRIPTION =
       "a JSON blob with search filters;"
@@ -75,6 +85,150 @@ public class ReactiveDocumentResourceV2 {
   @Inject private DocumentDBFactory dbFactory;
   @Inject private ReactiveDocumentService reactiveDocumentService;
   @Inject private DocsSchemaChecker schemaChecker;
+  @Inject private ObjectMapper objectMapper;
+
+  @POST
+  @ManagedAsync
+  @ApiOperation(
+      value = "Create a new document",
+      notes =
+          "Auto-generates an ID for the newly created document. Use \\ to escape periods, commas, and asterisks.",
+      code = 201)
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            code = 201,
+            message = "Created",
+            responseHeaders = @ResponseHeader(name = "Location"),
+            response = WriteDocResponse.class),
+        @ApiResponse(code = 400, message = "Bad request", response = ApiError.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = ApiError.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = ApiError.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = ApiError.class)
+      })
+  @Path("collections/{collection-id}")
+  @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_FORM_URLENCODED})
+  @Produces(MediaType.APPLICATION_JSON)
+  public void postDoc(
+      @Context HttpHeaders headers,
+      @Context UriInfo ui,
+      @ApiParam(
+              value =
+                  "The token returned from the authorization endpoint. Use this token in each request.",
+              required = true)
+          @HeaderParam("X-Cassandra-Token")
+          String authToken,
+      @ApiParam(value = "the namespace that the collection is in", required = true)
+          @PathParam("namespace-id")
+          String namespace,
+      @ApiParam(value = "the name of the collection", required = true) @PathParam("collection-id")
+          String collection,
+      @ApiParam(value = "The JSON document", required = true) String payload,
+      @ApiParam(
+              value = "Whether to include profiling information in the response (advanced)",
+              defaultValue = "false",
+              required = false)
+          @QueryParam("profile")
+          Boolean profile,
+      @Context HttpServletRequest request,
+      @Suspended AsyncResponse asyncResponse) {
+    // create table if needed, if not validate it's a doc table
+    Single.fromCallable(
+            () -> createOrValidateDbFromToken(authToken, request, namespace, collection))
+
+        // then generate id and create execution context
+        .flatMap(
+            db -> {
+              String documentId = UUID.randomUUID().toString();
+              ExecutionContext context = ExecutionContext.create(profile);
+
+              // and call the document service to fire write
+              return reactiveDocumentService
+                  .writeDocument(db, namespace, collection, documentId, payload, context)
+
+                  // map to response
+                  .map(
+                      result -> {
+                        String url =
+                            String.format(
+                                "/v2/namespaces/%s/collections/%s/%s",
+                                namespace, collection, documentId);
+                        String response = objectMapper.writeValueAsString(result);
+                        return Response.created(URI.create(url)).entity(response).build();
+                      });
+            })
+
+        // then subscribe
+        .safeSubscribe(
+            AsyncObserver.forResponseWithHandler(
+                asyncResponse, ErrorHandler.EXCEPTION_TO_RESPONSE));
+  }
+
+  @PUT
+  @ManagedAsync
+  @ApiOperation(value = "Create or update a document with the provided document-id")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 200, message = "OK", response = WriteDocResponse.class),
+        @ApiResponse(code = 400, message = "Bad request", response = ApiError.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = ApiError.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = ApiError.class),
+        @ApiResponse(code = 422, message = "Unprocessable entity", response = ApiError.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = ApiError.class)
+      })
+  @Path("collections/{collection-id}/{document-id}")
+  @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_FORM_URLENCODED})
+  @Produces(MediaType.APPLICATION_JSON)
+  public void putDoc(
+      @Context HttpHeaders headers,
+      @Context UriInfo ui,
+      @ApiParam(
+              value =
+                  "The token returned from the authorization endpoint. Use this token in each request.",
+              required = true)
+          @HeaderParam("X-Cassandra-Token")
+          String authToken,
+      @ApiParam(value = "the namespace that the collection is in", required = true)
+          @PathParam("namespace-id")
+          String namespace,
+      @ApiParam(value = "the name of the collection", required = true) @PathParam("collection-id")
+          String collection,
+      @ApiParam(value = "the name of the document", required = true) @PathParam("document-id")
+          String id,
+      @ApiParam(value = "The JSON document", required = true) String payload,
+      @ApiParam(
+              value = "Whether to include profiling information in the response (advanced)",
+              defaultValue = "false")
+          @QueryParam("profile")
+          Boolean profile,
+      @Context HttpServletRequest request,
+      @Suspended AsyncResponse asyncResponse) {
+    // create table if needed, if not validate it's a doc table
+    Single.fromCallable(
+            () -> createOrValidateDbFromToken(authToken, request, namespace, collection))
+
+        // then generate id and create execution context
+        .flatMap(
+            db -> {
+              ExecutionContext context = ExecutionContext.create(profile);
+
+              // and call the document service to fire write
+              return reactiveDocumentService
+                  .updateDocument(db, namespace, collection, id, payload, context)
+
+                  // map to response
+                  .map(
+                      result -> {
+                        String response = objectMapper.writeValueAsString(result);
+                        return Response.ok().entity(response).build();
+                      });
+            })
+
+        // then subscribe
+        .safeSubscribe(
+            AsyncObserver.forResponseWithHandler(
+                asyncResponse, ErrorHandler.EXCEPTION_TO_RESPONSE));
+  }
 
   @GET
   @ManagedAsync
@@ -424,14 +578,39 @@ public class ReactiveDocumentResourceV2 {
     return db;
   }
 
+  private DocumentDB createOrValidateDbFromToken(
+      String authToken, HttpServletRequest request, String namespace, String collection)
+      throws UnauthorizedException {
+    // get DB
+    Map<String, String> headers = getAllHeaders(request);
+    DocumentDB db = dbFactory.getDocDBForToken(authToken, headers);
+
+    // try to create
+    boolean created = db.maybeCreateTable(namespace, collection);
+
+    // after creating the table, it can take up to 2 seconds for permissions cache to be updated,
+    // but we can force the permissions re-fetch by logging in again.
+    if (created) {
+      // if created re-fetch
+      db = dbFactory.getDocDBForToken(authToken, headers);
+      db.maybeCreateTableIndexes(namespace, collection);
+    } else {
+      // if it was existing, simply validate
+      schemaChecker.checkValidity(namespace, collection, db);
+    }
+    return db;
+  }
+
   private Function<DocumentResponseWrapper<? extends JsonNode>, Response> rawDocumentHandler(
       Boolean raw) {
     return results -> {
+      String result;
       if (raw != null && raw) {
-        return Response.ok(results.getData()).build();
+        result = objectMapper.writeValueAsString(results.getData());
       } else {
-        return Response.ok(results).build();
+        result = objectMapper.writeValueAsString(results);
       }
+      return Response.ok(result).build();
     };
   }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/ReactiveDocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/ReactiveDocumentResourceV2.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -142,12 +141,11 @@ public class ReactiveDocumentResourceV2 {
         // then generate id and create execution context
         .flatMap(
             db -> {
-              String documentId = UUID.randomUUID().toString();
               ExecutionContext context = ExecutionContext.create(profile);
 
               // and call the document service to fire write
               return reactiveDocumentService
-                  .writeDocument(db, namespace, collection, documentId, payload, context)
+                  .writeDocument(db, namespace, collection, payload, context)
 
                   // map to response
                   .map(
@@ -155,7 +153,7 @@ public class ReactiveDocumentResourceV2 {
                         String url =
                             String.format(
                                 "/v2/namespaces/%s/collections/%s/%s",
-                                namespace, collection, documentId);
+                                namespace, collection, result.getDocumentId());
                         String response = objectMapper.writeValueAsString(result);
                         return Response.created(URI.create(url)).entity(response).build();
                       });

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/ReactiveDocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/ReactiveDocumentResourceV2.java
@@ -42,6 +42,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -123,7 +124,9 @@ public class ReactiveDocumentResourceV2 {
           String namespace,
       @ApiParam(value = "the name of the collection", required = true) @PathParam("collection-id")
           String collection,
-      @ApiParam(value = "The JSON document", required = true) String payload,
+      @ApiParam(value = "The JSON document", required = true)
+          @NotBlank(message = "payload must not be empty")
+          String payload,
       @ApiParam(
               value = "Whether to include profiling information in the response (advanced)",
               defaultValue = "false",
@@ -195,7 +198,9 @@ public class ReactiveDocumentResourceV2 {
           String collection,
       @ApiParam(value = "the name of the document", required = true) @PathParam("document-id")
           String id,
-      @ApiParam(value = "The JSON document", required = true) String payload,
+      @ApiParam(value = "The JSON document", required = true)
+          @NotBlank(message = "payload must not be empty")
+          String payload,
       @ApiParam(
               value = "Whether to include profiling information in the response (advanced)",
               defaultValue = "false")

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/ReactiveDocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/ReactiveDocumentResourceV2.java
@@ -108,7 +108,7 @@ public class ReactiveDocumentResourceV2 {
         @ApiResponse(code = 500, message = "Internal Server Error", response = ApiError.class)
       })
   @Path("collections/{collection-id}")
-  @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_FORM_URLENCODED})
+  @Consumes({MediaType.APPLICATION_JSON})
   @Produces(MediaType.APPLICATION_JSON)
   public void postDoc(
       @Context HttpHeaders headers,
@@ -180,7 +180,7 @@ public class ReactiveDocumentResourceV2 {
         @ApiResponse(code = 500, message = "Internal Server Error", response = ApiError.class)
       })
   @Path("collections/{collection-id}/{document-id}")
-  @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_FORM_URLENCODED})
+  @Consumes({MediaType.APPLICATION_JSON})
   @Produces(MediaType.APPLICATION_JSON)
   public void putDoc(
       @Context HttpHeaders headers,

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocsApiComponentsBinder.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocsApiComponentsBinder.java
@@ -3,6 +3,7 @@ package io.stargate.web.docsapi.service;
 import io.stargate.web.docsapi.service.query.DocumentSearchService;
 import io.stargate.web.docsapi.service.query.ExpressionParser;
 import io.stargate.web.docsapi.service.query.condition.ConditionParser;
+import io.stargate.web.docsapi.service.write.DocumentWriteService;
 import javax.inject.Singleton;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 
@@ -13,6 +14,7 @@ public class DocsApiComponentsBinder extends AbstractBinder {
 
     // services
     bindAsContract(JsonConverter.class).in(Singleton.class);
+    bindAsContract(JsonDocumentShredder.class).in(Singleton.class);
     bindAsContract(DocsShredder.class).in(Singleton.class);
     bindAsContract(DocsSchemaChecker.class).in(Singleton.class);
     bindAsContract(DocumentService.class).in(Singleton.class);
@@ -21,6 +23,7 @@ public class DocsApiComponentsBinder extends AbstractBinder {
     bindAsContract(ExpressionParser.class).in(Singleton.class);
     bindAsContract(ConditionParser.class).in(Singleton.class);
     bindAsContract(DocumentSearchService.class).in(Singleton.class);
+    bindAsContract(DocumentWriteService.class).in(Singleton.class);
     bindAsContract(ReactiveDocumentService.class).in(Singleton.class);
   }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
@@ -126,8 +126,7 @@ public class ReactiveDocumentService {
                   authenticationSubject, namespace, collection, Scope.MODIFY, SourceAPI.REST);
 
               // read the root
-              // TODO proper error mapping in case of failure
-              JsonNode root = objectMapper.readTree(payload);
+              JsonNode root = readPayload(payload);
 
               // check the schema
               checkSchemaFullDocument(db, namespace, collection, root);
@@ -168,8 +167,7 @@ public class ReactiveDocumentService {
                   authenticationSubject, namespace, collection, Scope.DELETE, SourceAPI.REST);
 
               // read the root
-              // TODO proper error mapping in case of failure
-              JsonNode root = objectMapper.readTree(payload);
+              JsonNode root = readPayload(payload);
 
               // check the schema
               checkSchemaFullDocument(db, namespace, collection, root);
@@ -201,6 +199,15 @@ public class ReactiveDocumentService {
         // TODO validate unchecked better?
         throw new RuntimeException(e);
       }
+    }
+  }
+
+  private JsonNode readPayload(String payload) throws JsonProcessingException {
+    try {
+      return objectMapper.readTree(payload);
+    } catch (JsonProcessingException e) {
+      throw new ErrorCodeRuntimeException(
+          ErrorCode.DOCS_API_INVALID_JSON_VALUE, "Malformed JSON object found during read.", e);
     }
   }
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
@@ -59,6 +59,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.ws.rs.core.PathSegment;
@@ -107,13 +108,24 @@ public class ReactiveDocumentService {
     this.configuration = configuration;
   }
 
+  /**
+   * Writes a document in the given namespace and collection using the randomly generated ID.
+   *
+   * @param db {@link DocumentDB} to write in
+   * @param namespace Namespace
+   * @param collection Collection name
+   * @param payload Document represented as JSON string
+   * @param context Execution content
+   * @return Document response wrapper containing the generated ID.
+   */
   public Single<DocumentResponseWrapper<Void>> writeDocument(
       DocumentDB db,
       String namespace,
       String collection,
-      String documentId,
       String payload,
       ExecutionContext context) {
+    // generate the document id
+    String documentId = UUID.randomUUID().toString();
 
     return Single.defer(
             () -> {
@@ -145,6 +157,18 @@ public class ReactiveDocumentService {
         .map(any -> new DocumentResponseWrapper<>(documentId, null, null, context.toProfile()));
   }
 
+  /**
+   * Updates a document with given ID in the given namespace and collection. Any previously existing
+   * document with the same ID will be overwritten.
+   *
+   * @param db {@link DocumentDB} to write in
+   * @param namespace Namespace
+   * @param collection Collection name
+   * @param documentId The ID of the document to update
+   * @param payload Document represented as JSON string
+   * @param context Execution content
+   * @return Document response wrapper containing the generated ID.
+   */
   public Single<DocumentResponseWrapper<Void>> updateDocument(
       DocumentDB db,
       String namespace,

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
@@ -25,12 +25,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
+import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.UnauthorizedException;
 import io.stargate.db.datastore.Row;
@@ -50,6 +52,7 @@ import io.stargate.web.docsapi.service.query.ExpressionParser;
 import io.stargate.web.docsapi.service.query.FilterExpression;
 import io.stargate.web.docsapi.service.query.FilterPath;
 import io.stargate.web.docsapi.service.util.DocsApiUtils;
+import io.stargate.web.docsapi.service.write.DocumentWriteService;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -70,8 +73,11 @@ public class ReactiveDocumentService {
 
   @Inject ExpressionParser expressionParser;
   @Inject DocumentSearchService searchService;
+  @Inject DocumentWriteService writeService;
   @Inject JsonConverter jsonConverter;
+  @Inject JsonSchemaHandler jsonSchemaHandler;
   @Inject DocsShredder docsShredder;
+  @Inject JsonDocumentShredder jsonDocumentShredder;
   @Inject ObjectMapper objectMapper;
   @Inject TimeSource timeSource;
   @Inject DocsApiConfiguration configuration;
@@ -81,18 +87,121 @@ public class ReactiveDocumentService {
   public ReactiveDocumentService(
       ExpressionParser expressionParser,
       DocumentSearchService searchService,
+      DocumentWriteService writeService,
       JsonConverter jsonConverter,
+      JsonSchemaHandler jsonSchemaHandler,
       DocsShredder docsShredder,
+      JsonDocumentShredder jsonDocumentShredder,
       ObjectMapper objectMapper,
       TimeSource timeSource,
       DocsApiConfiguration configuration) {
     this.expressionParser = expressionParser;
     this.searchService = searchService;
+    this.writeService = writeService;
     this.jsonConverter = jsonConverter;
+    this.jsonSchemaHandler = jsonSchemaHandler;
     this.docsShredder = docsShredder;
+    this.jsonDocumentShredder = jsonDocumentShredder;
     this.objectMapper = objectMapper;
     this.timeSource = timeSource;
     this.configuration = configuration;
+  }
+
+  public Single<DocumentResponseWrapper<Void>> writeDocument(
+      DocumentDB db,
+      String namespace,
+      String collection,
+      String documentId,
+      String payload,
+      ExecutionContext context) {
+
+    return Single.defer(
+            () -> {
+
+              // authentication for writing before anything
+              // we don't need the DELETE scope here
+              AuthorizationService authorizationService = db.getAuthorizationService();
+              AuthenticationSubject authenticationSubject = db.getAuthenticationSubject();
+              authorizationService.authorizeDataWrite(
+                  authenticationSubject, namespace, collection, Scope.MODIFY, SourceAPI.REST);
+
+              // read the root
+              // TODO proper error mapping in case of failure
+              JsonNode root = objectMapper.readTree(payload);
+
+              // check the schema
+              checkSchemaFullDocument(db, namespace, collection, root);
+
+              // shred rows
+              List<JsonShreddedRow> rows =
+                  jsonDocumentShredder.shred(root, Collections.emptyList());
+
+              // call write document
+              return writeService.writeDocument(
+                  db.getQueryExecutor().getDataStore(),
+                  namespace,
+                  collection,
+                  documentId,
+                  rows,
+                  db.treatBooleansAsNumeric(),
+                  context);
+            })
+        .map(any -> new DocumentResponseWrapper<>(documentId, null, null, context.toProfile()));
+  }
+
+  public Single<DocumentResponseWrapper<Void>> updateDocument(
+      DocumentDB db,
+      String namespace,
+      String collection,
+      String documentId,
+      String payload,
+      ExecutionContext context) {
+
+    return Single.defer(
+            () -> {
+              // authentication for writing before anything
+              AuthorizationService authorizationService = db.getAuthorizationService();
+              AuthenticationSubject authenticationSubject = db.getAuthenticationSubject();
+              authorizationService.authorizeDataWrite(
+                  authenticationSubject, namespace, collection, Scope.MODIFY, SourceAPI.REST);
+              authorizationService.authorizeDataWrite(
+                  authenticationSubject, namespace, collection, Scope.DELETE, SourceAPI.REST);
+
+              // read the root
+              // TODO proper error mapping in case of failure
+              JsonNode root = objectMapper.readTree(payload);
+
+              // check the schema
+              checkSchemaFullDocument(db, namespace, collection, root);
+
+              // shred rows
+              List<JsonShreddedRow> rows =
+                  jsonDocumentShredder.shred(root, Collections.emptyList());
+
+              // call write document
+              return writeService.updateDocument(
+                  db.getQueryExecutor().getDataStore(),
+                  namespace,
+                  collection,
+                  documentId,
+                  rows,
+                  db.treatBooleansAsNumeric(),
+                  context);
+            })
+        .map(any -> new DocumentResponseWrapper<>(documentId, null, null, context.toProfile()));
+  }
+
+  private void checkSchemaFullDocument(
+      DocumentDB db, String namespace, String collection, JsonNode root) {
+    JsonNode schema = jsonSchemaHandler.getCachedJsonSchema(db, namespace, collection);
+    if (null != schema) {
+      try {
+        jsonSchemaHandler.validate(schema, root);
+      } catch (ProcessingException e) {
+        // TODO validate unchecked better?
+        throw new RuntimeException(e);
+      }
+    }
   }
 
   /**

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/write/DocumentWriteService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/write/DocumentWriteService.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.web.docsapi.service.write;
+
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.core.SingleSource;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import io.stargate.db.datastore.DataStore;
+import io.stargate.db.datastore.ResultSet;
+import io.stargate.db.query.BoundQuery;
+import io.stargate.db.query.Query;
+import io.stargate.web.docsapi.service.DocsApiConfiguration;
+import io.stargate.web.docsapi.service.ExecutionContext;
+import io.stargate.web.docsapi.service.JsonShreddedRow;
+import io.stargate.web.docsapi.service.TimeSource;
+import io.stargate.web.docsapi.service.write.db.DeleteQueryBuilder;
+import io.stargate.web.docsapi.service.write.db.InsertQueryBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import javax.inject.Inject;
+import org.apache.cassandra.stargate.db.ConsistencyLevel;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DocumentWriteService {
+
+  private static final Logger logger = LoggerFactory.getLogger(DocumentWriteService.class);
+
+  private final TimeSource timeSource;
+  private final DocsApiConfiguration config;
+  private final InsertQueryBuilder insertQueryBuilder;
+  private final DeleteQueryBuilder deleteQueryBuilder;
+  private final Optional<Boolean> useLoggedBatches;
+
+  @Inject
+  public DocumentWriteService(TimeSource timeSource, DocsApiConfiguration config) {
+    this.timeSource = timeSource;
+    this.config = config;
+    this.insertQueryBuilder = new InsertQueryBuilder(config.getMaxDepth());
+    this.deleteQueryBuilder = new DeleteQueryBuilder();
+
+    // only set log batches if explicitly disabled
+    this.useLoggedBatches =
+        Optional.ofNullable(System.getProperty("stargate.document_use_logged_batches"))
+            .map(Boolean::parseBoolean)
+            .filter(use -> !use);
+  }
+
+  /**
+   * Writes a single document, without deleting the existing document with the same key. Please call
+   * this method only if you are sure that the document with given ID does not exist.
+   *
+   * @param dataStore {@link DataStore}
+   * @param keyspace Keyspace to store document in.
+   * @param collection Collection the document belongs to.
+   * @param documentId Document ID.
+   * @param rows Rows of this document.
+   * @param numericBooleans If numeric boolean should be stored.
+   * @param context Execution content for profiling.
+   * @return Single containing the {@link ResultSet} of the batch execution.
+   */
+  public Single<ResultSet> writeDocument(
+      DataStore dataStore,
+      String keyspace,
+      String collection,
+      String documentId,
+      List<JsonShreddedRow> rows,
+      boolean numericBooleans,
+      ExecutionContext context) {
+    // create and cache the insert query prepare
+    return prepareInsertDocumentRowQuery(dataStore, keyspace, collection)
+
+        // then map to the list of the bound queries
+        .observeOn(Schedulers.computation())
+        .map(
+            insertPrepared -> {
+              // take current timestamp for binding
+              long timestamp = timeSource.currentTimeMicros();
+
+              // create list of queries to send in batch
+              List<BoundQuery> queries = new ArrayList<>(rows.size());
+
+              // then all inserts
+              rows.forEach(
+                  row -> {
+                    BoundQuery query =
+                        insertQueryBuilder.bind(
+                            insertPrepared, documentId, row, timestamp, numericBooleans);
+                    queries.add(query);
+                  });
+
+              return queries;
+            })
+
+        // then execute batch
+        .flatMap(
+            boundQueries -> executeBatch(dataStore, boundQueries, context.nested("ASYNC INSERT")))
+
+        // move away from the data store thread
+        .observeOn(Schedulers.io());
+  }
+
+  /**
+   * Updates a single document, ensuring that existing document with the same key will be deleted
+   * first.
+   *
+   * @param dataStore {@link DataStore}
+   * @param keyspace Keyspace to store document in.
+   * @param collection Collection the document belongs to.
+   * @param documentId Document ID.
+   * @param rows Rows of this document.
+   * @param numericBooleans If numeric boolean should be stored.
+   * @param context Execution content for profiling.
+   * @return Single containing the {@link ResultSet} of the batch execution.
+   */
+  public Single<ResultSet> updateDocument(
+      DataStore dataStore,
+      String keyspace,
+      String collection,
+      String documentId,
+      List<JsonShreddedRow> rows,
+      boolean numericBooleans,
+      ExecutionContext context) {
+    // create and cache the remove query prepare
+    Single<? extends Query<? extends BoundQuery>> deleteQueryPrepare =
+        prepareDeleteDocumentQuery(dataStore, keyspace, collection);
+
+    // create and cache the insert query prepare
+    Single<? extends Query<? extends BoundQuery>> insertQueryPrepare =
+        prepareInsertDocumentRowQuery(dataStore, keyspace, collection);
+
+    // execute when both done
+    return Single.zip(deleteQueryPrepare, insertQueryPrepare, Pair::of)
+        .observeOn(Schedulers.computation())
+        .map(
+            pair -> {
+              // take current timestamp for binding
+              long timestamp = timeSource.currentTimeMicros();
+
+              // create list of queries to send in batch
+              List<BoundQuery> queries = new ArrayList<>(rows.size() + 1);
+
+              // add delete
+              BoundQuery deleteExistingQuery =
+                  deleteQueryBuilder.bind(pair.getLeft(), documentId, timestamp - 1);
+              queries.add(deleteExistingQuery);
+
+              // then all inserts
+              rows.forEach(
+                  row -> {
+                    BoundQuery query =
+                        insertQueryBuilder.bind(
+                            pair.getRight(), documentId, row, timestamp, numericBooleans);
+                    queries.add(query);
+                  });
+
+              return queries;
+            })
+        // then execute batch
+        .flatMap(
+            boundQueries -> executeBatch(dataStore, boundQueries, context.nested("ASYNC UPDATE")))
+
+        // move away from the data store thread
+        .observeOn(Schedulers.io());
+  }
+
+  // create and cache the remove query prepare
+  private Single<? extends Query<? extends BoundQuery>> prepareInsertDocumentRowQuery(
+      DataStore dataStore, String keyspace, String collection) {
+
+    return Single.fromCallable(
+            () -> insertQueryBuilder.buildQuery(dataStore::queryBuilder, keyspace, collection))
+        .flatMap(query -> Single.fromCompletionStage(dataStore.prepare(query)))
+        .cache();
+  }
+
+  // create and cache the insert query prepare
+  private Single<? extends Query<? extends BoundQuery>> prepareDeleteDocumentQuery(
+      DataStore dataStore, String keyspace, String collection) {
+
+    return Single.fromCallable(
+            () -> deleteQueryBuilder.buildQuery(dataStore::queryBuilder, keyspace, collection))
+        .flatMap(query -> Single.fromCompletionStage(dataStore.prepare(query)))
+        .cache();
+  }
+
+  // executes batch
+  private SingleSource<ResultSet> executeBatch(
+      DataStore dataStore, List<BoundQuery> boundQueries, ExecutionContext context) {
+
+    // trace queries in context
+    boundQueries.forEach(context::traceDeferredDml);
+
+    // then execute batch
+    boolean loggedBatch = useLoggedBatches.orElse(dataStore.supportsLoggedBatches());
+    CompletableFuture<ResultSet> future;
+    if (loggedBatch) {
+      future = dataStore.batch(boundQueries, ConsistencyLevel.LOCAL_QUORUM);
+    } else {
+      future = dataStore.unloggedBatch(boundQueries, ConsistencyLevel.LOCAL_QUORUM);
+    }
+
+    // return
+    return Single.fromCompletionStage(future);
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/write/db/DeleteQueryBuilder.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/write/db/DeleteQueryBuilder.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.web.docsapi.service.write.db;
+
+import io.stargate.db.query.BoundQuery;
+import io.stargate.db.query.Predicate;
+import io.stargate.db.query.Query;
+import io.stargate.db.query.builder.BuiltQuery;
+import io.stargate.db.query.builder.QueryBuilder;
+import io.stargate.web.docsapi.service.query.DocsApiConstants;
+import java.util.function.Supplier;
+
+public class DeleteQueryBuilder {
+
+  /** Constructs the query builder for deleting all document rows for a single document. */
+  public DeleteQueryBuilder() {}
+
+  /**
+   * Builds the query for deleting all rows for a document.
+   *
+   * @param queryBuilder Query builder
+   * @param keyspace keyspace
+   * @param table table
+   * @return BuiltQuery
+   */
+  public BuiltQuery<? extends BoundQuery> buildQuery(
+      Supplier<QueryBuilder> queryBuilder, String keyspace, String table) {
+    return queryBuilder
+        .get()
+        .delete()
+        .from(keyspace, table)
+        .timestamp()
+        .where(DocsApiConstants.KEY_COLUMN_NAME, Predicate.EQ)
+        .build();
+  }
+
+  /**
+   * Binds the query built with this query builder from supplied data.
+   *
+   * @param builtQuery Prepared query built by this query builder.
+   * @param documentId The document id the row is inserted for.
+   * @param timestamp Timestamp
+   * @param <E> generics param
+   * @return Bound query.
+   */
+  public <E extends Query<? extends BoundQuery>> BoundQuery bind(
+      E builtQuery, String documentId, long timestamp) {
+    return builtQuery.bind(timestamp, documentId);
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/write/db/InsertQueryBuilder.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/write/db/InsertQueryBuilder.java
@@ -37,7 +37,7 @@ public class InsertQueryBuilder {
   /**
    * Constructs the query builder for inserting document rows based on the defined max depth.
    *
-   * @param maxDepth Mac depth of the document storage
+   * @param maxDepth Max depth of the document storage
    */
   public InsertQueryBuilder(int maxDepth) {
     this.maxDepth = maxDepth;

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/write/db/InsertQueryBuilder.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/write/db/InsertQueryBuilder.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.web.docsapi.service.write.db;
+
+import io.stargate.db.query.BoundQuery;
+import io.stargate.db.query.Query;
+import io.stargate.db.query.builder.BuiltQuery;
+import io.stargate.db.query.builder.QueryBuilder;
+import io.stargate.db.query.builder.ValueModifier;
+import io.stargate.web.docsapi.service.JsonShreddedRow;
+import io.stargate.web.docsapi.service.query.DocsApiConstants;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class InsertQueryBuilder {
+
+  private final int maxDepth;
+  private final List<ValueModifier> insertValueModifiers;
+
+  /**
+   * Constructs the query builder for inserting document rows based on the defined max depth.
+   *
+   * @param maxDepth Mac depth of the document storage
+   */
+  public InsertQueryBuilder(int maxDepth) {
+    this.maxDepth = maxDepth;
+    insertValueModifiers =
+        Arrays.stream(DocsApiConstants.ALL_COLUMNS_NAMES.apply(maxDepth))
+            .map(ValueModifier::marker)
+            .collect(Collectors.toList());
+  }
+
+  /**
+   * Builds the query for inserting one row of a document data.
+   *
+   * @param queryBuilder Query builder
+   * @param keyspace keyspace
+   * @param table table
+   * @return BuiltQuery
+   */
+  public BuiltQuery<? extends BoundQuery> buildQuery(
+      Supplier<QueryBuilder> queryBuilder, String keyspace, String table) {
+    return queryBuilder
+        .get()
+        .insertInto(keyspace, table)
+        .value(insertValueModifiers)
+        .timestamp()
+        .build();
+  }
+
+  /**
+   * Binds the query built with this query builder from supplied data.
+   *
+   * @param builtQuery Prepared query built by this query builder.
+   * @param documentId The document id the row is inserted for.
+   * @param row {@link JsonShreddedRow} containing data for the row.
+   * @param timestamp Timestamp
+   * @param numericBooleans If number booleans should be used
+   * @param <E> generics param
+   * @return Bound query.
+   */
+  public <E extends Query<? extends BoundQuery>> BoundQuery bind(
+      E builtQuery,
+      String documentId,
+      JsonShreddedRow row,
+      long timestamp,
+      boolean numericBooleans) {
+    // sanity check
+    if (maxDepth != row.getMaxDepth()) {
+      String msg =
+          String.format(
+              "Row with max depth of %d, cannot be bound with the insert query builder created for max depth of %d",
+              row.getMaxDepth(), this.maxDepth);
+      throw new IllegalArgumentException(msg);
+    }
+
+    // respect the order in the DocsApiConstants.ALL_COLUMNS_NAMES
+    Object[] values = new Object[maxDepth + 6];
+    // key at index 0
+    values[0] = documentId;
+
+    // then the path, based on the max depth
+    List<String> path = row.getPath();
+    for (int i = 0; i < maxDepth; i++) {
+      if (i < path.size()) {
+        values[i + 1] = path.get(i);
+      } else {
+        values[i + 1] = "";
+      }
+    }
+
+    // rest at the end
+    values[maxDepth + 1] = row.getLeaf();
+    values[maxDepth + 2] = row.getStringValue();
+    values[maxDepth + 3] = row.getDoubleValue();
+    values[maxDepth + 4] = convertToBackendBooleanValue(row.getBooleanValue(), numericBooleans);
+
+    // respect the timestamp
+    values[maxDepth + 5] = timestamp;
+
+    return builtQuery.bind(values);
+  }
+
+  private Object convertToBackendBooleanValue(Boolean value, boolean numericBooleans) {
+    if (null == value) {
+      return null;
+    } else if (numericBooleans) {
+      return Boolean.TRUE.equals(value) ? 1 : 0;
+    }
+    return value;
+  }
+}

--- a/restapi/src/test/java/io/stargate/db/datastore/ValidatingDataStore.java
+++ b/restapi/src/test/java/io/stargate/db/datastore/ValidatingDataStore.java
@@ -302,7 +302,10 @@ public class ValidatingDataStore implements DataStore {
       }
 
       assertThat(this.batchType)
-          .withFailMessage("Query does not match the expected batch type.")
+          .withFailMessage(
+              String.format(
+                  "Query with pattern %s does not match the expected batch type %s.",
+                  cqlPattern, batchType))
           .isEqualTo(batchType);
 
       ValidatingPaginator paginator = ValidatingPaginator.of(pageSize, pagingState);

--- a/restapi/src/test/java/io/stargate/db/datastore/ValidatingDataStore.java
+++ b/restapi/src/test/java/io/stargate/db/datastore/ValidatingDataStore.java
@@ -118,6 +118,11 @@ public class ValidatingDataStore implements DataStore {
   @Override
   public CompletableFuture<ResultSet> execute(
       BoundQuery query, UnaryOperator<Parameters> parametersModifier) {
+    return executeInternal(query, parametersModifier, null);
+  }
+
+  private CompletableFuture<ResultSet> executeInternal(
+      BoundQuery query, UnaryOperator<Parameters> parametersModifier, BatchType batchType) {
     MD5Digest preparedId =
         query
             .source()
@@ -132,7 +137,7 @@ public class ValidatingDataStore implements DataStore {
     QueryExpectation expectation = prepared.bindValues(query.values());
 
     Parameters parameters = parametersModifier.apply(Parameters.defaults());
-    return expectation.execute(parameters);
+    return expectation.execute(parameters, batchType);
   }
 
   @Override
@@ -142,7 +147,7 @@ public class ValidatingDataStore implements DataStore {
       UnaryOperator<Parameters> parametersModifier) {
     CompletableFuture<ResultSet> last = null;
     for (BoundQuery query : queries) {
-      last = execute(query);
+      last = executeInternal(query, p -> p, batchType);
     }
 
     assertThat(last).isNotNull();
@@ -240,6 +245,7 @@ public class ValidatingDataStore implements DataStore {
     private final Pattern cqlPattern;
     private final Object[] params;
     private int pageSize = Integer.MAX_VALUE;
+    private BatchType batchType;
     private List<Map<String, Object>> rows;
 
     private QueryExpectation(Table table, String cqlRegEx, Object[] params) {
@@ -256,6 +262,11 @@ public class ValidatingDataStore implements DataStore {
 
     public QueryExpectation withPageSize(int pageSize) {
       this.pageSize = pageSize;
+      return this;
+    }
+
+    public QueryExpectation inBatch(BatchType batchType) {
+      this.batchType = batchType;
       return this;
     }
 
@@ -280,7 +291,7 @@ public class ValidatingDataStore implements DataStore {
       return matches(cql) && (params == null || Arrays.equals(params, values(values)));
     }
 
-    private CompletableFuture<ResultSet> execute(Parameters parameters) {
+    private CompletableFuture<ResultSet> execute(Parameters parameters, BatchType batchType) {
       Optional<ByteBuffer> pagingState = parameters.pagingState();
       int pageSize;
       if (this.pageSize < Integer.MAX_VALUE) {
@@ -289,6 +300,10 @@ public class ValidatingDataStore implements DataStore {
       } else {
         pageSize = parameters.pageSize().orElse(this.pageSize);
       }
+
+      assertThat(this.batchType)
+          .withFailMessage("Query does not match the expected batch type.")
+          .isEqualTo(batchType);
 
       ValidatingPaginator paginator = ValidatingPaginator.of(pageSize, pagingState);
 

--- a/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
@@ -50,24 +50,6 @@ public class DocumentResourceV2Test {
   }
 
   @Test
-  public void postDoc_success() throws JsonProcessingException {
-    HttpHeaders headers = mock(HttpHeaders.class);
-    when(headers.getHeaderString(anyString())).thenReturn("application/json");
-    UriInfo ui = mock(UriInfo.class);
-    String authToken = "auth_token";
-    String keyspace = "keyspace";
-    String collection = "collection";
-    String payload = "{}";
-
-    Response r =
-        documentResourceV2.postDoc(
-            headers, ui, authToken, keyspace, collection, payload, false, httpServletRequest);
-
-    assertThat(r.getStatus()).isEqualTo(201);
-    mapper.readTree((String) r.getEntity()).requiredAt("/documentId");
-  }
-
-  @Test
   public void postMultiDoc_success() throws JsonProcessingException {
     HttpHeaders headers = mock(HttpHeaders.class);
     when(headers.getHeaderString(anyString())).thenReturn("application/json");
@@ -83,25 +65,6 @@ public class DocumentResourceV2Test {
 
     assertThat(r.getStatus()).isEqualTo(202);
     mapper.readTree((String) r.getEntity()).requiredAt("/documentIds");
-  }
-
-  @Test
-  public void putDoc_success() throws JsonProcessingException {
-    HttpHeaders headers = mock(HttpHeaders.class);
-    when(headers.getHeaderString(anyString())).thenReturn("application/json");
-    UriInfo ui = mock(UriInfo.class);
-    String authToken = "auth_token";
-    String keyspace = "keyspace";
-    String collection = "collection";
-    String id = "id";
-    String payload = "{}";
-
-    Response r =
-        documentResourceV2.putDoc(
-            headers, ui, authToken, keyspace, collection, id, payload, false, httpServletRequest);
-
-    assertThat(r.getStatus()).isEqualTo(200);
-    mapper.readTree((String) r.getEntity()).requiredAt("/documentId");
   }
 
   @Test

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -531,39 +531,6 @@ public class DocumentServiceTest extends AbstractDataStoreTest {
     }
 
     @Test
-    void putDoc() throws JsonProcessingException {
-      when(headers.getHeaderString(eq(HttpHeaders.CONTENT_TYPE))).thenReturn("application/json");
-
-      String delete = "DELETE FROM test_docs.collection1 USING TIMESTAMP ? WHERE key = ?";
-      withQuery(table, delete, 199L, "id3").returningNothing();
-
-      now.set(200);
-      DocumentResponseWrapper<Object> r =
-          unwrap(
-              resource.putDoc(
-                  headers,
-                  uriInfo,
-                  authToken,
-                  keyspace.name(),
-                  table.name(),
-                  "id3",
-                  "{\"a\":123}",
-                  true,
-                  request));
-      assertThat(r.getProfile())
-          .isEqualTo(
-              ImmutableExecutionProfile.builder()
-                  .description("root")
-                  .addNested(
-                      ImmutableExecutionProfile.builder()
-                          .description("ASYNC INSERT")
-                          // row count for DELETE is not known
-                          .addQueries(QueryInfo.of(insert, 1, 1), QueryInfo.of(delete, 1, 0))
-                          .build())
-                  .build());
-    }
-
-    @Test
     void putManyDocs() throws JsonProcessingException {
       String delete = "DELETE FROM test_docs.collection1 USING TIMESTAMP ? WHERE key = ?";
       withQuery(table, delete, 199L, "123").returningNothing();

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/DocumentServiceTest.java
@@ -39,6 +39,7 @@ import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
 import io.stargate.auth.SourceAPI;
 import io.stargate.auth.UnauthorizedException;
+import io.stargate.db.BatchType;
 import io.stargate.db.datastore.AbstractDataStoreTest;
 import io.stargate.db.datastore.DataStoreFactory;
 import io.stargate.db.schema.Column;
@@ -271,14 +272,21 @@ public class DocumentServiceTest extends AbstractDataStoreTest {
 
   @Test
   void testPutAtPathRoot() throws UnauthorizedException, ProcessingException {
+    BatchType batchType =
+        datastore().supportsLoggedBatches() ? BatchType.LOGGED : BatchType.UNLOGGED;
+
     withQuery(table, "DELETE FROM %s USING TIMESTAMP ? WHERE key = ?", 99L, "id1")
+        .inBatch(batchType)
         .returningNothing();
 
     withQuery(table, insert, fillParams(70, "id1", "a", SEPARATOR, "a", null, 123.0d, null, 100L))
+        .inBatch(batchType)
         .returningNothing();
     withQuery(table, insert, fillParams(70, "id1", "b", SEPARATOR, "b", null, null, true, 100L))
+        .inBatch(batchType)
         .returningNothing();
     withQuery(table, insert, fillParams(70, "id1", "c", SEPARATOR, "c", "text", null, null, 100L))
+        .inBatch(batchType)
         .returningNothing();
     withQuery(
             table,
@@ -293,6 +301,7 @@ public class DocumentServiceTest extends AbstractDataStoreTest {
                 null,
                 null,
                 100L))
+        .inBatch(batchType)
         .returningNothing();
     withQuery(
             table,
@@ -307,13 +316,16 @@ public class DocumentServiceTest extends AbstractDataStoreTest {
                 null,
                 null,
                 100L))
+        .inBatch(batchType)
         .returningNothing();
     withQuery(table, insert, fillParams(70, "id1", "f", SEPARATOR, "f", null, null, null, 100L))
+        .inBatch(batchType)
         .returningNothing();
     withQuery(
             table,
             insert,
             fillParams(70, "id1", "g", "[000000]", "h", SEPARATOR, "h", null, 1.0d, null, 100L))
+        .inBatch(batchType)
         .returningNothing();
 
     now.set(100);
@@ -333,6 +345,9 @@ public class DocumentServiceTest extends AbstractDataStoreTest {
 
   @Test
   void testPutAtPathNested() throws UnauthorizedException, ProcessingException {
+    BatchType batchType =
+        datastore().supportsLoggedBatches() ? BatchType.LOGGED : BatchType.UNLOGGED;
+
     withQuery(
             table,
             "DELETE FROM test_docs.collection1 USING TIMESTAMP ? WHERE key = ? AND p0 = ? AND p1 = ? AND p2 = ?",
@@ -341,6 +356,7 @@ public class DocumentServiceTest extends AbstractDataStoreTest {
             "x",
             "y",
             "[000000]")
+        .inBatch(batchType)
         .returningNothing();
 
     String insert =
@@ -350,6 +366,7 @@ public class DocumentServiceTest extends AbstractDataStoreTest {
             insert,
             fillParams(
                 70, "id2", "x", "y", "[000000]", "a", SEPARATOR, "a", null, 123.0d, null, 200L))
+        .inBatch(batchType)
         .returningNothing();
 
     now.set(200);
@@ -369,9 +386,13 @@ public class DocumentServiceTest extends AbstractDataStoreTest {
 
   @Test
   void testPutAtPathPatch() throws UnauthorizedException, ProcessingException {
+    BatchType batchType =
+        datastore().supportsLoggedBatches() ? BatchType.LOGGED : BatchType.UNLOGGED;
+
     String insert =
         "INSERT INTO %s (key, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p30, p31, p32, p33, p34, p35, p36, p37, p38, p39, p40, p41, p42, p43, p44, p45, p46, p47, p48, p49, p50, p51, p52, p53, p54, p55, p56, p57, p58, p59, p60, p61, p62, p63, leaf, text_value, dbl_value, bool_value) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) USING TIMESTAMP ?";
     withQuery(table, insert, fillParams(70, "id3", "a", SEPARATOR, "a", null, 123.0d, null, 200L))
+        .inBatch(batchType)
         .returningNothing();
 
     withQuery(
@@ -381,6 +402,7 @@ public class DocumentServiceTest extends AbstractDataStoreTest {
             "id3",
             "[000000]",
             "[999999]")
+        .inBatch(batchType)
         .returningNothing();
     withQuery(
             table,
@@ -388,6 +410,7 @@ public class DocumentServiceTest extends AbstractDataStoreTest {
             199L,
             "id3",
             ImmutableList.of("a"))
+        .inBatch(batchType)
         .returningNothing();
 
     now.set(200);
@@ -443,12 +466,16 @@ public class DocumentServiceTest extends AbstractDataStoreTest {
 
   @Test
   void testWriteManyDocs() throws UnauthorizedException, IOException {
+    BatchType batchType =
+        datastore().supportsLoggedBatches() ? BatchType.LOGGED : BatchType.UNLOGGED;
     ByteArrayInputStream in =
         new ByteArrayInputStream("[{\"a\":\"b\"}]".getBytes(StandardCharsets.UTF_8));
     now.set(200);
     withQuery(table, "DELETE FROM %s USING TIMESTAMP ? WHERE key = ?", 199L, "b")
+        .inBatch(batchType)
         .returningNothing();
     withQuery(table, insert, fillParams(70, "b", "a", SEPARATOR, "a", "b", null, null, 200L))
+        .inBatch(batchType)
         .returningNothing();
     service.writeManyDocs(
         authToken,
@@ -495,6 +522,8 @@ public class DocumentServiceTest extends AbstractDataStoreTest {
 
     @BeforeEach
     void setQueryExpectations() {
+      BatchType batchType =
+          datastore().supportsLoggedBatches() ? BatchType.LOGGED : BatchType.UNLOGGED;
 
       withQuery(table, dblValueGtQuery, params("a", "c", "", 1.0))
           .returning(ImmutableList.of(leafRow(id1), leafRow(id2), leafRow(id3)));
@@ -519,6 +548,7 @@ public class DocumentServiceTest extends AbstractDataStoreTest {
                   row(id2, 5.0, "a", "b"), row(id2, 10.0, "a", "c"), row(id2, 5.0, "a", "d")));
 
       withQuery(table, insert, fillParams(70, id3, "a", SEPARATOR, "a", null, 123.0d, null, 200L))
+          .inBatch(batchType)
           .returningNothing();
     }
 
@@ -532,12 +562,17 @@ public class DocumentServiceTest extends AbstractDataStoreTest {
 
     @Test
     void putManyDocs() throws JsonProcessingException {
+      BatchType batchType =
+          datastore().supportsLoggedBatches() ? BatchType.LOGGED : BatchType.UNLOGGED;
+
       String delete = "DELETE FROM test_docs.collection1 USING TIMESTAMP ? WHERE key = ?";
-      withQuery(table, delete, 199L, "123").returningNothing();
-      withQuery(table, delete, 199L, "234").returningNothing();
+      withQuery(table, delete, 199L, "123").inBatch(batchType).returningNothing();
+      withQuery(table, delete, 199L, "234").inBatch(batchType).returningNothing();
       withQuery(table, insert, fillParams(70, "123", "a", SEPARATOR, "a", "123", null, null, 200L))
+          .inBatch(batchType)
           .returningNothing();
       withQuery(table, insert, fillParams(70, "234", "a", SEPARATOR, "a", "234", null, null, 200L))
+          .inBatch(batchType)
           .returningNothing();
 
       now.set(200);
@@ -568,14 +603,21 @@ public class DocumentServiceTest extends AbstractDataStoreTest {
 
     @Test
     void patchDoc() throws JsonProcessingException {
+      BatchType batchType =
+          datastore().supportsLoggedBatches() ? BatchType.LOGGED : BatchType.UNLOGGED;
+
       when(headers.getHeaderString(eq(HttpHeaders.CONTENT_TYPE))).thenReturn("application/json");
 
       String delete1 =
           "DELETE FROM test_docs.collection1 USING TIMESTAMP ? WHERE key = ? AND p0 >= ? AND p0 <= ?";
-      withQuery(table, delete1, 199L, "id3", "[000000]", "[999999]").returningNothing();
+      withQuery(table, delete1, 199L, "id3", "[000000]", "[999999]")
+          .inBatch(batchType)
+          .returningNothing();
       String delete2 =
           "DELETE FROM test_docs.collection1 USING TIMESTAMP ? WHERE key = ? AND p0 IN ?";
-      withQuery(table, delete2, 199L, "id3", ImmutableList.of("a")).returningNothing();
+      withQuery(table, delete2, 199L, "id3", ImmutableList.of("a"))
+          .inBatch(batchType)
+          .returningNothing();
 
       now.set(200);
       DocumentResponseWrapper<Object> r =

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/ReactiveDocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/ReactiveDocumentServiceTest.java
@@ -125,8 +125,11 @@ class ReactiveDocumentServiceTest {
         new ReactiveDocumentService(
             expressionParser,
             searchService,
+            null, // TODO
             jsonConverter,
+            null, // TODO
             docsShredder,
+            null, // TODO
             objectMapper,
             timeSource,
             config);

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/write/DocumentWriteServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/write/DocumentWriteServiceTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.web.docsapi.service.write;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.reactivex.rxjava3.core.Single;
+import io.stargate.db.BatchType;
+import io.stargate.db.datastore.AbstractDataStoreTest;
+import io.stargate.db.datastore.DataStore;
+import io.stargate.db.datastore.ResultSet;
+import io.stargate.db.datastore.ValidatingDataStore;
+import io.stargate.db.schema.Schema;
+import io.stargate.db.schema.Table;
+import io.stargate.web.docsapi.DocsApiTestSchemaProvider;
+import io.stargate.web.docsapi.service.DocsApiConfiguration;
+import io.stargate.web.docsapi.service.ExecutionContext;
+import io.stargate.web.docsapi.service.ImmutableJsonShreddedRow;
+import io.stargate.web.docsapi.service.JsonShreddedRow;
+import io.stargate.web.docsapi.service.TimeSource;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DocumentWriteServiceTest extends AbstractDataStoreTest {
+
+  private static final int MAX_DEPTH = 4;
+  private static final DocsApiTestSchemaProvider SCHEMA_PROVIDER =
+      new DocsApiTestSchemaProvider(MAX_DEPTH);
+  private static final Table TABLE = SCHEMA_PROVIDER.getTable();
+  private static final String KEYSPACE_NAME = SCHEMA_PROVIDER.getKeyspace().name();
+  private static final String COLLECTION_NAME = SCHEMA_PROVIDER.getTable().name();
+
+  DocumentWriteService service;
+
+  ExecutionContext context;
+
+  @Mock DocsApiConfiguration configuration;
+
+  @Mock TimeSource timeSource;
+
+  @Override
+  protected Schema schema() {
+    return SCHEMA_PROVIDER.getSchema();
+  }
+
+  @BeforeEach
+  public void init() {
+    when(configuration.getMaxDepth()).thenReturn(MAX_DEPTH);
+    context = ExecutionContext.create(true);
+    service = new DocumentWriteService(timeSource, configuration);
+  }
+
+  @Nested
+  class WriteDocument {
+
+    @Test
+    public void happyPath() throws Exception {
+      DataStore datastore = datastore();
+      BatchType batchType =
+          datastore.supportsLoggedBatches() ? BatchType.LOGGED : BatchType.UNLOGGED;
+      String documentId = RandomStringUtils.randomAlphanumeric(16);
+      JsonShreddedRow row1 =
+          ImmutableJsonShreddedRow.builder()
+              .maxDepth(MAX_DEPTH)
+              .addPath("key1")
+              .stringValue("value1")
+              .build();
+      JsonShreddedRow row2 =
+          ImmutableJsonShreddedRow.builder()
+              .maxDepth(MAX_DEPTH)
+              .addPath("key2")
+              .addPath("nested")
+              .doubleValue(2.2d)
+              .build();
+      List<JsonShreddedRow> rows = Arrays.asList(row1, row2);
+
+      long timestamp = RandomUtils.nextLong();
+      when(timeSource.currentTimeMicros()).thenReturn(timestamp);
+
+      String insertCql =
+          "INSERT INTO %s (key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) USING TIMESTAMP ?";
+      ValidatingDataStore.QueryAssert row1QueryAssert =
+          withQuery(
+                  SCHEMA_PROVIDER.getTable(),
+                  insertCql,
+                  documentId,
+                  "key1",
+                  "",
+                  "",
+                  "",
+                  "key1",
+                  "value1",
+                  null,
+                  null,
+                  timestamp)
+              .inBatch(batchType)
+              .returningNothing();
+      ValidatingDataStore.QueryAssert row2QueryAssert =
+          withQuery(
+                  SCHEMA_PROVIDER.getTable(),
+                  insertCql,
+                  documentId,
+                  "key2",
+                  "nested",
+                  "",
+                  "",
+                  "nested",
+                  null,
+                  2.2d,
+                  null,
+                  timestamp)
+              .inBatch(batchType)
+              .returningNothing();
+
+      Single<ResultSet> result =
+          service.writeDocument(
+              datastore, KEYSPACE_NAME, COLLECTION_NAME, documentId, rows, false, context);
+
+      result.test().await().assertValueCount(1).assertComplete();
+      row1QueryAssert.assertExecuteCount().isEqualTo(1);
+      row2QueryAssert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(context.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description()).isEqualTo("ASYNC INSERT");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.preparedCQL())
+                              .isEqualTo(
+                                  String.format(insertCql, KEYSPACE_NAME + "." + COLLECTION_NAME));
+                          assertThat(queryInfo.execCount()).isEqualTo(2);
+                          assertThat(queryInfo.rowCount()).isEqualTo(2);
+                        });
+              });
+    }
+  }
+
+  @Nested
+  class UpdateDocument {
+
+    @Test
+    public void happyPath() throws Exception {
+      DataStore datastore = datastore();
+      BatchType batchType =
+          datastore.supportsLoggedBatches() ? BatchType.LOGGED : BatchType.UNLOGGED;
+      String documentId = RandomStringUtils.randomAlphanumeric(16);
+      JsonShreddedRow row1 =
+          ImmutableJsonShreddedRow.builder()
+              .maxDepth(MAX_DEPTH)
+              .addPath("key1")
+              .stringValue("value1")
+              .build();
+      JsonShreddedRow row2 =
+          ImmutableJsonShreddedRow.builder()
+              .maxDepth(MAX_DEPTH)
+              .addPath("key2")
+              .addPath("nested")
+              .doubleValue(2.2d)
+              .build();
+      List<JsonShreddedRow> rows = Arrays.asList(row1, row2);
+
+      long timestamp = RandomUtils.nextLong();
+      when(timeSource.currentTimeMicros()).thenReturn(timestamp);
+
+      String insertCql =
+          "INSERT INTO %s (key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) USING TIMESTAMP ?";
+      ValidatingDataStore.QueryAssert row1QueryAssert =
+          withQuery(
+                  SCHEMA_PROVIDER.getTable(),
+                  insertCql,
+                  documentId,
+                  "key1",
+                  "",
+                  "",
+                  "",
+                  "key1",
+                  "value1",
+                  null,
+                  null,
+                  timestamp)
+              .inBatch(batchType)
+              .returningNothing();
+      ValidatingDataStore.QueryAssert row2QueryAssert =
+          withQuery(
+                  SCHEMA_PROVIDER.getTable(),
+                  insertCql,
+                  documentId,
+                  "key2",
+                  "nested",
+                  "",
+                  "",
+                  "nested",
+                  null,
+                  2.2d,
+                  null,
+                  timestamp)
+              .inBatch(batchType)
+              .returningNothing();
+
+      String deleteCql = "DELETE FROM %s USING TIMESTAMP ? WHERE key = ?";
+      ValidatingDataStore.QueryAssert deleteQueryAssert =
+          withQuery(SCHEMA_PROVIDER.getTable(), deleteCql, timestamp - 1, documentId)
+              .inBatch(batchType)
+              .returningNothing();
+
+      Single<ResultSet> result =
+          service.updateDocument(
+              datastore, KEYSPACE_NAME, COLLECTION_NAME, documentId, rows, false, context);
+
+      result.test().await().assertValueCount(1).assertComplete();
+      row1QueryAssert.assertExecuteCount().isEqualTo(1);
+      row2QueryAssert.assertExecuteCount().isEqualTo(1);
+      deleteQueryAssert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(context.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description()).isEqualTo("ASYNC UPDATE");
+                assertThat(nested.queries())
+                    .hasSize(2)
+                    .anySatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.preparedCQL())
+                              .isEqualTo(
+                                  String.format(deleteCql, KEYSPACE_NAME + "." + COLLECTION_NAME));
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(0);
+                        })
+                    .anySatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.preparedCQL())
+                              .isEqualTo(
+                                  String.format(insertCql, KEYSPACE_NAME + "." + COLLECTION_NAME));
+                          assertThat(queryInfo.execCount()).isEqualTo(2);
+                          assertThat(queryInfo.rowCount()).isEqualTo(2);
+                        });
+              });
+    }
+  }
+}

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/write/db/DeleteQueryBuilderTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/write/db/DeleteQueryBuilderTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.web.docsapi.service.write.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.stargate.db.datastore.AbstractDataStoreTest;
+import io.stargate.db.datastore.DataStore;
+import io.stargate.db.query.BoundQuery;
+import io.stargate.db.query.Query;
+import io.stargate.db.query.builder.BuiltQuery;
+import io.stargate.db.schema.Schema;
+import io.stargate.web.docsapi.DocsApiTestSchemaProvider;
+import java.util.concurrent.CompletableFuture;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class DeleteQueryBuilderTest extends AbstractDataStoreTest {
+
+  private static final DocsApiTestSchemaProvider SCHEMA_PROVIDER = new DocsApiTestSchemaProvider(0);
+  private static final String KEYSPACE_NAME = SCHEMA_PROVIDER.getKeyspace().name();
+  private static final String COLLECTION_NAME = SCHEMA_PROVIDER.getTable().name();
+
+  @Override
+  protected Schema schema() {
+    return SCHEMA_PROVIDER.getSchema();
+  }
+
+  @Nested
+  class BuildQuery {
+
+    @Test
+    public void happyPath() {
+      DeleteQueryBuilder queryBuilder = new DeleteQueryBuilder();
+
+      BuiltQuery<? extends BoundQuery> query =
+          queryBuilder.buildQuery(datastore()::queryBuilder, KEYSPACE_NAME, COLLECTION_NAME);
+
+      String expected =
+          String.format(
+              "DELETE FROM %s.%s USING TIMESTAMP ? WHERE key = ?", KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.toString()).isEqualTo(expected);
+    }
+  }
+
+  @Nested
+  class Bind {
+
+    @Test
+    public void happyPath() {
+      DataStore datastore = datastore();
+      DeleteQueryBuilder queryBuilder = new DeleteQueryBuilder();
+      BuiltQuery<? extends BoundQuery> query =
+          queryBuilder.buildQuery(datastore::queryBuilder, KEYSPACE_NAME, COLLECTION_NAME);
+
+      long timestamp = RandomUtils.nextLong();
+      String documentId = RandomStringUtils.randomAlphanumeric(16);
+
+      withQuery(
+              SCHEMA_PROVIDER.getTable(),
+              "DELETE FROM %s USING TIMESTAMP ? WHERE key = ?",
+              new Object[] {timestamp, documentId})
+          .returningNothing();
+
+      CompletableFuture<? extends Query<? extends BoundQuery>> prepareFuture =
+          datastore.prepare(query);
+      BoundQuery boundQuery = queryBuilder.bind(prepareFuture.join(), documentId, timestamp);
+      datastore.execute(boundQuery);
+    }
+  }
+}

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/write/db/InsertQueryBuilderTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/write/db/InsertQueryBuilderTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.web.docsapi.service.write.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import io.stargate.db.datastore.AbstractDataStoreTest;
+import io.stargate.db.datastore.DataStore;
+import io.stargate.db.query.BoundQuery;
+import io.stargate.db.query.Query;
+import io.stargate.db.query.builder.BuiltQuery;
+import io.stargate.db.schema.Schema;
+import io.stargate.web.docsapi.DocsApiTestSchemaProvider;
+import io.stargate.web.docsapi.service.ImmutableJsonShreddedRow;
+import io.stargate.web.docsapi.service.JsonShreddedRow;
+import java.util.concurrent.CompletableFuture;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class InsertQueryBuilderTest extends AbstractDataStoreTest {
+
+  private static final int MAX_DEPTH = 8;
+  private static final DocsApiTestSchemaProvider SCHEMA_PROVIDER =
+      new DocsApiTestSchemaProvider(MAX_DEPTH);
+  private static final String KEYSPACE_NAME = SCHEMA_PROVIDER.getKeyspace().name();
+  private static final String COLLECTION_NAME = SCHEMA_PROVIDER.getTable().name();
+
+  @Override
+  protected Schema schema() {
+    return SCHEMA_PROVIDER.getSchema();
+  }
+
+  @Nested
+  class BuildQuery {
+
+    @Test
+    public void happyPath() {
+      InsertQueryBuilder queryBuilder = new InsertQueryBuilder(MAX_DEPTH);
+
+      BuiltQuery<? extends BoundQuery> query =
+          queryBuilder.buildQuery(datastore()::queryBuilder, KEYSPACE_NAME, COLLECTION_NAME);
+
+      String expected =
+          String.format(
+              "INSERT INTO %s.%s (key, p0, p1, p2, p3, p4, p5, p6, p7, leaf, text_value, dbl_value, bool_value) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) USING TIMESTAMP ?",
+              KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.toString()).isEqualTo(expected);
+    }
+  }
+
+  @Nested
+  class Bind {
+
+    @Test
+    public void stringValue() {
+      DataStore datastore = datastore();
+      InsertQueryBuilder queryBuilder = new InsertQueryBuilder(MAX_DEPTH);
+      BuiltQuery<? extends BoundQuery> query =
+          queryBuilder.buildQuery(datastore::queryBuilder, KEYSPACE_NAME, COLLECTION_NAME);
+
+      long timestamp = RandomUtils.nextLong();
+      String documentId = RandomStringUtils.randomAlphanumeric(16);
+      String value = RandomStringUtils.randomAlphanumeric(16);
+      JsonShreddedRow row =
+          ImmutableJsonShreddedRow.builder()
+              .maxDepth(MAX_DEPTH)
+              .addPath("first")
+              .addPath("second")
+              .stringValue(value)
+              .build();
+
+      withQuery(
+              SCHEMA_PROVIDER.getTable(),
+              "INSERT INTO %s (key, p0, p1, p2, p3, p4, p5, p6, p7, leaf, text_value, dbl_value, bool_value) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) USING TIMESTAMP ?",
+              documentId,
+              "first",
+              "second",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "second",
+              value,
+              null,
+              null,
+              timestamp)
+          .returningNothing();
+
+      CompletableFuture<? extends Query<? extends BoundQuery>> prepareFuture =
+          datastore.prepare(query);
+      BoundQuery boundQuery =
+          queryBuilder.bind(prepareFuture.join(), documentId, row, timestamp, false);
+      datastore.execute(boundQuery);
+    }
+
+    @Test
+    public void doubleValue() {
+      DataStore datastore = datastore();
+      InsertQueryBuilder queryBuilder = new InsertQueryBuilder(MAX_DEPTH);
+      BuiltQuery<? extends BoundQuery> query =
+          queryBuilder.buildQuery(datastore::queryBuilder, KEYSPACE_NAME, COLLECTION_NAME);
+
+      long timestamp = RandomUtils.nextLong();
+      String documentId = RandomStringUtils.randomAlphanumeric(16);
+      double value = RandomUtils.nextDouble();
+      JsonShreddedRow row =
+          ImmutableJsonShreddedRow.builder()
+              .maxDepth(MAX_DEPTH)
+              .addPath("first")
+              .addPath("second")
+              .doubleValue(value)
+              .build();
+
+      withQuery(
+              SCHEMA_PROVIDER.getTable(),
+              "INSERT INTO %s (key, p0, p1, p2, p3, p4, p5, p6, p7, leaf, text_value, dbl_value, bool_value) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) USING TIMESTAMP ?",
+              documentId,
+              "first",
+              "second",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "second",
+              null,
+              value,
+              null,
+              timestamp)
+          .returningNothing();
+
+      CompletableFuture<? extends Query<? extends BoundQuery>> prepareFuture =
+          datastore.prepare(query);
+      BoundQuery boundQuery =
+          queryBuilder.bind(prepareFuture.join(), documentId, row, timestamp, false);
+      datastore.execute(boundQuery);
+    }
+
+    @Test
+    public void booleanValue() {
+      DataStore datastore = datastore();
+      InsertQueryBuilder queryBuilder = new InsertQueryBuilder(MAX_DEPTH);
+      BuiltQuery<? extends BoundQuery> query =
+          queryBuilder.buildQuery(datastore::queryBuilder, KEYSPACE_NAME, COLLECTION_NAME);
+
+      long timestamp = RandomUtils.nextLong();
+      String documentId = RandomStringUtils.randomAlphanumeric(16);
+      boolean value = RandomUtils.nextBoolean();
+      JsonShreddedRow row =
+          ImmutableJsonShreddedRow.builder()
+              .maxDepth(MAX_DEPTH)
+              .addPath("first")
+              .addPath("second")
+              .booleanValue(value)
+              .build();
+
+      withQuery(
+              SCHEMA_PROVIDER.getTable(),
+              "INSERT INTO %s (key, p0, p1, p2, p3, p4, p5, p6, p7, leaf, text_value, dbl_value, bool_value) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) USING TIMESTAMP ?",
+              documentId,
+              "first",
+              "second",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "second",
+              null,
+              null,
+              value,
+              timestamp)
+          .returningNothing();
+
+      CompletableFuture<? extends Query<? extends BoundQuery>> prepareFuture =
+          datastore.prepare(query);
+      BoundQuery boundQuery =
+          queryBuilder.bind(prepareFuture.join(), documentId, row, timestamp, false);
+      datastore.execute(boundQuery);
+    }
+
+    @Test
+    public void maxDepthDifferent() {
+      DataStore datastore = datastore();
+      InsertQueryBuilder queryBuilder = new InsertQueryBuilder(MAX_DEPTH);
+      BuiltQuery<? extends BoundQuery> query =
+          queryBuilder.buildQuery(datastore::queryBuilder, KEYSPACE_NAME, COLLECTION_NAME);
+
+      long timestamp = RandomUtils.nextLong();
+      String documentId = RandomStringUtils.randomAlphanumeric(16);
+      JsonShreddedRow row =
+          ImmutableJsonShreddedRow.builder()
+              .maxDepth(4)
+              .addPath("first")
+              .booleanValue(true)
+              .build();
+
+      withQuery(
+          SCHEMA_PROVIDER.getTable(),
+          "INSERT INTO %s (key, p0, p1, p2, p3, p4, p5, p6, p7, leaf, text_value, dbl_value, bool_value) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) USING TIMESTAMP ?");
+
+      CompletableFuture<? extends Query<? extends BoundQuery>> prepareFuture =
+          datastore.prepare(query);
+      Throwable result =
+          catchThrowable(
+              () -> queryBuilder.bind(prepareFuture.join(), documentId, row, timestamp, true));
+
+      assertThat(result).isInstanceOf(IllegalArgumentException.class);
+      resetExpectations();
+    }
+  }
+}

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -676,7 +676,7 @@ public abstract class BaseDocumentApiV2Test extends BaseIntegrationTest {
     r = RestUtils.put(authToken, collectionPath + "/1", obj.toString(), 400);
     assertThat(r)
         .isEqualTo(
-            "{\"description\":\"Updating a key with just a JSON primitive, empty object, or empty array is not allowed. Found: 3. Hint: update the parent path with a defined object instead.\",\"code\":400}");
+            "{\"description\":\"Updating a key with just a JSON primitive is not allowed. Hint: update the parent path with a defined object instead.\",\"code\":400}");
 
     obj = OBJECT_MAPPER.readTree("true");
     r = RestUtils.put(authToken, collectionPath + "/1/quiz", obj.toString(), 400);

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -183,18 +183,6 @@ public abstract class BaseDocumentApiV2Test extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBasicForms() throws IOException {
-    RestUtils.putForm(authToken, collectionPath + "/1", "a=b&b=null&c.b=3.3&d.[0].[2]=true", 200);
-
-    String resp = RestUtils.get(authToken, collectionPath + "/1", 200);
-    JsonNode expected =
-        OBJECT_MAPPER.readTree(
-            "{\"a\":\"b\", \"b\":null, \"c\":{\"b\": 3.3}, \"d\":[[null, null, true]]}");
-    assertThat(OBJECT_MAPPER.readTree(resp).toString())
-        .isEqualTo(wrapResponse(expected, "1", null).toString());
-  }
-
-  @Test
   public void testInvalidKeyspaceAndTable() throws IOException {
     JsonNode obj =
         OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("example.json"));


### PR DESCRIPTION
**ATTENTION: This PR removes support for the `x-www-form-urlencoded` content type when writing docs.**

**What this PR does**:
A refactored write of documents based on top of the new shredding. Beside shredding, we have these improvements:
* query preparing is done in parallel
* write document path does not need a delete query
* cleaner code, better tests (added batch validation in `ValidatingDataStore`) and separation of concerns in components

Note that document patching and batch writes is not part of this PR and will be done after this one is merged. The final goal would be to remove majority of existing code in `DocumentResourceV2`, `DocumentService` and `DocumentDB`.

**Which issue(s) this PR fixes**:
Internal issue.

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] proper error codes in `ReactiveDocumentService`
- [x] test code for `ReactiveDocumentService` and `DocumentWriteService`
