### PR TITLE
Add SGv2 implementation of UDT endpoint (create, update, delete)

### DIFF
--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/impl/RestServiceServer.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/impl/RestServiceServer.java
@@ -38,6 +38,7 @@ import io.stargate.sgv2.restsvc.resources.schemas.Sgv2ColumnsResourceImpl;
 import io.stargate.sgv2.restsvc.resources.schemas.Sgv2IndexesResourceImpl;
 import io.stargate.sgv2.restsvc.resources.schemas.Sgv2KeyspacesResourceImpl;
 import io.stargate.sgv2.restsvc.resources.schemas.Sgv2TablesResourceImpl;
+import io.stargate.sgv2.restsvc.resources.schemas.Sgv2UDTsResourceImpl;
 import io.swagger.config.ScannerFactory;
 import io.swagger.jaxrs.config.BeanConfig;
 import io.swagger.jaxrs.config.DefaultJaxrsScanner;
@@ -126,6 +127,7 @@ public class RestServiceServer extends Application<RestServiceServerConfiguratio
     environment.jersey().register(Sgv2KeyspacesResourceImpl.class);
     environment.jersey().register(Sgv2TablesResourceImpl.class);
     environment.jersey().register(Sgv2IndexesResourceImpl.class);
+    environment.jersey().register(Sgv2UDTsResourceImpl.class);
 
     // Swagger endpoints
     environment.jersey().register(SwaggerSerializers.class);

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2UDT.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2UDT.java
@@ -1,0 +1,70 @@
+package io.stargate.sgv2.restsvc.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Sgv2UDT {
+  private final String name;
+  private final String keyspace;
+  private final List<UDTField> fields;
+
+  @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+  public Sgv2UDT(
+      @JsonProperty("name") final String name,
+      @JsonProperty("keyspace") final String keyspace,
+      @JsonProperty("fields") final List<UDTField> fields) {
+    this.name = name;
+    this.keyspace = keyspace;
+    this.fields = fields;
+  }
+
+  @ApiModelProperty(value = "The name of the user defined type.")
+  public String getName() {
+    return name;
+  }
+
+  @ApiModelProperty(value = "Name of the keyspace the user defined type belongs.")
+  public String getKeyspace() {
+    return keyspace;
+  }
+
+  @ApiModelProperty(value = "Definition of columns within the user defined type.")
+  public List<UDTField> getFields() {
+    return fields;
+  }
+
+  /** Represents a column in a User Defined type ({@link Sgv2UDT}) */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public static class UDTField {
+    private final String name;
+    private final String typeDefinition;
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public UDTField(
+        @JsonProperty("name") final String name,
+        @JsonProperty("typeDefinition") final String typeDefinition) {
+      this.name = name;
+      this.typeDefinition = typeDefinition;
+    }
+
+    @ApiModelProperty(
+        example = "emailaddress",
+        required = true,
+        value = "Name for the type, which must be unique.")
+    public String getName() {
+      return name;
+    }
+
+    @ApiModelProperty(
+        example = "text",
+        required = true,
+        value = "A valid type of data (e.g, text, int, etc) allowed in the type.")
+    public String getTypeDefinition() {
+      return typeDefinition;
+    }
+  }
+}

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2UDT.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2UDT.java
@@ -3,9 +3,11 @@ package io.stargate.sgv2.restsvc.models;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.List;
 
+@ApiModel(value = "UserDefinedType")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Sgv2UDT {
   private final String name;
@@ -38,6 +40,7 @@ public class Sgv2UDT {
   }
 
   /** Represents a column in a User Defined type ({@link Sgv2UDT}) */
+  @ApiModel(value = "UserDefinedTypeField")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public static class UDTField {
     private final String name;

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2UDTAddRequest.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2UDTAddRequest.java
@@ -2,10 +2,12 @@ package io.stargate.sgv2.restsvc.models;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.List;
 import javax.validation.constraints.NotNull;
 
+@ApiModel(value = "UserDefinedTypeAdd")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Sgv2UDTAddRequest {
   @NotNull private String name;

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2UDTAddRequest.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2UDTAddRequest.java
@@ -1,0 +1,47 @@
+package io.stargate.sgv2.restsvc.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.List;
+import javax.validation.constraints.NotNull;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Sgv2UDTAddRequest {
+  @NotNull private String name;
+
+  @JsonProperty("fields")
+  @NotNull
+  private List<Sgv2UDT.UDTField> fields;
+
+  private boolean ifNotExists;
+
+  @ApiModelProperty(required = true, value = "User Defined Type name")
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @ApiModelProperty(
+      value =
+          "Determines whether to create a new UDT if an UDT with the same name exists. Attempting to create an existing UDT returns an error unless this option is true.")
+  public boolean getIfNotExists() {
+    return ifNotExists;
+  }
+
+  public void setIfNotExists(boolean ifNotExists) {
+    this.ifNotExists = ifNotExists;
+  }
+
+  @ApiModelProperty(required = true, value = "User Defined Type fields")
+  public List<Sgv2UDT.UDTField> getFields() {
+    return fields;
+  }
+
+  public void setFields(List<Sgv2UDT.UDTField> fields) {
+    this.fields = fields;
+  }
+}

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2UDTUpdateRequest.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2UDTUpdateRequest.java
@@ -1,0 +1,72 @@
+package io.stargate.sgv2.restsvc.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.List;
+import javax.validation.constraints.NotNull;
+
+@ApiModel(value = "UserDefinedTypeUpdate")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Sgv2UDTUpdateRequest {
+  @NotNull private String name;
+
+  @JsonProperty("addFields")
+  private List<Sgv2UDT.UDTField> addFields;
+
+  @JsonProperty("renameFields")
+  private List<RenameUdtField> renameFields;
+
+  @ApiModelProperty(required = true, value = "User Defined Type name")
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @ApiModelProperty(value = "User Defined Type fields to add")
+  public List<Sgv2UDT.UDTField> getAddFields() {
+    return addFields;
+  }
+
+  public void setAddFields(List<Sgv2UDT.UDTField> addFields) {
+    this.addFields = addFields;
+  }
+
+  @ApiModelProperty(value = "User Defined Type fields to rename")
+  public List<RenameUdtField> getRenameFields() {
+    return renameFields;
+  }
+
+  public void setRenameFields(List<RenameUdtField> renameFields) {
+    this.renameFields = renameFields;
+  }
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public static class RenameUdtField {
+
+    private String from;
+    private String to;
+
+    @ApiModelProperty(value = "User Defined Type's old field name")
+    public String getFrom() {
+      return from;
+    }
+
+    public void setFrom(String from) {
+      this.from = from;
+    }
+
+    @ApiModelProperty(value = "User Defined Type's new field name")
+    public String getTo() {
+      return to;
+    }
+
+    public void setTo(String to) {
+      this.to = to;
+    }
+  }
+}

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2UDTUpdateRequest.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/models/Sgv2UDTUpdateRequest.java
@@ -16,7 +16,7 @@ public class Sgv2UDTUpdateRequest {
   private List<Sgv2UDT.UDTField> addFields;
 
   @JsonProperty("renameFields")
-  private List<RenameUdtField> renameFields;
+  private List<FieldRename> renameFields;
 
   @ApiModelProperty(required = true, value = "User Defined Type name")
   public String getName() {
@@ -37,16 +37,17 @@ public class Sgv2UDTUpdateRequest {
   }
 
   @ApiModelProperty(value = "User Defined Type fields to rename")
-  public List<RenameUdtField> getRenameFields() {
+  public List<FieldRename> getRenameFields() {
     return renameFields;
   }
 
-  public void setRenameFields(List<RenameUdtField> renameFields) {
+  public void setRenameFields(List<FieldRename> renameFields) {
     this.renameFields = renameFields;
   }
 
+  @ApiModel(value = "UserDefinedTypeFieldRename")
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  public static class RenameUdtField {
+  public static class FieldRename {
 
     private String from;
     private String to;

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceApi.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceApi.java
@@ -8,6 +8,7 @@ import io.stargate.sgv2.restsvc.models.RestServiceError;
 import io.stargate.sgv2.restsvc.models.Sgv2RESTResponse;
 import io.stargate.sgv2.restsvc.models.Sgv2UDT;
 import io.stargate.sgv2.restsvc.models.Sgv2UDTAddRequest;
+import io.stargate.sgv2.restsvc.models.Sgv2UDTUpdateRequest;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
@@ -45,8 +46,6 @@ import javax.ws.rs.core.Response;
       required = true)
 })
 public interface Sgv2UDTsResourceApi {
-  static class UserDefinedTypeUpdate {}
-
   @Timed
   @GET
   @ApiOperation(
@@ -187,6 +186,6 @@ public interface Sgv2UDTsResourceApi {
       @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
           @PathParam("keyspaceName")
           final String keyspaceName,
-      @ApiParam(value = "", required = true) @NotNull final UserDefinedTypeUpdate udtUpdate,
+      @ApiParam(value = "", required = true) @NotNull final Sgv2UDTUpdateRequest udtUpdate,
       @Context HttpServletRequest request);
 }

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceApi.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceApi.java
@@ -6,6 +6,8 @@ import com.codahale.metrics.annotation.Timed;
 import io.stargate.proto.StargateGrpc;
 import io.stargate.sgv2.restsvc.models.RestServiceError;
 import io.stargate.sgv2.restsvc.models.Sgv2RESTResponse;
+import io.stargate.sgv2.restsvc.models.Sgv2UDT;
+import io.stargate.sgv2.restsvc.models.Sgv2UDTAddRequest;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
@@ -43,11 +45,6 @@ import javax.ws.rs.core.Response;
       required = true)
 })
 public interface Sgv2UDTsResourceApi {
-  // !!! TESTING
-  static class UserDefinedTypeResponse {}
-
-  static class UserDefinedTypeAdd {}
-
   static class UserDefinedTypeUpdate {}
 
   @Timed
@@ -55,11 +52,11 @@ public interface Sgv2UDTsResourceApi {
   @ApiOperation(
       value = "Get all user defined types (UDT). ",
       notes = "Retrieve all user defined types (UDT) in a specific keyspace.",
-      response = UserDefinedTypeResponse.class,
+      response = Sgv2UDT.class,
       responseContainer = "List")
   @ApiResponses(
       value = {
-        @ApiResponse(code = 200, message = "OK", response = UserDefinedTypeResponse.class),
+        @ApiResponse(code = 200, message = "OK", response = Sgv2UDT.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = RestServiceError.class),
         @ApiResponse(
             code = 404,
@@ -141,7 +138,7 @@ public interface Sgv2UDTsResourceApi {
       @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
           @PathParam("keyspaceName")
           final String keyspaceName,
-      @ApiParam(value = "", required = true) @NotNull final UserDefinedTypeAdd udtAdd,
+      @ApiParam(value = "", required = true) @NotNull final Sgv2UDTAddRequest udtAdd,
       @Context final HttpServletRequest request);
 
   @Timed

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceApi.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceApi.java
@@ -1,0 +1,195 @@
+package io.stargate.sgv2.restsvc.resources.schemas;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import com.codahale.metrics.annotation.Timed;
+import io.stargate.proto.StargateGrpc;
+import io.stargate.sgv2.restsvc.models.RestServiceError;
+import io.stargate.sgv2.restsvc.models.Sgv2RESTResponse;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+
+/**
+ * Exposes REST Endpoint to work with Cassandra User Defined Types
+ *
+ * @see "https://cassandra.apache.org/doc/latest/cql/types.html"
+ */
+@Api(
+    produces = APPLICATION_JSON,
+    consumes = APPLICATION_JSON,
+    tags = {"schemas"})
+@ApiImplicitParams({
+  @ApiImplicitParam(
+      name = "X-Cassandra-Token",
+      paramType = "header",
+      value = "The token returned from the authorization endpoint. Use this token in each request.",
+      required = true)
+})
+public interface Sgv2UDTsResourceApi {
+  // !!! TESTING
+  static class UserDefinedTypeResponse {}
+
+  static class UserDefinedTypeAdd {}
+
+  static class UserDefinedTypeUpdate {}
+
+  @Timed
+  @GET
+  @ApiOperation(
+      value = "Get all user defined types (UDT). ",
+      notes = "Retrieve all user defined types (UDT) in a specific keyspace.",
+      response = UserDefinedTypeResponse.class,
+      responseContainer = "List")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 200, message = "OK", response = UserDefinedTypeResponse.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = RestServiceError.class),
+        @ApiResponse(
+            code = 404,
+            message = "Keyspace has not been found",
+            response = RestServiceError.class),
+        @ApiResponse(
+            code = 500,
+            message = "Internal server error",
+            response = RestServiceError.class)
+      })
+  Response findAll(
+      @Context StargateGrpc.StargateBlockingStub blockingStub,
+      @ApiParam(value = "Keyspace to find all udts", required = true) @PathParam("keyspaceName")
+          final String keyspaceName,
+      @ApiParam(value = "Unwrap results", defaultValue = "false") @QueryParam("raw")
+          final boolean raw,
+      @Context HttpServletRequest request);
+
+  @Timed
+  @GET
+  @ApiOperation(
+      value = "Get an user defined type (UDT) from its identifier",
+      notes = "Retrieve data for a single table in a specific keyspace.",
+      response = Sgv2RESTResponse.class)
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 200, message = "OK", response = Sgv2RESTResponse.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = RestServiceError.class),
+        @ApiResponse(code = 404, message = "Not Found", response = RestServiceError.class),
+        @ApiResponse(
+            code = 500,
+            message = "Internal server error",
+            response = RestServiceError.class)
+      })
+  @Path("/{typeName}")
+  Response findById(
+      @Context StargateGrpc.StargateBlockingStub blockingStub,
+      @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
+          @PathParam("keyspaceName")
+          final String keyspaceName,
+      @ApiParam(
+              value = "Name of the user defined type (UDT) to use for the request.",
+              required = true)
+          @PathParam("typeName")
+          final String typeName,
+      @ApiParam(value = "Unwrap results", defaultValue = "false") @QueryParam("raw")
+          final boolean raw,
+      @Context HttpServletRequest request);
+
+  @Timed
+  @POST
+  @ApiOperation(
+      value = "Create an user defined type (UDT)",
+      notes = "Add an user defined type (udt) in a specific keyspace.",
+      response = Map.class,
+      code = 201)
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 201, message = "Created", response = Map.class),
+        @ApiResponse(
+            code = 400,
+            message = "Bad Request, the input is not well formated",
+            response = RestServiceError.class),
+        @ApiResponse(
+            code = 401,
+            message = "Unauthorized, token is not valid or not enough permissions",
+            response = RestServiceError.class),
+        @ApiResponse(
+            code = 409,
+            message = "Conflict, the object may already exist",
+            response = RestServiceError.class),
+        @ApiResponse(
+            code = 500,
+            message = "Internal server error",
+            response = RestServiceError.class)
+      })
+  Response createType(
+      @Context StargateGrpc.StargateBlockingStub blockingStub,
+      @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
+          @PathParam("keyspaceName")
+          final String keyspaceName,
+      @ApiParam(value = "", required = true) @NotNull final UserDefinedTypeAdd udtAdd,
+      @Context final HttpServletRequest request);
+
+  @Timed
+  @DELETE
+  @ApiOperation(
+      value = "Delete an User Defined type (UDT)",
+      notes = "Delete a single user defined type (UDT) in the specified keyspace.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 204, message = "No Content"),
+        @ApiResponse(code = 401, message = "Unauthorized", response = RestServiceError.class),
+        @ApiResponse(
+            code = 500,
+            message = "Internal server error",
+            response = RestServiceError.class)
+      })
+  @Path("/{typeName}")
+  Response delete(
+      @Context StargateGrpc.StargateBlockingStub blockingStub,
+      @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
+          @PathParam("keyspaceName")
+          final String keyspaceName,
+      @ApiParam(
+              value = "Name of the user defined type (UDT) to use for the request.",
+              required = true)
+          @PathParam("typeName")
+          final String typeName,
+      @Context HttpServletRequest request);
+
+  @Timed
+  @PUT
+  @ApiOperation(
+      value = "Update an User Defined type (UDT)",
+      notes = "Update an user defined type (UDT) adding or renaming fields.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 204, message = "No Content"),
+        @ApiResponse(code = 401, message = "Unauthorized", response = RestServiceError.class),
+        @ApiResponse(
+            code = 500,
+            message = "Internal server error",
+            response = RestServiceError.class)
+      })
+  Response update(
+      @Context StargateGrpc.StargateBlockingStub blockingStub,
+      @ApiParam(value = "Name of the keyspace to use for the request.", required = true)
+          @PathParam("keyspaceName")
+          final String keyspaceName,
+      @ApiParam(value = "", required = true) @NotNull final UserDefinedTypeUpdate udtUpdate,
+      @Context HttpServletRequest request);
+}

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceImpl.java
@@ -1,0 +1,81 @@
+package io.stargate.sgv2.restsvc.resources.schemas;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import io.stargate.proto.StargateGrpc;
+import io.stargate.sgv2.restsvc.resources.CreateGrpcStub;
+import io.stargate.sgv2.restsvc.resources.ResourceBase;
+import javax.inject.Singleton;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+@Produces(APPLICATION_JSON)
+@Consumes(APPLICATION_JSON)
+@Path("/v2/schemas/keyspaces/{keyspaceName}/types")
+@Singleton
+@CreateGrpcStub
+public class Sgv2UDTsResourceImpl extends ResourceBase implements Sgv2UDTsResourceApi {
+  @Override
+  public Response findAll(
+      final StargateGrpc.StargateBlockingStub blockingStub,
+      final String keyspaceName,
+      final boolean raw,
+      final HttpServletRequest request) {
+    requireNonEmptyKeyspace(keyspaceName);
+
+    // !!! TO IMPLEMENT
+    return Response.status(Response.Status.NOT_IMPLEMENTED).build();
+  }
+
+  @Override
+  public Response findById(
+      final StargateGrpc.StargateBlockingStub blockingStub,
+      final String keyspaceName,
+      final String typeName,
+      final boolean raw,
+      final HttpServletRequest request) {
+    requireNonEmptyKeyspace(keyspaceName);
+
+    // !!! TO IMPLEMENT
+    return Response.status(Response.Status.NOT_IMPLEMENTED).build();
+  }
+
+  @Override
+  public Response createType(
+      final StargateGrpc.StargateBlockingStub blockingStub,
+      final String keyspaceName,
+      final UserDefinedTypeAdd udtAdd,
+      final HttpServletRequest request) {
+    requireNonEmptyKeyspace(keyspaceName);
+
+    // !!! TO IMPLEMENT
+    return Response.status(Response.Status.NOT_IMPLEMENTED).build();
+  }
+
+  @Override
+  public Response delete(
+      final StargateGrpc.StargateBlockingStub blockingStub,
+      final String keyspaceName,
+      final String typeName,
+      final HttpServletRequest request) {
+    requireNonEmptyKeyspace(keyspaceName);
+
+    // !!! TO IMPLEMENT
+    return Response.status(Response.Status.NOT_IMPLEMENTED).build();
+  }
+
+  @Override
+  public Response update(
+      final StargateGrpc.StargateBlockingStub blockingStub,
+      final String keyspaceName,
+      final UserDefinedTypeUpdate udtUpdate,
+      final HttpServletRequest request) {
+    requireNonEmptyKeyspace(keyspaceName);
+
+    // !!! TO IMPLEMENT
+    return Response.status(Response.Status.NOT_IMPLEMENTED).build();
+  }
+}

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceImpl.java
@@ -54,6 +54,22 @@ public class Sgv2UDTsResourceImpl extends ResourceBase implements Sgv2UDTsResour
       final boolean raw,
       final HttpServletRequest request) {
     requireNonEmptyKeyspace(keyspaceName);
+    requireNonEmptyTypename(typeName);
+
+    /*
+        String cql =
+                new QueryBuilder()
+                        .create()
+                        .type(keyspaceName, typeName)
+                        .column(columns2columns(udtAdd.getFields()))
+                        .build();
+        QueryOuterClass.Query query =
+                QueryOuterClass.Query.newBuilder().setParameters(paramsB.build()).setCql(cql).build();
+        QueryOuterClass.Response grpcResponse = blockingStub.executeQuery(query);
+
+    //    final Object payload = raw ? tableResponses : new Sgv2RESTResponse(tableResponses);
+    //    return Response.status(Response.Status.OK).entity(payload).build();
+         */
 
     // !!! TO IMPLEMENT
     return Response.status(Response.Status.NOT_IMPLEMENTED).build();

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceImpl.java
@@ -121,6 +121,46 @@ public class Sgv2UDTsResourceImpl extends ResourceBase implements Sgv2UDTsResour
         .build();
   }
 
+  @Override
+  public Response delete(
+      final StargateGrpc.StargateBlockingStub blockingStub,
+      final String keyspaceName,
+      final String typeName,
+      final HttpServletRequest request) {
+    requireNonEmptyKeyspace(keyspaceName);
+    requireNonEmptyTypename(typeName);
+
+    String cql =
+        new QueryBuilder()
+            .drop()
+            .type(keyspaceName, typeName)
+            // 15-Dec-2021, tatu: Why no "ifExists" option? SGv1 had none which
+            //    seems inconsistent; would be good for idempotency
+            // .ifExists()
+            .build();
+    QueryOuterClass.Query query = QueryOuterClass.Query.newBuilder().setCql(cql).build();
+    /*QueryOuterClass.Response grpcResponse =*/ blockingStub.executeQuery(query);
+    return Response.status(Response.Status.NO_CONTENT).build();
+  }
+
+  @Override
+  public Response update(
+      final StargateGrpc.StargateBlockingStub blockingStub,
+      final String keyspaceName,
+      final UserDefinedTypeUpdate udtUpdate,
+      final HttpServletRequest request) {
+    requireNonEmptyKeyspace(keyspaceName);
+
+    // !!! TO IMPLEMENT
+    return Response.status(Response.Status.NOT_IMPLEMENTED).build();
+  }
+
+  /*
+  /////////////////////////////////////////////////////////////////////////
+  // Helper methods
+  /////////////////////////////////////////////////////////////////////////
+   */
+
   private List<Column> columns2columns(List<Sgv2UDT.UDTField> fields) {
     List<Column> result = new ArrayList<>();
     for (Sgv2UDT.UDTField colDef : fields) {
@@ -142,30 +182,6 @@ public class Sgv2UDTsResourceImpl extends ResourceBase implements Sgv2UDTsResour
           "There should be at least one field defined", Response.Status.BAD_REQUEST);
     }
     return result;
-  }
-
-  @Override
-  public Response delete(
-      final StargateGrpc.StargateBlockingStub blockingStub,
-      final String keyspaceName,
-      final String typeName,
-      final HttpServletRequest request) {
-    requireNonEmptyKeyspace(keyspaceName);
-
-    // !!! TO IMPLEMENT
-    return Response.status(Response.Status.NOT_IMPLEMENTED).build();
-  }
-
-  @Override
-  public Response update(
-      final StargateGrpc.StargateBlockingStub blockingStub,
-      final String keyspaceName,
-      final UserDefinedTypeUpdate udtUpdate,
-      final HttpServletRequest request) {
-    requireNonEmptyKeyspace(keyspaceName);
-
-    // !!! TO IMPLEMENT
-    return Response.status(Response.Status.NOT_IMPLEMENTED).build();
   }
 
   private static void requireNonEmptyTypename(String typeName) {

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceImpl.java
@@ -2,14 +2,22 @@ package io.stargate.sgv2.restsvc.resources.schemas;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
+import io.stargate.proto.QueryOuterClass;
 import io.stargate.proto.StargateGrpc;
+import io.stargate.sgv2.common.cql.builder.Column;
+import io.stargate.sgv2.common.cql.builder.QueryBuilder;
+import io.stargate.sgv2.restsvc.models.Sgv2UDTAddRequest;
 import io.stargate.sgv2.restsvc.resources.CreateGrpcStub;
 import io.stargate.sgv2.restsvc.resources.ResourceBase;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
 @Produces(APPLICATION_JSON)
@@ -47,12 +55,32 @@ public class Sgv2UDTsResourceImpl extends ResourceBase implements Sgv2UDTsResour
   public Response createType(
       final StargateGrpc.StargateBlockingStub blockingStub,
       final String keyspaceName,
-      final UserDefinedTypeAdd udtAdd,
+      final Sgv2UDTAddRequest udtAdd,
       final HttpServletRequest request) {
     requireNonEmptyKeyspace(keyspaceName);
+    final String typeName = udtAdd.getName();
+    requireNonEmptyTypename(typeName);
+
+    List<Column> columns = Arrays.asList();
+
+    String cql =
+        new QueryBuilder()
+            .create()
+            .type(keyspaceName, typeName)
+            .ifNotExists()
+            .column(columns)
+            .build();
+
+    blockingStub.executeQuery(
+        QueryOuterClass.Query.newBuilder()
+            .setParameters(parametersForLocalQuorum())
+            .setCql(cql)
+            .build());
 
     // !!! TO IMPLEMENT
-    return Response.status(Response.Status.NOT_IMPLEMENTED).build();
+    return Response.status(Response.Status.OK)
+        .entity(Collections.singletonMap("name", typeName))
+        .build();
   }
 
   @Override
@@ -77,5 +105,11 @@ public class Sgv2UDTsResourceImpl extends ResourceBase implements Sgv2UDTsResour
 
     // !!! TO IMPLEMENT
     return Response.status(Response.Status.NOT_IMPLEMENTED).build();
+  }
+
+  private static void requireNonEmptyTypename(String typeName) {
+    if (isStringEmpty(typeName)) {
+      throw new WebApplicationException("Type name must be provided", Response.Status.BAD_REQUEST);
+    }
   }
 }

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceImpl.java
@@ -10,6 +10,7 @@ import io.stargate.sgv2.common.cql.builder.ImmutableColumn;
 import io.stargate.sgv2.common.cql.builder.QueryBuilder;
 import io.stargate.sgv2.restsvc.models.Sgv2UDT;
 import io.stargate.sgv2.restsvc.models.Sgv2UDTAddRequest;
+import io.stargate.sgv2.restsvc.models.Sgv2UDTUpdateRequest;
 import io.stargate.sgv2.restsvc.resources.CreateGrpcStub;
 import io.stargate.sgv2.restsvc.resources.ResourceBase;
 import java.util.ArrayList;
@@ -147,9 +148,11 @@ public class Sgv2UDTsResourceImpl extends ResourceBase implements Sgv2UDTsResour
   public Response update(
       final StargateGrpc.StargateBlockingStub blockingStub,
       final String keyspaceName,
-      final UserDefinedTypeUpdate udtUpdate,
+      final Sgv2UDTUpdateRequest udtUpdate,
       final HttpServletRequest request) {
     requireNonEmptyKeyspace(keyspaceName);
+    final String typeName = udtUpdate.getName();
+    requireNonEmptyTypename(typeName);
 
     // !!! TO IMPLEMENT
     return Response.status(Response.Status.NOT_IMPLEMENTED).build();

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -2466,9 +2466,9 @@ public class RestApiv2Test extends BaseIntegrationTest {
     ApiError apiError = objectMapper.readValue(response, ApiError.class);
     assertThat(apiError.getCode()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
     assertThat(apiError.getDescription())
-            .contains("Bad request")
-            .contains(typeName)
-            .contains("already exists");
+        .contains("Bad request")
+        .contains(typeName)
+        .contains("already exists");
 
     // don't create and don't throw exception because ifNotExists = true
     udtString =

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -2466,9 +2466,9 @@ public class RestApiv2Test extends BaseIntegrationTest {
     ApiError apiError = objectMapper.readValue(response, ApiError.class);
     assertThat(apiError.getCode()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
     assertThat(apiError.getDescription())
-        .isEqualTo(
-            String.format(
-                "Bad request: A type named \"%s\".%s already exists", keyspaceName, typeName));
+            .contains("Bad request")
+            .contains(typeName)
+            .contains("already exists");
 
     // don't create and don't throw exception because ifNotExists = true
     udtString =


### PR DESCRIPTION
**What this PR does**:

Adds 3 out of 5 User-Defined Type endpoints to SGv2; one of last missing pieces:

* Create UDT
* Update UDT
* Delete UDT

Remaining 2 endpoints (get all, get by id) will be in a separate PR since they need bit more work it seems (no schema access yet).

**Which issue(s) this PR fixes**:
Fixes #1478

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated -- passes a few more ITs
- [ ] Documentation added/updated
