### PR TITLE
SGv2: exclude old validation api, update to latest DropWizard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,12 +15,12 @@
     <doclint>none</doclint>
     <driver.version>4.9.0</driver.version>
     <xml-format.skip>true</xml-format.skip>
-    <dropwizard.version>2.0.21</dropwizard.version>
+    <dropwizard.version>2.0.26</dropwizard.version>
     <!--
       Note that this is currently aligned with the metrics version that DropWizard transitively depends on.
       It's probably a good idea to keep the two versions in sync.
     -->
-    <dropwizard.metrics.version>4.1.19</dropwizard.metrics.version>
+    <dropwizard.metrics.version>4.1.27</dropwizard.metrics.version>
     <!--
       Note that this is currently aligned with the Jetty version that DropWizard transitively depends on.
       It's probably a good idea to keep the two versions in sync.

--- a/sgv2-restapi/pom.xml
+++ b/sgv2-restapi/pom.xml
@@ -94,14 +94,17 @@
       <artifactId>jetty-servlet</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-      <version>1.1.0.Final</version>
-    </dependency>
-    <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-jersey2-jaxrs</artifactId>
       <version>1.6.2</version>
+      <exclusions>
+        <exclusion> <!-- conflicts with Validation API from DropWizard,
+                         see https://github.com/dropwizard/dropwizard/issues/3089
+                     -->
+	  <groupId>javax.validation</groupId>
+	  <artifactId>validation-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Other 3rd party deps -->


### PR DESCRIPTION
**What this PR does**:

Fixes a version conflict that occurs if building Docker image of Stargate V2 REST service; conflict between older 1.x validation api jar brought to by swagger (and for some reason, directly?) vs DropWizard.
For some reason does not break things with "fat jar" (maybe order dependant) but does with cleaner Docker build.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
