### PR TITLE
removing reference to google email list

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can reference the [CONTRIBUTING.md](CONTRIBUTING.md) for a full description 
 but the short of it is below.
 
 - If you've found a bug (use the bug label) or want to request a new feature (use the enhancement label), file a GitHub issue
-- If you're not sure about it or want to chat, reach out on our [Discord](https://discord.gg/GravUqY) or [mailing list](https://groups.google.com/a/lists.stargate.io/g/stargate-users)
+- If you're not sure about it or want to chat, reach out on our [Discord](https://discord.gg/GravUqY) 
 - If you want to write some user docs 🎉 head over to the [stargate/docs](https://github.com/stargate/docs) repo, Pull Requests accepted!
 
 ## Thanks


### PR DESCRIPTION
phasing out the Google groups email list in favor of Discord.