### PR TITLE
update and unify dependencies

### DIFF
--- a/auth-api/pom.xml
+++ b/auth-api/pom.xml
@@ -36,12 +36,6 @@
       <artifactId>persistence-api</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hibernate.validator</groupId>
-          <artifactId>hibernate-validator</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- 3rd party dependencies -->

--- a/auth-api/pom.xml
+++ b/auth-api/pom.xml
@@ -13,6 +13,7 @@
     <osgi.bundle.version>${project.version}</osgi.bundle.version>
   </properties>
   <dependencies>
+    <!-- Stargate component dependencies -->
     <dependency>
       <groupId>io.stargate.core</groupId>
       <artifactId>core</artifactId>
@@ -31,14 +32,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.dropwizard</groupId>
-      <artifactId>dropwizard-jersey</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.dropwizard</groupId>
-      <artifactId>dropwizard-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.stargate.db</groupId>
       <artifactId>persistence-api</artifactId>
       <version>${project.version}</version>
@@ -50,6 +43,16 @@
         </exclusion>
       </exclusions>
     </dependency>
+
+    <!-- 3rd party dependencies -->
+    <dependency>
+      <groupId>io.dropwizard</groupId>
+      <artifactId>dropwizard-jersey</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard</groupId>
+      <artifactId>dropwizard-core</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-logging</artifactId>
@@ -59,6 +62,8 @@
       <artifactId>swagger-jersey2-jaxrs</artifactId>
       <version>${swagger-jersey2-jaxrs.version}</version>
     </dependency>
+
+    <!-- Test dependencies -->
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-testing</artifactId>

--- a/auth-api/pom.xml
+++ b/auth-api/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-jersey2-jaxrs</artifactId>
-      <version>1.6.2</version>
+      <version>${swagger-jersey2-jaxrs.version}</version>
     </dependency>
     <dependency>
       <groupId>io.dropwizard</groupId>

--- a/auth-jwt-service/pom.xml
+++ b/auth-jwt-service/pom.xml
@@ -9,6 +9,8 @@
   <groupId>io.stargate.auth.jwt</groupId>
   <artifactId>auth-jwt-service</artifactId>
   <dependencies>
+    <!-- Stargate component dependencies -->
+
     <dependency>
       <groupId>io.stargate.auth</groupId>
       <artifactId>authnz</artifactId>
@@ -21,6 +23,8 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <!-- 3rd party dependencies -->
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
@@ -31,6 +35,8 @@
       <artifactId>nimbus-jose-jwt</artifactId>
       <version>9.0.1</version>
     </dependency>
+
+    <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/auth-table-based-service/pom.xml
+++ b/auth-table-based-service/pom.xml
@@ -9,15 +9,12 @@
   <groupId>io.stargate.auth.table</groupId>
   <artifactId>auth-table-based-service</artifactId>
   <dependencies>
+    <!-- Stargate component dependencies -->
     <dependency>
       <groupId>io.stargate.auth</groupId>
       <artifactId>authnz</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.github.ben-manes.caffeine</groupId>
-      <artifactId>caffeine</artifactId>
     </dependency>
     <dependency>
       <groupId>io.stargate.core</groupId>
@@ -31,6 +28,19 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <!-- 3rd party dependencies -->
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mindrot</groupId>
+      <artifactId>jbcrypt</artifactId>
+      <version>0.4</version>
+    </dependency>
+
+    <!-- Test dependencies -->
     <!-- 21-Sep-2021, tatu: If you need to use Guava for NON-test code (runtime),
              note that you need to BOTH change scope to "runtime" AND add
              OSGi import: see f.ex "cql/pom.xml" for example of how to do it.
@@ -41,11 +51,6 @@
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-shaded-guava</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mindrot</groupId>
-      <artifactId>jbcrypt</artifactId>
-      <version>0.4</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/authnz/pom.xml
+++ b/authnz/pom.xml
@@ -9,6 +9,7 @@
   <groupId>io.stargate.auth</groupId>
   <artifactId>authnz</artifactId>
   <dependencies>
+    <!-- Stargate component dependencies -->
     <dependency>
       <groupId>io.stargate.db</groupId>
       <artifactId>persistence-api</artifactId>

--- a/config-store-api/pom.xml
+++ b/config-store-api/pom.xml
@@ -12,13 +12,11 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
-			<version>3.17.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/config-store-api/pom.xml
+++ b/config-store-api/pom.xml
@@ -9,6 +9,15 @@
 	<groupId>io.stargate.config-store</groupId>
 	<artifactId>config-store-api</artifactId>
     <dependencies>
+
+		<!-- 3rd party dependencies -->
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<version>3.0.2</version>
+		</dependency>
+
+		<!-- Test dependencies -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
@@ -18,11 +27,6 @@
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.google.code.findbugs</groupId>
-			<artifactId>jsr305</artifactId>
-			<version>3.0.2</version>
 		</dependency>
     </dependencies>
 	<build>

--- a/config-store-yaml/pom.xml
+++ b/config-store-yaml/pom.xml
@@ -42,19 +42,16 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.17.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter</artifactId>
-        <version>${junit.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-inline</artifactId>
-        <version>3.5.10</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/config-store-yaml/pom.xml
+++ b/config-store-yaml/pom.xml
@@ -22,7 +22,9 @@
         <version>${project.version}</version>
         <scope>provided</scope>
       </dependency>
+
       <!-- 3rd party dependencies -->
+      <!-- This fasterxml dep does not have to be in sync with the main pom as this module is not using Dropwizard  -->
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
@@ -35,7 +37,6 @@
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-graphite</artifactId>
-        <version>${dropwizard.metrics.version}</version>
       </dependency>
 
       <!-- Test dependencies -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -9,6 +9,7 @@
     <groupId>io.stargate.core</groupId>
     <artifactId>core</artifactId>
     <dependencies>
+        <!-- 3rd party dependencies -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -16,17 +17,14 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>${dropwizard.metrics.version}</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-healthchecks</artifactId>
-            <version>${dropwizard.metrics.version}</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jvm</artifactId>
-            <version>${dropwizard.metrics.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -48,6 +46,8 @@
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient_dropwizard</artifactId>
         </dependency>
+
+        <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/cql/pom.xml
+++ b/cql/pom.xml
@@ -83,7 +83,6 @@
     <dependency>
       <groupId>org.javatuples</groupId>
       <artifactId>javatuples</artifactId>
-      <version>1.2</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/cql/pom.xml
+++ b/cql/pom.xml
@@ -83,6 +83,7 @@
     <dependency>
       <groupId>org.javatuples</groupId>
       <artifactId>javatuples</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Test dependencies -->

--- a/cql/pom.xml
+++ b/cql/pom.xml
@@ -9,6 +9,7 @@
   <groupId>io.stargate.cql</groupId>
   <artifactId>cql</artifactId>
   <dependencies>
+    <!-- C* dependencies -->
     <dependency>
       <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-all</artifactId>
@@ -20,6 +21,8 @@
         </exclusion>
       </exclusions>
     </dependency>
+
+    <!-- Stargate component dependencies -->
     <dependency>
       <groupId>io.stargate.core</groupId>
       <artifactId>core</artifactId>
@@ -38,6 +41,8 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <!-- 3rd party dependencies -->
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
@@ -51,12 +56,10 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-jvm</artifactId>
-      <version>${dropwizard.metrics.version}</version>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-      <version>${dropwizard.metrics.version}</version>
     </dependency>
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
@@ -82,6 +85,8 @@
       <artifactId>javatuples</artifactId>
       <version>1.2</version>
     </dependency>
+
+    <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/ServerConnection.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/ServerConnection.java
@@ -27,7 +27,6 @@ import io.stargate.db.Persistence;
 import java.net.InetSocketAddress;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.security.cert.X509Certificate;
-import javax.validation.constraints.NotNull;
 import org.apache.cassandra.stargate.metrics.ClientMetrics;
 import org.apache.cassandra.stargate.transport.ProtocolException;
 import org.apache.cassandra.stargate.transport.ProtocolVersion;
@@ -80,7 +79,6 @@ public class ServerConnection extends Connection {
     this.stage = ConnectionStage.ESTABLISHED;
   }
 
-  @NotNull
   private static ClientInfo getClientInfo(Channel channel, int boundPort, ProxyInfo proxyInfo) {
     return new ClientInfo(
         proxyInfo != null ? proxyInfo.sourceAddress : (InetSocketAddress) channel.remoteAddress(),

--- a/graphqlapi/pom.xml
+++ b/graphqlapi/pom.xml
@@ -13,6 +13,7 @@
     <osgi.bundle.version>${project.version}</osgi.bundle.version>
   </properties>
   <dependencies>
+    <!-- Stargate component dependencies -->
     <dependency>
       <groupId>io.stargate.db</groupId>
       <artifactId>persistence-api</artifactId>
@@ -36,10 +37,11 @@
       <artifactId>metrics-jersey</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- 3rd party dependencies -->
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-servlet</artifactId>
-      <version>${dropwizard.metrics.version}</version>
     </dependency>
     <dependency>
       <groupId>com.datastax.oss</groupId>
@@ -72,7 +74,6 @@
     <dependency>
     <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-healthchecks</artifactId>
-      <version>${dropwizard.metrics.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -126,6 +127,8 @@
       <artifactId>federation-graphql-java-support</artifactId>
       <version>0.6.3</version>
     </dependency>
+
+    <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/grpc-examples/pom.xml
+++ b/grpc-examples/pom.xml
@@ -9,11 +9,6 @@
 
     <artifactId>grpc-examples</artifactId>
 
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.stargate.grpc</groupId>

--- a/grpc-examples/pom.xml
+++ b/grpc-examples/pom.xml
@@ -16,14 +16,14 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty-shaded</artifactId>
-            <version>${grpc.version}</version>
-        </dependency>
-        <dependency>
             <groupId>io.stargate.grpc</groupId>
             <artifactId>grpc-proto</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <version>${grpc.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/grpc-proto/pom.xml
+++ b/grpc-proto/pom.xml
@@ -13,6 +13,7 @@
   <artifactId>grpc-proto</artifactId>
 
   <dependencies>
+    <!-- gRPC -->
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
@@ -23,6 +24,8 @@
       <artifactId>grpc-stub</artifactId>
       <version>${grpc.version}</version>
     </dependency>
+
+    <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/grpc/pom.xml
+++ b/grpc/pom.xml
@@ -74,7 +74,6 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>annotations</artifactId>
       <version>2.0.1</version>
-      <scope>compile</scope>
     </dependency>
 
     <!-- Test dependencies -->

--- a/grpc/pom.xml
+++ b/grpc/pom.xml
@@ -67,7 +67,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/grpc/pom.xml
+++ b/grpc/pom.xml
@@ -9,7 +9,7 @@
   <groupId>io.stargate.grpc</groupId>
   <artifactId>grpc</artifactId>
   <dependencies>
-    <!-- Stargate -->
+    <!-- Stargate component dependencies -->
     <dependency>
       <groupId>io.stargate.core</groupId>
       <artifactId>core</artifactId>
@@ -28,6 +28,7 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
     <!-- gRPC -->
     <dependency>
       <groupId>io.stargate.grpc</groupId>
@@ -49,7 +50,8 @@
       <artifactId>grpc-stub</artifactId>
       <version>${grpc.version}</version>
     </dependency>
-    <!-- Other -->
+
+    <!-- 3rd party dependencies -->
     <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-shaded-guava</artifactId>
@@ -63,7 +65,19 @@
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
     </dependency>
-    <!-- Test -->
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>19.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>annotations</artifactId>
+      <version>2.0.1</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
@@ -83,17 +97,6 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jetbrains</groupId>
-      <artifactId>annotations</artifactId>
-      <version>19.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-      <version>2.0.1</version>
-      <scope>compile</scope>
     </dependency>
   </dependencies>
   <build>

--- a/health-checker/pom.xml
+++ b/health-checker/pom.xml
@@ -74,12 +74,6 @@
       <artifactId>jetty-servlet</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-      <version>1.1.0.Final</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
       <scope>provided</scope>

--- a/health-checker/pom.xml
+++ b/health-checker/pom.xml
@@ -10,6 +10,7 @@
   <groupId>io.stargate.health</groupId>
   <artifactId>health-checker</artifactId>
   <dependencies>
+    <!-- Stargate component dependencies -->
     <dependency>
       <groupId>io.stargate.db</groupId>
       <artifactId>persistence-api</artifactId>
@@ -27,6 +28,8 @@
       <artifactId>metrics-jersey</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- 3rd party dependencies -->
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-jersey</artifactId>
@@ -44,7 +47,6 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-healthchecks</artifactId>
-      <version>${dropwizard.metrics.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -91,6 +93,8 @@
       <artifactId>oshi-core-shaded</artifactId>
       <version>5.3.6</version>
     </dependency>
+
+    <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/metrics-jersey/pom.xml
+++ b/metrics-jersey/pom.xml
@@ -9,12 +9,15 @@
   <groupId>io.stargate.metrics</groupId>
   <artifactId>metrics-jersey</artifactId>
   <dependencies>
+    <!-- Stargate component dependencies -->
     <dependency>
       <groupId>io.stargate.core</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <!-- 3rd party dependencies -->
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
@@ -35,6 +38,7 @@
       </exclusions>
     </dependency>
 
+    <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/persistence-api/pom.xml
+++ b/persistence-api/pom.xml
@@ -53,16 +53,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>1.3.2</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-      <version>1.1.0.Final</version>
-    </dependency>
-    <dependency>
       <groupId>org.javatuples</groupId>
       <artifactId>javatuples</artifactId>
     </dependency>

--- a/persistence-api/pom.xml
+++ b/persistence-api/pom.xml
@@ -65,7 +65,6 @@
     <dependency>
       <groupId>org.javatuples</groupId>
       <artifactId>javatuples</artifactId>
-      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>

--- a/persistence-api/pom.xml
+++ b/persistence-api/pom.xml
@@ -38,7 +38,6 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
-      <version>2.8.8</version>
     </dependency>
     <dependency>
       <groupId>net.nicoulaj.compile-command-annotations</groupId>

--- a/persistence-api/pom.xml
+++ b/persistence-api/pom.xml
@@ -16,13 +16,14 @@
     </repository>
   </repositories>
   <dependencies>
-    <!-- Stargate -->
+    <!-- Stargate component dependencies -->
     <dependency>
       <groupId>io.stargate.core</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
     <!-- Cassandra/DataStax -->
     <dependency>
       <groupId>com.datastax.oss</groupId>
@@ -34,7 +35,8 @@
       <artifactId>java-driver-shaded-guava</artifactId>
       <scope>provided</scope>
     </dependency>
-    <!-- Other, runtime -->
+
+    <!-- 3rd party dependencies -->
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
@@ -69,6 +71,7 @@
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
     </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/persistence-api/src/main/java/io/stargate/db/ComparableKey.java
+++ b/persistence-api/src/main/java/io/stargate/db/ComparableKey.java
@@ -16,7 +16,6 @@
 package io.stargate.db;
 
 import java.util.Objects;
-import javax.validation.constraints.NotNull;
 
 /**
  * Represents a row key (e.g., a partition key) decorated in a way that the objects can be compared
@@ -38,7 +37,7 @@ public final class ComparableKey<T extends Comparable<? super T>>
   }
 
   @Override
-  public int compareTo(@NotNull ComparableKey<?> o) {
+  public int compareTo(ComparableKey<?> o) {
     if (equals(o)) {
       return 0;
     }

--- a/persistence-api/src/main/java/io/stargate/db/datastore/ResultSet.java
+++ b/persistence-api/src/main/java/io/stargate/db/datastore/ResultSet.java
@@ -24,7 +24,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Predicate;
-import javax.validation.constraints.NotNull;
 
 public interface ResultSet extends Iterable<Row> {
 
@@ -109,7 +108,6 @@ public interface ResultSet extends Iterable<Row> {
 
   List<Column> columns();
 
-  @NotNull
   @Override
   Iterator<Row> iterator();
 

--- a/persistence-cassandra-3.11/pom.xml
+++ b/persistence-cassandra-3.11/pom.xml
@@ -100,6 +100,7 @@
     <dependency>
       <groupId>org.javatuples</groupId>
       <artifactId>javatuples</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.reactivex.rxjava2</groupId>

--- a/persistence-cassandra-3.11/pom.xml
+++ b/persistence-cassandra-3.11/pom.xml
@@ -21,7 +21,6 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
-      <version>2.8.8</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/persistence-cassandra-3.11/pom.xml
+++ b/persistence-cassandra-3.11/pom.xml
@@ -18,11 +18,7 @@
     <cassandra.bundled-driver.version>3.0.1</cassandra.bundled-driver.version>
   </properties>
   <dependencies>
-    <dependency>
-      <groupId>org.immutables</groupId>
-      <artifactId>value</artifactId>
-      <scope>provided</scope>
-    </dependency>
+    <!-- Stargate component dependencies -->
     <dependency>
       <groupId>io.stargate.db</groupId>
       <artifactId>persistence-api</artifactId>
@@ -40,6 +36,14 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>io.stargate.auth</groupId>
+      <artifactId>authnz</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Cassandra/DataStax -->
     <dependency>
       <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-all</artifactId>
@@ -61,6 +65,24 @@
       <version>${cassandra.bundled-driver.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.datastax.oss</groupId>
+      <artifactId>java-driver-core</artifactId>
+      <version>${driver.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.datastax.oss</groupId>
+      <artifactId>java-driver-shaded-guava</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- 3rd party dependencies -->
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.gridkit.jvmtool</groupId>
       <artifactId>sjk-core</artifactId>
       <version>0.14</version>
@@ -69,7 +91,6 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>
-      <version>${dropwizard.metrics.version}</version>
     </dependency>
     <dependency>
       <groupId>com.github.akarnokd</groupId>
@@ -82,27 +103,12 @@
       <version>1.2</version>
     </dependency>
     <dependency>
-      <groupId>com.datastax.oss</groupId>
-      <artifactId>java-driver-core</artifactId>
-      <version>${driver.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.datastax.oss</groupId>
-      <artifactId>java-driver-shaded-guava</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>io.reactivex.rxjava2</groupId>
       <artifactId>rxjava</artifactId>
       <version>2.2.15</version>
     </dependency>
-    <dependency>
-      <groupId>io.stargate.auth</groupId>
-      <artifactId>authnz</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
+
+    <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/persistence-cassandra-3.11/pom.xml
+++ b/persistence-cassandra-3.11/pom.xml
@@ -100,7 +100,6 @@
     <dependency>
       <groupId>org.javatuples</groupId>
       <artifactId>javatuples</artifactId>
-      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>io.reactivex.rxjava2</groupId>

--- a/persistence-cassandra-4.0/pom.xml
+++ b/persistence-cassandra-4.0/pom.xml
@@ -18,11 +18,7 @@
     <cassandra.bundled-driver.version>3.11.0</cassandra.bundled-driver.version>
   </properties>
   <dependencies>
-    <dependency>
-      <groupId>org.immutables</groupId>
-      <artifactId>value</artifactId>
-      <scope>provided</scope>
-    </dependency>
+    <!-- Stargate component dependencies -->
     <dependency>
       <groupId>io.stargate.db</groupId>
       <artifactId>persistence-api</artifactId>
@@ -40,6 +36,14 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>io.stargate.auth</groupId>
+      <artifactId>authnz</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Cassandra/DataStax -->
     <dependency>
       <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-all</artifactId>
@@ -61,6 +65,24 @@
       <version>${cassandra.bundled-driver.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.datastax.oss</groupId>
+      <artifactId>java-driver-core</artifactId>
+      <version>${driver.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.datastax.oss</groupId>
+      <artifactId>java-driver-shaded-guava</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- 3rd party dependencies -->
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.gridkit.jvmtool</groupId>
       <artifactId>sjk-core</artifactId>
       <version>0.14</version>
@@ -69,7 +91,6 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>
-      <version>${dropwizard.metrics.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.auto.factory</groupId>
@@ -93,27 +114,12 @@
       <version>1.2</version>
     </dependency>
     <dependency>
-      <groupId>com.datastax.oss</groupId>
-      <artifactId>java-driver-core</artifactId>
-      <version>${driver.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.datastax.oss</groupId>
-      <artifactId>java-driver-shaded-guava</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>io.reactivex.rxjava2</groupId>
       <artifactId>rxjava</artifactId>
       <version>2.2.15</version>
     </dependency>
-    <dependency>
-      <groupId>io.stargate.auth</groupId>
-      <artifactId>authnz</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
+
+    <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/persistence-cassandra-4.0/pom.xml
+++ b/persistence-cassandra-4.0/pom.xml
@@ -111,6 +111,7 @@
     <dependency>
       <groupId>org.javatuples</groupId>
       <artifactId>javatuples</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.reactivex.rxjava2</groupId>

--- a/persistence-cassandra-4.0/pom.xml
+++ b/persistence-cassandra-4.0/pom.xml
@@ -21,7 +21,6 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
-      <version>2.8.8</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/persistence-cassandra-4.0/pom.xml
+++ b/persistence-cassandra-4.0/pom.xml
@@ -111,7 +111,6 @@
     <dependency>
       <groupId>org.javatuples</groupId>
       <artifactId>javatuples</artifactId>
-      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>io.reactivex.rxjava2</groupId>

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/StargateQueryHandler.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/StargateQueryHandler.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.validation.constraints.NotNull;
 import org.apache.cassandra.auth.IResource;
 import org.apache.cassandra.auth.RoleResource;
 import org.apache.cassandra.cql3.BatchQueryOptions;
@@ -290,7 +289,6 @@ public class StargateQueryHandler implements QueryHandler {
     }
   }
 
-  @NotNull
   private AuthenticationSubject loadAuthenticationSubject(Map<String, ByteBuffer> customPayload) {
     AuthenticatedUser user = Serializer.load(customPayload);
     return AuthenticationSubject.of(user);

--- a/persistence-common/pom.xml
+++ b/persistence-common/pom.xml
@@ -12,12 +12,15 @@
     <cassandra.version>3.11.9</cassandra.version>
   </properties>
   <dependencies>
+    <!-- Stargate component dependencies -->
     <dependency>
       <groupId>io.stargate.db</groupId>
       <artifactId>persistence-api</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <!-- Cassandra/DataStax -->
     <dependency>
       <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-all</artifactId>
@@ -29,11 +32,15 @@
       <artifactId>java-driver-shaded-guava</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <!-- 3rd party dependencies -->
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/persistence-common/pom.xml
+++ b/persistence-common/pom.xml
@@ -32,7 +32,6 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
-      <version>2.8.8</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -166,6 +166,7 @@
     <dependency>
       <groupId>org.javatuples</groupId>
       <artifactId>javatuples</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Test dependencies -->

--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -27,6 +27,7 @@
     </repository>
   </repositories>
   <dependencies>
+    <!-- Stargate component dependencies -->
     <dependency>
       <groupId>io.stargate.db</groupId>
       <artifactId>persistence-common</artifactId>
@@ -50,6 +51,14 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>io.stargate.auth</groupId>
+      <artifactId>authnz</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Cassandra/DataStax -->
     <dependency>
       <groupId>com.datastax.dse</groupId>
       <artifactId>dse-core</artifactId>
@@ -111,6 +120,13 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>com.datastax.oss</groupId>
+      <artifactId>java-driver-shaded-guava</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- 3rd party dependencies -->
+    <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
       <scope>provided</scope>
@@ -130,7 +146,6 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>
-      <version>${dropwizard.metrics.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.auto.factory</groupId>
@@ -153,12 +168,8 @@
       <artifactId>javatuples</artifactId>
       <version>1.2</version>
     </dependency>
-    <dependency>
-      <groupId>io.stargate.auth</groupId>
-      <artifactId>authnz</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
+
+    <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
@@ -184,11 +195,6 @@
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.datastax.oss</groupId>
-      <artifactId>java-driver-shaded-guava</artifactId>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>

--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -113,7 +113,6 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
-      <version>2.8.8</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -183,7 +183,6 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <version>4.0.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -166,7 +166,6 @@
     <dependency>
       <groupId>org.javatuples</groupId>
       <artifactId>javatuples</artifactId>
-      <version>1.2</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/persistence-test/pom.xml
+++ b/persistence-test/pom.xml
@@ -9,12 +9,15 @@
   <groupId>io.stargate.db</groupId>
   <artifactId>persistence-test</artifactId>
   <dependencies>
+    <!-- Stargate component dependencies -->
     <dependency>
       <groupId>io.stargate.db</groupId>
       <artifactId>persistence-api</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <!-- Other dependencies, note that these are not in the test scope -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
@@ -51,10 +54,11 @@
       <artifactId>commons-io</artifactId>
       <scope>compile</scope>
     </dependency>
+    <!-- IMPORTANT: please note that this dependency must be in sync with the transitive version in the cassandra-all in persistence 3.11, 4.0 and DSE 6.8 projects -->
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.9.8</version>
+      <version>2.9.10</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/persistence-test/pom.xml
+++ b/persistence-test/pom.xml
@@ -52,14 +52,12 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <scope>compile</scope>
     </dependency>
     <!-- IMPORTANT: please note that this dependency must be in sync with the transitive version in the cassandra-all in persistence 3.11, 4.0 and DSE 6.8 projects -->
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
       <version>2.9.10</version>
-      <scope>compile</scope>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,9 @@
   <description>Core modules for Stargate</description>
   <url>http://github.com/stargate/stargate</url>
   <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+
     <osgi.bundle.version>${project.version}</osgi.bundle.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.scm.id>github</project.scm.id>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,9 @@
     <errorprone.version>2.3.4</errorprone.version>
     <jacoco.version>0.8.6</jacoco.version>
     <junit.version>5.8.2</junit.version>
-    <mockito.version>3.5.13</mockito.version>
+    <mockito.version>3.12.4</mockito.version>
+    <assertj.version>3.21.0</assertj.version>
+    <awaitility.version>4.1.1</awaitility.version>
   </properties>
   <dependencies>
     <!-- Basic OSGi dependency, provided by container -->
@@ -626,7 +628,7 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.17.2</version>
+        <version>${assertj.version}</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard</groupId>
@@ -642,7 +644,7 @@
       <dependency>
         <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
-        <version>4.0.3</version>
+        <version>${awaitility.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <caffeine.version>2.9.3</caffeine.version>
     <commons-io.version>2.7</commons-io.version>
     <grpc.version>1.42.1</grpc.version>
-    <immutables.version>2.5.6</immutables.version>
+    <immutables.version>2.8.8</immutables.version>
     <!-- Make sure micrometer and prometheus versions are in sync  -->
     <micrometer.version>1.7.3</micrometer.version>
     <prometheus.version>0.10.0</prometheus.version>
@@ -576,6 +576,11 @@
         <groupId>io.prometheus</groupId>
         <artifactId>simpleclient_dropwizard</artifactId>
         <version>${prometheus.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.immutables</groupId>
+        <artifactId>value</artifactId>
+        <version>${immutables.version}</version>
       </dependency>
       <dependency>
         <groupId>com.bpodgursky</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <micrometer.version>1.7.3</micrometer.version>
     <prometheus.version>0.10.0</prometheus.version>
     <swagger-ui.version>3.52.5</swagger-ui.version>
+    <swagger-jersey2-jaxrs.version>1.6.3</swagger-jersey2-jaxrs.version>
 
     <!-- And finally test/build deps -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -501,6 +501,31 @@
         <version>${dropwizard.version}</version>
       </dependency>
       <dependency>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-core</artifactId>
+        <version>${dropwizard.metrics.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-healthchecks</artifactId>
+        <version>${dropwizard.metrics.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-jvm</artifactId>
+        <version>${dropwizard.metrics.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-servlet</artifactId>
+        <version>${dropwizard.metrics.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-graphite</artifactId>
+        <version>${dropwizard.metrics.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
         <version>${jetty.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
     <commons-io.version>2.7</commons-io.version>
     <grpc.version>1.42.1</grpc.version>
     <immutables.version>2.8.8</immutables.version>
+    <javatuples.version>1.2</javatuples.version>
     <!-- Make sure micrometer and prometheus versions are in sync  -->
     <micrometer.version>1.7.3</micrometer.version>
     <prometheus.version>0.10.0</prometheus.version>
@@ -609,6 +610,11 @@
         <groupId>org.immutables</groupId>
         <artifactId>value</artifactId>
         <version>${immutables.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.javatuples</groupId>
+        <artifactId>javatuples</artifactId>
+        <version>${javatuples.version}</version>
       </dependency>
       <dependency>
         <groupId>com.bpodgursky</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,12 +20,12 @@
     <xml-format.skip>true</xml-format.skip>
 
     <!-- First DropWizard version and things it directly depends on that make sense to sync -->
-    <dropwizard.version>2.0.26</dropwizard.version>
+    <dropwizard.version>2.0.27</dropwizard.version>
     <!--
       Note that this is currently aligned with the metrics version that DropWizard transitively depends on.
       It's probably a good idea to keep the two versions in sync.
     -->
-    <dropwizard.metrics.version>4.1.27</dropwizard.metrics.version>
+    <dropwizard.metrics.version>4.1.28</dropwizard.metrics.version>
     <!--
       Note that this is currently aligned with the Jetty version that DropWizard transitively depends on.
       It's probably a good idea to keep the two versions in sync.

--- a/rate-limiting-global/pom.xml
+++ b/rate-limiting-global/pom.xml
@@ -9,6 +9,7 @@
   <groupId>io.stargate.db.limiter.global</groupId>
   <artifactId>rate-limiting-global</artifactId>
   <dependencies>
+    <!-- Stargate component dependencies -->
     <dependency>
       <groupId>io.stargate.db</groupId>
       <artifactId>persistence-api</artifactId>

--- a/restapi/pom.xml
+++ b/restapi/pom.xml
@@ -13,16 +13,11 @@
     <osgi.bundle.version>${project.version}</osgi.bundle.version>
   </properties>
   <dependencies>
+    <!-- Stargate component dependencies -->
     <dependency>
       <groupId>io.stargate.core</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-healthchecks</artifactId>
-      <version>${dropwizard.metrics.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -41,6 +36,13 @@
       <groupId>io.stargate.metrics</groupId>
       <artifactId>metrics-jersey</artifactId>
       <version>${project.version}</version>
+    </dependency>
+
+    <!-- 3rd party dependencies -->
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-healthchecks</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.dropwizard</groupId>
@@ -119,6 +121,18 @@
       <artifactId>jbool_expressions</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.reactivex.rxjava3</groupId>
+      <artifactId>rxjava</artifactId>
+      <version>3.0.12</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.akarnokd</groupId>
+      <artifactId>rxjava3-extensions</artifactId>
+      <version>3.0.1</version>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
@@ -144,20 +158,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.reactivex.rxjava3</groupId>
-      <artifactId>rxjava</artifactId>
-      <version>3.0.12</version>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-junit-jupiter</artifactId>
+        <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.github.akarnokd</groupId>
-      <artifactId>rxjava3-extensions</artifactId>
-      <version>3.0.1</version>
-    </dependency>
-      <dependency>
-          <groupId>org.mockito</groupId>
-          <artifactId>mockito-junit-jupiter</artifactId>
-          <scope>test</scope>
-      </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>

--- a/restapi/pom.xml
+++ b/restapi/pom.xml
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-jersey2-jaxrs</artifactId>
-      <version>1.6.2</version>
+      <version>${swagger-jersey2-jaxrs.version}</version>
     </dependency>
     <dependency>
       <groupId>com.github.jsurfer</groupId>

--- a/restapi/pom.xml
+++ b/restapi/pom.xml
@@ -88,12 +88,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-      <version>1.1.0.Final</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-logging</artifactId>
     </dependency>

--- a/testing-services/pom.xml
+++ b/testing-services/pom.xml
@@ -9,6 +9,7 @@
   <groupId>io.stargate.it</groupId>
   <artifactId>testing-services</artifactId>
   <dependencies>
+    <!-- Stargate component dependencies -->
     <dependency>
       <groupId>io.stargate.auth</groupId>
       <artifactId>authnz</artifactId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -171,7 +171,6 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
-      <version>2.8.8</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -15,16 +15,7 @@
     <code.coverage.overall.data.folder>${basedir}/../target/</code.coverage.overall.data.folder>
   </properties>
   <dependencies>
-    <dependency>
-      <groupId>com.datastax.oss</groupId>
-      <artifactId>java-driver-core</artifactId>
-      <version>${driver.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.datastax.oss</groupId>
-      <artifactId>java-driver-query-builder</artifactId>
-      <version>${driver.version}</version>
-    </dependency>
+    <!-- Stargate component dependencies -->
     <dependency>
       <groupId>io.stargate.db</groupId>
       <artifactId>persistence-test</artifactId>
@@ -34,20 +25,6 @@
       <groupId>io.stargate.db</groupId>
       <artifactId>persistence-api</artifactId>
       <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-exec</artifactId>
-      <version>1.3</version>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.11</version>
     </dependency>
     <dependency>
       <groupId>io.stargate.auth.api</groupId>
@@ -71,6 +48,46 @@
       <artifactId>grpc-proto</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.stargate.starter</groupId>
+      <artifactId>stargate-starter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.stargate.it</groupId>
+      <artifactId>testing-services</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Cassandra/DataStax -->
+    <dependency>
+      <groupId>com.datastax.oss</groupId>
+      <artifactId>java-driver-core</artifactId>
+      <version>${driver.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.datastax.oss</groupId>
+      <artifactId>java-driver-query-builder</artifactId>
+      <version>${driver.version}</version>
+    </dependency>
+
+    <!-- 3rd party dependencies -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-exec</artifactId>
+      <version>1.3</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.11</version>
+    </dependency>
+
+    <!-- Other dependencies, note that these are not in the test scope -->
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
@@ -120,11 +137,6 @@
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.framework</artifactId>
       <version>6.0.2</version>
-    </dependency>
-    <dependency>
-      <groupId>io.stargate.starter</groupId>
-      <artifactId>stargate-starter</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.github.rvesse</groupId>
@@ -185,11 +197,6 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
       <version>1.15.2</version>
-    </dependency>
-    <dependency>
-      <groupId>io.stargate.it</groupId>
-      <artifactId>testing-services</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>


### PR DESCRIPTION
This PR does a maintenance on the dependencies. Here is the full list of the things done:

* centralize the `immutables` version and updates to latest
* centralize the `swagger-jersey2-jaxrs` and update to latest
* update all test frameworks to the latest (except `mockito` which is updated to the latest 3.x line)
* organization of the dependencies in all projects in groups - stargate, C, 3rd party, test
* removing the `javax.validation-api` and `javax.annotation-api` from the `persistence-api` as this makes no sense at all
* `javatuples` version centralized, and defined correct scope for the projects that depend on it
* setting the explicit maven compiler java version to `1.8`
* remove all `<scope>compile</scope>` from the poms, as this is default
* updates `dropwizard` to latest version `2.0.27`

Note that of course there is bunch of other dependencies to be updated. Here is my overview on the most important ones:
* `cassandra-all` from `3.11.9` to `3.11.11`
* DS OSS `java-driver-core` from `4.9.0` to `4.13.0`

Tasks:
* [ ] Rebase before merge