### PR TITLE
Rename Column.Type.Varchar to Text, remove protocol code 10 (fixes #1499)

### DIFF
--- a/auth-jwt-service/src/main/java/io/stargate/auth/jwt/AuthzJwtService.java
+++ b/auth-jwt-service/src/main/java/io/stargate/auth/jwt/AuthzJwtService.java
@@ -283,7 +283,7 @@ public class AuthzJwtService implements AuthorizationService {
       // the request is not allowed.
       if (stargateClaims.has(STARGATE_PREFIX + typedKeyValue.getName())) {
         ColumnType targetCellType = typedKeyValue.getType();
-        if (!(targetCellType.equals(Type.Varchar) || targetCellType.equals(Type.Text))) {
+        if (!targetCellType.equals(Type.Text)) {
           throw new IllegalArgumentException(
               "Column must be of type text to be used for authorization");
         }

--- a/graphqlapi/src/main/java/io/stargate/graphql/persistence/graphqlfirst/SchemaSourceDao.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/persistence/graphqlfirst/SchemaSourceDao.java
@@ -73,14 +73,13 @@ public class SchemaSourceDao {
           .name(TABLE_NAME)
           .addColumns(
               ImmutableColumn.create(
-                  KEYSPACE_COLUMN_NAME, Column.Kind.PartitionKey, Column.Type.Varchar),
+                  KEYSPACE_COLUMN_NAME, Column.Kind.PartitionKey, Column.Type.Text),
               ImmutableColumn.create(
                   VERSION_COLUMN_NAME,
                   Column.Kind.Clustering,
                   Column.Type.Timeuuid,
                   Column.Order.DESC),
-              ImmutableColumn.create(
-                  CONTENTS_COLUMN_NAME, Column.Kind.Regular, Column.Type.Varchar),
+              ImmutableColumn.create(CONTENTS_COLUMN_NAME, Column.Kind.Regular, Column.Type.Text),
               ImmutableColumn.create(
                   LATEST_VERSION_COLUMN_NAME, Column.Kind.Static, Column.Type.Timeuuid),
               ImmutableColumn.create(

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/FieldTypeCache.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/cqlfirst/dml/FieldTypeCache.java
@@ -75,11 +75,6 @@ abstract class FieldTypeCache<GraphqlT> {
       type = ImmutableListType.builder().addAllParameters(type.parameters()).build();
     }
 
-    // CQL text and varchar use the same GraphQL type.
-    if (type == Type.Varchar) {
-      type = Type.Text;
-    }
-
     return type;
   }
 
@@ -99,7 +94,6 @@ abstract class FieldTypeCache<GraphqlT> {
       case Int:
         return Scalars.GraphQLInt;
       case Text:
-      case Varchar:
         return Scalars.GraphQLString;
       default:
         return CqlScalar.fromCqlType(type)

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/DeployedFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/DeployedFetcher.java
@@ -109,7 +109,6 @@ abstract class DeployedFetcher<ResultT> extends CassandraFetcher<ResultT> {
         expectedClass = Double.class;
         graphqlScalar = Scalars.GraphQLFloat;
         break;
-      case Varchar:
       case Text:
         expectedClass = String.class;
         graphqlScalar = Scalars.GraphQLString;

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/FieldModelBuilder.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/FieldModelBuilder.java
@@ -42,7 +42,7 @@ class FieldModelBuilder extends ModelBuilderBase<FieldModel> {
       ImmutableMap.<String, Column.ColumnType>builder()
           .put(Scalars.GraphQLInt.getName(), Column.Type.Int)
           .put(Scalars.GraphQLFloat.getName(), Column.Type.Double)
-          .put(Scalars.GraphQLString.getName(), Column.Type.Varchar)
+          .put(Scalars.GraphQLString.getName(), Column.Type.Text)
           .put(Scalars.GraphQLBoolean.getName(), Column.Type.Boolean)
           .put(Scalars.GraphQLID.getName(), Column.Type.Uuid)
           .build();
@@ -167,7 +167,7 @@ class FieldModelBuilder extends ModelBuilderBase<FieldModel> {
         TypeDefinition<?> definition =
             typeRegistry.getType(typeName).orElseThrow(AssertionError::new);
         if (definition instanceof EnumTypeDefinition) {
-          return Column.Type.Varchar;
+          return Column.Type.Text;
         }
         if (definition instanceof ObjectTypeDefinition) {
           return expectUdt((ObjectTypeDefinition) definition);

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/cqlfirst/dml/FieldTypeCachesTest.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/cqlfirst/dml/FieldTypeCachesTest.java
@@ -218,8 +218,7 @@ public class FieldTypeCachesTest {
             arguments(Type.Boolean, Scalars.GraphQLBoolean),
             arguments(Type.Double, Scalars.GraphQLFloat),
             arguments(Type.Int, Scalars.GraphQLInt),
-            arguments(Type.Text, Scalars.GraphQLString),
-            arguments(Type.Varchar, Scalars.GraphQLString));
+            arguments(Type.Text, Scalars.GraphQLString));
     Stream<Arguments> cqlScalars =
         Arrays.stream(CqlScalar.values()).map(s -> arguments(s.getCqlType(), s.getGraphqlType()));
     return Stream.concat(builtinScalars, cqlScalars);

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/ScalarsDmlTest.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/cqlfirst/dml/fetchers/ScalarsDmlTest.java
@@ -260,8 +260,6 @@ public class ScalarsDmlTest extends DmlTestBase {
         arguments(Column.Type.Tinyint, (long) Byte.MAX_VALUE, null),
         arguments(Column.Type.Timeuuid, "30821634-13ad-11eb-adc1-0242ac120002", null),
         arguments(Column.Type.Uuid, "f3abdfbf-479f-407b-9fde-128145bd7bef", null),
-        arguments(Column.Type.Varchar, "abc123", "'abc123'"),
-        arguments(Column.Type.Varchar, "", "''"),
         arguments(Column.Type.Varint, "0", null),
         arguments(Column.Type.Varint, "-1", null),
         arguments(Column.Type.Varint, "1", null),

--- a/grpc-proto/proto/query.proto
+++ b/grpc-proto/proto/query.proto
@@ -230,7 +230,9 @@ message TypeSpec {
     DOUBLE = 0x07;
     FLOAT = 0x08;
     INT = 0x09;
-    TEXT = 0xA;
+    // Note that TEXT and VARCHAR are synonyms in Cassandra. gRPC responses will always use VARCHAR,
+    // regardless of the name that was used for creation.
+    TEXT = 0xA [deprecated = true];
     TIMESTAMP = 0x0B;
     UUID = 0x0C;
     VARCHAR = 0x0D;

--- a/grpc/src/main/java/io/stargate/grpc/codec/ValueCodecs.java
+++ b/grpc/src/main/java/io/stargate/grpc/codec/ValueCodecs.java
@@ -45,7 +45,6 @@ public class ValueCodecs {
               .put(Type.Timeuuid, new UuidCodec())
               .put(Type.Tinyint, new TinyintCodec())
               .put(Type.Uuid, new UuidCodec())
-              .put(Type.Varchar, new StringCodec(TypeCodecs.TEXT))
               .put(Type.Varint, new VarintCodec())
               .put(Type.List, new CollectionCodec())
               .put(Type.Set, new CollectionCodec())

--- a/grpc/src/test/java/io/stargate/grpc/codec/ValueCodecTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/codec/ValueCodecTest.java
@@ -296,9 +296,7 @@ public class ValueCodecTest {
   public static Stream<Arguments> stringValues() {
     return Stream.of(
         arguments(Type.Ascii, Values.of("Hello, world")),
-        arguments(Type.Varchar, Values.of("你好，世界")),
         arguments(Type.Text, Values.of("你好，世界")),
-        arguments(Type.Varchar, Values.of("")),
         arguments(Type.Text, Values.of("")),
         arguments(Type.Ascii, Values.of("")));
   }
@@ -306,7 +304,6 @@ public class ValueCodecTest {
   public static Stream<Arguments> invalidStringValues() {
     return Stream.of(
         arguments(Type.Text, Values.NULL, "Expected string type"),
-        arguments(Type.Varchar, Values.UNSET, "Expected string type"),
         arguments(
             Type.Ascii,
             Values.of("你好，世界"),
@@ -367,9 +364,9 @@ public class ValueCodecTest {
 
   public static Stream<Arguments> listValues() {
     return Stream.of(
-        arguments(Type.List.of(Type.Varchar), Values.of()),
+        arguments(Type.List.of(Type.Text), Values.of()),
         arguments(
-            Type.List.of(Type.Varchar), Values.of(Values.of("a"), Values.of("b"), Values.of("c"))),
+            Type.List.of(Type.Text), Values.of(Values.of("a"), Values.of("b"), Values.of("c"))),
         arguments(Type.List.of(Type.Int), Values.of(Values.of(1), Values.of(2), Values.of(3))),
         arguments(
             Type.List.of(Type.Int),
@@ -379,27 +376,25 @@ public class ValueCodecTest {
   public static Stream<Arguments> invalidListValues() {
     return Stream.of(
         arguments(
-            Type.List.of(Type.Varchar),
+            Type.List.of(Type.Text),
             Values.of(Values.of("a"), Values.of(1)),
             "Expected string type"),
-        arguments(Type.List.of(Type.Varchar), Values.of(Values.UNSET), "Expected string type"),
+        arguments(Type.List.of(Type.Text), Values.of(Values.UNSET), "Expected string type"),
         arguments(Type.List.of(Type.Int), Values.NULL, "Expected collection type"),
         arguments(Type.List.of(Type.Int), Values.UNSET, "Expected collection type"),
         arguments(
-            Type.List.of(Type.Varchar),
-            Values.of(Values.NULL),
-            "null is not supported inside lists"),
+            Type.List.of(Type.Text), Values.of(Values.NULL), "null is not supported inside lists"),
         arguments(
             Type.List.of(Type.Int), Values.of(Values.NULL), "null is not supported inside lists"));
   }
 
   public static Stream<Arguments> setValues() {
     return Stream.of(
-        arguments(Type.Set.of(Type.Varchar), Values.of()),
+        arguments(Type.Set.of(Type.Text), Values.of()),
         arguments(
-            Type.Set.of(Type.Varchar), Values.of(Values.of("a"), Values.of("b"), Values.of("c"))),
+            Type.Set.of(Type.Text), Values.of(Values.of("a"), Values.of("b"), Values.of("c"))),
         arguments(
-            Type.Set.of(Type.Varchar),
+            Type.Set.of(Type.Text),
             Values.of(
                 new HashSet<Value>() {
                   {
@@ -413,28 +408,28 @@ public class ValueCodecTest {
   public static Stream<Arguments> invalidSetValues() {
     return Stream.of(
         arguments(
-            Type.Set.of(Type.Varchar), Values.of(Values.NULL), "null is not supported inside sets"),
+            Type.Set.of(Type.Text), Values.of(Values.NULL), "null is not supported inside sets"),
         arguments(
             Type.Set.of(Type.Int), Values.of(Values.NULL), "null is not supported inside sets"));
   }
 
   public static Stream<Arguments> mapValues() {
     return Stream.of(
-        arguments(Type.Map.of(Type.Varchar, Type.Int), Values.of()),
+        arguments(Type.Map.of(Type.Text, Type.Int), Values.of()),
         arguments(
-            Type.Map.of(Type.Varchar, Type.Int),
+            Type.Map.of(Type.Text, Type.Int),
             Values.of(
                 Values.of("a"), Values.of(1),
                 Values.of("b"), Values.of(2),
                 Values.of("c"), Values.of(3))),
         arguments(
-            Type.Map.of(Type.Uuid, Type.Varchar),
+            Type.Map.of(Type.Uuid, Type.Text),
             Values.of(
                 Values.of(Uuids.random()), Values.of("a"),
                 Values.of(Uuids.random()), Values.of("b"),
                 Values.of(Uuids.random()), Values.of("c"))),
         arguments(
-            Type.Map.of(Type.Uuid, Type.Varchar),
+            Type.Map.of(Type.Uuid, Type.Text),
             Values.of(
                 ImmutableMap.<Value, Value>builder()
                     .put(Values.of(Uuids.random()), Values.of("a"))
@@ -446,28 +441,28 @@ public class ValueCodecTest {
   public static Stream<Arguments> invalidMapValues() {
     return Stream.of(
         arguments(
-            Type.Map.of(Type.Varchar, Type.Int),
+            Type.Map.of(Type.Text, Type.Int),
             Values.of(
                 Values.of("a"), Values.of(1),
                 Values.of("b"), Values.of(2),
                 Values.of("c"), Values.of(Uuids.random())),
             "Expected integer type"),
         arguments(
-            Type.Map.of(Type.Varchar, Type.Int),
+            Type.Map.of(Type.Text, Type.Int),
             Values.of(
                 Values.of("a"), Values.of(1),
                 Values.of("b"), Values.of(2),
                 Values.of("c"), Values.UNSET),
             "Expected integer type"),
         arguments(
-            Type.Map.of(Type.Uuid, Type.Varchar),
+            Type.Map.of(Type.Uuid, Type.Text),
             Values.of(
                 Values.of(Uuids.random()), Values.of("a"),
                 Values.of(Uuids.random()), Values.of("b"),
                 Values.of(1), Values.of("c")),
             "Expected UUID type"),
         arguments(
-            Type.Map.of(Type.Uuid, Type.Varchar),
+            Type.Map.of(Type.Uuid, Type.Text),
             Values.of(
                 Values.of(Uuids.random()),
                 Values.of("a"),
@@ -477,55 +472,52 @@ public class ValueCodecTest {
                 Values.of("c")),
             "Expected UUID type"),
         arguments(
-            Type.Map.of(Type.Uuid, Type.Varchar),
+            Type.Map.of(Type.Uuid, Type.Text),
             Values.of(Values.of(Uuids.random())),
             "Expected an even number of elements"),
-        arguments(Type.Map.of(Type.Uuid, Type.Varchar), Values.NULL, "Expected collection type"),
-        arguments(Type.Map.of(Type.Uuid, Type.Varchar), Values.UNSET, "Expected collection type"),
+        arguments(Type.Map.of(Type.Uuid, Type.Text), Values.NULL, "Expected collection type"),
+        arguments(Type.Map.of(Type.Uuid, Type.Text), Values.UNSET, "Expected collection type"),
         arguments(
-            Type.Map.of(Type.Varchar, Type.Int),
+            Type.Map.of(Type.Text, Type.Int),
             Values.of(Values.of("a"), Values.NULL),
             "null is not supported inside maps"),
         arguments(
-            Type.Map.of(Type.Uuid, Type.Varchar),
+            Type.Map.of(Type.Uuid, Type.Text),
             Values.of(Values.NULL, Values.of("a")),
             "null is not supported inside maps"));
   }
 
   public static Stream<Arguments> tupleValues() {
     return Stream.of(
-        arguments(Type.Tuple.of(Type.Varchar, Type.Int, Type.Uuid), Values.of(Values.of("a"))),
+        arguments(Type.Tuple.of(Type.Text, Type.Int, Type.Uuid), Values.of(Values.of("a"))),
         arguments(
-            Type.Tuple.of(Type.Varchar, Type.Int, Type.Uuid),
-            Values.of(Values.of("a"), Values.of(1))),
+            Type.Tuple.of(Type.Text, Type.Int, Type.Uuid), Values.of(Values.of("a"), Values.of(1))),
         arguments(
-            Type.Tuple.of(Type.Varchar, Type.Int, Type.Uuid),
+            Type.Tuple.of(Type.Text, Type.Int, Type.Uuid),
             Values.of(Values.of("a"), Values.of(1), Values.of(Uuids.random()))),
         arguments(
-            Type.Tuple.of(Type.Varchar, Type.Int, Type.Uuid),
+            Type.Tuple.of(Type.Text, Type.Int, Type.Uuid),
             Values.of(Values.NULL, Values.NULL, Values.NULL)));
   }
 
   public static Stream<Arguments> invalidTupleValues() {
     return Stream.of(
         arguments(
-            Type.Tuple.of(Type.Varchar, Type.Int, Type.Uuid),
+            Type.Tuple.of(Type.Text, Type.Int, Type.Uuid),
             Values.of(Values.of("a"), Values.of(1), Values.of("wrong")),
             "Expected UUID type"),
         arguments(
-            Type.Tuple.of(Type.Varchar, Type.Int, Type.Uuid),
+            Type.Tuple.of(Type.Text, Type.Int, Type.Uuid),
             Values.of(Values.of("a"), Values.of(1), Values.UNSET),
             "Expected UUID type"),
         arguments(
-            Type.Tuple.of(Type.Varchar),
+            Type.Tuple.of(Type.Text),
             Values.of(Values.of("a"), Values.of(1)),
             "Too many tuple fields. Expected 1, but received 2"),
         arguments(
-            Type.Tuple.of(Type.Varchar, Type.Int, Type.Uuid),
-            Values.NULL,
-            "Expected collection type"),
+            Type.Tuple.of(Type.Text, Type.Int, Type.Uuid), Values.NULL, "Expected collection type"),
         arguments(
-            Type.Tuple.of(Type.Varchar, Type.Int, Type.Uuid),
+            Type.Tuple.of(Type.Text, Type.Int, Type.Uuid),
             Values.UNSET,
             "Expected collection type"));
   }
@@ -533,33 +525,33 @@ public class ValueCodecTest {
   public static Stream<Arguments> udtValues() {
     return Stream.of(
         arguments( // Simple case
-            udt(Column.create("a", Type.Int), Column.create("b", Type.Varchar)),
+            udt(Column.create("a", Type.Int), Column.create("b", Type.Text)),
             Values.udtOf(ImmutableMap.of("a", Values.of(1), "b", Values.of("abc"))),
             Values.udtOf(ImmutableMap.of("a", Values.of(1), "b", Values.of("abc")))),
         arguments( // Flipped
-            udt(Column.create("a", Type.Int), Column.create("b", Type.Varchar)),
+            udt(Column.create("a", Type.Int), Column.create("b", Type.Text)),
             Values.udtOf(ImmutableMap.of("a", Values.of(1), "b", Values.of("abc"))),
             Values.udtOf(ImmutableMap.of("b", Values.of("abc"), "a", Values.of(1)))),
         arguments( // Single first value
-            udt(Column.create("a", Type.Int), Column.create("b", Type.Varchar)),
+            udt(Column.create("a", Type.Int), Column.create("b", Type.Text)),
             Values.udtOf(ImmutableMap.of("a", Values.of(1))),
             Values.udtOf(ImmutableMap.of("a", Values.of(1), "b", Values.NULL))),
         arguments( // Single second value
-            udt(Column.create("a", Type.Int), Column.create("b", Type.Varchar)),
+            udt(Column.create("a", Type.Int), Column.create("b", Type.Text)),
             Values.udtOf(ImmutableMap.of("b", Values.of("abc"))),
             Values.udtOf(ImmutableMap.of("a", Values.NULL, "b", Values.of("abc")))),
         arguments( // Empty
-            udt(Column.create("a", Type.Int), Column.create("b", Type.Varchar)),
+            udt(Column.create("a", Type.Int), Column.create("b", Type.Text)),
             Values.udtOf(ImmutableMap.of()),
             Values.udtOf(ImmutableMap.of("a", Values.NULL, "b", Values.NULL))),
         arguments( // Null
-            udt(Column.create("a", Type.Int), Column.create("b", Type.Varchar)),
+            udt(Column.create("a", Type.Int), Column.create("b", Type.Text)),
             Values.udtOf(ImmutableMap.of("a", Values.NULL, "b", Values.NULL)),
             Values.udtOf(ImmutableMap.of("a", Values.NULL, "b", Values.NULL))),
         arguments( // Embedded UDT
             udt(
                 Column.create(
-                    "c", udt(Column.create("a", Type.Int), Column.create("b", Type.Varchar)))),
+                    "c", udt(Column.create("a", Type.Int), Column.create("b", Type.Text)))),
             Values.udtOf(
                 ImmutableMap.of(
                     "c", Values.udtOf(ImmutableMap.of("a", Values.of(1), "b", Values.of("abc"))))),
@@ -569,7 +561,7 @@ public class ValueCodecTest {
         arguments( // Embedded collections
             udt(
                 Column.create("a", Type.List.of(Type.Int)),
-                Column.create("b", Type.Tuple.of(Type.Varchar, Type.Boolean))),
+                Column.create("b", Type.Tuple.of(Type.Text, Type.Boolean))),
             Values.udtOf(
                 ImmutableMap.of(
                     "a",
@@ -587,23 +579,23 @@ public class ValueCodecTest {
   public static Stream<Arguments> invalidUdtValues() {
     return Stream.of(
         arguments(
-            udt(Column.create("a", Type.Int), Column.create("b", Type.Varchar)),
+            udt(Column.create("a", Type.Int), Column.create("b", Type.Text)),
             Values.udtOf(ImmutableMap.of("c", Values.of(1))),
             "User-defined type doesn't contain a field named 'c'"),
         arguments(
-            udt(Column.create("a", Type.Int), Column.create("b", Type.Varchar)),
+            udt(Column.create("a", Type.Int), Column.create("b", Type.Text)),
             Values.udtOf(ImmutableMap.of("a", Values.of("abc"), "b", Values.of("abc"))),
             "Expected integer type"),
         arguments(
-            udt(Column.create("a", Type.Int), Column.create("b", Type.Varchar)),
+            udt(Column.create("a", Type.Int), Column.create("b", Type.Text)),
             Values.udtOf(ImmutableMap.of("a", Values.of(1), "b", Values.of(2))),
             "Expected string type"),
         arguments(
-            udt(Column.create("a", Type.Int), Column.create("b", Type.Varchar)),
+            udt(Column.create("a", Type.Int), Column.create("b", Type.Text)),
             Values.NULL,
             "Expected user-defined type"),
         arguments(
-            udt(Column.create("a", Type.Int), Column.create("b", Type.Varchar)),
+            udt(Column.create("a", Type.Int), Column.create("b", Type.Text)),
             Values.UNSET,
             "Expected user-defined type"));
   }

--- a/grpc/src/test/java/io/stargate/grpc/service/ExecuteBatchTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/ExecuteBatchTest.java
@@ -64,8 +64,7 @@ public class ExecuteBatchTest extends BaseGrpcServiceTest {
             Utils.STATEMENT_ID,
             Utils.RESULT_METADATA_ID,
             Utils.makeResultMetadata(),
-            Utils.makePreparedMetadata(
-                Column.create("k", Type.Varchar), Column.create("v", Type.Int)),
+            Utils.makePreparedMetadata(Column.create("k", Type.Text), Column.create("v", Type.Int)),
             false,
             false);
     when(connection.prepare(anyString(), any(Parameters.class)))
@@ -202,12 +201,12 @@ public class ExecuteBatchTest extends BaseGrpcServiceTest {
     return Stream.of(
         // Invalid arity
         arguments(
-            Arrays.array(Column.create("k", Type.Varchar), Column.create("v", Type.Int)),
+            Arrays.array(Column.create("k", Type.Text), Column.create("v", Type.Int)),
             Arrays.array(Values.of("a")),
             "Invalid number of bind values. Expected 2, but received 1"),
         // Invalid type
         arguments(
-            Arrays.array(Column.create("k", Type.Varchar)),
+            Arrays.array(Column.create("k", Type.Text)),
             Arrays.array(Values.of(1)),
             "Invalid argument at position 1"));
   }

--- a/grpc/src/test/java/io/stargate/grpc/service/ExecuteQueryTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/ExecuteQueryTest.java
@@ -254,7 +254,7 @@ public class ExecuteQueryTest extends BaseGrpcServiceTest {
             .addExpected(
                 ColumnSpec.newBuilder()
                     .setName("c2")
-                    .setType(TypeSpec.newBuilder().setBasic(TypeSpec.Basic.TEXT)))
+                    .setType(TypeSpec.newBuilder().setBasic(TypeSpec.Basic.VARCHAR)))
             .addExpected(
                 ColumnSpec.newBuilder()
                     .setName("c3")
@@ -269,7 +269,7 @@ public class ExecuteQueryTest extends BaseGrpcServiceTest {
                         TypeSpec.newBuilder()
                             .setList(
                                 TypeSpec.List.newBuilder()
-                                    .setElement(TypeSpec.newBuilder().setBasic(Basic.TEXT)))))
+                                    .setElement(TypeSpec.newBuilder().setBasic(Basic.VARCHAR)))))
             .build(false),
         ColumnMetadataBuilder.builder()
             .addActual(Column.create("l", Type.List.of(Type.Int)))
@@ -304,7 +304,7 @@ public class ExecuteQueryTest extends BaseGrpcServiceTest {
                         TypeSpec.newBuilder()
                             .setMap(
                                 TypeSpec.Map.newBuilder()
-                                    .setKey(TypeSpec.newBuilder().setBasic(TypeSpec.Basic.TEXT))
+                                    .setKey(TypeSpec.newBuilder().setBasic(TypeSpec.Basic.VARCHAR))
                                     .setValue(
                                         TypeSpec.newBuilder().setBasic(TypeSpec.Basic.BIGINT)))))
             .build(false),

--- a/grpc/src/test/java/io/stargate/grpc/service/ExecuteQueryTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/ExecuteQueryTest.java
@@ -68,13 +68,13 @@ public class ExecuteQueryTest extends BaseGrpcServiceTest {
     final String releaseVersion = "4.0.0";
 
     ResultMetadata resultMetadata =
-        Utils.makeResultMetadata(Column.create("release_version", Type.Varchar));
+        Utils.makeResultMetadata(Column.create("release_version", Type.Text));
     Prepared prepared =
         new Prepared(
             Utils.STATEMENT_ID,
             Utils.RESULT_METADATA_ID,
             resultMetadata,
-            Utils.makePreparedMetadata(Column.create("key", Type.Varchar)),
+            Utils.makePreparedMetadata(Column.create("key", Type.Text)),
             false,
             false);
     when(connection.prepare(eq(query), any(Parameters.class)))
@@ -167,12 +167,12 @@ public class ExecuteQueryTest extends BaseGrpcServiceTest {
         // Invalid arity
         arguments(
             org.assertj.core.util.Arrays.array(
-                Column.create("k", Type.Varchar), Column.create("v", Type.Int)),
+                Column.create("k", Type.Text), Column.create("v", Type.Int)),
             org.assertj.core.util.Arrays.array(Values.of("a")),
             "Invalid number of bind values. Expected 2, but received 1"),
         // Invalid type
         arguments(
-            org.assertj.core.util.Arrays.array(Column.create("k", Type.Varchar)),
+            org.assertj.core.util.Arrays.array(Column.create("k", Type.Text)),
             org.assertj.core.util.Arrays.array(Values.of(1)),
             "Invalid argument at position 1"));
   }
@@ -245,7 +245,7 @@ public class ExecuteQueryTest extends BaseGrpcServiceTest {
     return Stream.of(
         ColumnMetadataBuilder.builder()
             .addActual(Column.create("c1", Column.Type.Int))
-            .addActual(Column.create("c2", Column.Type.Varchar))
+            .addActual(Column.create("c2", Column.Type.Text))
             .addActual(Column.create("c3", Column.Type.Uuid))
             .addExpected(
                 ColumnSpec.newBuilder()
@@ -254,7 +254,7 @@ public class ExecuteQueryTest extends BaseGrpcServiceTest {
             .addExpected(
                 ColumnSpec.newBuilder()
                     .setName("c2")
-                    .setType(TypeSpec.newBuilder().setBasic(TypeSpec.Basic.VARCHAR)))
+                    .setType(TypeSpec.newBuilder().setBasic(TypeSpec.Basic.TEXT)))
             .addExpected(
                 ColumnSpec.newBuilder()
                     .setName("c3")
@@ -296,7 +296,7 @@ public class ExecuteQueryTest extends BaseGrpcServiceTest {
                                         TypeSpec.newBuilder().setBasic(TypeSpec.Basic.UUID)))))
             .build(false),
         ColumnMetadataBuilder.builder()
-            .addActual(Column.create("m", Type.Map.of(Type.Varchar, Type.Bigint)))
+            .addActual(Column.create("m", Type.Map.of(Type.Text, Type.Bigint)))
             .addExpected(
                 ColumnSpec.newBuilder()
                     .setName("m")
@@ -304,13 +304,13 @@ public class ExecuteQueryTest extends BaseGrpcServiceTest {
                         TypeSpec.newBuilder()
                             .setMap(
                                 TypeSpec.Map.newBuilder()
-                                    .setKey(TypeSpec.newBuilder().setBasic(TypeSpec.Basic.VARCHAR))
+                                    .setKey(TypeSpec.newBuilder().setBasic(TypeSpec.Basic.TEXT))
                                     .setValue(
                                         TypeSpec.newBuilder().setBasic(TypeSpec.Basic.BIGINT)))))
             .build(false),
         ColumnMetadataBuilder.builder()
             .addActual(Column.create("c1", Column.Type.Int))
-            .addActual(Column.create("c2", Column.Type.Varchar))
+            .addActual(Column.create("c2", Column.Type.Text))
             .addActual(Column.create("c3", Column.Type.Uuid))
             .build(true));
   }

--- a/grpc/src/test/java/io/stargate/grpc/service/ProcessResultTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/ProcessResultTest.java
@@ -53,7 +53,7 @@ public class ProcessResultTest {
     return Stream.of(
         ResultSetBuilder.builder()
             .addActualColumn(Column.create("c1", Column.Type.Int))
-            .addActualColumn(Column.create("c2", Column.Type.Varchar))
+            .addActualColumn(Column.create("c2", Column.Type.Text))
             .addActualColumn(Column.create("c3", Column.Type.Uuid))
             .addExpectedColumn(
                 ColumnSpec.newBuilder()
@@ -80,7 +80,7 @@ public class ProcessResultTest {
             .build(false),
         ResultSetBuilder.builder()
             .addActualColumn(Column.create("c1", Column.Type.Int))
-            .addActualColumn(Column.create("c2", Column.Type.Varchar))
+            .addActualColumn(Column.create("c2", Column.Type.Text))
             .addActualColumn(Column.create("c3", Column.Type.Uuid))
             .addActualRow(1, "a", UUID.fromString("d1dbc5ca-b4e9-43ec-9ffd-e5bada9dc531"))
             .addActualRow(2, "b", UUID.fromString("f09f1429-05d1-4dd3-98fc-a5324ebcb113"))

--- a/grpc/src/test/java/io/stargate/grpc/service/RetryTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/RetryTest.java
@@ -62,13 +62,13 @@ public class RetryTest extends BaseGrpcServiceTest {
     final String releaseVersion = "4.0.0";
 
     ResultMetadata resultMetadata =
-        Utils.makeResultMetadata(Column.create("release_version", Type.Varchar));
+        Utils.makeResultMetadata(Column.create("release_version", Type.Text));
     Prepared prepared =
         new Prepared(
             Utils.STATEMENT_ID,
             Utils.RESULT_METADATA_ID,
             resultMetadata,
-            Utils.makePreparedMetadata(Column.create("key", Type.Varchar)),
+            Utils.makePreparedMetadata(Column.create("key", Type.Text)),
             true,
             false);
     when(connection.prepare(eq(query), any(Parameters.class)))
@@ -96,8 +96,7 @@ public class RetryTest extends BaseGrpcServiceTest {
             Utils.STATEMENT_ID,
             Utils.RESULT_METADATA_ID,
             Utils.makeResultMetadata(),
-            Utils.makePreparedMetadata(
-                Column.create("k", Type.Varchar), Column.create("v", Type.Int)),
+            Utils.makePreparedMetadata(Column.create("k", Type.Text), Column.create("v", Type.Int)),
             true,
             false);
     when(connection.prepare(anyString(), any(Parameters.class)))
@@ -125,8 +124,7 @@ public class RetryTest extends BaseGrpcServiceTest {
             Utils.STATEMENT_ID,
             Utils.RESULT_METADATA_ID,
             Utils.makeResultMetadata(),
-            Utils.makePreparedMetadata(
-                Column.create("k", Type.Varchar), Column.create("v", Type.Int)),
+            Utils.makePreparedMetadata(Column.create("k", Type.Text), Column.create("v", Type.Int)),
             true,
             false);
     when(connection.prepare(anyString(), any(Parameters.class)))
@@ -153,13 +151,13 @@ public class RetryTest extends BaseGrpcServiceTest {
     final String releaseVersion = "4.0.0";
 
     ResultMetadata resultMetadata =
-        Utils.makeResultMetadata(Column.create("release_version", Type.Varchar));
+        Utils.makeResultMetadata(Column.create("release_version", Type.Text));
     Prepared prepared =
         new Prepared(
             Utils.STATEMENT_ID,
             Utils.RESULT_METADATA_ID,
             resultMetadata,
-            Utils.makePreparedMetadata(Column.create("key", Type.Varchar)),
+            Utils.makePreparedMetadata(Column.create("key", Type.Text)),
             true,
             false);
     when(connection.prepare(eq(query), any(Parameters.class)))
@@ -187,13 +185,13 @@ public class RetryTest extends BaseGrpcServiceTest {
     final String releaseVersion = "4.0.0";
 
     ResultMetadata resultMetadata =
-        Utils.makeResultMetadata(Column.create("release_version", Type.Varchar));
+        Utils.makeResultMetadata(Column.create("release_version", Type.Text));
     Prepared prepared =
         new Prepared(
             Utils.STATEMENT_ID,
             Utils.RESULT_METADATA_ID,
             resultMetadata,
-            Utils.makePreparedMetadata(Column.create("key", Type.Varchar)),
+            Utils.makePreparedMetadata(Column.create("key", Type.Text)),
             true,
             false);
     when(connection.prepare(eq(query), any(Parameters.class)))
@@ -221,13 +219,13 @@ public class RetryTest extends BaseGrpcServiceTest {
     final String releaseVersion = "4.0.0";
 
     ResultMetadata resultMetadata =
-        Utils.makeResultMetadata(Column.create("release_version", Type.Varchar));
+        Utils.makeResultMetadata(Column.create("release_version", Type.Text));
     Prepared prepared =
         new Prepared(
             Utils.STATEMENT_ID,
             Utils.RESULT_METADATA_ID,
             resultMetadata,
-            Utils.makePreparedMetadata(Column.create("key", Type.Varchar)),
+            Utils.makePreparedMetadata(Column.create("key", Type.Text)),
             true,
             false);
     when(connection.prepare(eq(query), any(Parameters.class)))
@@ -255,13 +253,13 @@ public class RetryTest extends BaseGrpcServiceTest {
     final String releaseVersion = "4.0.0";
 
     ResultMetadata resultMetadata =
-        Utils.makeResultMetadata(Column.create("release_version", Type.Varchar));
+        Utils.makeResultMetadata(Column.create("release_version", Type.Text));
     Prepared prepared =
         new Prepared(
             Utils.STATEMENT_ID,
             Utils.RESULT_METADATA_ID,
             resultMetadata,
-            Utils.makePreparedMetadata(Column.create("key", Type.Varchar)),
+            Utils.makePreparedMetadata(Column.create("key", Type.Text)),
             true,
             false);
     when(connection.prepare(eq(query), any(Parameters.class)))
@@ -288,13 +286,13 @@ public class RetryTest extends BaseGrpcServiceTest {
     final String releaseVersion = "4.0.0";
 
     ResultMetadata resultMetadata =
-        Utils.makeResultMetadata(Column.create("release_version", Type.Varchar));
+        Utils.makeResultMetadata(Column.create("release_version", Type.Text));
     Prepared prepared =
         new Prepared(
             Utils.STATEMENT_ID,
             Utils.RESULT_METADATA_ID,
             resultMetadata,
-            Utils.makePreparedMetadata(Column.create("key", Type.Varchar)),
+            Utils.makePreparedMetadata(Column.create("key", Type.Text)),
             false,
             false);
     when(connection.prepare(eq(query), any(Parameters.class)))
@@ -372,8 +370,7 @@ public class RetryTest extends BaseGrpcServiceTest {
             Utils.STATEMENT_ID,
             Utils.RESULT_METADATA_ID,
             Utils.makeResultMetadata(),
-            Utils.makePreparedMetadata(
-                Column.create("k", Type.Varchar), Column.create("v", Type.Int)),
+            Utils.makePreparedMetadata(Column.create("k", Type.Text), Column.create("v", Type.Int)),
             false,
             false);
     when(connection.prepare(anyString(), any(Parameters.class)))

--- a/health-checker/src/main/java/io/stargate/health/StorageHealthChecker.java
+++ b/health-checker/src/main/java/io/stargate/health/StorageHealthChecker.java
@@ -60,7 +60,7 @@ public class StorageHealthChecker extends HealthCheck {
           .name(TABLE_NAME)
           .addColumns(
               ImmutableColumn.create(PK_COLUMN_NAME, Column.Kind.PartitionKey, Column.Type.Uuid),
-              ImmutableColumn.create(VALUE_COLUMN_NAME, Column.Kind.Regular, Column.Type.Varchar))
+              ImmutableColumn.create(VALUE_COLUMN_NAME, Column.Kind.Regular, Column.Type.Text))
           .build();
   private final DataStoreFactory dataStoreFactory;
 

--- a/persistence-api/src/main/java/io/stargate/db/schema/Column.java
+++ b/persistence-api/src/main/java/io/stargate/db/schema/Column.java
@@ -709,7 +709,7 @@ public abstract class Column implements SchemaEntity, Comparable<Column> {
     }
 
     private static Type parseBaseType(String str) {
-      if (str.equalsIgnoreCase("varchar")) {
+      if ("varchar".equalsIgnoreCase(str)) {
         return Text;
       }
       for (Type t : values()) {

--- a/persistence-api/src/main/java/io/stargate/db/schema/Column.java
+++ b/persistence-api/src/main/java/io/stargate/db/schema/Column.java
@@ -19,7 +19,6 @@ import static io.stargate.db.schema.Column.Kind.Regular;
 import static io.stargate.db.schema.Column.Type.Ascii;
 import static io.stargate.db.schema.Column.Type.Counter;
 import static io.stargate.db.schema.Column.Type.Timeuuid;
-import static io.stargate.db.schema.Column.Type.Varchar;
 import static java.lang.String.format;
 
 import com.datastax.oss.driver.api.core.ProtocolVersion;
@@ -359,7 +358,7 @@ public abstract class Column implements SchemaEntity, Comparable<Column> {
 
     Smallint(19, Short.class, false, "16-bit signed integer"),
 
-    Text(10, String.class, true, "UTF-8 encoded string"),
+    Text(13, String.class, true, "UTF-8 encoded string"),
 
     Time(
         18,
@@ -413,8 +412,6 @@ public abstract class Column implements SchemaEntity, Comparable<Column> {
     },
 
     Uuid(12, UUID.class, false, "128 bit universally unique identifier (UUID)"),
-
-    Varchar(13, String.class, true, "UTF-8 encoded string"),
 
     Varint(14, BigInteger.class, false, "Arbitrary-precision integer"),
 
@@ -839,13 +836,7 @@ public abstract class Column implements SchemaEntity, Comparable<Column> {
           .put(Date.class, Type.Date)
           .putAll(
               Arrays.stream(Type.values())
-                  .filter(
-                      r ->
-                          !r.isCollection()
-                              && r != Counter
-                              && r != Ascii
-                              && r != Timeuuid
-                              && r != Varchar)
+                  .filter(r -> !r.isCollection() && r != Counter && r != Ascii && r != Timeuuid)
                   .collect(Collectors.toMap(r -> r.javaType, r -> r)))
           .build();
 
@@ -857,7 +848,7 @@ public abstract class Column implements SchemaEntity, Comparable<Column> {
   }
 
   public static boolean ofTypeText(ColumnType type) {
-    return Type.Varchar.equals(type) || Type.Text.equals(type);
+    return Type.Text.equals(type);
   }
 
   public boolean ofTypeListOrSet() {

--- a/persistence-api/src/main/java/io/stargate/db/schema/Column.java
+++ b/persistence-api/src/main/java/io/stargate/db/schema/Column.java
@@ -709,6 +709,9 @@ public abstract class Column implements SchemaEntity, Comparable<Column> {
     }
 
     private static Type parseBaseType(String str) {
+      if (str.equalsIgnoreCase("varchar")) {
+        return Text;
+      }
       for (Type t : values()) {
         // Technically, the string "udt" does not correspond to a proper base type in CQL.
         if (t != UDT && t.name().equalsIgnoreCase(str)) {

--- a/persistence-api/src/main/java/io/stargate/db/schema/ColumnUtils.java
+++ b/persistence-api/src/main/java/io/stargate/db/schema/ColumnUtils.java
@@ -58,7 +58,6 @@ public class ColumnUtils {
     CODECS.put(Column.Type.Timeuuid, ImmutableCodecs.builder().codec(TypeCodecs.TIMEUUID).build());
     CODECS.put(Column.Type.Tinyint, ImmutableCodecs.builder().codec(TypeCodecs.TINYINT).build());
     CODECS.put(Column.Type.Uuid, ImmutableCodecs.builder().codec(TypeCodecs.UUID).build());
-    CODECS.put(Column.Type.Varchar, ImmutableCodecs.builder().codec(TypeCodecs.TEXT).build());
     CODECS.put(Column.Type.Varint, ImmutableCodecs.builder().codec(TypeCodecs.VARINT).build());
   }
 

--- a/persistence-api/src/test/java/io/stargate/db/schema/ColumnTest.java
+++ b/persistence-api/src/test/java/io/stargate/db/schema/ColumnTest.java
@@ -63,20 +63,19 @@ public class ColumnTest {
     assertThat(Type.Tinyint.fromString("2")).isEqualTo((byte) 2);
 
     assertThat(Type.Uuid.fromString(uuid.toString())).isEqualTo(uuid);
-    assertThat(Type.Varchar.fromString("2")).isEqualTo("2");
     assertThat(Type.Varint.fromString("2")).isEqualTo(BigInteger.valueOf(2L));
   }
 
   @Test
   public void tupleFromString() {
-    Column.ColumnType tupleType = Type.Tuple.of(Type.Varchar, Type.Tuple.of(Type.Int, Type.Double));
+    Column.ColumnType tupleType = Type.Tuple.of(Type.Text, Type.Tuple.of(Type.Int, Type.Double));
     TupleValue tuple = tupleType.create("Test", tupleType.parameters().get(1).create(2, 3.0));
     assertThat(tupleType.fromString("('Test',(2,3.0))")).isEqualTo(tuple);
   }
 
   @Test
   public void udtFromString() {
-    Column.ColumnType tupleType = Type.Tuple.of(Type.Varchar, Type.Tuple.of(Type.Int, Type.Double));
+    Column.ColumnType tupleType = Type.Tuple.of(Type.Text, Type.Tuple.of(Type.Int, Type.Double));
     Keyspace ks =
         Schema.build()
             .keyspace("test")
@@ -127,13 +126,13 @@ public class ColumnTest {
     assertThat(Type.Timeuuid.toString(null)).isEqualTo("null");
     assertThat(Type.Tinyint.toString(null)).isEqualTo("null");
     assertThat(Type.Uuid.toString(null)).isEqualTo("null");
-    assertThat(Type.Varchar.toString(null)).isEqualTo("null");
+    assertThat(Type.Text.toString(null)).isEqualTo("null");
     assertThat(Type.Varint.toString(null)).isEqualTo("null");
 
     assertThat(Type.List.of(Type.Int).toString(null)).isEqualTo("null");
     assertThat(Type.Set.of(Type.Int).toString(null)).isEqualTo("null");
     assertThat(Type.Map.of(Type.Int, Type.Int).toString(null)).isEqualTo("null");
-    assertThat(Type.Tuple.of(Type.Varchar, Type.Tuple.of(Type.Int, Type.Double)).toString(null))
+    assertThat(Type.Tuple.of(Type.Text, Type.Tuple.of(Type.Int, Type.Double)).toString(null))
         .isEqualTo("null");
 
     Keyspace ks =
@@ -214,8 +213,8 @@ public class ColumnTest {
     assertThatThrownBy(() -> Type.Tinyint.toString("2"))
         .hasMessage(invalidValueMsg(Type.Tinyint, "2", String.class));
 
-    assertThatThrownBy(() -> Type.Varchar.toString(2L))
-        .hasMessage(invalidValueMsg(Type.Varchar, 2L, Long.class));
+    assertThatThrownBy(() -> Type.Text.toString(2L))
+        .hasMessage(invalidValueMsg(Type.Text, 2L, Long.class));
 
     assertThatThrownBy(() -> Type.Varint.toString(BigInteger.valueOf(2L).toString()))
         .hasMessage(invalidValueMsg(Type.Varint, BigInteger.valueOf(2L).toString(), String.class));
@@ -246,7 +245,7 @@ public class ColumnTest {
     assertThat(Type.Tinyint.toString((byte) 2)).isEqualTo("2");
 
     assertThat(Type.Uuid.toString(uuid)).isEqualTo(uuid.toString());
-    assertThat(Type.Varchar.toString("2")).isEqualTo("2");
+    assertThat(Type.Text.toString("2")).isEqualTo("2");
     assertThat(Type.Varint.toString(BigInteger.valueOf(2L))).isEqualTo("2");
   }
 
@@ -301,14 +300,14 @@ public class ColumnTest {
 
   @Test
   public void tupleToString() {
-    Column.ColumnType tupleType = Type.Tuple.of(Type.Varchar, Type.Tuple.of(Type.Int, Type.Double));
+    Column.ColumnType tupleType = Type.Tuple.of(Type.Text, Type.Tuple.of(Type.Int, Type.Double));
     TupleValue tuple = tupleType.create("Test", tupleType.parameters().get(1).create(2, 3.0));
     assertThat(tupleType.toString(tuple)).isEqualTo("('Test',(2,3.0))");
   }
 
   @Test
   public void tupleToStringWithInvalidType() {
-    Column.ColumnType tupleType = Type.Tuple.of(Type.Varchar, Type.Tuple.of(Type.Int, Type.Double));
+    Column.ColumnType tupleType = Type.Tuple.of(Type.Text, Type.Tuple.of(Type.Int, Type.Double));
     TupleValue tuple = tupleType.create("Test", tupleType.parameters().get(1).create(2, 3.0));
     assertThatThrownBy(() -> tupleType.toString(tuple.toString()))
         .hasMessage(invalidValueMsg(tupleType, tuple.toString(), String.class));
@@ -327,7 +326,7 @@ public class ColumnTest {
   @Test
   public void udtToString() {
     // UDT
-    Column.ColumnType tupleType = Type.Tuple.of(Type.Varchar, Type.Tuple.of(Type.Int, Type.Double));
+    Column.ColumnType tupleType = Type.Tuple.of(Type.Text, Type.Tuple.of(Type.Int, Type.Double));
     Keyspace ks =
         Schema.build()
             .keyspace("test")

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
@@ -187,8 +187,7 @@ public class Conversion {
     types.put(IntegerType.instance.getClass(), Column.Type.Varint);
     types.put(ShortType.instance.getClass(), Column.Type.Smallint);
     types.put(UUIDType.instance.getClass(), Column.Type.Uuid);
-    // TODO update to Text after #1506
-    types.put(UTF8Type.instance.getClass(), Column.Type.Varchar);
+    types.put(UTF8Type.instance.getClass(), Column.Type.Text);
     types.put(TimeType.instance.getClass(), Column.Type.Time);
     types.put(TimestampType.instance.getClass(), Column.Type.Timestamp);
     types.put(TimeUUIDType.instance.getClass(), Column.Type.Timeuuid);

--- a/persistence-cassandra-3.11/src/test/java/io/stargate/db/cassandra/impl/ConversionTest.java
+++ b/persistence-cassandra-3.11/src/test/java/io/stargate/db/cassandra/impl/ConversionTest.java
@@ -277,7 +277,7 @@ class ConversionTest {
     public void utf8Type() {
       Column.ColumnType result = Conversion.getTypeFromInternal(UTF8Type.instance);
 
-      assertThat(result.rawType()).isEqualTo(Column.Type.Varchar);
+      assertThat(result.rawType()).isEqualTo(Column.Type.Text);
     }
 
     @Test

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
@@ -123,8 +123,7 @@ public class Conversion {
     types.put(IntegerType.instance.getClass(), Column.Type.Varint);
     types.put(ShortType.instance.getClass(), Column.Type.Smallint);
     types.put(UUIDType.instance.getClass(), Column.Type.Uuid);
-    // TODO update to Text after #1506
-    types.put(UTF8Type.instance.getClass(), Column.Type.Varchar);
+    types.put(UTF8Type.instance.getClass(), Column.Type.Text);
     types.put(TimeType.instance.getClass(), Column.Type.Time);
     types.put(TimestampType.instance.getClass(), Column.Type.Timestamp);
     types.put(TimeUUIDType.instance.getClass(), Column.Type.Timeuuid);

--- a/persistence-cassandra-4.0/src/test/java/io/stargate/db/cassandra/impl/ConversionTest.java
+++ b/persistence-cassandra-4.0/src/test/java/io/stargate/db/cassandra/impl/ConversionTest.java
@@ -299,7 +299,7 @@ class ConversionTest {
     public void utf8Type() {
       Column.ColumnType result = Conversion.getTypeFromInternal(UTF8Type.instance);
 
-      assertThat(result.rawType()).isEqualTo(Column.Type.Varchar);
+      assertThat(result.rawType()).isEqualTo(Column.Type.Text);
     }
 
     @Test

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/Conversion.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/Conversion.java
@@ -177,8 +177,7 @@ public class Conversion {
     types.put(IntegerType.instance.getClass(), Column.Type.Varint);
     types.put(ShortType.instance.getClass(), Column.Type.Smallint);
     types.put(UUIDType.instance.getClass(), Column.Type.Uuid);
-    // TODO update to Text after #1506
-    types.put(UTF8Type.instance.getClass(), Column.Type.Varchar);
+    types.put(UTF8Type.instance.getClass(), Column.Type.Text);
     types.put(TimeType.instance.getClass(), Column.Type.Time);
     types.put(TimestampType.instance.getClass(), Column.Type.Timestamp);
     types.put(TimeUUIDType.instance.getClass(), Column.Type.Timeuuid);

--- a/persistence-dse-6.8/src/test/java/io/stargate/db/dse/impl/ConversionTest.java
+++ b/persistence-dse-6.8/src/test/java/io/stargate/db/dse/impl/ConversionTest.java
@@ -287,7 +287,7 @@ class ConversionTest extends BaseDseTest {
     public void utf8Type() {
       Column.ColumnType result = Conversion.getTypeFromInternal(UTF8Type.instance);
 
-      assertThat(result.rawType()).isEqualTo(Column.Type.Varchar);
+      assertThat(result.rawType()).isEqualTo(Column.Type.Text);
     }
 
     @Test

--- a/persistence-test/src/main/java/io/stargate/it/PersistenceTest.java
+++ b/persistence-test/src/main/java/io/stargate/it/PersistenceTest.java
@@ -503,7 +503,6 @@ public abstract class PersistenceTest {
             .put(Timeuuid, timeBased())
             .put(Tinyint, (byte) 4)
             .put(Uuid, random())
-            .put(Text, "some Text")
             .put(Varint, BigInteger.valueOf(23))
             //                .put(Point, new Point(3.3, 4.4))
             //                .put(Polygon, new Polygon(new Point(30, 10), new Point(10, 20), new
@@ -1006,7 +1005,7 @@ public abstract class PersistenceTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
             "Invalid value provided for 'name': "
-                + "Java value 42 of type 'java.lang.Integer' is not a valid value for CQL type Text");
+                + "Java value 42 of type 'java.lang.Integer' is not a valid value for CQL type text");
   }
 
   @Disabled("Disabling for now since it fails with a strange MV schema generated")

--- a/persistence-test/src/main/java/io/stargate/it/PersistenceTest.java
+++ b/persistence-test/src/main/java/io/stargate/it/PersistenceTest.java
@@ -46,7 +46,6 @@ import static io.stargate.db.schema.Column.Type.Timeuuid;
 import static io.stargate.db.schema.Column.Type.Tinyint;
 import static io.stargate.db.schema.Column.Type.Tuple;
 import static io.stargate.db.schema.Column.Type.Uuid;
-import static io.stargate.db.schema.Column.Type.Varchar;
 import static io.stargate.db.schema.Column.Type.Varint;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
@@ -266,14 +265,14 @@ public abstract class PersistenceTest {
         .queryBuilder()
         .create()
         .table(keyspace, table)
-        .column("PK1", Varchar, PartitionKey)
-        .column("PK2", Varchar, PartitionKey)
-        .column("CC1", Varchar, Clustering, ASC)
-        .column("CC2", Varchar, Clustering, DESC)
-        .column("R1", Varchar)
-        .column("R2", Varchar)
-        .column("S1", Varchar, Static)
-        .column("S2", Varchar, Static)
+        .column("PK1", Text, PartitionKey)
+        .column("PK2", Text, PartitionKey)
+        .column("CC1", Text, Clustering, ASC)
+        .column("CC2", Text, Clustering, DESC)
+        .column("R1", Text)
+        .column("R2", Text)
+        .column("S1", Text, Static)
+        .column("S2", Text, Static)
         .build()
         .execute()
         .join();
@@ -282,14 +281,14 @@ public abstract class PersistenceTest {
             Schema.build()
                 .keyspace(keyspace)
                 .table(table)
-                .column("PK1", Varchar, PartitionKey)
-                .column("PK2", Varchar, PartitionKey)
-                .column("CC1", Varchar, Clustering, ASC)
-                .column("CC2", Varchar, Clustering, DESC)
-                .column("S1", Varchar, Static)
-                .column("S2", Varchar, Static)
-                .column("R1", Varchar)
-                .column("R2", Varchar)
+                .column("PK1", Text, PartitionKey)
+                .column("PK2", Text, PartitionKey)
+                .column("CC1", Text, Clustering, ASC)
+                .column("CC2", Text, Clustering, DESC)
+                .column("S1", Text, Static)
+                .column("S2", Text, Static)
+                .column("R1", Text)
+                .column("R2", Text)
                 .build()
                 .keyspace(keyspace)
                 .table(table));
@@ -302,9 +301,9 @@ public abstract class PersistenceTest {
     createKeyspace();
 
     Column.ColumnType nestedTuple = Tuple.of(Int, Double);
-    Column.ColumnType tupleType = Tuple.of(Varchar, nestedTuple);
+    Column.ColumnType tupleType = Tuple.of(Text, nestedTuple);
     Column.ColumnType nestedDuration = Tuple.of(Int, Duration);
-    Column.ColumnType tupleTypeWithDuration = Tuple.of(Varchar, nestedDuration);
+    Column.ColumnType tupleTypeWithDuration = Tuple.of(Text, nestedDuration);
     //        Column.ColumnType nestedGeo = Tuple.of(Polygon, LineString);
     //        Column.ColumnType tupleTypeWithGeo = Tuple.of(Point, nestedGeo);
 
@@ -318,7 +317,7 @@ public abstract class PersistenceTest {
     //        UserDefinedType udtType =
     // ImmutableUserDefinedType.builder().name("My_udt").keyspace(ks.name())
     //                .addColumns(Column.create("a", Int), Column.create("b", Int),
-    // Column.create("c", Varchar)).build();
+    // Column.create("c", Text)).build();
 
     List<Pair<Column.ColumnType, Object>> values =
         ImmutableList.<Pair<Column.ColumnType, Object>>builder()
@@ -341,7 +340,7 @@ public abstract class PersistenceTest {
             .add(Pair.with(Inet, Inet4Address.getByAddress(new byte[] {2, 3, 4, 5})))
             .add(Pair.with(Int, 4))
             .add(Pair.with(List.of(Double), Arrays.asList(3.0, 4.5)))
-            .add(Pair.with(Map.of(Varchar, Int), ImmutableMap.of("Alice", 3, "Bob", 4)))
+            .add(Pair.with(Map.of(Text, Int), ImmutableMap.of("Alice", 3, "Bob", 4)))
             .add(Pair.with(Set.of(Double), ImmutableSet.of(3.4, 5.3)))
             .add(
                 Pair.with(
@@ -350,7 +349,7 @@ public abstract class PersistenceTest {
                         CqlDuration.newInstance(2, 3, 5), CqlDuration.newInstance(2, 3, 6))))
             .add(
                 Pair.with(
-                    Map.of(Varchar, Duration),
+                    Map.of(Text, Duration),
                     ImmutableMap.of(
                         "Alice",
                         CqlDuration.newInstance(2, 3, 5),
@@ -368,7 +367,7 @@ public abstract class PersistenceTest {
                     tupleTypeWithDuration.create(
                         "Test", nestedDuration.create(2, CqlDuration.newInstance(2, 3, 6)))))
             .add(Pair.with(Uuid, random()))
-            .add(Pair.with(Varchar, "Hi"))
+            .add(Pair.with(Text, "Hi"))
             .add(Pair.with(Varint, BigInteger.valueOf(23)))
             //                .add(Pair.with(Point, point))
             //                .add(Pair.with(Polygon, polygon))
@@ -396,7 +395,7 @@ public abstract class PersistenceTest {
 
             // Frozen types
             .add(Pair.with(List.of(Double).frozen(), Arrays.asList(3.0, 4.5)))
-            .add(Pair.with(Map.of(Varchar, Int).frozen(), ImmutableMap.of("Alice", 3, "Bob", 4)))
+            .add(Pair.with(Map.of(Text, Int).frozen(), ImmutableMap.of("Alice", 3, "Bob", 4)))
             .add(Pair.with(Set.of(Double).frozen(), ImmutableSet.of(3.4, 5.3)))
             .build();
 
@@ -504,7 +503,7 @@ public abstract class PersistenceTest {
             .put(Timeuuid, timeBased())
             .put(Tinyint, (byte) 4)
             .put(Uuid, random())
-            .put(Varchar, "some varchar")
+            .put(Text, "some Text")
             .put(Varint, BigInteger.valueOf(23))
             //                .put(Point, new Point(3.3, 4.4))
             //                .put(Polygon, new Polygon(new Point(30, 10), new Point(10, 20), new
@@ -561,9 +560,9 @@ public abstract class PersistenceTest {
         .create()
         .table(keyspace, table)
         .column("a", Int, PartitionKey)
-        .column("b", Varchar)
+        .column("b", Text)
         .column("c", Uuid)
-        .column("d", Varchar)
+        .column("d", Text)
         .build()
         .execute()
         .join();
@@ -584,9 +583,9 @@ public abstract class PersistenceTest {
                 .keyspace(keyspace)
                 .table(table)
                 .column("a", Int, PartitionKey)
-                .column("b", Varchar)
+                .column("b", Text)
                 .column("c", Uuid)
-                .column("d", Varchar)
+                .column("d", Text)
                 .secondaryIndex("byB")
                 .column("b")
                 .build()
@@ -610,9 +609,9 @@ public abstract class PersistenceTest {
                 .keyspace(keyspace)
                 .table(table)
                 .column("a", Int, PartitionKey)
-                .column("b", Varchar)
+                .column("b", Text)
                 .column("c", Uuid)
-                .column("d", Varchar)
+                .column("d", Text)
                 .secondaryIndex("byB")
                 .column("b")
                 .secondaryIndex("byC")
@@ -644,9 +643,9 @@ public abstract class PersistenceTest {
             .keyspace(keyspace)
             .table(table)
             .column("a", Int, PartitionKey)
-            .column("b", Varchar)
+            .column("b", Text)
             .column("c", Uuid)
-            .column("d", Varchar)
+            .column("d", Text)
             .secondaryIndex("byB")
             .column("b")
             .secondaryIndex("byC")
@@ -674,7 +673,7 @@ public abstract class PersistenceTest {
         .create()
         .table(keyspace, table)
         .column("a", Int, PartitionKey)
-        .column("b", Varchar, Clustering)
+        .column("b", Text, Clustering)
         .withComment("test-comment1")
         .build()
         .execute()
@@ -698,7 +697,7 @@ public abstract class PersistenceTest {
     assertThat(mv.comment()).isEqualTo("test-comment2");
     assertThat(mv.columns()).hasSize(2);
     assertThat(mv.column("b").kind()).isEqualTo(PartitionKey);
-    assertThat(mv.column("b").type()).isEqualTo(Varchar);
+    assertThat(mv.column("b").type()).isEqualTo(Text);
     assertThat(mv.column("a").kind()).isEqualTo(Clustering);
     assertThat(mv.column("a").type()).isEqualTo(Int);
   }
@@ -853,7 +852,7 @@ public abstract class PersistenceTest {
         .put(Timeuuid, timeBased())
         .put(Tinyint, (byte) 4)
         .put(Uuid, random())
-        .put(Varchar, "some varchar")
+        .put(Text, "some Text")
         .put(Varint, BigInteger.valueOf(23))
         //                .put(Point, new Point(3.3, 4.4))
         //                .put(Polygon, new Polygon(new Point(30, 10), new Point(10, 20), new
@@ -877,13 +876,13 @@ public abstract class PersistenceTest {
                 Column.create("a", Int),
                 Column.create("mylist", List.of(Double)),
                 Column.create("myset", Set.of(Double)),
-                Column.create("mymap", Map.of(Varchar, Int)),
-                Column.create("mytuple", Tuple.of(Varchar, Tuple.of(Int, Double))))
+                Column.create("mymap", Map.of(Text, Int)),
+                Column.create("mytuple", Tuple.of(Text, Tuple.of(Int, Double))))
             .build();
     dataStore.queryBuilder().create().type(keyspace, udtType).build().execute().join();
     ks = dataStore.schema().keyspace(ks.name());
     Column.ColumnType nestedTuple = Tuple.of(Int, Double);
-    Column.ColumnType tupleType = Tuple.of(Varchar, nestedTuple);
+    Column.ColumnType tupleType = Tuple.of(Text, nestedTuple);
 
     dataStore
         .queryBuilder()
@@ -940,9 +939,9 @@ public abstract class PersistenceTest {
   public void testTupleMismatch() throws ExecutionException, InterruptedException {
     Keyspace ks = createKeyspace();
     Column.ColumnType nested = Tuple.of(Text, Double);
-    Column.ColumnType tupleType = Tuple.of(Varchar, nested);
+    Column.ColumnType tupleType = Tuple.of(Text, nested);
     Column.ColumnType alternativeNested = Tuple.of(Int, Double);
-    Column.ColumnType alternativeType = Tuple.of(Varchar, alternativeNested);
+    Column.ColumnType alternativeType = Tuple.of(Text, alternativeNested);
 
     dataStore
         .queryBuilder()
@@ -975,7 +974,7 @@ public abstract class PersistenceTest {
     } catch (IllegalArgumentException ex) {
       assertThat(ex)
           .hasMessage(
-              "Wrong value type provided for column 'tuple'. Provided type 'Integer' is not compatible with expected CQL type 'varchar' at location 'tuple.frozen<tuple<varchar, frozen<tuple<varchar, double>>>>[1].frozen<tuple<varchar, double>>[0]'.");
+              "Wrong value type provided for column 'tuple'. Provided type 'Integer' is not compatible with expected CQL type 'Text' at location 'tuple.frozen<tuple<Text, frozen<tuple<Text, double>>>>[1].frozen<tuple<Text, double>>[0]'.");
     }
   }
 
@@ -1007,7 +1006,7 @@ public abstract class PersistenceTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
             "Invalid value provided for 'name': "
-                + "Java value 42 of type 'java.lang.Integer' is not a valid value for CQL type varchar");
+                + "Java value 42 of type 'java.lang.Integer' is not a valid value for CQL type Text");
   }
 
   @Disabled("Disabling for now since it fails with a strange MV schema generated")
@@ -1019,7 +1018,7 @@ public abstract class PersistenceTest {
         .create()
         .table(keyspace, table)
         .column("a", Int, PartitionKey)
-        .column("b", Varchar)
+        .column("b", Text)
         .column("c", Uuid)
         .build()
         .execute()
@@ -1044,7 +1043,7 @@ public abstract class PersistenceTest {
                 .keyspace(keyspace)
                 .table(table)
                 .column("a", Int, PartitionKey)
-                .column("b", Varchar)
+                .column("b", Text)
                 .column("c", Uuid)
                 .materializedView("byB")
                 .column("b", PartitionKey)
@@ -1073,7 +1072,7 @@ public abstract class PersistenceTest {
                 .keyspace(keyspace)
                 .table(table)
                 .column("a", Int, PartitionKey)
-                .column("b", Varchar)
+                .column("b", Text)
                 .column("c", Uuid)
                 .materializedView("byB")
                 .column("b", PartitionKey)

--- a/persistence-test/src/main/java/io/stargate/it/PersistenceTest.java
+++ b/persistence-test/src/main/java/io/stargate/it/PersistenceTest.java
@@ -851,7 +851,6 @@ public abstract class PersistenceTest {
         .put(Timeuuid, timeBased())
         .put(Tinyint, (byte) 4)
         .put(Uuid, random())
-        .put(Text, "some Text")
         .put(Varint, BigInteger.valueOf(23))
         //                .put(Point, new Point(3.3, 4.4))
         //                .put(Polygon, new Polygon(new Point(30, 10), new Point(10, 20), new

--- a/restapi/src/main/java/io/stargate/web/resources/Converters.java
+++ b/restapi/src/main/java/io/stargate/web/resources/Converters.java
@@ -210,7 +210,6 @@ public class Converters {
 
     switch (type.rawType()) {
       case Text:
-      case Varchar:
       case Ascii:
       case Uuid:
       case Timeuuid:
@@ -537,9 +536,7 @@ public class Converters {
       return toCqlUdt((UserDefinedType) type, value);
     }
 
-    if (rawType == Column.Type.Text
-        || rawType == Column.Type.Varchar
-        || rawType == Column.Type.Ascii) {
+    if (rawType == Column.Type.Text || rawType == Column.Type.Ascii) {
       return value;
     }
 

--- a/restapi/src/test/java/io/stargate/web/resources/ConvertersTest.java
+++ b/restapi/src/test/java/io/stargate/web/resources/ConvertersTest.java
@@ -143,7 +143,6 @@ public class ConvertersTest {
     return new Arguments[] {
       // Primitives:
       arguments(Type.Text, "\"abc\"", "abc"),
-      arguments(Type.Varchar, "\"abc\"", "abc"),
       arguments(Type.Ascii, "\"abc\"", "abc"),
       arguments(Type.Boolean, "true", true),
       arguments(Type.Boolean, "\"true\"", true),
@@ -254,7 +253,6 @@ public class ConvertersTest {
   private static Arguments[] toCqlErrorSamples() {
     return new Arguments[] {
       arguments(Type.Text, "1", "Invalid Text value '1': expected a string"),
-      arguments(Type.Varchar, "[]", "Invalid Varchar value '[]': expected a string"),
       arguments(Type.Ascii, "true", "Invalid Ascii value 'true': expected a string"),
       arguments(Type.Boolean, "1", "Invalid Boolean value '1': expected a boolean or a string"),
       arguments(Type.Boolean, "\"a\"", "Invalid Boolean value 'a': cannot parse"),

--- a/testing/src/main/java/io/stargate/it/http/RestApiTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiTest.java
@@ -233,8 +233,7 @@ public class RestApiTest extends BaseIntegrationTest {
     assertThat(columnDefinitions.size()).isEqualTo(4);
     columnDefinitions.sort(Comparator.comparing(ColumnDefinition::getName));
     assertThat(columnDefinitions.get(0).getName()).isEqualTo("col1");
-    assertThat(columnDefinitions.get(0).getTypeDefinition())
-        .isEqualTo("frozen<map<date, text>>");
+    assertThat(columnDefinitions.get(0).getTypeDefinition()).isEqualTo("frozen<map<date, text>>");
   }
 
   @Test
@@ -1195,8 +1194,7 @@ public class RestApiTest extends BaseIntegrationTest {
     assertThat(columnDefinitions.size()).isEqualTo(4);
     columnDefinitions.sort(Comparator.comparing(ColumnDefinition::getName));
     assertThat(columnDefinitions.get(0).getName()).isEqualTo("col1");
-    assertThat(columnDefinitions.get(0).getTypeDefinition())
-        .isEqualTo("frozen<map<date, text>>");
+    assertThat(columnDefinitions.get(0).getTypeDefinition()).isEqualTo("frozen<map<date, text>>");
   }
 
   @Test

--- a/testing/src/main/java/io/stargate/it/http/RestApiTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiTest.java
@@ -234,7 +234,7 @@ public class RestApiTest extends BaseIntegrationTest {
     columnDefinitions.sort(Comparator.comparing(ColumnDefinition::getName));
     assertThat(columnDefinitions.get(0).getName()).isEqualTo("col1");
     assertThat(columnDefinitions.get(0).getTypeDefinition())
-        .isEqualTo("frozen<map<date, varchar>>");
+        .isEqualTo("frozen<map<date, text>>");
   }
 
   @Test
@@ -1196,7 +1196,7 @@ public class RestApiTest extends BaseIntegrationTest {
     columnDefinitions.sort(Comparator.comparing(ColumnDefinition::getName));
     assertThat(columnDefinitions.get(0).getName()).isEqualTo("col1");
     assertThat(columnDefinitions.get(0).getTypeDefinition())
-        .isEqualTo("frozen<map<date, varchar>>");
+        .isEqualTo("frozen<map<date, text>>");
   }
 
   @Test
@@ -1214,7 +1214,7 @@ public class RestApiTest extends BaseIntegrationTest {
     ColumnDefinition columnDefinition =
         objectMapper.readValue(body, new TypeReference<ColumnDefinition>() {});
     assertThat(columnDefinition.getName()).isEqualTo("firstName");
-    assertThat(columnDefinition.getTypeDefinition()).isEqualTo("varchar");
+    assertThat(columnDefinition.getTypeDefinition()).isEqualTo("text");
   }
 
   @Test
@@ -1278,7 +1278,7 @@ public class RestApiTest extends BaseIntegrationTest {
     List<ColumnDefinition> columnDefinitions = new ArrayList<>();
 
     columnDefinitions.add(new ColumnDefinition("pk0", "uuid"));
-    columnDefinitions.add(new ColumnDefinition("col1", "frozen<map<date, varchar>>"));
+    columnDefinitions.add(new ColumnDefinition("col1", "frozen<map<date, text>>"));
     columnDefinitions.add(new ColumnDefinition("col2", "frozen<set<boolean>>"));
     columnDefinitions.add(new ColumnDefinition("col3", "frozen<tuple<duration, inet>>"));
 

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -341,7 +341,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
             columnDefinition ->
                 assertThat(columnDefinition)
                     .usingRecursiveComparison()
-                    .isEqualTo(new ColumnDefinition("col1", "frozen<map<date, varchar>>", false)));
+                    .isEqualTo(new ColumnDefinition("col1", "frozen<map<date, text>>", false)));
   }
 
   @Test
@@ -2177,7 +2177,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
     ColumnDefinition column = readWrappedRESTResponse(body, ColumnDefinition.class);
     assertThat(column)
         .usingRecursiveComparison()
-        .isEqualTo(new ColumnDefinition("col1", "frozen<map<date, varchar>>", false));
+        .isEqualTo(new ColumnDefinition("col1", "frozen<map<date, text>>", false));
   }
 
   @Test
@@ -2217,7 +2217,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
     createKeyspace(keyspaceName);
     createTable(keyspaceName, tableName);
 
-    ColumnDefinition columnDefinition = new ColumnDefinition("name", "varchar");
+    ColumnDefinition columnDefinition = new ColumnDefinition("name", "text");
 
     String body =
         RestUtils.post(
@@ -2544,7 +2544,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
 
     // create UDT
     String udtString =
-        "{\"name\": \"udt1\", \"fields\":[{\"name\":\"firstname\",\"typeDefinition\":\"varchar\"}]}";
+        "{\"name\": \"udt1\", \"fields\":[{\"name\":\"firstname\",\"typeDefinition\":\"text\"}]}";
 
     RestUtils.post(
         authToken,
@@ -2554,7 +2554,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
 
     // update UDT: add new field
     udtString =
-        "{\"name\": \"udt1\", \"addFields\":[{\"name\":\"lastname\",\"typeDefinition\":\"varchar\"}]}";
+        "{\"name\": \"udt1\", \"addFields\":[{\"name\":\"lastname\",\"typeDefinition\":\"text\"}]}";
 
     RestUtils.put(
         authToken,
@@ -2607,7 +2607,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
     // update UDT: add and rename field
     udtString =
         "{\"name\": \"udt2\","
-            + "\"addFields\":[{\"name\":\"name\",\"typeDefinition\":\"varchar\"}]},"
+            + "\"addFields\":[{\"name\":\"name\",\"typeDefinition\":\"text\"}]},"
             + "\"renameFields\": [{\"from\": \"name\", \"to\": \"firstname\"}";
 
     RestUtils.put(
@@ -2777,7 +2777,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
     List<Map<String, String>> fields = (List<Map<String, String>>) response.get(0).get("fields");
     assertThat(fields.size()).isEqualTo(1);
     assertThat(fields.get(0).get("name")).isEqualTo("firstname");
-    assertThat(fields.get(0).get("typeDefinition")).isEqualTo("varchar");
+    assertThat(fields.get(0).get("typeDefinition")).isEqualTo("text");
   }
 
   @Test
@@ -2904,7 +2904,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
     List<ColumnDefinition> columnDefinitions = new ArrayList<>();
 
     columnDefinitions.add(new ColumnDefinition("pk0", "uuid"));
-    columnDefinitions.add(new ColumnDefinition("col1", "frozen<map<date, varchar>>"));
+    columnDefinitions.add(new ColumnDefinition("col1", "frozen<map<date, text>>"));
     columnDefinitions.add(new ColumnDefinition("col2", "frozen<set<boolean>>"));
     columnDefinitions.add(new ColumnDefinition("col3", "frozen<tuple<duration, inet>>"));
 

--- a/testing/src/main/java/io/stargate/it/http/graphql/cqlfirst/ScalarsTest.java
+++ b/testing/src/main/java/io/stargate/it/http/graphql/cqlfirst/ScalarsTest.java
@@ -127,13 +127,13 @@ public class ScalarsTest extends BaseIntegrationTest {
         // Serialized as JSON Number
         arguments(Column.Type.Smallint, 32_767),
         arguments(Column.Type.Text, "abc123", "'abc123'"),
+        arguments(Column.Type.Text, ""),
         arguments(Column.Type.Time, "23:59:31.123456789"),
         arguments(Column.Type.Timestamp, formatInstant(now())),
         arguments(Column.Type.Tinyint, -128),
         arguments(Column.Type.Tinyint, 1),
         arguments(Column.Type.Timeuuid, Uuids.timeBased().toString()),
         arguments(Column.Type.Uuid, "f3abdfbf-479f-407b-9fde-128145bd7bef"),
-        arguments(Column.Type.Varchar, ""),
         arguments(Column.Type.Varint, "92233720368547758070000"));
   }
 


### PR DESCRIPTION
**What this PR does**:
CQL types `varchar` and `text` are synonyms, they can be used interchangeably. User-facing Cassandra features (DESCRIBE, name of the type in system tables...) always use `text`, even if the user specified `varchar` at creation time.

Stargate does the opposite: text types are always returned as `varchar`. In addition, `Column.Type` has an extra `Text` constant that is never used (it corresponds to native protocol code 10, which was removed in v3, the oldest version that Stargate supports).

This PR does two things:
* remove the obsolete `Column.Type` constant for code 10 (that used to called `Text`).
* in addition, also rename the `Varchar` constant to `Text`. This is a bit more controversial, but I think it's nice for the Persistence API to be consistent with Cassandra. (alternatively, we could keep the name `Varchar` internally, and only format it as `text` when it gets returned to clients).

**Which issue(s) this PR fixes**:
Fixes #1499

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
