### PR TITLE
updated persistence-cassandra-3.11 to 3.11.11

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -67,13 +67,13 @@ Docker: Start a Cassandra 3.11 instance:
 docker run --name local-cassandra \
 --net=host \
 -e CASSANDRA_CLUSTER_NAME=stargate \
--d cassandra:3.11.8
+-d cassandra:3.11.11
 ```
 
 Cassandra Cluster Manager: Start a Cassandra 3.11 instance ([link to ccm](https://github.com/riptano/ccm))
 
 ```sh
-ccm create stargate -v 3.11.8 -n 1 -s -b
+ccm create stargate -v 3.11.11 -n 1 -s -b
 ```
 
 ### Start commands
@@ -142,7 +142,7 @@ Connect to CQL as normal on port 9042:
 ```sh
 $ cqlsh 127.0.0.2 9042
 Connected to stargate at 127.0.0.2:9042.
-[cqlsh 5.0.1 | Cassandra 3.11.8 | CQL spec 3.4.4 | Native protocol v4]
+[cqlsh 5.0.1 | Cassandra 3.11.11 | CQL spec 3.4.4 | Native protocol v4]
 Use HELP for help.
 ```
 
@@ -269,7 +269,7 @@ execution environment (`PATH`).
 When tests are started manually via an IDE or JUnit Console Launcher, you can specify the type and version
 of the storage backend using the following Java system properties:
 
-* `-Dccm.version=<version>` - the version of the storage cluster (e.g. `3.11.8`)
+* `-Dccm.version=<version>` - the version of the storage cluster (e.g. `3.11.11`)
 * `-Dccm.dse=<true|false>` - specifies whether the storage cluster is DSE or OSS Cassandra.
   If `false` this option can be omitted.
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -43,7 +43,7 @@ RUN git clone --branch master --single-branch https://github.com/riptano/ccm.git
 
 # Create clusters to pre-download necessary artifacts
 RUN ccm create -v 4.0.0 stargate_40 && ccm remove stargate_40
-RUN ccm create -v 3.11.8 stargate_311 && ccm remove stargate_311
+RUN ccm create -v 3.11.11 stargate_311 && ccm remove stargate_311
 RUN ccm create -v 6.8.13 --dse stargate_dse68 && ccm remove stargate_dse68
 
 CMD ["/bin/bash"]

--- a/persistence-cassandra-3.11/README.md
+++ b/persistence-cassandra-3.11/README.md
@@ -1,0 +1,18 @@
+# Persistence Cassandra 3.11
+
+This module represents the implementation of the [persistence-api](../persistence-api) for the Cassandra `3.11.x` version.
+
+## Cassandra version update
+
+The current Cassandra version this module depends on is `3.11.11`.
+In order to update to a newer patch version, please follow the guidelines below:
+
+* Update the `cassandra.version` property in the [pom.xml](pom.xml).
+* Check what is the version of the `com.datastax.cassandra:cassandra-driver-core` in the `org.apache.cassandra:cassandra-all` for the updated version. 
+This dependency is set as optional in the `cassandra-all`, but we need it to correctly handle UDFs.
+Set the version of the driver in the `cassandra.bundled-driver.version` property in the [pom.xml](pom.xml).
+* Change the version in the [Cassandra311MetricsRegistryTest.java](src/test/java/org/apache/cassandra/metrics/Cassandra311MetricsRegistryTest.java) to the new one.
+* Check if the new version has a transitive dependency to `org.apache.cassandra:cassandra-thrift`, and if it does remove that dependency from our [pom.xml](pom.xml).
+The `cassandra-thrift` was explicitly added when updating to `3.11.11` as it was not anymore in the `cassandra-all`.
+* Make sure everything compiles and tests are green.
+* Update this `README.md` file with the new or updated instructions.

--- a/persistence-cassandra-3.11/README.md
+++ b/persistence-cassandra-3.11/README.md
@@ -15,6 +15,7 @@ Set the version of the driver in the `cassandra.bundled-driver.version` property
 * Check if the new version has a transitive dependency to `org.apache.cassandra:cassandra-thrift`, and if it does remove that dependency from our [pom.xml](pom.xml).
 The `cassandra-thrift` was explicitly added when updating to `3.11.11` as it was not anymore in the `cassandra-all`.
 * Update the [CI Dockerfile](../ci/Dockerfile) and set the new version in the `ccm create` command related to 3.11.
+Note that this will have no effect until the docker image is rebuilt and pushed to the remote repository, thus creating an issue for that would be a good idea.
 * Make sure everything compiles and CI tests are green.
 * Update the [DEVGUIDE.md](../DEV_GUIDE.md) and replace the old version in the examples.
 * Update this `README.md` file with the new or updated instructions.

--- a/persistence-cassandra-3.11/README.md
+++ b/persistence-cassandra-3.11/README.md
@@ -14,5 +14,13 @@ Set the version of the driver in the `cassandra.bundled-driver.version` property
 * Change the version in the [Cassandra311MetricsRegistryTest.java](src/test/java/org/apache/cassandra/metrics/Cassandra311MetricsRegistryTest.java) to the new one.
 * Check if the new version has a transitive dependency to `org.apache.cassandra:cassandra-thrift`, and if it does remove that dependency from our [pom.xml](pom.xml).
 The `cassandra-thrift` was explicitly added when updating to `3.11.11` as it was not anymore in the `cassandra-all`.
-* Make sure everything compiles and tests are green.
+* Update the [CI Dockerfile](../ci/Dockerfile) and set the new version in the `ccm create` command related to 3.11.
+* Make sure everything compiles and CI tests are green.
+* Update the [DEVGUIDE.md](../DEV_GUIDE.md) and replace the old version in the examples.
 * Update this `README.md` file with the new or updated instructions.
+
+It's always good to validate your work against the pull requests that bumped the version in the past:
+
+* `3.11.9 -> 3.11.11` [stargate/stargate#1507](https://github.com/stargate/stargate/pull/1507)
+* `3.11.8 -> 3.11.9` [stargate/stargate#1337](https://github.com/stargate/stargate/pull/1337) & [stargate/stargate#1346](https://github.com/stargate/stargate/pull/1346)
+* `3.11.6 -> 3.11.8` [stargate/stargate#938](https://github.com/stargate/stargate/pull/938)

--- a/persistence-cassandra-3.11/README.md
+++ b/persistence-cassandra-3.11/README.md
@@ -8,9 +8,10 @@ The current Cassandra version this module depends on is `3.11.11`.
 In order to update to a newer patch version, please follow the guidelines below:
 
 * Update the `cassandra.version` property in the [pom.xml](pom.xml).
-* Check what is the version of the `com.datastax.cassandra:cassandra-driver-core` in the `org.apache.cassandra:cassandra-all` for the updated version. 
+* Check the transitive dependencies of the `org.apache.cassandra:cassandra-all` for the new version.
+Make sure that the version of the `com.datastax.cassandra:cassandra-driver-core` that `cassandra-all` depends on, is same as in the `cassandra.bundled-driver.version` property in the [pom.xml](pom.xml).
 This dependency is set as optional in the `cassandra-all`, but we need it to correctly handle UDFs.
-Set the version of the driver in the `cassandra.bundled-driver.version` property in the [pom.xml](pom.xml).
+Note that transitive dependencies can be seen on [mvnrepository.com](https://mvnrepository.com/artifact/org.apache.cassandra/cassandra-all) or by running `./mvnw dependency:tree -pl persistence-cassandra-3.11`.
 * Change the version in the [Cassandra311MetricsRegistryTest.java](src/test/java/org/apache/cassandra/metrics/Cassandra311MetricsRegistryTest.java) to the new one.
 * Check if the new version has a transitive dependency to `org.apache.cassandra:cassandra-thrift`, and if it does remove that dependency from our [pom.xml](pom.xml).
 The `cassandra-thrift` was explicitly added when updating to `3.11.11` as it was not anymore in the `cassandra-all`.

--- a/persistence-cassandra-3.11/pom.xml
+++ b/persistence-cassandra-3.11/pom.xml
@@ -55,6 +55,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.apache.cassandra</groupId>
+      <artifactId>cassandra-thrift</artifactId>
+      <version>${cassandra.version}</version>
+    </dependency>
     <!--
       Redeclare the driver dependency because it's optional in cassandra-all (this is required to
       correctly handle UDFs).

--- a/persistence-cassandra-3.11/pom.xml
+++ b/persistence-cassandra-3.11/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>persistence-cassandra-3.11</artifactId>
   <properties>
     <!-- If you update this, make sure to keep `cassandra.bundled-driver.version` in sync -->
-    <cassandra.version>3.11.9</cassandra.version>
+    <cassandra.version>3.11.11</cassandra.version>
     <!--
       The driver used internally by cassandra-all for UDFs (must match the version declared in
       cassandra-all's POM).

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Cassandra311Persistence.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Cassandra311Persistence.java
@@ -113,6 +113,10 @@ public class Cassandra311Persistence
 
   private static final Logger logger = LoggerFactory.getLogger(Cassandra311Persistence.class);
 
+  // copied from org.apache.cassandra.service.MigrationCoordinator.MIGRATION_DELAY_IN_MS
+  // please keep in sync
+  private static final int MIGRATION_DELAY_IN_MS = 60000;
+
   private static final boolean USE_TRANSITIONAL_AUTH =
       Boolean.getBoolean("stargate.cql_use_transitional_auth");
 
@@ -122,7 +126,7 @@ public class Cassandra311Persistence
    * unknown how long a schema migration takes this waits for an extra MIGRATION_DELAY_IN_MS.
    */
   private static final int STARTUP_DELAY_MS =
-      Integer.getInteger("stargate.startup_delay_ms", 3 * MigrationManager.MIGRATION_DELAY_IN_MS);
+      Integer.getInteger("stargate.startup_delay_ms", 3 * MIGRATION_DELAY_IN_MS);
 
   // SCHEMA_SYNC_GRACE_PERIOD should be longer than MigrationManager.MIGRATION_DELAY_IN_MS to allow
   // the schema pull tasks to be initiated, plus some time for executing the pull requests plus
@@ -131,9 +135,7 @@ public class Cassandra311Persistence
   // operation should complete within the default MIGRATION_DELAY_IN_MS.
   private static final Duration SCHEMA_SYNC_GRACE_PERIOD =
       Duration.ofMillis(
-          Long.getLong(
-              "stargate.schema_sync_grace_period_ms",
-              2 * MigrationManager.MIGRATION_DELAY_IN_MS + 10_000));
+          Long.getLong("stargate.schema_sync_grace_period_ms", 2 * MIGRATION_DELAY_IN_MS + 10_000));
 
   private final SchemaCheck schemaCheck = new SchemaCheck();
 
@@ -203,7 +205,6 @@ public class Cassandra311Persistence
     executor =
         SHARED.newExecutor(
             DatabaseDescriptor.getNativeTransportMaxThreads(),
-            Integer.MAX_VALUE,
             "transport",
             "Native-Transport-Requests");
 

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/StargateQueryHandler.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/StargateQueryHandler.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.validation.constraints.NotNull;
 import org.apache.cassandra.auth.IResource;
 import org.apache.cassandra.auth.RoleResource;
 import org.apache.cassandra.cql3.BatchQueryOptions;
@@ -310,7 +309,6 @@ public class StargateQueryHandler implements QueryHandler {
     }
   }
 
-  @NotNull
   private AuthenticationSubject loadAuthenticationSubject(Map<String, ByteBuffer> customPayload) {
     AuthenticatedUser user = Serializer.load(customPayload);
     return AuthenticationSubject.of(user);

--- a/persistence-cassandra-3.11/src/test/java/io/stargate/db/cassandra/Cassandra311PersistenceActivatorTest.java
+++ b/persistence-cassandra-3.11/src/test/java/io/stargate/db/cassandra/Cassandra311PersistenceActivatorTest.java
@@ -50,7 +50,7 @@ class Cassandra311PersistenceActivatorTest {
 
   @Test
   void testMakeConfigWithCustomConfig() throws IOException {
-    // This is the path to the default Cassandra 3.11.8 cassandra.yaml
+    // This is the path to the default Cassandra 3.11.x cassandra.yaml
     // with row_cache_size_in_mb set to 1024 to test the override.
     System.setProperty(
         "stargate.unsafe.cassandra_config_path", "src/test/resources/cassandra.yaml");

--- a/persistence-cassandra-3.11/src/test/java/org/apache/cassandra/metrics/Cassandra311MetricsRegistryTest.java
+++ b/persistence-cassandra-3.11/src/test/java/org/apache/cassandra/metrics/Cassandra311MetricsRegistryTest.java
@@ -50,7 +50,7 @@ public class Cassandra311MetricsRegistryTest {
 
   @Test
   public void versionCheck() {
-    String supportedVersion = "3.11.9";
+    String supportedVersion = "3.11.11";
     String currentVersion = FBUtilities.getReleaseVersionString();
 
     assertThat(currentVersion)


### PR DESCRIPTION
**What this PR does**:
Updates the `persistence-cassandra-3.11` to use the latest version `3.11.11`. The `cassandra-driver-core` stayed on `3.0.1` in this version, so no update there needed.

**Tasks:**
* [x] extend `README.md` with the C update instructions