### PR TITLE
aligned the DSE version to 6.8.16 in the integration test profile

### DIFF
--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -419,7 +419,7 @@
                 <configuration>
                   <systemPropertyVariables>
                     <ccm.dse>true</ccm.dse>
-                    <ccm.version>6.8.13</ccm.version>
+                    <ccm.version>6.8.16</ccm.version>
                     <stargate.test.nodes>1</stargate.test.nodes>
                   </systemPropertyVariables>
                   <failIfNoTests>true</failIfNoTests>


### PR DESCRIPTION
**What this PR does**:
Small fix to align the target DSE version to `6.8.16` in the profile `it-dse-6.8` used for the integration tests.
