### PR TITLE
closes #1520: updated CI docker image, correct ccm versions, updated …

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,7 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
+
+ENV TZ=UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update \
     && apt-get install -y \
@@ -13,13 +16,14 @@ RUN apt-get update \
     sudo \
     maven \
     apt-transport-https \
+    apt-utils \
     ca-certificates \
     curl \
     software-properties-common
 
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 
-RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" \
+RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable" \
     && apt-get update \
     && apt-cache policy docker-ce \
     && apt-get install docker-ce -y
@@ -42,8 +46,8 @@ RUN git clone --branch master --single-branch https://github.com/riptano/ccm.git
     sudo python setup.py install
 
 # Create clusters to pre-download necessary artifacts
-RUN ccm create -v 4.0.0 stargate_40 && ccm remove stargate_40
+RUN ccm create -v 4.0.1 stargate_40 && ccm remove stargate_40
 RUN ccm create -v 3.11.11 stargate_311 && ccm remove stargate_311
-RUN ccm create -v 6.8.13 --dse stargate_dse68 && ccm remove stargate_dse68
+RUN ccm create -v 6.8.16 --dse stargate_dse68 && ccm remove stargate_dse68
 
 CMD ["/bin/bash"]

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:focal
 
+ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
@@ -16,7 +17,6 @@ RUN apt-get update \
     sudo \
     maven \
     apt-transport-https \
-    apt-utils \
     ca-certificates \
     curl \
     software-properties-common

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -1,0 +1,24 @@
+HOSTNAME        := gcr.io
+PROJECT         := stargateio
+NAME            := stargate-builder
+VERSION         := v1.0.6
+TAG             := ${VERSION}
+IMG             := ${NAME}:${TAG}
+IMG_GCP         := ${HOSTNAME}/${PROJECT}/${IMG}
+
+.PHONY : info build
+
+info:
+	@echo Version ${VERSION}
+	@echo GCP image ${IMG_GCP}
+
+build: build-docker
+
+build-docker:
+	@echo Building docker image and tagging..
+	docker build -t ${IMG} .
+	docker tag ${IMG} ${IMG_GCP}
+
+push:
+	@echo Push docker image ${IMG_GCP} to GCP..
+	docker push ${IMG_GCP}

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -19,6 +19,17 @@ build-docker:
 	docker build -t ${IMG} .
 	docker tag ${IMG} ${IMG_GCP}
 
-push:
+push: check-image push-exe
+
+check-image:
+	$(eval image := $(shell gcloud container images list-tags gcr.io/stargateio/stargate-builder | grep "${VERSION}"))
+	@if [ -n "${image}" ]; then \
+		echo -n "The image with the version ${VERSION} exists, do you want to overwrite [Y/n]?" \
+			&& read ans \
+			&& [ $${ans:-y} = y ] \
+			|| (echo "Aborted!"; exit 1) \
+	fi
+
+push-exe:
 	@echo Push docker image ${IMG_GCP} to GCP..
 	docker push ${IMG_GCP}

--- a/ci/README.md
+++ b/ci/README.md
@@ -13,18 +13,19 @@ The docker image is directly referenced in the [cloudbuild.yaml](../cloudbuild.y
 
 ### Prerequisites
 
-In order to push the new docker image to the GCP image registry `gcr.io/stargateio`, besides having permissions to do so, you should authenticate and setup your docker configuration using:
+In order to push the new docker image to the GCP image registry `gcr.io/stargateio`, besides having permissions to do so, you should authenticate and set up your docker configuration using:
 
 ```bash
 gcloud auth login
 gcloud auth configure-docker
 ```
 
+That said, it's assumed that `gcloud` is available on the system, as it's going to be used for getting the existing image tags in the [Makefile](./Makefile).
+
 ### Process
 
 * Perform wanted updates related to the image.
 * Bump the `VERSION` variable in the [Makefile](Makefile).
-**This step is mandatory, otherwise you will overwrite the existing image.**
 * Run `make info` and confirm that the image you are about to build and push has a correct tag.
 * Run `make build push`.
 It will build the image and push to the GCP repository.

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,33 @@
+# Stargate Continuous Integration
+
+This folder contains necessary files for the docker image being used during the CI:
+
+* `Dockerfile` - docker file for the container that will be used during the CI
+* `test.sh` - script that is actually executed during the CI
+* `Makefile` - small Makefile that enables easier building and pushing of a new CI docker image
+
+*Note that we run the CI on the GCP using [Cloud Build](https://cloud.google.com/build).
+The docker image is directly referenced in the [cloudbuild.yaml](../cloudbuild.yaml), [cloudbuild-3_11.yaml](../cloudbuild-3_11.yaml), , [cloudbuild-4_0.yaml](../cloudbuild-4_0.yaml) and [cloudbuild-dse.yaml](../cloudbuild-dse.yaml) files which represent the jobs we do during the CI.*
+
+## Updating the docker image
+
+### Prerequisites
+
+In order to push the new docker image to the GCP image registry `gcr.io/stargateio`, besides having permissions to do so, you should authenticate and setup your docker configuration using:
+
+```bash
+gcloud auth login
+gcloud auth configure-docker
+```
+
+### Process
+
+* Perform wanted updates related to the image.
+* Bump the `VERSION` variable in the [Makefile](Makefile).
+**This step is mandatory, otherwise you will overwrite the existing image.**
+* Run `make info` and confirm that the image you are about to build and push has a correct tag.
+* Run `make build push`.
+It will build the image and push to the GCP repository.
+* Update all the `cloudbuild*.yaml` files with the new version of the image.
+* Commit and create a pull request.
+Note that the created pull request will run the CI using the new image.

--- a/cloudbuild-3_11.yaml
+++ b/cloudbuild-3_11.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.5'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.6'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'
@@ -30,7 +30,7 @@ steps:
         name: 'm2_cache'
   - id: 'cassandra-3.11'
     waitFor: [ 'fetch_secret', 'init_cache' ]
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.5'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.6'
     entrypoint: 'bash'
     args: [ 'ci/test.sh' ]
     volumes:

--- a/cloudbuild-4_0.yaml
+++ b/cloudbuild-4_0.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.5'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.6'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'
@@ -30,7 +30,7 @@ steps:
         name: 'm2_cache'
   - id: 'cassandra-4.0'
     waitFor: [ 'fetch_secret', 'init_cache' ]
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.5'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.6'
     entrypoint: 'bash'
     args: [ 'ci/test.sh' ]
     volumes:

--- a/cloudbuild-dse.yaml
+++ b/cloudbuild-dse.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.3'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.6'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'
@@ -30,7 +30,7 @@ steps:
         name: 'm2_cache'
   - id: 'dse-6.8'
     waitFor: [ 'fetch_secret', 'init_cache' ]
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.3'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.6'
     entrypoint: 'bash'
     args: [ 'ci/test.sh' ]
     volumes:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.5'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.6'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'


### PR DESCRIPTION
**What this PR does**:

Updates our CI docker image:
* updated Ubuntu
* set `ccm` to "prebake" currently used versions for the INT tests

**Which issue(s) this PR fixes**:
Fixes #1520

**Checklist**
- [x] add `README.md` with update instructions
- [x] create `Makefile` for easier workflow
