### PR TITLE
Fix 3 ITs that now expect "text" as type for all columns, tables etc.

### DIFF
--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/BridgeProtoTypeTranslator.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/BridgeProtoTypeTranslator.java
@@ -160,7 +160,13 @@ public class BridgeProtoTypeTranslator {
     static {
       simpleBridgeToCqlTypes = new EnumMap<>(QueryOuterClass.TypeSpec.Basic.class);
       for (QueryOuterClass.TypeSpec.Basic basicType : QueryOuterClass.TypeSpec.Basic.values()) {
-        simpleBridgeToCqlTypes.put(basicType, basicType.name().toLowerCase());
+        String cqlName = basicType.name().toLowerCase();
+        // 06-Jan-2021, tatu: One exception; let's map "Varchar" to "Text". Not the cleanest
+        //    way but has to do since internally Varchar is still used:
+        if ("varchar".equals(cqlName)) {
+          cqlName = "text";
+        }
+        simpleBridgeToCqlTypes.put(basicType, cqlName);
       }
     }
 


### PR DESCRIPTION
**What this PR does**:

Changes mapping from gRPC internal column type of `VARCHAR` (used internally by persistence) into `TEXT` which is the expected external type (see #1499).

**Which issue(s) this PR fixes**:

No separate PR filed.

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated -- passes 3 regressed tests for StargateV2
- [ ] Documentation added/updated
