### PR TITLE
Add Integration Test that inserts+gets a Tuple value (was missing)

### DIFF
--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -1468,6 +1468,31 @@ public class RestApiv2Test extends BaseIntegrationTest {
   }
 
   @Test
+  public void getRowsWithTuple() throws IOException {
+    createKeyspace(keyspaceName);
+    createTestTable(
+        tableName,
+        Arrays.asList("id text", "data tuple<int,boolean>"),
+        Collections.singletonList("id"),
+        Collections.emptyList());
+    insertTestTableRows(
+        Arrays.asList(
+            Arrays.asList("id 1", "data (28,false)"), Arrays.asList("id 2", "data (39,true)")));
+    String body =
+        RestUtils.get(
+            authToken,
+            String.format(
+                "%s/v2/keyspaces/%s/%s/%s?raw=true", restUrlBase, keyspaceName, tableName, "2"),
+            HttpStatus.SC_OK);
+    JsonNode json = objectMapper.readTree(body);
+    assertThat(json.size()).isEqualTo(1);
+    assertThat(json.at("/0/id").asText()).isEqualTo("2");
+    assertThat(json.at("/0/data/0").intValue()).isEqualTo(39);
+    assertThat(json.at("/0/data/1").booleanValue()).isTrue();
+    assertThat(json.at("/0/data").size()).isEqualTo(2);
+  }
+
+  @Test
   public void getRowsWithUDT() throws IOException {
     createKeyspace(keyspaceName);
 


### PR DESCRIPTION
**What this PR does**:

As per title, adds an Integration Test to ensure we can insert and get Tuple values (and not just create Tuple-valued columns which has been tested).

**Which issue(s) this PR fixes**:

No PR filed.

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
