### PR TITLE
Fix an IT failing for some backends in CI by less strict message comparison

### DIFF
--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -483,7 +483,11 @@ public class RestApiv2Test extends BaseIntegrationTest {
 
     ApiError response = objectMapper.readValue(body, ApiError.class);
     assertThat(response.getCode()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
-    assertThat(response.getDescription()).contains("Index test_idx already exists");
+    // 11-Jan-2022, tatu: Specific message seems to vary a bit depending on backend
+    //  (some quote index name, some don't) so need to use looser match:
+    final String failDesc = response.getDescription();
+
+    assertThat(response.getDescription()).containsPattern("Index .*test_idx .*already exists");
 
     // successufully index a collection
     indexAdd.setColumn("email");


### PR DESCRIPTION
**What this PR does**:

Resolves one bogus IT failure in CI by considering that error messages from persistence seem to vary slightly:
index name is quoted in some cases, not in others.

**Which issue(s) this PR fixes**:

No PR filed for SGv2

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
