### PR TITLE
Fix #1538: do not verify quoting for Column as it prevents use of mixed-case UDT names

### DIFF
--- a/persistence-api/src/main/java/io/stargate/db/schema/Column.java
+++ b/persistence-api/src/main/java/io/stargate/db/schema/Column.java
@@ -586,10 +586,11 @@ public abstract class Column implements SchemaEntity, Comparable<Column> {
       int paramsIdx = dataTypeName.indexOf('<');
       String baseTypeName =
           paramsIdx < 0 ? dataTypeName : dataTypeName.substring(0, paramsIdx).trim();
-      if (!ColumnUtils.isValidUnquotedIdentifier(baseTypeName)) {
-        throw new IllegalArgumentException(
-            "Malformed type name (requires quoting but is not quoted): " + dataTypeName);
-      }
+
+      // 11-Jan-2022, tatu: There used to be a call to
+      //     `ColumnUtils.isValidUnquotedIdentifier(baseTypeName)`
+      //   but it caused issue #1538 and seems like this is not the place for such check.
+
       Type baseType = parseBaseType(baseTypeName);
       boolean isFrozen = baseType == null && baseTypeName.equalsIgnoreCase("frozen");
       boolean isParameterized = isFrozen || (baseType != null && baseType.isParameterized());

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -1498,7 +1498,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
 
     // create UDT: note -- UDT names must be lower-case it seems (mixed case fails)
     String udtString =
-        "{\"name\": \"test_udt\", \"fields\":"
+        "{\"name\": \"testUDT\", \"fields\":"
             + "[{\"name\":\"name\",\"typeDefinition\":\"text\"},"
             + "{\"name\":\"age\",\"typeDefinition\":\"int\"}]}";
     RestUtils.post(
@@ -1509,7 +1509,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
 
     createTestTable(
         tableName,
-        Arrays.asList("id text", "details test_udt"),
+        Arrays.asList("id text", "details testUDT"),
         Collections.singletonList("id"),
         Collections.emptyList());
 


### PR DESCRIPTION
**What this PR does**:

Removes validation call that seems misplaced (will need help validating this is the case) -- and causes unexpected failure when referencing UDT names that require quoting. Quoting here, however, is to be handled by query builder and not passed as pre-quoted.

**Which issue(s) this PR fixes**:
Fixes #1538

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated -- change UDT test to use mixed-case name to verify initial fail, fix.
- [ ] Documentation added/updated
