### PR TITLE
Fix HealthCheck IT tests to work with StargateV2/REST rearchitecting

### DIFF
--- a/testing/src/main/java/io/stargate/it/http/HealthCheckerTest.java
+++ b/testing/src/main/java/io/stargate/it/http/HealthCheckerTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+// Tests for StargateV1 backend health endpoints.
 @NotThreadSafe
 public class HealthCheckerTest extends BaseIntegrationTest {
 

--- a/testing/src/main/java/io/stargate/it/http/RestHealthCheckerTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestHealthCheckerTest.java
@@ -5,15 +5,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.stargate.it.BaseIntegrationTest;
 import java.io.IOException;
-import java.util.Map;
 import net.jcip.annotations.NotThreadSafe;
 import org.apache.http.HttpStatus;
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
 @NotThreadSafe
 @ExtendWith(RestApiExtension.class)

--- a/testing/src/main/java/io/stargate/it/http/RestHealthCheckerTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestHealthCheckerTest.java
@@ -42,49 +42,11 @@ public class RestHealthCheckerTest extends BaseIntegrationTest {
     assertThat(body).isEqualTo("UP");
   }
 
-  // TODO: what should the parameters be for REST? Or do we even have this capability?
-  @ParameterizedTest
-  @CsvSource({
-    ",",
-    "?check=deadlocks",
-    "?check=graphql",
-    "?check=grpc",
-    "?check=deadlocks&check=graphql",
-    "?check=datastore",
-    "?check=storage"
-  })
-  public void readiness(String query) throws IOException {
-    query = query == null ? "" : query;
-    String body =
-        RestUtils.get(
-            "", String.format("%s/checker/readiness%s", healthUrlBase, query), HttpStatus.SC_OK);
-
-    assertThat(body).isEqualTo("READY");
-  }
-
   @Test
-  public void missingReadinessCheck() throws IOException {
-    String body =
-        RestUtils.get(
-            "",
-            String.format("%s/checker/readiness?check=testUnknown", healthUrlBase),
-            HttpStatus.SC_SERVICE_UNAVAILABLE);
+  public void readiness() throws IOException {
+    // Root URL responds like Ping at this point: may change in future
+    String body = RestUtils.get("", String.format("%s/", healthUrlBase), HttpStatus.SC_OK);
 
-    assertThat(body).isEqualTo("NOT READY");
-  }
-
-  @Test
-  public void healthCheck() throws IOException {
-    String body =
-        RestUtils.get("", String.format("%s/admin/healthcheck", healthUrlBase), HttpStatus.SC_OK);
-    @SuppressWarnings("unchecked")
-    Map<String, Object> json = OBJECT_MAPPER.readValue(body, Map.class);
-    assertThat(json)
-        .extracting("deadlocks", InstanceOfAssertFactories.MAP)
-        .containsEntry("healthy", true);
-    assertThat(json)
-        .extracting("graphql", InstanceOfAssertFactories.MAP)
-        .containsEntry("healthy", true)
-        .containsEntry("message", "Available");
+    assertThat(body).isEqualTo("It's Alive");
   }
 }


### PR DESCRIPTION
**What this PR does**:

Fixes 3 failing ITs for Stargate V2: full SGv1 backend tests remain in `HealthCheckTest`, newer `RestHealthCheckTest` only verifying basic liveness/readiness endpoints.
Tests will be improved in future when we implement proper readiness check(s).

**Which issue(s) this PR fixes**:

No separate PR.

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
