### PR TITLE
Fix gRPC to properly skip connection creation for GetSchemaNotifications

### DIFF
--- a/grpc/src/main/java/io/stargate/grpc/service/interceptors/NewConnectionInterceptor.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/interceptors/NewConnectionInterceptor.java
@@ -37,8 +37,6 @@ import org.slf4j.LoggerFactory;
 public class NewConnectionInterceptor implements ServerInterceptor {
 
   private static final Logger logger = LoggerFactory.getLogger(NewConnectionInterceptor.class);
-  // stargate.Stargate.GetSchemaNotifications
-  // stargate.Stargate/GetSchemaNotifications
   private static final String GET_SCHEMA_NOTIFICATIONS_NAME =
       getFullMethodName("GetSchemaNotifications");
 

--- a/testing/src/main/java/io/stargate/it/grpc/SchemaNotificationsTest.java
+++ b/testing/src/main/java/io/stargate/it/grpc/SchemaNotificationsTest.java
@@ -1,5 +1,8 @@
 package io.stargate.it.grpc;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
 import io.grpc.ManagedChannel;
@@ -22,9 +25,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 @ExtendWith(CqlSessionExtension.class)
 public class SchemaNotificationsTest extends BaseIntegrationTest {

--- a/testing/src/main/java/io/stargate/it/grpc/SchemaNotificationsTest.java
+++ b/testing/src/main/java/io/stargate/it/grpc/SchemaNotificationsTest.java
@@ -1,18 +1,13 @@
 package io.stargate.it.grpc;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
-import io.stargate.grpc.StargateBearerToken;
 import io.stargate.it.BaseIntegrationTest;
 import io.stargate.it.driver.CqlSessionExtension;
 import io.stargate.it.driver.TestKeyspace;
-import io.stargate.it.http.RestUtils;
 import io.stargate.it.storage.StargateConnectionInfo;
 import io.stargate.proto.QueryOuterClass.SchemaChange;
 import io.stargate.proto.QueryOuterClass.SchemaChange.Target;
@@ -28,6 +23,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 @ExtendWith(CqlSessionExtension.class)
 public class SchemaNotificationsTest extends BaseIntegrationTest {
 
@@ -38,9 +36,7 @@ public class SchemaNotificationsTest extends BaseIntegrationTest {
     String seedAddress = cluster.seedAddress();
     ManagedChannel channel =
         ManagedChannelBuilder.forAddress(seedAddress, 8090).usePlaintext().build();
-    asyncStub =
-        StargateGrpc.newStub(channel)
-            .withCallCredentials(new StargateBearerToken(RestUtils.getAuthToken(seedAddress)));
+    asyncStub = StargateGrpc.newStub(channel);
   }
 
   @Test


### PR DESCRIPTION
**What this PR does**:
Fix gRPC to skip auth and not create a persistence connection for `GetSchemaNotifications`. Also fix the integration test that was supposed to cover this.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
