### PR TITLE
Update/Unify Jackson components used by SGv2 REST API to use 2.12.6

### DIFF
--- a/sgv2-restapi/pom.xml
+++ b/sgv2-restapi/pom.xml
@@ -13,6 +13,19 @@
     <airline.version>2.8.2</airline.version>
     <swagger-ui.version>3.35.0</swagger-ui.version>
   </properties>
+  <dependencyManagement>
+    <dependencies>
+      <!-- To get a consistent set of Jackson components, use BOM:
+        -->
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>2.12.6</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <!-- Stargate cross-component core deps -->
 


### PR DESCRIPTION
**What this PR does**:

Upgrades Jackson components (2.10.5 (by DropWizard) -> 2.12.6) for SGv2/REST API. Later on likely upgrade globally but initially just the newly refactored component to minimize risks wrt Persistence.

**Which issue(s) this PR fixes**:
No PR

**Checklist**
- [x] Changes manually tested -- will rely on CI/IT
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
