### PR TITLE
Handle bridge auth for background operations

### DIFF
--- a/core/src/main/java/io/stargate/core/grpc/BridgeConfig.java
+++ b/core/src/main/java/io/stargate/core/grpc/BridgeConfig.java
@@ -1,0 +1,18 @@
+package io.stargate.core.grpc;
+
+public class BridgeConfig {
+
+  /**
+   * The token that can be used by Stargate services to query the gRPC bridge when no user token is
+   * available (e.g. background queries).
+   */
+  public static final String ADMIN_TOKEN;
+
+  static {
+    String propertyName = "stargate.grpc.admin_token";
+    ADMIN_TOKEN = System.getProperty(propertyName);
+    if (ADMIN_TOKEN == null || ADMIN_TOKEN.isEmpty()) {
+      throw new IllegalStateException(String.format("'%s' must be provided", propertyName));
+    }
+  }
+}

--- a/grpc/src/main/java/io/stargate/grpc/GrpcActivator.java
+++ b/grpc/src/main/java/io/stargate/grpc/GrpcActivator.java
@@ -17,6 +17,7 @@ package io.stargate.grpc;
 
 import io.stargate.auth.AuthenticationService;
 import io.stargate.core.activator.BaseActivator;
+import io.stargate.core.grpc.BridgeConfig;
 import io.stargate.core.metrics.api.Metrics;
 import io.stargate.db.DbActivator;
 import io.stargate.db.Persistence;
@@ -46,7 +47,9 @@ public class GrpcActivator extends BaseActivator {
     if (grpc != null) { // Already started
       return null;
     }
-    grpc = new GrpcImpl(persistence.get(), metrics.get(), authentication.get());
+    grpc =
+        new GrpcImpl(
+            persistence.get(), metrics.get(), authentication.get(), BridgeConfig.ADMIN_TOKEN);
     grpc.start();
 
     return null;

--- a/grpc/src/main/java/io/stargate/grpc/impl/GrpcImpl.java
+++ b/grpc/src/main/java/io/stargate/grpc/impl/GrpcImpl.java
@@ -45,7 +45,10 @@ public class GrpcImpl {
   private final ScheduledExecutorService executor;
 
   public GrpcImpl(
-      Persistence persistence, Metrics metrics, AuthenticationService authenticationService) {
+      Persistence persistence,
+      Metrics metrics,
+      AuthenticationService authenticationService,
+      String adminToken) {
 
     String listenAddress = null;
 
@@ -69,7 +72,7 @@ public class GrpcImpl {
             // `Persistence` operations are done asynchronously so there isn't a need for a separate
             // thread pool for handling gRPC callbacks in `GrpcService`.
             .directExecutor()
-            .intercept(new NewConnectionInterceptor(persistence, authenticationService))
+            .intercept(new NewConnectionInterceptor(persistence, authenticationService, adminToken))
             .intercept(new MetricCollectingServerInterceptor(metrics.getMeterRegistry()))
             .addService(new GrpcService(persistence, executor))
             .build();

--- a/grpc/src/main/java/io/stargate/grpc/service/interceptors/NewConnectionInterceptor.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/interceptors/NewConnectionInterceptor.java
@@ -2,7 +2,6 @@ package io.stargate.grpc.service.interceptors;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
-import com.google.protobuf.Descriptors;
 import io.grpc.Context;
 import io.grpc.Contexts;
 import io.grpc.Grpc;
@@ -21,7 +20,6 @@ import io.stargate.db.ClientInfo;
 import io.stargate.db.Persistence;
 import io.stargate.db.Persistence.Connection;
 import io.stargate.grpc.service.GrpcService;
-import io.stargate.proto.StargateOuterClass;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Duration;
@@ -37,8 +35,6 @@ import org.slf4j.LoggerFactory;
 public class NewConnectionInterceptor implements ServerInterceptor {
 
   private static final Logger logger = LoggerFactory.getLogger(NewConnectionInterceptor.class);
-  private static final String GET_SCHEMA_NOTIFICATIONS_NAME =
-      getFullMethodName("GetSchemaNotifications");
 
   public static final Metadata.Key<String> TOKEN_KEY =
       Metadata.Key.of("X-Cassandra-Token", Metadata.ASCII_STRING_MARSHALLER);
@@ -51,6 +47,7 @@ public class NewConnectionInterceptor implements ServerInterceptor {
 
   private final Persistence persistence;
   private final AuthenticationService authenticationService;
+  private final String adminToken;
   private final LoadingCache<RequestInfo, Connection> connectionCache =
       Caffeine.newBuilder()
           .expireAfterWrite(Duration.ofSeconds(CACHE_TTL_SECS))
@@ -70,9 +67,10 @@ public class NewConnectionInterceptor implements ServerInterceptor {
   }
 
   public NewConnectionInterceptor(
-      Persistence persistence, AuthenticationService authenticationService) {
+      Persistence persistence, AuthenticationService authenticationService, String adminToken) {
     this.persistence = persistence;
     this.authenticationService = authenticationService;
+    this.adminToken = adminToken;
   }
 
   @Override
@@ -81,34 +79,36 @@ public class NewConnectionInterceptor implements ServerInterceptor {
     try {
       Context context = Context.current();
 
-      if (shouldCreateConnection(call)) {
-        String token = headers.get(TOKEN_KEY);
-
-        Map<String, String> stringHeaders = convertAndFilterHeaders(headers);
-
-        // Some authentication service and persistence implementations depend on the "host" header
-        // being set. HTTP/2 uses the ":authority" pseudo-header for this purpose and the
-        // `grpc-netty-shaded` implementation will move the "host" header into the ":authority"
-        // value:
-        // https://github.com/grpc/grpc-java/commit/122b3b2f7cf2b50fe0a0cebc55a84133441a4348
-        String authority = call.getAuthority();
-        if (authority != null && !authority.isEmpty()) {
-          stringHeaders.put("host", authority);
-        }
-
-        RequestInfo info =
-            ImmutableRequestInfo.builder()
-                .token(token)
-                .headers(stringHeaders)
-                .remoteAddress(call.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR))
-                .build();
-
-        Connection connection = connectionCache.get(info);
-        context =
-            context
-                .withValue(GrpcService.HEADERS_KEY, stringHeaders)
-                .withValue(GrpcService.CONNECTION_KEY, connection);
+      String token = headers.get(TOKEN_KEY);
+      if (token == null) {
+        call.close(Status.UNAUTHENTICATED.withDescription("No token provided"), new Metadata());
+        return new NopListener<>();
       }
+
+      Map<String, String> stringHeaders = convertAndFilterHeaders(headers);
+
+      // Some authentication service and persistence implementations depend on the "host" header
+      // being set. HTTP/2 uses the ":authority" pseudo-header for this purpose and the
+      // `grpc-netty-shaded` implementation will move the "host" header into the ":authority"
+      // value:
+      // https://github.com/grpc/grpc-java/commit/122b3b2f7cf2b50fe0a0cebc55a84133441a4348
+      String authority = call.getAuthority();
+      if (authority != null && !authority.isEmpty()) {
+        stringHeaders.put("host", authority);
+      }
+
+      RequestInfo info =
+          ImmutableRequestInfo.builder()
+              .token(token)
+              .headers(stringHeaders)
+              .remoteAddress(call.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR))
+              .build();
+
+      Connection connection = connectionCache.get(info);
+      context =
+          context
+              .withValue(GrpcService.HEADERS_KEY, stringHeaders)
+              .withValue(GrpcService.CONNECTION_KEY, connection);
 
       return Contexts.interceptCall(context, call, headers, next);
     } catch (Exception e) {
@@ -130,15 +130,10 @@ public class NewConnectionInterceptor implements ServerInterceptor {
     return new NopListener<>();
   }
 
-  private boolean shouldCreateConnection(ServerCall<?, ?> call) {
-    // getSchemaNotifications only interacts with the Persistence, we don't need a connection.
-    return !GET_SCHEMA_NOTIFICATIONS_NAME.equals(call.getMethodDescriptor().getFullMethodName());
-  }
-
   private Connection newConnection(RequestInfo info) throws UnauthorizedException {
     Connection connection;
     String token = info.token();
-    if (token == null) {
+    if (adminToken.equals(token)) {
       connection = persistence.newConnection();
     } else {
       AuthenticationSubject authenticationSubject =
@@ -183,12 +178,4 @@ public class NewConnectionInterceptor implements ServerInterceptor {
   }
 
   private static class NopListener<ReqT> extends ServerCall.Listener<ReqT> {}
-
-  private static String getFullMethodName(String simpleName) {
-    Descriptors.MethodDescriptor fromProtobuf =
-        StargateOuterClass.getDescriptor().getServices().get(0).findMethodByName(simpleName);
-    // Can't use getFullName() here because it uses '.' as the separator between service and method,
-    // whereas ServerCall.getMethodDescriptor().getFullName() uses '/'.
-    return fromProtobuf.getService().getFullName() + '/' + fromProtobuf.getName();
-  }
 }

--- a/grpc/src/test/java/io/stargate/grpc/service/HeadersTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/HeadersTest.java
@@ -78,7 +78,7 @@ public class HeadersTest extends BaseGrpcServiceTest {
     when(authenticationService.validateToken(anyString(), any(Map.class)))
         .thenReturn(authenticationSubject);
 
-    startServer(new NewConnectionInterceptor(persistence, authenticationService));
+    startServer(new NewConnectionInterceptor(persistence, authenticationService, "mockAdminToken"));
 
     // When
     executeQuery(stub, "mock query");

--- a/grpc/src/test/java/io/stargate/grpc/service/interceptors/NewConnectionInterceptorTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/service/interceptors/NewConnectionInterceptorTest.java
@@ -72,7 +72,7 @@ public class NewConnectionInterceptorTest {
     metadata.put(NewConnectionInterceptor.TOKEN_KEY, "abc");
 
     NewConnectionInterceptor interceptor =
-        new NewConnectionInterceptor(persistence, authenticationService);
+        new NewConnectionInterceptor(persistence, authenticationService, "mockAdminToken");
     interceptor.interceptCall(
         call,
         metadata,
@@ -98,7 +98,7 @@ public class NewConnectionInterceptorTest {
 
     Metadata metadata = new Metadata();
     NewConnectionInterceptor interceptor =
-        new NewConnectionInterceptor(persistence, authenticationService);
+        new NewConnectionInterceptor(persistence, authenticationService, "mockAdminToken");
     interceptor.interceptCall(call, metadata, next);
 
     verify(call, times(1))
@@ -126,7 +126,7 @@ public class NewConnectionInterceptorTest {
     Metadata metadata = new Metadata();
     metadata.put(NewConnectionInterceptor.TOKEN_KEY, "invalid");
     NewConnectionInterceptor interceptor =
-        new NewConnectionInterceptor(persistence, authenticationService);
+        new NewConnectionInterceptor(persistence, authenticationService, "mockAdminToken");
     interceptor.interceptCall(call, metadata, next);
 
     verify(call, times(1))
@@ -154,7 +154,7 @@ public class NewConnectionInterceptorTest {
     Metadata metadata = new Metadata();
     metadata.put(NewConnectionInterceptor.TOKEN_KEY, "someToken");
     NewConnectionInterceptor interceptor =
-        new NewConnectionInterceptor(persistence, authenticationService);
+        new NewConnectionInterceptor(persistence, authenticationService, "mockAdminToken");
     interceptor.interceptCall(call, metadata, next);
 
     verify(call, times(1))
@@ -194,7 +194,7 @@ public class NewConnectionInterceptorTest {
     Metadata metadata = new Metadata();
     metadata.put(NewConnectionInterceptor.TOKEN_KEY, "someToken");
     NewConnectionInterceptor interceptor =
-        new NewConnectionInterceptor(persistence, authenticationService);
+        new NewConnectionInterceptor(persistence, authenticationService, "mockAdminToken");
     interceptor.interceptCall(call, metadata, next);
 
     verify(authenticationService, times(1)).validateToken(anyString(), any(Map.class));

--- a/testing/src/main/java/io/stargate/it/grpc/SchemaNotificationsTest.java
+++ b/testing/src/main/java/io/stargate/it/grpc/SchemaNotificationsTest.java
@@ -8,6 +8,7 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
+import io.stargate.grpc.StargateBearerToken;
 import io.stargate.it.BaseIntegrationTest;
 import io.stargate.it.driver.CqlSessionExtension;
 import io.stargate.it.driver.TestKeyspace;
@@ -36,7 +37,9 @@ public class SchemaNotificationsTest extends BaseIntegrationTest {
     String seedAddress = cluster.seedAddress();
     ManagedChannel channel =
         ManagedChannelBuilder.forAddress(seedAddress, 8090).usePlaintext().build();
-    asyncStub = StargateGrpc.newStub(channel);
+    asyncStub =
+        StargateGrpc.newStub(channel)
+            .withCallCredentials(new StargateBearerToken("mockAdminToken"));
   }
 
   @Test

--- a/testing/src/main/java/io/stargate/it/http/RestApiExtension.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiExtension.java
@@ -230,6 +230,8 @@ public class RestApiExtension extends ExternalResource<RestApiSpec, RestApiExten
         cmd.addArgument("-D" + e.getKey() + "=" + e.getValue());
       }
 
+      cmd.addArgument("-Dstargate.grpc.admin_token=mockAdminToken");
+
       if (isDebug()) {
         int debuggerPort = 5200;
         cmd.addArgument(

--- a/testing/src/main/java/io/stargate/it/storage/StargateExtension.java
+++ b/testing/src/main/java/io/stargate/it/storage/StargateExtension.java
@@ -381,6 +381,8 @@ public class StargateExtension extends ExternalResource<StargateSpec, StargateEx
 
       cmd.addArgument("-Dstargate.enable_user_defined_functions=true");
 
+      cmd.addArgument("-Dstargate.grpc.admin_token=mockAdminToken");
+
       for (Entry<String, String> e : params.systemProperties().entrySet()) {
         cmd.addArgument("-D" + e.getKey() + "=" + e.getValue());
       }


### PR DESCRIPTION
With gRPC being the internal transport in v2, there are certain operations that are executed in the background, for example maintaining a schema metadata cache. In that context we don't have a user token to authenticate, so this change introduces a special "admin token", that will be managed as a shared secret between the gRPC server and the client Stargate services.

Obviously this is not for public gRPC. We plan to split the two APIs, this would only exist in the internal one.