### PR TITLE
Fix #1558: allow insertion of JSON `null` values via REST API

### DIFF
--- a/restapi/src/main/java/io/stargate/web/resources/Converters.java
+++ b/restapi/src/main/java/io/stargate/web/resources/Converters.java
@@ -203,7 +203,9 @@ public class Converters {
   /** Converts an incoming JSON value into a Java type suitable for the given column type. */
   @SuppressWarnings("unchecked")
   public static Object toCqlValue(Column.ColumnType type, Object jsonValue) {
-
+    if (jsonValue == null) {
+      return null;
+    }
     if (jsonValue instanceof String) {
       return toCqlValue(type, (String) jsonValue);
     }

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -24,7 +24,6 @@ import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
-import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -74,17 +73,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(CqlSessionExtension.class)
 @CqlSessionSpec()
 public class RestApiv2Test extends BaseIntegrationTest {
-  // Due to Guava's null hatred, ImmutableMap cannot contain nulls.
-  // But we have a need for null values in JSON so here's something that
-  // will get serialized as JSON null.
-  final Object GUAVA_NULL_VALUE =
-      new Object() {
-        @JsonValue
-        public Integer nullValue() {
-          return null;
-        }
-      };
-
   private String keyspaceName;
   private String tableName;
   private static String authToken;
@@ -1520,7 +1508,12 @@ public class RestApiv2Test extends BaseIntegrationTest {
             ImmutableMap.of(
                 "id", "1", "data", Arrays.asList(28, false, "foobar"), "alt_id", altUid1),
             ImmutableMap.of(
-                "id", "2", "data", Arrays.asList(39, true, "bingo"), "alt_id", GUAVA_NULL_VALUE)));
+                "id",
+                "2",
+                "data",
+                Arrays.asList(39, true, "bingo"),
+                "alt_id",
+                objectMapper.nullNode())));
     JsonNode json = readRawRowsBySingleKey(keyspaceName, tableName, "2");
     assertThat(json.size()).isEqualTo(1);
     assertThat(json.at("/0/id").asText()).isEqualTo("2");

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -17,6 +17,7 @@ package io.stargate.it.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.junit.Assert.assertTrue;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
@@ -945,13 +946,12 @@ public class RestApiv2Test extends BaseIntegrationTest {
     String rowIdentifier = setupClusteringTestCase();
 
     String whereClause = String.format("{\"id\":{\"$eq\":\"%s\"}}", rowIdentifier);
-    String body =
-        RestUtils.get(
-            authToken,
-            String.format(
-                "%s:8082/v2/keyspaces/%s/%s?where=%s&sort={\"expense_id\"\":\"desc\"}",
-                host, keyspaceName, tableName, whereClause),
-            HttpStatus.SC_BAD_REQUEST);
+    RestUtils.get(
+        authToken,
+        String.format(
+            "%s:8082/v2/keyspaces/%s/%s?where=%s&sort={\"expense_id\"\":\"desc\"}",
+            host, keyspaceName, tableName, whereClause),
+        HttpStatus.SC_BAD_REQUEST);
   }
 
   @Test
@@ -1501,7 +1501,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
     assertThat(json.at("/0/data/0").intValue()).isEqualTo(39);
     assertThat(json.at("/0/data/1").booleanValue()).isTrue();
     assertThat(json.at("/0/data").size()).isEqualTo(3);
-    assertThat(json.at("/0/alt_id").isNull());
+    assertTrue(json.at("/0/alt_id").isNull());
   }
 
   // Test for inserting and fetching row(s) with Tuple values: inserts using
@@ -1527,7 +1527,7 @@ public class RestApiv2Test extends BaseIntegrationTest {
     assertThat(json.at("/0/data/0").intValue()).isEqualTo(39);
     assertThat(json.at("/0/data/1").booleanValue()).isTrue();
     assertThat(json.at("/0/data").size()).isEqualTo(3);
-    assertThat(json.at("/0/alt_id").isNull());
+    assertTrue(json.at("/0/alt_id").isNull());
   }
 
   @Test
@@ -1943,21 +1943,20 @@ public class RestApiv2Test extends BaseIntegrationTest {
     Map<String, String> update2 = new HashMap<>();
     update2.put("firstName", "Roger");
     update2.put("lastName", null);
-    body =
-        RestUtils.put(
-            authToken,
-            String.format(
-                "%s/v2/keyspaces/%s/%s/%s", restUrlBase, keyspaceName, tableName, rowIdentifier),
-            objectMapper.writeValueAsString(update2),
-            HttpStatus.SC_OK);
+    RestUtils.put(
+        authToken,
+        String.format(
+            "%s/v2/keyspaces/%s/%s/%s", restUrlBase, keyspaceName, tableName, rowIdentifier),
+        objectMapper.writeValueAsString(update2),
+        HttpStatus.SC_OK);
 
     // And that change actually occurs
     JsonNode json = readRawRowsBySingleKey(keyspaceName, tableName, rowIdentifier);
     assertThat(json.size()).isEqualTo(1);
     assertThat(json.at("/0/id").asText()).isEqualTo(rowIdentifier);
     assertThat(json.at("/0/firstName").asText()).isEqualTo("Roger");
-    assertThat(json.at("/0/lastName").isNull());
-    assertThat(json.at("/0/age").isNull());
+    assertTrue(json.at("/0/lastName").isNull());
+    assertTrue(json.at("/0/age").isNull());
     assertThat(json.at("/0").size()).isEqualTo(4);
   }
 


### PR DESCRIPTION
**What this PR does**:

Allows use of `null` values with JSON payload when inserting rows using REST API.

Also improves testing, including `null` inserting case (for UUIDs): no tests covered this case; and in general JSON-payload taking inserts were (and are) under tests compared to "stringified" payload.

**Which issue(s) this PR fixes**:
Fixes #1558

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
