### PR TITLE
Upgrade Micrometer and prometheus-client versions in v2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
     <immutables.version>2.8.8</immutables.version>
     <javatuples.version>1.2</javatuples.version>
     <!-- Make sure micrometer and prometheus versions are in sync  -->
-    <micrometer.version>1.7.3</micrometer.version>
-    <prometheus.version>0.10.0</prometheus.version>
+    <micrometer.version>1.8.2</micrometer.version>
+    <prometheus.version>0.12.0</prometheus.version>
     <swagger-ui.version>3.52.5</swagger-ui.version>
     <swagger-jersey2-jaxrs.version>1.6.3</swagger-jersey2-jaxrs.version>
 


### PR DESCRIPTION
**What this PR does**:

Upgrade Micrometer dependency (as well as related Prometheus client with matching version) to the latest available.
This might help with an issue with gRPC server metrics logging.
First for v2.0.0 branch; if everything appears to work can backport for Stargate 1.0.x as well.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated -- should pass same integration tests as before
- [ ] Documentation added/updated
