### PR TITLE
refactor update document sub-path to use new write service

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
@@ -124,7 +124,11 @@ public enum ErrorCode {
   DOCS_API_WRITE_BATCH_INVALID_ID_PATH(
       Response.Status.BAD_REQUEST, "ID path is invalid for document during batch write."),
   DOCS_API_WRITE_BATCH_FAILED(
-      Response.Status.INTERNAL_SERVER_ERROR, "Write failed during batched document write.");
+      Response.Status.INTERNAL_SERVER_ERROR, "Write failed during batched document write."),
+
+  DOCS_API_UPDATE_PATH_NOT_MATCHING(
+      Response.Status.INTERNAL_SERVER_ERROR,
+      "Updating a document failed as internally shredded rows did not match the update path.");
 
   /** Status of the response. */
   private final Response.Status responseStatus;

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
@@ -37,7 +37,6 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.PATCH;
 import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -149,83 +148,6 @@ public class DocumentResourceV2 {
           return Response.accepted()
               .entity(
                   mapper.writeValueAsString(new MultiDocsResponse(idsCreated, context.toProfile())))
-              .build();
-        });
-  }
-
-  @PUT
-  @ManagedAsync
-  @ApiOperation(
-      value = "Replace data at a path in a document",
-      notes = "Removes whatever was previously present at the path")
-  @ApiResponses(
-      value = {
-        @ApiResponse(code = 200, message = "OK", response = WriteDocResponse.class),
-        @ApiResponse(code = 400, message = "Bad request", response = ApiError.class),
-        @ApiResponse(code = 401, message = "Unauthorized", response = ApiError.class),
-        @ApiResponse(code = 403, message = "Forbidden", response = ApiError.class),
-        @ApiResponse(code = 422, message = "Unprocessable entity", response = ApiError.class),
-        @ApiResponse(code = 500, message = "Internal Server Error", response = ApiError.class)
-      })
-  @Path("collections/{collection-id}/{document-id}/{document-path: .*}")
-  @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_FORM_URLENCODED})
-  @Produces(MediaType.APPLICATION_JSON)
-  public Response putDocPath(
-      @Context HttpHeaders headers,
-      @Context UriInfo ui,
-      @ApiParam(
-              value =
-                  "The token returned from the authorization endpoint. Use this token in each request.",
-              required = true)
-          @HeaderParam("X-Cassandra-Token")
-          String authToken,
-      @ApiParam(value = "the namespace that the collection is in", required = true)
-          @PathParam("namespace-id")
-          String namespace,
-      @ApiParam(value = "the name of the collection", required = true) @PathParam("collection-id")
-          String collection,
-      @ApiParam(value = "the name of the document", required = true) @PathParam("document-id")
-          String id,
-      @ApiParam(value = "the path in the JSON that you want to retrieve", required = true)
-          @PathParam("document-path")
-          List<PathSegment> path,
-      @ApiParam(value = "The JSON document", required = true)
-          @NotNull(message = "payload not provided")
-          @NotBlank(message = "payload must not be empty")
-          String payload,
-      @ApiParam(
-              value = "Whether to include profiling information in the response (advanced)",
-              defaultValue = "false")
-          @QueryParam("profile")
-          Boolean profile,
-      @Context HttpServletRequest request) {
-    logger.debug("Put: Collection = {}, id = {}, path = {}", collection, id, path);
-    return handle(
-        () -> {
-          boolean isJson =
-              headers
-                  .getHeaderString(HttpHeaders.CONTENT_TYPE)
-                  .toLowerCase()
-                  .contains("application/json");
-
-          ExecutionContext context = ExecutionContext.create(profile);
-
-          documentService.putAtPath(
-              authToken,
-              namespace,
-              collection,
-              id,
-              payload,
-              path,
-              false,
-              dbFactory,
-              isJson,
-              getAllHeaders(request),
-              context);
-          return Response.ok()
-              .entity(
-                  mapper.writeValueAsString(
-                      new DocumentResponseWrapper<>(id, null, null, context.toProfile())))
               .build();
         });
   }

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/ReactiveDocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/ReactiveDocumentResourceV2.java
@@ -602,8 +602,12 @@ public class ReactiveDocumentResourceV2 {
         .flatMap(
             db -> {
               ExecutionContext context = ExecutionContext.create(profile);
+              List<String> pathStrings =
+                  path.stream().map(PathSegment::getPath).collect(Collectors.toList());
+
               return reactiveDocumentService
-                  .executeBuiltInFunction(db, namespace, collection, id, payload, path, context)
+                  .executeBuiltInFunction(
+                      db, namespace, collection, id, payload, pathStrings, context)
                   .map(rawDocumentHandler(raw))
                   .defaultIfEmpty(Response.status(Response.Status.NOT_FOUND).build());
             })

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/write/DocumentWriteService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/write/DocumentWriteService.java
@@ -31,6 +31,7 @@ import io.stargate.web.docsapi.service.JsonShreddedRow;
 import io.stargate.web.docsapi.service.write.db.DeleteQueryBuilder;
 import io.stargate.web.docsapi.service.write.db.InsertQueryBuilder;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -55,7 +56,7 @@ public class DocumentWriteService {
     this.timeSource = timeSource;
     this.config = config;
     this.insertQueryBuilder = new InsertQueryBuilder(config.getMaxDepth());
-    this.deleteQueryBuilder = new DeleteQueryBuilder();
+    this.deleteQueryBuilder = new DeleteQueryBuilder(config.getMaxDepth());
 
     // only set log batches if explicitly disabled
     this.useLoggedBatches =
@@ -139,9 +140,48 @@ public class DocumentWriteService {
       List<JsonShreddedRow> rows,
       boolean numericBooleans,
       ExecutionContext context) {
+    List<String> subDocumentPath = Collections.emptyList();
+    return updateDocument(
+        dataStore,
+        keyspace,
+        collection,
+        documentId,
+        subDocumentPath,
+        rows,
+        numericBooleans,
+        context);
+  }
+
+  /**
+   * Updates a single document, ensuring that existing document with the same key have the given
+   * sub-path deleted.
+   *
+   * @param dataStore {@link DataStore}
+   * @param keyspace Keyspace to store document in.
+   * @param collection Collection the document belongs to.
+   * @param documentId Document ID.
+   * @param subDocumentPath The sub-document path to delete.
+   * @param rows Rows of this document.
+   * @param numericBooleans If numeric boolean should be stored.
+   * @param context Execution content for profiling.
+   * @return Single containing the {@link ResultSet} of the batch execution.
+   */
+  public Single<ResultSet> updateDocument(
+      DataStore dataStore,
+      String keyspace,
+      String collection,
+      String documentId,
+      List<String> subDocumentPath,
+      List<JsonShreddedRow> rows,
+      boolean numericBooleans,
+      ExecutionContext context) {
+    // TODO for review
+    //  should we double check that each row begins with the given sub-path
+    //  ensuring correctness of the update
+
     // create and cache the remove query prepare
     Single<? extends Query<? extends BoundQuery>> deleteQueryPrepare =
-        prepareDeleteDocumentQuery(dataStore, keyspace, collection);
+        prepareDeleteDocumentQuery(dataStore, keyspace, collection, subDocumentPath);
 
     // create and cache the insert query prepare
     Single<? extends Query<? extends BoundQuery>> insertQueryPrepare =
@@ -160,7 +200,8 @@ public class DocumentWriteService {
 
               // add delete
               BoundQuery deleteExistingQuery =
-                  deleteQueryBuilder.bind(pair.getLeft(), documentId, timestamp - 1);
+                  deleteQueryBuilder.bind(
+                      pair.getLeft(), documentId, subDocumentPath, timestamp - 1);
               queries.add(deleteExistingQuery);
 
               // then all inserts
@@ -192,12 +233,14 @@ public class DocumentWriteService {
         .cache();
   }
 
-  // create and cache the insert query prepare
+  // create and cache delete query prepare
   private Single<? extends Query<? extends BoundQuery>> prepareDeleteDocumentQuery(
-      DataStore dataStore, String keyspace, String collection) {
+      DataStore dataStore, String keyspace, String collection, List<String> subDocumentPath) {
 
     return Single.fromCallable(
-            () -> deleteQueryBuilder.buildQuery(dataStore::queryBuilder, keyspace, collection))
+            () ->
+                deleteQueryBuilder.buildQuery(
+                    dataStore::queryBuilder, keyspace, collection, subDocumentPath))
         .flatMap(query -> Single.fromCompletionStage(dataStore.prepare(query)))
         .cache();
   }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/write/db/DeleteQueryBuilder.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/write/db/DeleteQueryBuilder.java
@@ -22,13 +22,25 @@ import io.stargate.db.query.Predicate;
 import io.stargate.db.query.Query;
 import io.stargate.db.query.builder.BuiltQuery;
 import io.stargate.db.query.builder.QueryBuilder;
+import io.stargate.web.docsapi.exception.ErrorCode;
+import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
 import io.stargate.web.docsapi.service.query.DocsApiConstants;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 public class DeleteQueryBuilder {
 
-  /** Constructs the query builder for deleting all document rows for a single document. */
-  public DeleteQueryBuilder() {}
+  private final int maxDepth;
+
+  /**
+   * Constructs the query builder for deleting all document rows for a single document.
+   *
+   * @param maxDepth
+   */
+  public DeleteQueryBuilder(int maxDepth) {
+    this.maxDepth = maxDepth;
+  }
 
   /**
    * Builds the query for deleting all rows for a document.
@@ -40,13 +52,60 @@ public class DeleteQueryBuilder {
    */
   public BuiltQuery<? extends BoundQuery> buildQuery(
       Supplier<QueryBuilder> queryBuilder, String keyspace, String table) {
-    return queryBuilder
-        .get()
-        .delete()
-        .from(keyspace, table)
-        .timestamp()
-        .where(DocsApiConstants.KEY_COLUMN_NAME, Predicate.EQ)
-        .build();
+    return buildQuery(queryBuilder, keyspace, table, 0);
+  }
+
+  /**
+   * Builds the query for deleting rows for a document on a specific sub-path.
+   *
+   * <p><i>Note that binding of this query still requires the sub-path values.</i>
+   *
+   * @param queryBuilder Query builder
+   * @param keyspace keyspace
+   * @param table table
+   * @param subDocumentPath The sub-path of the document to delete. If empty, deletes a complete
+   *     document.
+   * @return BuiltQuery
+   */
+  public BuiltQuery<? extends BoundQuery> buildQuery(
+      Supplier<QueryBuilder> queryBuilder,
+      String keyspace,
+      String table,
+      List<String> subDocumentPath) {
+    int size = Optional.ofNullable(subDocumentPath).map(List::size).orElse(0);
+    return buildQuery(queryBuilder, keyspace, table, size);
+  }
+
+  /**
+   * Builds the query for deleting rows for a document on a specific sub-path size.
+   *
+   * @param queryBuilder Query builder
+   * @param keyspace keyspace
+   * @param table table
+   * @param subDocumentPathSize The sub-path size.
+   * @return BuiltQuery
+   */
+  public BuiltQuery<? extends BoundQuery> buildQuery(
+      Supplier<QueryBuilder> queryBuilder, String keyspace, String table, int subDocumentPathSize) {
+    // make sure we are not exceeding the max depth
+    if (subDocumentPathSize > maxDepth) {
+      throw new ErrorCodeRuntimeException(ErrorCode.DOCS_API_GENERAL_DEPTH_EXCEEDED);
+    }
+
+    QueryBuilder.QueryBuilder__40 where =
+        queryBuilder
+            .get()
+            .delete()
+            .from(keyspace, table)
+            .timestamp()
+            .where(DocsApiConstants.KEY_COLUMN_NAME, Predicate.EQ);
+
+    // if we have the sub-document path add that as well
+    for (int i = 0; i < subDocumentPathSize; i++) {
+      where.where(DocsApiConstants.P_COLUMN_NAME.apply(i), Predicate.EQ);
+    }
+
+    return where.build();
   }
 
   /**
@@ -54,12 +113,25 @@ public class DeleteQueryBuilder {
    *
    * @param builtQuery Prepared query built by this query builder.
    * @param documentId The document id the row is inserted for.
+   * @param subDocumentPath Sub-document path to bind.
    * @param timestamp Timestamp
    * @param <E> generics param
    * @return Bound query.
    */
   public <E extends Query<? extends BoundQuery>> BoundQuery bind(
-      E builtQuery, String documentId, long timestamp) {
-    return builtQuery.bind(timestamp, documentId);
+      E builtQuery, String documentId, List<String> subDocumentPath, long timestamp) {
+    int subPathSize = Optional.ofNullable(subDocumentPath).map(List::size).orElse(0);
+    Object[] values = new Object[subPathSize + 2];
+
+    // timestamp and document id as first
+    values[0] = timestamp;
+    values[1] = documentId;
+
+    // then sub-document paths
+    for (int i = 0; i < subPathSize; i++) {
+      values[i + 2] = subDocumentPath.get(i);
+    }
+
+    return builtQuery.bind(values);
   }
 }

--- a/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
@@ -68,36 +68,6 @@ public class DocumentResourceV2Test {
   }
 
   @Test
-  public void putDocPath() throws JsonProcessingException {
-    HttpHeaders headers = mock(HttpHeaders.class);
-    when(headers.getHeaderString(anyString())).thenReturn("application/json");
-    UriInfo ui = mock(UriInfo.class);
-    String authToken = "auth_token";
-    String keyspace = "keyspace";
-    String collection = "collection";
-    String id = "id";
-    List<PathSegment> path = new ArrayList<>();
-    String payload = "{}";
-
-    Response r =
-        documentResourceV2.putDocPath(
-            headers,
-            ui,
-            authToken,
-            keyspace,
-            collection,
-            id,
-            path,
-            payload,
-            false,
-            httpServletRequest);
-
-    assertThat(r.getStatus()).isEqualTo(200);
-    assertThat(mapper.readTree((String) r.getEntity()).requiredAt("/documentId").asText())
-        .isEqualTo(id);
-  }
-
-  @Test
   public void patchDoc() throws JsonProcessingException {
     HttpHeaders headers = mock(HttpHeaders.class);
     when(headers.getHeaderString(anyString())).thenReturn("application/json");

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/ReactiveDocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/ReactiveDocumentServiceTest.java
@@ -102,8 +102,6 @@ class ReactiveDocumentServiceTest {
 
   @Mock JsonConverter jsonConverter;
 
-  @Mock DocsShredder docsShredder;
-
   @Mock JsonDocumentShredder jsonDocumentShredder;
 
   @Mock JsonSchemaHandler jsonSchemaHandler;
@@ -143,7 +141,6 @@ class ReactiveDocumentServiceTest {
             writeService,
             jsonConverter,
             jsonSchemaHandler,
-            docsShredder,
             jsonDocumentShredder,
             objectMapper,
             timeSource,

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/util/DocsApiUtilsTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/util/DocsApiUtilsTest.java
@@ -63,6 +63,16 @@ class DocsApiUtilsTest {
     }
 
     @Test
+    public void doubleConversionWorks() {
+      int index = RandomUtils.nextInt(100, 999);
+      String first = DocsApiUtils.convertArrayPath(String.format("[%d]", index), 999999);
+
+      String result = DocsApiUtils.convertArrayPath(first, 999999);
+
+      assertThat(result).isEqualTo(String.format("[000%d]", index));
+    }
+
+    @Test
     public void limitExceeded() {
       int index = RandomUtils.nextInt(100, 999);
 

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/write/DocumentWriteServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/write/DocumentWriteServiceTest.java
@@ -35,6 +35,7 @@ import io.stargate.web.docsapi.service.ExecutionContext;
 import io.stargate.web.docsapi.service.ImmutableJsonShreddedRow;
 import io.stargate.web.docsapi.service.JsonShreddedRow;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
@@ -236,6 +237,115 @@ class DocumentWriteServiceTest extends AbstractDataStoreTest {
       Single<ResultSet> result =
           service.updateDocument(
               datastore, KEYSPACE_NAME, COLLECTION_NAME, documentId, rows, false, context);
+
+      result.test().await().assertValueCount(1).assertComplete();
+      row1QueryAssert.assertExecuteCount().isEqualTo(1);
+      row2QueryAssert.assertExecuteCount().isEqualTo(1);
+      deleteQueryAssert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(context.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description()).isEqualTo("ASYNC UPDATE");
+                assertThat(nested.queries())
+                    .hasSize(2)
+                    .anySatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.preparedCQL())
+                              .isEqualTo(
+                                  String.format(deleteCql, KEYSPACE_NAME + "." + COLLECTION_NAME));
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(0);
+                        })
+                    .anySatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.preparedCQL())
+                              .isEqualTo(
+                                  String.format(insertCql, KEYSPACE_NAME + "." + COLLECTION_NAME));
+                          assertThat(queryInfo.execCount()).isEqualTo(2);
+                          assertThat(queryInfo.rowCount()).isEqualTo(2);
+                        });
+              });
+    }
+
+    @Test
+    public void updateSubPath() throws Exception {
+      DataStore datastore = datastore();
+      BatchType batchType =
+          datastore.supportsLoggedBatches() ? BatchType.LOGGED : BatchType.UNLOGGED;
+      String documentId = RandomStringUtils.randomAlphanumeric(16);
+      List<String> subDocumentPath = Collections.singletonList("key1");
+      JsonShreddedRow row1 =
+          ImmutableJsonShreddedRow.builder()
+              .maxDepth(MAX_DEPTH)
+              .addPath("key1")
+              .stringValue("value1")
+              .build();
+      JsonShreddedRow row2 =
+          ImmutableJsonShreddedRow.builder()
+              .maxDepth(MAX_DEPTH)
+              .addPath("key1")
+              .addPath("nested")
+              .doubleValue(2.2d)
+              .build();
+      List<JsonShreddedRow> rows = Arrays.asList(row1, row2);
+
+      long timestamp = RandomUtils.nextLong();
+      when(timeSource.currentTimeMicros()).thenReturn(timestamp);
+
+      String insertCql =
+          "INSERT INTO %s (key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) USING TIMESTAMP ?";
+      ValidatingDataStore.QueryAssert row1QueryAssert =
+          withQuery(
+                  SCHEMA_PROVIDER.getTable(),
+                  insertCql,
+                  documentId,
+                  "key1",
+                  "",
+                  "",
+                  "",
+                  "key1",
+                  "value1",
+                  null,
+                  null,
+                  timestamp)
+              .inBatch(batchType)
+              .returningNothing();
+      ValidatingDataStore.QueryAssert row2QueryAssert =
+          withQuery(
+                  SCHEMA_PROVIDER.getTable(),
+                  insertCql,
+                  documentId,
+                  "key1",
+                  "nested",
+                  "",
+                  "",
+                  "nested",
+                  null,
+                  2.2d,
+                  null,
+                  timestamp)
+              .inBatch(batchType)
+              .returningNothing();
+
+      String deleteCql = "DELETE FROM %s USING TIMESTAMP ? WHERE key = ? AND p0 = ?";
+      ValidatingDataStore.QueryAssert deleteQueryAssert =
+          withQuery(SCHEMA_PROVIDER.getTable(), deleteCql, timestamp - 1, documentId, "key1")
+              .inBatch(batchType)
+              .returningNothing();
+
+      Single<ResultSet> result =
+          service.updateDocument(
+              datastore,
+              KEYSPACE_NAME,
+              COLLECTION_NAME,
+              documentId,
+              subDocumentPath,
+              rows,
+              false,
+              context);
 
       result.test().await().assertValueCount(1).assertComplete();
       row1QueryAssert.assertExecuteCount().isEqualTo(1);

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -3553,26 +3553,22 @@ public abstract class BaseDocumentApiV2Test extends BaseIntegrationTest {
         collectionPath + "/1/[0]/array/function",
         "{\"operation\": \"$push\", \"value\": \"new_value\"}",
         200);
-    String currentDoc =
-        RestUtils.get(authToken, collectionPath + "/1?raw=true", 200);
-    assertThat(OBJECT_MAPPER.readTree(currentDoc)).isEqualTo(OBJECT_MAPPER.readTree("[{\"array\":[\"new_value\"]}]"));
+    String currentDoc = RestUtils.get(authToken, collectionPath + "/1?raw=true", 200);
+    assertThat(OBJECT_MAPPER.readTree(currentDoc))
+        .isEqualTo(OBJECT_MAPPER.readTree("[{\"array\":[\"new_value\"]}]"));
 
     // then pop string
     String popped =
-            RestUtils.post(
-                    authToken,
-                    collectionPath + "/1/[0]/array/function",
-                    "{\"operation\": \"$pop\"}",
-                    200);
+        RestUtils.post(
+            authToken, collectionPath + "/1/[0]/array/function", "{\"operation\": \"$pop\"}", 200);
     assertThat(OBJECT_MAPPER.readTree(popped).requiredAt("/data"))
-            .isEqualTo(OBJECT_MAPPER.readTree("\"new_value\""));
+        .isEqualTo(OBJECT_MAPPER.readTree("\"new_value\""));
 
-    currentDoc =
-            RestUtils.get(authToken, collectionPath + "/1?raw=true", 200);
+    currentDoc = RestUtils.get(authToken, collectionPath + "/1?raw=true", 200);
     assertThat(OBJECT_MAPPER.readTree(currentDoc)).isEqualTo(OBJECT_MAPPER.readTree(json));
-    }
+  }
 
-    @Test
+  @Test
   public void testPaginationFilterDocWithFields() throws IOException {
     JsonNode doc1 =
         OBJECT_MAPPER.readTree(this.getClass().getClassLoader().getResource("longSearch.json"));


### PR DESCRIPTION
**What this PR does**:
Continues refactoring of the Document API write path.. This PR handles updates of sub-documents and execution of built-in functions.

:information_source: *Improvement:* Put with the JSON primitive that is targeting a sub-document path is now allowed. Meaning you can do a put in a form (cc @polandll):

```
curl -X POST 
    -H "Content-Type: application/json" \
    -d 'true' \
    https://.../v2/namespaces/keyspace/collection/document-id/key
```

:information_source: *Bug fix:* `$push` and `$pop` to the nested arrays were not working, meaning you could not push to a document like `[{"array":[]}]` targeting the nested array with `/doc-id/[0]/array/function`

:information_source: Note that I removed `HttpHeaders` and `UriInfo` parameters from resource methods as they are not used.

**Which issue(s) this PR fixes**:
Internal ticket.

**Open questions for @EricBorczuk regarding built in functions**
* What was the intention with the `ExecuteBuiltInFunction` DTO and the `value` being an object? How to convert this to the correct JsonNode? I saw you used object all way, but that's not possible anymore.
* Can I move the `value` to be `JsonNode`? If yes, how do we want to handle cases where there is no value in the `$push`, until now this was resolved as the bad request, but new implementation would construct the `NullNode` and insert null to the array.
* Another options is to use `valueToTree` conversion (current code changes have that).
* Do any unit tests exist for the execute built-in functions? Could not locate any.

**Checklist**
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] Clear-up the Reactive document service now
- [x] ~Delete unused code~ (still not possible)
- [x] Resolve `//TODO`s added
- [x] Unit tests for the execute built-in functions 
