### PR TITLE
Fix error handling in SchemaNotificationsHandler

### DIFF
--- a/grpc-proto/proto/schema.proto
+++ b/grpc-proto/proto/schema.proto
@@ -99,6 +99,9 @@ message SchemaNotification {
   SchemaChange change = 1;
 
   // The full metadata of the keyspace that was impacted by the change.
-  // This is present for every kind of change, except DROP KEYSPACE.
+  // This is present for every kind of change, except if the keyspace doesn't exist anymore at the
+  // time of the notification (note that this is not only for a DROP KEYSPACE event, for example if
+  // a keyspace that contained a table gets dropped, the DROP TABLE event will also have no
+  // keyspace).
   CqlKeyspaceDescribe keyspace = 2;
 }

--- a/grpc/src/main/java/io/stargate/grpc/service/SchemaNotificationsHandler.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/SchemaNotificationsHandler.java
@@ -16,13 +16,16 @@
 package io.stargate.grpc.service;
 
 import com.google.protobuf.StringValue;
+import io.grpc.StatusException;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import io.stargate.db.EventListener;
 import io.stargate.db.Persistence;
+import io.stargate.db.schema.Keyspace;
 import io.stargate.proto.QueryOuterClass.SchemaChange;
 import io.stargate.proto.QueryOuterClass.SchemaChange.Target;
 import io.stargate.proto.QueryOuterClass.SchemaChange.Type;
+import io.stargate.proto.Schema;
 import io.stargate.proto.Schema.SchemaNotification;
 import java.util.Collections;
 import java.util.List;
@@ -52,27 +55,38 @@ class SchemaNotificationsHandler implements EventListener {
   }
 
   private void onSchemaChange(
-      Type type, Target target, String keyspace, String name, List<String> argumentTypes) {
+      Type type,
+      Target target,
+      String keyspaceName,
+      String elementName,
+      List<String> argumentTypes) {
     synchronized (responseObserver) {
       if (isFailed) {
         return;
       }
       try {
         SchemaChange.Builder change =
-            SchemaChange.newBuilder().setChangeType(type).setTarget(target).setKeyspace(keyspace);
-        if (name != null) {
-          change.setName(StringValue.of(name));
+            SchemaChange.newBuilder()
+                .setChangeType(type)
+                .setTarget(target)
+                .setKeyspace(keyspaceName);
+        if (elementName != null) {
+          change.setName(StringValue.of(elementName));
         }
         change.addAllArgumentTypes(argumentTypes);
 
         SchemaNotification.Builder notification = SchemaNotification.newBuilder().setChange(change);
-        if (type != Type.DROPPED || target != Target.KEYSPACE) {
-          notification.setKeyspace(SchemaHandler.buildKeyspaceDescription(keyspace, persistence));
+        Schema.CqlKeyspaceDescribe keyspaceDescription = describeKeyspace(keyspaceName);
+        if (keyspaceDescription != null) {
+          notification.setKeyspace(keyspaceDescription);
         }
         responseObserver.onNext(notification.build());
       } catch (Throwable t) {
         try {
+          // responseObserver.onCloseHandler runs asynchronously, so more events can arrive before
+          // we've had a chance to unregister. Make sure we won't notify the observer anymore.
           isFailed = true;
+
           responseObserver.onError(t);
         } catch (Throwable t2) {
           // Be defensive here because the Cassandra internals don't guard against listener errors.
@@ -81,6 +95,13 @@ class SchemaNotificationsHandler implements EventListener {
         }
       }
     }
+  }
+
+  private Schema.CqlKeyspaceDescribe describeKeyspace(String keyspaceName) throws StatusException {
+    String decoratedKeyspace =
+        persistence.decorateKeyspaceName(keyspaceName, GrpcService.HEADERS_KEY.get());
+    Keyspace keyspace = persistence.schema().keyspace(decoratedKeyspace);
+    return keyspace == null ? null : SchemaHandler.buildKeyspaceDescription(keyspace);
   }
 
   @Override

--- a/grpc/src/main/java/io/stargate/grpc/service/SchemaNotificationsHandler.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/SchemaNotificationsHandler.java
@@ -66,7 +66,14 @@ class SchemaNotificationsHandler implements EventListener {
       }
       responseObserver.onNext(notification.build());
     } catch (Throwable t) {
-      responseObserver.onError(t);
+      try {
+        responseObserver.onError(t);
+        persistence.unregisterEventListener(this);
+      } catch (Throwable t2) {
+        // Be defensive here because the Cassandra internals don't guard against listener errors.
+        t2.addSuppressed(t);
+        LOG.warn("Unexpected error while notifying error", t2);
+      }
     }
   }
 

--- a/grpc/src/main/java/io/stargate/grpc/service/SchemaNotificationsHandler.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/SchemaNotificationsHandler.java
@@ -45,27 +45,18 @@ class SchemaNotificationsHandler implements EventListener {
 
   public void handle() {
     synchronized (responseObserver) {
-      responseObserver.setOnCancelHandler(
-          () -> {
-            LOG.info("{} Unregister after cancellation", SchemaNotificationsHandler.this);
-            persistence.unregisterEventListener(this);
-          });
-      responseObserver.setOnCloseHandler(
-          () -> {
-            LOG.info("{} Unregister after error", SchemaNotificationsHandler.this);
-            persistence.unregisterEventListener(this);
-          });
+      responseObserver.setOnCancelHandler(() -> persistence.unregisterEventListener(this));
+      responseObserver.setOnCloseHandler(() -> persistence.unregisterEventListener(this));
     }
     persistence.registerEventListener(this);
   }
 
   private void onSchemaChange(
       Type type, Target target, String keyspace, String name, List<String> argumentTypes) {
-    LOG.info("{} onSchemaChange({}, {}, {}, {})", this, type, target, keyspace, name);
     synchronized (responseObserver) {
-      //      if (isFailed) {
-      //        return;
-      //      }
+      if (isFailed) {
+        return;
+      }
       try {
         SchemaChange.Builder change =
             SchemaChange.newBuilder().setChangeType(type).setTarget(target).setKeyspace(keyspace);
@@ -78,11 +69,9 @@ class SchemaNotificationsHandler implements EventListener {
         if (type != Type.DROPPED || target != Target.KEYSPACE) {
           notification.setKeyspace(SchemaHandler.buildKeyspaceDescription(keyspace, persistence));
         }
-        LOG.info("{} invoke responseObserver.onNext", this);
         responseObserver.onNext(notification.build());
       } catch (Throwable t) {
         try {
-          LOG.info("{} invoke responseObserver.onError", this, t);
           isFailed = true;
           responseObserver.onError(t);
         } catch (Throwable t2) {

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/schema/SchemaCache.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/schema/SchemaCache.java
@@ -16,8 +16,6 @@
 package io.stargate.sgv2.common.schema;
 
 import io.stargate.proto.QueryOuterClass.SchemaChange;
-import io.stargate.proto.QueryOuterClass.SchemaChange.Target;
-import io.stargate.proto.QueryOuterClass.SchemaChange.Type;
 import io.stargate.proto.Schema.CqlKeyspaceDescribe;
 import io.stargate.proto.Schema.SchemaNotification;
 import io.stargate.proto.StargateGrpc.StargateStub;
@@ -145,7 +143,6 @@ public class SchemaCache {
       if (notification.hasKeyspace()) {
         updateKeyspace(notification.getKeyspace(), false);
       } else {
-        assert change.getChangeType() == Type.DROPPED && change.getTarget() == Target.KEYSPACE;
         deleteKeyspace(change.getKeyspace());
       }
     }


### PR DESCRIPTION
**What this PR does**:
- ensure that `responseObserver.onError` in `SchemaNotificationsHandler` is called at most once (there were CI failures indicating that it was called multiple times).
- synchronize calls to the observer; not sure if this was a direct factor, but we've seen in other PRs that this is necessary.
- be more defensive about unexpected errors in `onSchemaChange`; otherwise exceptions bubble up to the Cassandra code that invoked the listener, and end up failing a completely unrelated request.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
