### PR TITLE
Fix issues with passing `null`s through grpc for SGv2/REST

### DIFF
--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/ToProtoConverter.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/ToProtoConverter.java
@@ -1,5 +1,6 @@
 package io.stargate.sgv2.restsvc.grpc;
 
+import io.stargate.grpc.Values;
 import io.stargate.proto.QueryOuterClass;
 import java.util.Map;
 
@@ -25,6 +26,9 @@ public class ToProtoConverter {
    * decoded and coerced as necessary).
    */
   public QueryOuterClass.Value protoValueFromLooselyTyped(String fieldName, Object value) {
+    if (value == null) {
+      return Values.NULL;
+    }
     final ToProtoValueCodec codec = getCodec(fieldName);
     try {
       if (value instanceof String) {
@@ -48,6 +52,9 @@ public class ToProtoConverter {
    * alternatives.
    */
   public QueryOuterClass.Value protoValueFromStrictlyTyped(String fieldName, Object value) {
+    if (value == null) {
+      return Values.NULL;
+    }
     final ToProtoValueCodec codec = getCodec(fieldName);
     try {
       return codec.protoValueFromStrictlyTyped(value);


### PR DESCRIPTION
**What this PR does**:

Fixes issue similar to #1558 in Stargate V1/REST, but for Stargate V2 (codebases differ wrt REST handling).

**Which issue(s) this PR fixes**:

Further fixes similar to #1558 work.

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
