### PR TITLE
restart docker before running tests on CI

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -13,6 +13,9 @@ chown -R ubuntu:ubuntu /cache/
 echo '127.0.1.11 internal-stargate.local' >> /etc/hosts
 echo '127.0.1.12 internal-stargate.local' >> /etc/hosts
 
+# restart docker
+service docker --full-restart
+
 # Need to switch users since we can't pass the right flag to allow running Cassandra as root
 sudo -i -u ubuntu bash << EOF
 set -euo pipefail


### PR DESCRIPTION
**What this PR does**:
Trying to fix the:

```
Step #4 - "cassandra-3.11": ERROR [main] 2022-01-19 19:06:27,600 DockerClientProviderStrategy.java:208 - Could not find a valid Docker environment. Please check configuration. Attempted configurations were:
Step #4 - "cassandra-3.11": ERROR [main] 2022-01-19 19:06:27,600 DockerClientProviderStrategy.java:210 -     UnixSocketClientProviderStrategy: failed with exception TimeoutException (Timeout waiting for result with exception). Root cause IOException (native connect() failed : Permission denied)
Step #4 - "cassandra-3.11": ERROR [main] 2022-01-19 19:06:27,600 DockerClientProviderStrategy.java:212 - As no valid configuration was found, execution cannot continue
Step #4 - "cassandra-3.11": [ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 30.417 s <<< FAILURE! - in io.stargate.it.cql.JwtAuthTest
Step #4 - "cassandra-3.11": [ERROR] io.stargate.it.cql.JwtAuthTest  Time elapsed: 30.417 s  <<< ERROR!
Step #4 - "cassandra-3.11": java.lang.reflect.InvocationTargetException
Step #4 - "cassandra-3.11": 	at io.stargate.it.cql.JwtAuthTest.buildParameters(JwtAuthTest.java:53)
Step #4 - "cassandra-3.11": 
```
