### PR TITLE
updated delete document paths to use new write service

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/dao/DocumentDB.java
@@ -640,20 +640,6 @@ public class DocumentDB {
     executeBatch(queries, context);
   }
 
-  public void delete(
-      String keyspace, String table, String key, List<String> pathToDelete, long microsSinceEpoch)
-      throws UnauthorizedException {
-
-    getAuthorizationService()
-        .authorizeDataWrite(
-            getAuthenticationSubject(), keyspace, table, Scope.DELETE, SourceAPI.REST);
-    dataStore
-        .execute(
-            getPrefixDeleteStatement(keyspace, table, key, microsSinceEpoch, pathToDelete),
-            ConsistencyLevel.LOCAL_QUORUM)
-        .join();
-  }
-
   public boolean authorizeDeleteDeadLeaves(String keyspaceName, String tableName) {
     try {
       getAuthorizationService()

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/DocumentResourceV2.java
@@ -5,7 +5,6 @@ import static io.stargate.web.docsapi.resources.RequestToHeadersMapper.getAllHea
 import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import io.stargate.web.docsapi.dao.DocumentDB;
 import io.stargate.web.docsapi.dao.DocumentDBFactory;
 import io.stargate.web.docsapi.examples.WriteDocResponse;
 import io.stargate.web.docsapi.models.DocumentResponseWrapper;
@@ -24,7 +23,6 @@ import io.swagger.annotations.ApiResponses;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import javax.inject.Inject;
@@ -33,7 +31,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.PATCH;
 import javax.ws.rs.POST;
@@ -301,89 +298,6 @@ public class DocumentResourceV2 {
                   mapper.writeValueAsString(
                       new DocumentResponseWrapper<>(id, null, null, context.toProfile())))
               .build();
-        });
-  }
-
-  @DELETE
-  @ManagedAsync
-  @ApiOperation(value = "Delete a document", notes = "Delete a document")
-  @ApiResponses(
-      value = {
-        @ApiResponse(code = 204, message = "No Content"),
-        @ApiResponse(code = 401, message = "Unauthorized", response = ApiError.class),
-        @ApiResponse(code = 403, message = "Forbidden", response = ApiError.class),
-        @ApiResponse(code = 500, message = "Internal Server Error", response = ApiError.class)
-      })
-  @Path("collections/{collection-id: [a-zA-Z_0-9]+}/{document-id}")
-  @Consumes(MediaType.APPLICATION_JSON)
-  @Produces(MediaType.APPLICATION_JSON)
-  public Response deleteDoc(
-      @Context HttpHeaders headers,
-      @Context UriInfo ui,
-      @ApiParam(
-              value =
-                  "The token returned from the authorization endpoint. Use this token in each request.",
-              required = true)
-          @HeaderParam("X-Cassandra-Token")
-          String authToken,
-      @ApiParam(value = "the namespace that the collection is in", required = true)
-          @PathParam("namespace-id")
-          String namespace,
-      @ApiParam(value = "the name of the collection", required = true) @PathParam("collection-id")
-          String collection,
-      @ApiParam(value = "the name of the document", required = true) @PathParam("document-id")
-          String id,
-      @Context HttpServletRequest request) {
-    logger.debug("Delete: Collection = {}, id = {}, path = {}", collection, id, new ArrayList<>());
-    return handle(
-        () -> {
-          Map<String, String> allHeaders = getAllHeaders(request);
-          DocumentDB db = dbFactory.getDocDBForToken(authToken, allHeaders);
-          documentService.deleteAtPath(db, namespace, collection, id, new ArrayList<>());
-          return Response.noContent().build();
-        });
-  }
-
-  @DELETE
-  @ManagedAsync
-  @ApiOperation(value = "Delete a path in a document", notes = "Delete a path in a document")
-  @ApiResponses(
-      value = {
-        @ApiResponse(code = 204, message = "No Content"),
-        @ApiResponse(code = 401, message = "Unauthorized", response = ApiError.class),
-        @ApiResponse(code = 403, message = "Forbidden", response = ApiError.class),
-        @ApiResponse(code = 500, message = "Internal Server Error", response = ApiError.class)
-      })
-  @Path("collections/{collection-id: [a-zA-Z_0-9]+}/{document-id}/{document-path: .*}")
-  @Consumes(MediaType.APPLICATION_JSON)
-  @Produces(MediaType.APPLICATION_JSON)
-  public Response deleteDocPath(
-      @Context HttpHeaders headers,
-      @Context UriInfo ui,
-      @ApiParam(
-              value =
-                  "The token returned from the authorization endpoint. Use this token in each request.",
-              required = true)
-          @HeaderParam("X-Cassandra-Token")
-          String authToken,
-      @ApiParam(value = "the namespace that the collection is in", required = true)
-          @PathParam("namespace-id")
-          String namespace,
-      @ApiParam(value = "the name of the collection", required = true) @PathParam("collection-id")
-          String collection,
-      @ApiParam(value = "the name of the document", required = true) @PathParam("document-id")
-          String id,
-      @ApiParam(value = "the path in the JSON that you want to retrieve", required = true)
-          @PathParam("document-path")
-          List<PathSegment> path,
-      @Context HttpServletRequest request) {
-    logger.debug("Delete: Collection = {}, id = {}, path = {}", collection, id, path);
-    return handle(
-        () -> {
-          Map<String, String> allHeaders = getAllHeaders(request);
-          DocumentDB db = dbFactory.getDocDBForToken(authToken, allHeaders);
-          documentService.deleteAtPath(db, namespace, collection, id, path);
-          return Response.noContent().build();
         });
   }
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocumentService.java
@@ -244,18 +244,4 @@ public class DocumentService {
           context.nested("ASYNC INSERT"));
     }
   }
-
-  public void deleteAtPath(
-      DocumentDB db, String keyspace, String collection, String id, List<PathSegment> path)
-      throws UnauthorizedException {
-    List<String> convertedPath = new ArrayList<>(path.size());
-    for (PathSegment pathSegment : path) {
-      String pathStr = pathSegment.getPath();
-      convertedPath.add(DocsApiUtils.convertArrayPath(pathStr, config.getMaxArrayLength()));
-    }
-
-    long now = timeSource.currentTimeMicros();
-
-    db.delete(keyspace, collection, id, convertedPath, now);
-  }
 }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/write/DocumentWriteService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/write/DocumentWriteService.java
@@ -291,8 +291,6 @@ public class DocumentWriteService {
               long timestamp = timeSource.currentTimeMicros();
 
               // return bind delete
-              // TODO Eric I feel keeping deletes always with the timestamp - 1 feels right
-              //  Although this should not make any difference what so ever
               return deleteQueryBuilder.bind(prepared, documentId, subDocumentPath, timestamp - 1);
             })
         // then execute single

--- a/restapi/src/test/java/io/stargate/web/docsapi/dao/DocumentDBTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/dao/DocumentDBTest.java
@@ -270,36 +270,6 @@ public class DocumentDBTest {
   }
 
   @Test
-  public void delete() throws UnauthorizedException {
-    ds = new TestDataStore(schema);
-    AuthorizationService authorizationService = mock(AuthorizationService.class);
-    doNothing()
-        .when(authorizationService)
-        .authorizeDataRead(
-            any(AuthenticationSubject.class), anyString(), anyString(), eq(SourceAPI.REST));
-    documentDB =
-        new DocumentDB(ds, AuthenticationSubject.of("foo", "bar"), authorizationService, config);
-    List<String> path = Arrays.asList("a", "b", "c");
-    List<Object[]> vars = new ArrayList<>();
-    vars.add(new Object[path.size() + 2]);
-    vars.get(0)[0] = 1L;
-    vars.get(0)[1] = "key";
-    vars.get(0)[2] = "a";
-    vars.get(0)[3] = "b";
-    vars.get(0)[4] = "c";
-
-    documentDB.delete("keyspace", "table", "key", path, 1L);
-
-    List<BoundQuery> generatedQueries = ds.getRecentStatements();
-    assertThat(generatedQueries).hasSize(1);
-
-    assertThat(generatedQueries.get(0).queryString())
-        .isEqualTo(
-            "DELETE FROM \"keyspace\".\"table\" USING TIMESTAMP ? WHERE key = ? AND p0 = ? AND p1 = ? AND p2 = ?");
-    assertThat(javaValues(generatedQueries.get(0).values())).isEqualTo(makeValues(1L, "key", path));
-  }
-
-  @Test
   public void deleteDeadLeaves() throws UnauthorizedException {
     ds = new TestDataStore(schema);
     AuthorizationService authorizationService = mock(AuthorizationService.class);

--- a/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/resources/DocumentResourceV2Test.java
@@ -116,37 +116,4 @@ public class DocumentResourceV2Test {
     assertThat(mapper.readTree((String) r.getEntity()).requiredAt("/documentId").asText())
         .isEqualTo(id);
   }
-
-  @Test
-  public void deleteDoc() {
-    HttpHeaders headers = mock(HttpHeaders.class);
-    UriInfo ui = mock(UriInfo.class);
-    String authToken = "auth_token";
-    String keyspace = "keyspace";
-    String collection = "collection";
-    String id = "id";
-
-    Response r =
-        documentResourceV2.deleteDoc(
-            headers, ui, authToken, keyspace, collection, id, httpServletRequest);
-
-    assertThat(r.getStatus()).isEqualTo(204);
-  }
-
-  @Test
-  public void deleteDocPath() {
-    HttpHeaders headers = mock(HttpHeaders.class);
-    UriInfo ui = mock(UriInfo.class);
-    String authToken = "auth_token";
-    String keyspace = "keyspace";
-    String collection = "collection";
-    String id = "id";
-    List<PathSegment> path = new ArrayList<>();
-
-    Response r =
-        documentResourceV2.deleteDocPath(
-            headers, ui, authToken, keyspace, collection, id, path, httpServletRequest);
-
-    assertThat(r.getStatus()).isEqualTo(204);
-  }
 }


### PR DESCRIPTION
**What this PR does**:
Refactor of the delete document.. Simple and clean, although it was already pretty straight forward.. *New feature*: `profile` query param is available on the delete endpoints as well now. 

**Which issue(s) this PR fixes**:
Internal.

**Checklist**
- [x] Unit test updates for the `ReactiveDocumentService`
- [ ] Resolve two `TODO`s, @EricBorczuk please advise..
- [x] Delete existing code
