### PR TITLE
add separate release workflow for v2

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v1.*.*'
+      - 'v2.*.*'
 
 jobs:
   create-release:
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: "master"
+          ref: "v2.0.0"
       - name: Setup Java JDK
         uses: actions/setup-java@v1
         with:
@@ -92,7 +92,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: "master"
+          ref: "v2.0.0"
       - name: Set version
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
@@ -147,4 +147,4 @@ jobs:
           commit-message: "Bumping version for next release"
           title: "Bumping version for next release"
           branch-suffix: "short-commit-hash"
-          base: "master"
+          base: "v2.0.0"


### PR DESCRIPTION
Setting up a separate workflow to build v2 releases since the current release.yml workflow is set up to work off of `master`. The v2 release builds from the `v2.0.0` branch and is triggered by tags matching `v2.*.*`. The original release workflow is modified to trigger off of `v1.*.*` tags instead of `v*.*.*`.

This workflow will be extended in a followup PR to build Docker images, which will be an a difference from v1 which builds Docker images via the separate `docker-images` repo.