### PR TITLE
setting versioning for v2

### DIFF
--- a/auth-api/pom.xml
+++ b/auth-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>stargate</artifactId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <groupId>io.stargate.auth.api</groupId>
   <artifactId>auth-api</artifactId>

--- a/auth-jwt-service/pom.xml
+++ b/auth-jwt-service/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>stargate</artifactId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <groupId>io.stargate.auth.jwt</groupId>
   <artifactId>auth-jwt-service</artifactId>

--- a/auth-table-based-service/pom.xml
+++ b/auth-table-based-service/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>stargate</artifactId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <groupId>io.stargate.auth.table</groupId>
   <artifactId>auth-table-based-service</artifactId>

--- a/authnz/pom.xml
+++ b/authnz/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>stargate</artifactId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <groupId>io.stargate.auth</groupId>
   <artifactId>authnz</artifactId>

--- a/config-store-api/pom.xml
+++ b/config-store-api/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>stargate</artifactId>
 		<groupId>io.stargate</groupId>
-		<version>1.0.48-SNAPSHOT</version>
+		<version>2.0.0-ALPHA-1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.stargate.config-store</groupId>

--- a/config-store-yaml/pom.xml
+++ b/config-store-yaml/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>stargate</artifactId>
     <groupId>io.stargate</groupId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
     <groupId>io.stargate.config.store.yaml</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>stargate</artifactId>
         <groupId>io.stargate</groupId>
-        <version>1.0.48-SNAPSHOT</version>
+        <version>2.0.0-ALPHA-1-SNAPSHOT</version>
     </parent>
     <groupId>io.stargate.core</groupId>
     <artifactId>core</artifactId>

--- a/cql/pom.xml
+++ b/cql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>stargate</artifactId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <groupId>io.stargate.cql</groupId>
   <artifactId>cql</artifactId>

--- a/graphqlapi/pom.xml
+++ b/graphqlapi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>stargate</artifactId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <groupId>io.stargate.graphql</groupId>
   <artifactId>graphqlapi</artifactId>

--- a/grpc-examples/pom.xml
+++ b/grpc-examples/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>stargate</artifactId>
         <groupId>io.stargate</groupId>
-        <version>1.0.48-SNAPSHOT</version>
+        <version>2.0.0-ALPHA-1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/grpc-proto/pom.xml
+++ b/grpc-proto/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>stargate</artifactId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
 
   <groupId>io.stargate.grpc</groupId>

--- a/grpc/pom.xml
+++ b/grpc/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>stargate</artifactId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <groupId>io.stargate.grpc</groupId>
   <artifactId>grpc</artifactId>

--- a/health-checker/pom.xml
+++ b/health-checker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>stargate</artifactId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <groupId>io.stargate.health</groupId>
   <artifactId>health-checker</artifactId>

--- a/metrics-jersey/pom.xml
+++ b/metrics-jersey/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>stargate</artifactId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <groupId>io.stargate.metrics</groupId>
   <artifactId>metrics-jersey</artifactId>

--- a/persistence-api/pom.xml
+++ b/persistence-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>stargate</artifactId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <groupId>io.stargate.db</groupId>
   <artifactId>persistence-api</artifactId>

--- a/persistence-cassandra-3.11/pom.xml
+++ b/persistence-cassandra-3.11/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>stargate</artifactId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <groupId>io.stargate.db.cassandra</groupId>
   <artifactId>persistence-cassandra-3.11</artifactId>

--- a/persistence-cassandra-4.0/pom.xml
+++ b/persistence-cassandra-4.0/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>stargate</artifactId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <groupId>io.stargate.db.cassandra</groupId>
   <artifactId>persistence-cassandra-4.0</artifactId>

--- a/persistence-common/pom.xml
+++ b/persistence-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>stargate</artifactId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <groupId>io.stargate.db</groupId>
   <artifactId>persistence-common</artifactId>

--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>stargate</artifactId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <groupId>io.stargate.db.dse</groupId>
   <artifactId>persistence-dse-6.8</artifactId>

--- a/persistence-test/pom.xml
+++ b/persistence-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>stargate</artifactId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <groupId>io.stargate.db</groupId>
   <artifactId>persistence-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.stargate</groupId>
   <artifactId>stargate</artifactId>
-  <version>1.0.48-SNAPSHOT</version>
+  <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>${project.groupId}:${project.artifactId}</name>
   <description>Core modules for Stargate</description>

--- a/rate-limiting-global/pom.xml
+++ b/rate-limiting-global/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>stargate</artifactId>
     <groupId>io.stargate</groupId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.stargate.db.limiter.global</groupId>

--- a/restapi/pom.xml
+++ b/restapi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>stargate</artifactId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <groupId>io.stargate.web</groupId>
   <artifactId>restapi</artifactId>

--- a/sgv2-restapi/pom.xml
+++ b/sgv2-restapi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>stargate</artifactId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <groupId>io.stargate.web</groupId>
   <artifactId>sgv2-rest-service</artifactId>

--- a/sgv2-service-common/pom.xml
+++ b/sgv2-service-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.stargate</groupId>
         <artifactId>stargate</artifactId>
-        <version>1.0.48-SNAPSHOT</version>
+        <version>2.0.0-ALPHA-1-SNAPSHOT</version>
     </parent>
     <artifactId>sgv2-service-common</artifactId>
     <dependencies>

--- a/stargate-starter/pom.xml
+++ b/stargate-starter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>stargate</artifactId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <groupId>io.stargate.starter</groupId>
   <artifactId>stargate-starter</artifactId>

--- a/testing-services/pom.xml
+++ b/testing-services/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>stargate</artifactId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <groupId>io.stargate.it</groupId>
   <artifactId>testing-services</artifactId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>stargate</artifactId>
-    <version>1.0.48-SNAPSHOT</version>
+    <version>2.0.0-ALPHA-1-SNAPSHOT</version>
   </parent>
   <groupId>io.stargate.it</groupId>
   <artifactId>testing</artifactId>


### PR DESCRIPTION
Working toward setting up releases for the v2 branch, this PR establishes a base version number `v2.0.0-ALPHA-1-SNAPSHOT` as per conventions described here: https://github.com/stargate/stargate/discussions/1532.
