### PR TITLE
Remove noisy logging statements that clutter perf tests

### DIFF
--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/Sgv2RowsResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/Sgv2RowsResourceImpl.java
@@ -32,8 +32,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 // note: JAX-RS Class Annotations MUST be in the impl class; only method annotations inherited
 // (but Swagger allows inheritance)
@@ -42,10 +40,6 @@ import org.slf4j.LoggerFactory;
 @Singleton
 @CreateGrpcStub
 public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResourceApi {
-
-  // Singleton resource so no need to be static
-  protected final Logger logger = LoggerFactory.getLogger(getClass());
-
   /*
   /////////////////////////////////////////////////////////////////////////
   // REST API endpoint implementation methods
@@ -152,8 +146,6 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
             tableDef,
             valuesBuilder,
             toProtoConverter);
-    logger.info("getRows(): try to call backend with CQL of '{}'", cql);
-
     return fetchRows(blockingStub, pageSizeParam, pageStateParam, raw, cql, valuesBuilder);
   }
 
@@ -224,8 +216,6 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
     } catch (IllegalArgumentException e) {
       throw new WebApplicationException(e.getMessage(), Status.BAD_REQUEST);
     }
-    logger.info("createRow(): try to call backend with CQL of '{}'", cql);
-
     final QueryOuterClass.Query query =
         QueryOuterClass.Query.newBuilder()
             .setParameters(parametersForLocalQuorum())
@@ -321,8 +311,6 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
     } catch (IllegalArgumentException e) {
       throw new WebApplicationException(e.getMessage(), Status.BAD_REQUEST);
     }
-    logger.info("modifyRow(): try to call backend with CQL of '{}'", cql);
-
     final QueryOuterClass.Query query =
         QueryOuterClass.Query.newBuilder()
             .setParameters(parametersForLocalQuorum())

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2ColumnsResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2ColumnsResourceImpl.java
@@ -21,17 +21,12 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Path("/v2/schemas/keyspaces/{keyspaceName}/tables/{tableName}/columns")
 @Produces(MediaType.APPLICATION_JSON)
 @Singleton
 @CreateGrpcStub
 public class Sgv2ColumnsResourceImpl extends ResourceBase implements Sgv2ColumnsResourceApi {
-  // Singleton resource so no need to be static
-  protected final Logger logger = LoggerFactory.getLogger(getClass());
-
   @Override
   public Response getAllColumns(
       StargateGrpc.StargateBlockingStub blockingStub,

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2KeyspacesResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2KeyspacesResourceImpl.java
@@ -41,17 +41,12 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Path("/v2/schemas/keyspaces")
 @Produces(MediaType.APPLICATION_JSON)
 @Singleton
 @CreateGrpcStub
 public class Sgv2KeyspacesResourceImpl extends ResourceBase implements Sgv2KeyspacesResourceApi {
-  // Singleton resource so no need to be static
-  private final Logger logger = LoggerFactory.getLogger(getClass());
-
   private static final JsonMapper JSON_MAPPER = new JsonMapper();
 
   private static final SchemaBuilderHelper schemaBuilder = new SchemaBuilderHelper(JSON_MAPPER);

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2TablesResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2TablesResourceImpl.java
@@ -27,17 +27,12 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Path("/v2/schemas/keyspaces/{keyspaceName}/tables")
 @Produces(MediaType.APPLICATION_JSON)
 @Singleton
 @CreateGrpcStub
 public class Sgv2TablesResourceImpl extends ResourceBase implements Sgv2TablesResourceApi {
-  // Singleton resource so no need to be static
-  private final Logger logger = LoggerFactory.getLogger(getClass());
-
   @Override
   public Response getAllTables(
       final StargateGrpc.StargateBlockingStub blockingStub,

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceImpl.java
@@ -29,8 +29,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
@@ -38,9 +36,6 @@ import org.slf4j.LoggerFactory;
 @Singleton
 @CreateGrpcStub
 public class Sgv2UDTsResourceImpl extends ResourceBase implements Sgv2UDTsResourceApi {
-  // Singleton resource so no need to be static
-  private final Logger logger = LoggerFactory.getLogger(getClass());
-
   @Override
   public Response findAll(
       final StargateGrpc.StargateBlockingStub blockingStub,
@@ -131,16 +126,13 @@ public class Sgv2UDTsResourceImpl extends ResourceBase implements Sgv2UDTsResour
     final String typeName = udtAdd.getName();
     requireNonEmptyTypename(typeName);
 
-    String cql =
+    final String cql =
         new QueryBuilder()
             .create()
             .type(keyspaceName, typeName)
             .ifNotExists(udtAdd.getIfNotExists())
             .column(columns2columns(udtAdd.getFields()))
             .build();
-
-    logger.info("createUDT() with CQL: {}", cql);
-
     try {
       blockingStub.executeQuery(
           QueryOuterClass.Query.newBuilder()


### PR DESCRIPTION
**What this PR does**:

Removes couple of info log output statements that were used for troubleshooting SGv2/REST, but add to noise in performance tests. If something similar was needed, should be at debug or trace level, but no current need so remove.
Also remove a few unneeded loggers from other resource implementations.

**Which issue(s) this PR fixes**:
No separate pr

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
