### PR TITLE
use doFinally in the `DseConnection#executeRequest` to reset warnings

### DIFF
--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -535,28 +535,29 @@ public class DsePersistence
                 .execute(queryState, queryStartNanoTime)
                 .map(
                     response -> {
-                        // There is only 2 types of response that can come out: either a
-                        // ResultMessage (which itself can of different kind), or an ErrorMessage.
-                        if (response instanceof ErrorMessage) {
-                          throw convertExceptionWithWarnings(
-                              (Throwable) ((ErrorMessage) response).error);
-                        }
+                      // There is only 2 types of response that can come out: either a
+                      // ResultMessage (which itself can of different kind), or an ErrorMessage.
+                      if (response instanceof ErrorMessage) {
+                        throw convertExceptionWithWarnings(
+                            (Throwable) ((ErrorMessage) response).error);
+                      }
 
-                        @SuppressWarnings("unchecked")
-                        T result =
-                            (T)
-                                Conversion.toResult(
-                                    (ResultMessage) response,
-                                    Conversion.toInternal(parameters.protocolVersion()),
-                                    ClientWarn.instance.getAndClearWarnings());
-                        return result;
+                      @SuppressWarnings("unchecked")
+                      T result =
+                          (T)
+                              Conversion.toResult(
+                                  (ResultMessage) response,
+                                  Conversion.toInternal(parameters.protocolVersion()),
+                                  ClientWarn.instance.getAndClearWarnings());
+                      return result;
                     })
                 // doFinally runs after onComplete or onError
                 // thus after the lambdas in subscribe below
-                .doFinally(() -> {
-                  // this is to clean the thread local in TPC thread
-                  ClientWarn.instance.resetWarnings();
-                })
+                .doFinally(
+                    () -> {
+                      // this is to clean the thread local in TPC thread
+                      ClientWarn.instance.resetWarnings();
+                    })
                 .subscribe(
                     future::complete,
                     ex -> {

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -552,7 +552,7 @@ public class DsePersistence
                         return result;
                     })
                 // doFinally runs after onComplete or onError
-                // thus after the lambdas in to subscribe below
+                // thus after the lambdas in subscribe below
                 .doFinally(() -> {
                   // this is to clean the thread local in TPC thread
                   ClientWarn.instance.resetWarnings();


### PR DESCRIPTION
**What this PR does**:
The ` ClientWarn.instance.resetWarnings();` is not called if the reactive sequence ends up in error. The error handler does call the `convertExceptionWithWarnings` which calls the `ClientWarn.instance.getAndClearWarnings()`, however, although name suggest different the `getAndClearWarnings()` is not clearing the thread local.

Proposed fix ensures that after either `onSuccess` or `onError` handlers are called, we reset the state.

**I would be very thankful if anybody has an idea about properly testing this?**

**Which issue(s) this PR fixes**:
No ticket.

**Checklist**
- [ ] Changes manually tested
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
