### PR TITLE
Improve code to help troubleshoot #1577, by more validation of UUID codec

### DIFF
--- a/grpc/src/main/java/io/stargate/grpc/codec/UuidCodec.java
+++ b/grpc/src/main/java/io/stargate/grpc/codec/UuidCodec.java
@@ -33,7 +33,7 @@ public class UuidCodec implements ValueCodec {
     ByteString uuid = value.getUuid().getValue();
     int size = uuid.size();
     if (size != 16) {
-      throw new IllegalArgumentException("Expected 16 bytes for a UUID");
+      throw new IllegalArgumentException("Expected 16 bytes for a UUID, got " + size);
     }
     ByteBuffer bytes = ByteBuffer.allocate(16);
     uuid.copyTo(bytes);
@@ -43,6 +43,9 @@ public class UuidCodec implements ValueCodec {
 
   @Override
   public Value decode(@NonNull ByteBuffer bytes, @NonNull ColumnType type) {
+    if (bytes.remaining() != 16) {
+      throw new IllegalArgumentException("Expected 16 bytes for a UUID, got " + bytes.remaining());
+    }
     return Value.newBuilder()
         .setUuid(Uuid.newBuilder().setValue(ByteString.copyFrom(bytes)).build())
         .build();

--- a/grpc/src/test/java/io/stargate/grpc/codec/ValueCodecTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/codec/ValueCodecTest.java
@@ -28,6 +28,7 @@ import io.stargate.db.schema.Column.Type;
 import io.stargate.db.schema.ImmutableUserDefinedType;
 import io.stargate.db.schema.UserDefinedType;
 import io.stargate.grpc.Values;
+import io.stargate.proto.QueryOuterClass;
 import io.stargate.proto.QueryOuterClass.Inet;
 import io.stargate.proto.QueryOuterClass.Value;
 import java.math.BigDecimal;
@@ -357,9 +358,22 @@ public class ValueCodecTest {
   }
 
   public static Stream<Arguments> invalidUuidValues() {
+    final Value invalidEmptyUuid =
+        Value.newBuilder()
+            .setUuid(QueryOuterClass.Uuid.newBuilder().setValue(ByteString.copyFrom(new byte[0])))
+            .build();
+    final Value invalidLongUuid =
+        Value.newBuilder()
+            .setUuid(QueryOuterClass.Uuid.newBuilder().setValue(ByteString.copyFrom(new byte[24])))
+            .build();
+
     return Stream.of(
         arguments(Type.Uuid, Values.NULL, "Expected UUID type"),
-        arguments(Type.Timeuuid, Values.UNSET, "Expected UUID type"));
+        arguments(Type.Timeuuid, Values.UNSET, "Expected UUID type"),
+        arguments(Type.Uuid, invalidEmptyUuid, "Expected 16 bytes for a UUID, got 0"),
+        arguments(Type.Timeuuid, invalidEmptyUuid, "Expected 16 bytes for a UUID, got 0"),
+        arguments(Type.Uuid, invalidLongUuid, "Expected 16 bytes for a UUID, got 24"),
+        arguments(Type.Timeuuid, invalidLongUuid, "Expected 16 bytes for a UUID, got 24"));
   }
 
   public static Stream<Arguments> listValues() {


### PR DESCRIPTION
**What this PR does**:

Adds one more check to ensure invalid UUIDs decoding is caught by gRPC; also adds bit more testing.

**Which issue(s) this PR fixes**:

Does not fix, but hopefully helps to eventually fix #1577

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
