### PR TITLE
Undo PR #1567

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -13,10 +13,6 @@ chown -R ubuntu:ubuntu /cache/
 echo '127.0.1.11 internal-stargate.local' >> /etc/hosts
 echo '127.0.1.12 internal-stargate.local' >> /etc/hosts
 
-# Ensure we can connect to Docker daemon to resolve issue #1580, see:
-# https://dhananjay4058.medium.com/solving-docker-permission-denied-while-trying-to-connect-to-the-docker-daemon-socket-2e53cccffbaa
-usermod -a -G docker ubuntu
-
 # Need to switch users since we can't pass the right flag to allow running Cassandra as root
 sudo -i -u ubuntu bash << EOF
 set -euo pipefail


### PR DESCRIPTION
**What this PR does**:

Undoes #1567 but without adding "restart docker" back since that won't do anything (nor does add group, already done in Docker image)

**Which issue(s) this PR fixes**:

None it seems.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
