### PR TITLE
Add tag/publish options to docker build script for v2

### DIFF
--- a/build_docker_images.sh
+++ b/build_docker_images.sh
@@ -5,8 +5,40 @@ set -euo pipefail
 # Assumes that you have done a complete build so that all jars have been created, i.e.:
 #   ./mvnw clean install -P dse -DskipTests=true
 
+#
+# Defaults
+#
+
+# generate for local platform, don't push
+DOCKER_FLAGS=
+
 # extract Stargate version from project pom file
-export SGTAG=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+SGTAG="v$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
+
+#
+# overrides via command line
+#
+
+while getopts ":pt:" opt; do
+  case $opt in
+    p)
+      DOCKER_FLAGS="--platform linux/amd64,linux/arm64 --push"
+      ;;
+    t)
+      SGTAG=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+
+echo "Building version $SGTAG"
+
+#
+# Persistence images
+#
 
 # Create a temp directory under current directory to use as a staging area for image creation
 # This is a workaround since Docker COPY command provides no way to exclude files.
@@ -17,23 +49,15 @@ mkdir ${LIBDIR}
 cp ./stargate-lib/* $LIBDIR
 rm ${LIBDIR}/persistence*.jar
 
-#ls ${LIBDIR}
-
-docker build --target coordinator-4_0 --build-arg LIBDIR="$LIBDIR" -t stargateio/coordinator-4_0:$SGTAG .
-docker build --target coordinator-3_11 --build-arg LIBDIR="$LIBDIR" -t stargateio/coordinator-3_11:$SGTAG .
-docker build --target coordinator-dse-68 --build-arg LIBDIR="$LIBDIR" -t stargateio/coordinator-dse-68:$SGTAG .
+docker buildx build --target coordinator-4_0 --build-arg LIBDIR="$LIBDIR" -t stargateio/coordinator-4_0:$SGTAG $DOCKER_FLAGS .
+docker buildx build --target coordinator-3_11 --build-arg LIBDIR="$LIBDIR" -t stargateio/coordinator-3_11:$SGTAG $DOCKER_FLAGS .
+docker buildx build --target coordinator-dse-68 --build-arg LIBDIR="$LIBDIR" -t stargateio/coordinator-dse-68:$SGTAG $DOCKER_FLAGS .
 
 rm -rf ${LIBDIR}
 
-docker build --target restapi -t stargateio/restapi:$SGTAG .
+#
+# API Service images
+#
 
+docker buildx build --target restapi -t stargateio/restapi:$SGTAG $DOCKER_FLAGS .
 
-
-echo "Building $DOCKER_IMAGE"
-docker buildx build --push \
---tag ${DOCKER_IMAGE}:${stargate_version} \
---file Dockerfile \
---platform linux/amd64,linux/arm64 .
-
-echo "Inspecting $DOCKER_IMAGE"
-docker buildx imagetools inspect ${DOCKER_IMAGE}:${stargate_version}

--- a/build_docker_images.sh
+++ b/build_docker_images.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 # Assumes that you have done a complete build so that all jars have been created, i.e.:
 #   ./mvnw clean install -P dse -DskipTests=true
 
-export SGTAG=v2.0.0-ALPHA1
+# extract Stargate version from project pom file
+export SGTAG=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
 
 # Create a temp directory under current directory to use as a staging area for image creation
 # This is a workaround since Docker COPY command provides no way to exclude files.
@@ -26,3 +27,13 @@ rm -rf ${LIBDIR}
 
 docker build --target restapi -t stargateio/restapi:$SGTAG .
 
+
+
+echo "Building $DOCKER_IMAGE"
+docker buildx build --push \
+--tag ${DOCKER_IMAGE}:${stargate_version} \
+--file Dockerfile \
+--platform linux/amd64,linux/arm64 .
+
+echo "Inspecting $DOCKER_IMAGE"
+docker buildx imagetools inspect ${DOCKER_IMAGE}:${stargate_version}

--- a/build_docker_images.sh
+++ b/build_docker_images.sh
@@ -5,6 +5,14 @@ set -euo pipefail
 # Assumes that you have done a complete build so that all jars have been created, i.e.:
 #   ./mvnw clean install -P dse -DskipTests=true
 
+# Options:
+# -p - causes the images to be built for all supported platform architectures and pushed to
+#   Docker Hub (assumes you are logged in to Stargate Docker Hub account).
+#   This is intended to be used as part of automated builds.
+# -t <version> - overrides the default tag that will be applied to the image with the one
+#   you provide. By default the tag consists of the version is obtained from the parent
+#   pom.xml file, prepended with v, i.e. v2.0.0.
+
 #
 # Defaults
 #


### PR DESCRIPTION
This adds flags to the `build_docker_images.sh` script:

- `-p` - causes the images to be built for all supported platform architectures and pushed to Docker Hub (assumes you are logged in). This is intended to be used as part of automated builds (see #1584).
- `-t <version>` - overrides the default tag that will be applied to the image with the one you provide. By default the tag consists of the version is obtained from the parent `pom.xml` file, prepended with `v`, i.e. `v2.0.0`.