### PR TITLE
Add a test case to reproduce #1577 fail on v2.0.0

### DIFF
--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -1668,8 +1668,10 @@ public class RestApiv2Test extends BaseIntegrationTest {
             HttpStatus.SC_OK);
     JsonNode json = objectMapper.readTree(body);
     assertThat(json.size()).isEqualTo(2);
+    assertThat(json.at("/0/id").asText()).isEqualTo(mainKey);
     assertThat(json.at("/0/id2").asText()).isEqualTo("a");
     assertThat(json.at("/0/name").asText()).isEqualTo("Bob");
+    assertThat(json.at("/1/id").asText()).isEqualTo(mainKey);
     assertThat(json.at("/1/id2").asText()).isEqualTo("b");
     assertThat(json.at("/1/name").asText()).isEqualTo("Joe");
   }

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2Test.java
@@ -1636,6 +1636,44 @@ public class RestApiv2Test extends BaseIntegrationTest {
     assertThat(data.get(0).get("expense_id")).isEqualTo(1);
   }
 
+  // Reproduction for https://github.com/stargate/stargate/issues/1577
+  @Test
+  public void getRowsPagingWithUUID() throws Exception {
+    createKeyspace(keyspaceName);
+    createTestTable(
+        tableName,
+        // NOTE! Original test passes if "uuid" -> "text"
+        Arrays.asList("id uuid", "id2 text", "name text"),
+        Collections.singletonList("id"),
+        Collections.singletonList("id2"));
+
+    String mainKey = "113fbac2-0cad-40f8-940c-6a95f8d1a4cf"; // from original test
+    String secondKey = "113fbac2-0cad-40f8-940c-6a95f8d1afff";
+    insertTestTableRows(
+        Arrays.asList(
+            Arrays.asList("id " + mainKey, "id2 a", "name Bob"),
+            Arrays.asList("id " + mainKey, "id2 b", "name Joe"),
+            Arrays.asList("id " + mainKey, "id2 x", "name Patrick"),
+            Arrays.asList("id " + secondKey, "id2 c", "name Rick"),
+            Arrays.asList("id " + secondKey, "id2 e", "name Alice")));
+
+    // get first page
+    String whereClause = String.format("{\"id\":{\"$eq\":\"%s\"}}", mainKey);
+    String body =
+        RestUtils.get(
+            authToken,
+            String.format(
+                "%s/v2/keyspaces/%s/%s?raw=true&page-size=2&where=%s",
+                restUrlBase, keyspaceName, tableName, whereClause),
+            HttpStatus.SC_OK);
+    JsonNode json = objectMapper.readTree(body);
+    assertThat(json.size()).isEqualTo(2);
+    assertThat(json.at("/0/id2").asText()).isEqualTo("a");
+    assertThat(json.at("/0/name").asText()).isEqualTo("Bob");
+    assertThat(json.at("/1/id2").asText()).isEqualTo("b");
+    assertThat(json.at("/1/name").asText()).isEqualTo("Joe");
+  }
+
   @Test
   public void getRowsNotFound() throws IOException {
     createKeyspace(keyspaceName);


### PR DESCRIPTION
**What this PR does**:

Reproduces issue #1577

The key requirements are:

* Partition key has `UUID` value
* At least 2 entries are read; of these partition key for first is fine, second fails due to "empty" (by either gRPC server noticing, or sending malformed key)

Root cause is within gRPC service handlers but this reproduces it via REST/SGv2 since that is where it was first observed (as part of Fallout/Haxx perf test).

**Which issue(s) this PR fixes**:
Won't fix anything yet.

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
