### PR TITLE
Fix root cause of #1577 (along with simple tests)

### DIFF
--- a/grpc/src/main/java/io/stargate/grpc/codec/BytesCodec.java
+++ b/grpc/src/main/java/io/stargate/grpc/codec/BytesCodec.java
@@ -34,6 +34,6 @@ public class BytesCodec implements ValueCodec {
 
   @Override
   public Value decode(@NonNull ByteBuffer bytes, @NonNull ColumnType type) {
-    return Value.newBuilder().setBytes(ByteString.copyFrom(bytes)).build();
+    return Value.newBuilder().setBytes(ByteString.copyFrom(bytes.duplicate())).build();
   }
 }

--- a/grpc/src/main/java/io/stargate/grpc/codec/InetCodec.java
+++ b/grpc/src/main/java/io/stargate/grpc/codec/InetCodec.java
@@ -44,7 +44,7 @@ public class InetCodec implements ValueCodec {
   @Override
   public Value decode(@NonNull ByteBuffer bytes, @NonNull ColumnType type) {
     return Value.newBuilder()
-        .setInet(Inet.newBuilder().setValue(ByteString.copyFrom(bytes)))
+        .setInet(Inet.newBuilder().setValue(ByteString.copyFrom(bytes.duplicate())))
         .build();
   }
 }

--- a/grpc/src/main/java/io/stargate/grpc/codec/UuidCodec.java
+++ b/grpc/src/main/java/io/stargate/grpc/codec/UuidCodec.java
@@ -47,7 +47,7 @@ public class UuidCodec implements ValueCodec {
       throw new IllegalArgumentException("Expected 16 bytes for a UUID, got " + bytes.remaining());
     }
     return Value.newBuilder()
-        .setUuid(Uuid.newBuilder().setValue(ByteString.copyFrom(bytes)).build())
+        .setUuid(Uuid.newBuilder().setValue(ByteString.copyFrom(bytes.duplicate())).build())
         .build();
   }
 }

--- a/grpc/src/main/java/io/stargate/grpc/codec/VarintCodec.java
+++ b/grpc/src/main/java/io/stargate/grpc/codec/VarintCodec.java
@@ -40,7 +40,7 @@ public class VarintCodec implements ValueCodec {
     }
 
     return Value.newBuilder()
-        .setVarint(Varint.newBuilder().setValue(ByteString.copyFrom(bytes)).build())
+        .setVarint(Varint.newBuilder().setValue(ByteString.copyFrom(bytes.duplicate())).build())
         .build();
   }
 }

--- a/grpc/src/test/java/io/stargate/grpc/codec/ValueCodecTest.java
+++ b/grpc/src/test/java/io/stargate/grpc/codec/ValueCodecTest.java
@@ -78,6 +78,11 @@ public class ValueCodecTest {
     ByteBuffer bytes = codec.encode(expectedValue, type);
     Value actualValue = codec.decode(bytes, type);
     assertThat(actualValue).isEqualTo(expectedValue);
+
+    // 27-Jan-2022, tatu: Specific kind of failure (see #1577) occurs if
+    //    we try to decode second time from same ByteBuffer!
+    Value actualValue2 = codec.decode(bytes, type);
+    assertThat(actualValue2).isEqualTo(expectedValue);
   }
 
   @ParameterizedTest
@@ -88,6 +93,11 @@ public class ValueCodecTest {
     ByteBuffer bytes = codec.encode(value, type);
     Value actualValue = codec.decode(bytes, type);
     assertThat(actualValue).isEqualTo(expectedValue);
+
+    // 27-Jan-2022, tatu: Specific kind of failure (see #1577) occurs if
+    //    we try to decode second time from same ByteBuffer!
+    Value actualValue2 = codec.decode(bytes, type);
+    assertThat(actualValue2).isEqualTo(expectedValue);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
**What this PR does**:

Adds `ByteBuffer.duplicate()` calls in codecs for:

* Bytes ("blob")
* Inet
* Uuid
* VarInt

to fix issue #1577 and adds simple unit tests to try to ensure that passing same `ByteBuffer` multiple times to `ValueCodec.encode()` is safe.

**Which issue(s) this PR fixes**:
Fixes #1577

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
