### PR TITLE
Add an example for streaming gRPC bi-streaming queries

### DIFF
--- a/grpc-examples/src/main/java/io/stargate/grpcexample/GrpcClientExecuteQuery.java
+++ b/grpc-examples/src/main/java/io/stargate/grpcexample/GrpcClientExecuteQuery.java
@@ -87,7 +87,7 @@ public class GrpcClientExecuteQuery {
   }
 
   private void executeStreamingBatchInsertQueries() throws InterruptedException {
-    CountDownLatch responseRetrieved = new CountDownLatch(1);
+    CountDownLatch responseRetrieved = new CountDownLatch(2);
     StreamObserver<QueryOuterClass.StreamingResponse> responseStreamObserver =
         new StreamObserver<QueryOuterClass.StreamingResponse>() {
           @Override
@@ -121,12 +121,20 @@ public class GrpcClientExecuteQuery {
                     .setCql("INSERT INTO ks.test (k, v) VALUES ('streaming_batch_b', 2)")
                     .build())
             .build());
+
+    queryStreamObserver.onNext(
+        QueryOuterClass.Batch.newBuilder()
+            .addQueries(
+                QueryOuterClass.BatchQuery.newBuilder()
+                    .setCql("INSERT INTO ks.test (k, v) VALUES ('streaming_batch_c', 1)")
+                    .build())
+            .build());
     queryStreamObserver.onCompleted();
     responseRetrieved.await();
   }
 
   private void executeStreamingInsertQuery() throws InterruptedException {
-    CountDownLatch responseRetrieved = new CountDownLatch(1);
+    CountDownLatch responseRetrieved = new CountDownLatch(2);
     StreamObserver<QueryOuterClass.StreamingResponse> responseStreamObserver =
         new StreamObserver<QueryOuterClass.StreamingResponse>() {
           @Override
@@ -152,6 +160,11 @@ public class GrpcClientExecuteQuery {
     queryStreamObserver.onNext(
         QueryOuterClass.Query.newBuilder()
             .setCql("INSERT INTO ks.test (k, v) VALUES ('streaming_query', 100)")
+            .build());
+
+    queryStreamObserver.onNext(
+        QueryOuterClass.Query.newBuilder()
+            .setCql("INSERT INTO ks.test (k, v) VALUES ('streaming_query2', 100)")
             .build());
     queryStreamObserver.onCompleted();
     responseRetrieved.await();

--- a/grpc-examples/src/main/java/io/stargate/grpcexample/GrpcClientExecuteQuery.java
+++ b/grpc-examples/src/main/java/io/stargate/grpcexample/GrpcClientExecuteQuery.java
@@ -67,7 +67,9 @@ public class GrpcClientExecuteQuery {
           }
 
           @Override
-          public void onError(Throwable t) {}
+          public void onError(Throwable t) {
+            System.out.println("Error: " + t);
+          }
 
           @Override
           public void onCompleted() {
@@ -95,7 +97,9 @@ public class GrpcClientExecuteQuery {
           }
 
           @Override
-          public void onError(Throwable t) {}
+          public void onError(Throwable t) {
+            System.out.println("Error: " + t);
+          }
 
           @Override
           public void onCompleted() {
@@ -132,7 +136,9 @@ public class GrpcClientExecuteQuery {
           }
 
           @Override
-          public void onError(Throwable t) {}
+          public void onError(Throwable t) {
+            System.out.println("Error: " + t);
+          }
 
           @Override
           public void onCompleted() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds example usage of `executeBatchStream` and `executeQueryStream` in the `GrpcClientExecuteQuery`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Changes manually tested
