### PR TITLE
Fix release-v2 workflow

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -152,6 +152,7 @@ jobs:
         run: |
           ./build_docker_images.sh -p -t ${{ steps.vars.outputs.tag }}
       - name: Update version numbers for next release
+        run: |
           mvn -B release:update-versions -DautoVersionSubmodules=true versions:commit -Pdse && \
           mvn xml-format:xml-format fmt:format -Pdse
       - name: Rev Version


### PR DESCRIPTION
The change pushed in #1584 inadvertently deleted a line from the release-v2 workflow which causes a parsing error every time Google cloud build tries to read the file, which is on every push. This PR is to add the line back in.
