### PR TITLE
relates to #1604: fix update of sub-document with JSON schema existing

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCode.java
@@ -119,10 +119,16 @@ public enum ErrorCode {
       Response.Status.BAD_REQUEST,
       "When a collection has a JSON schema, partial updates of documents are disallowed for performance reasons."),
 
+  DOCS_API_JSON_SCHEMA_PROCESSING_FAILED(
+      Response.Status.INTERNAL_SERVER_ERROR,
+      "Processing a JSON schema validation failed for a given document."),
+
   DOCS_API_INVALID_JSON_VALUE(
       Response.Status.BAD_REQUEST, "The provided JSON does not match the collection's schema."),
+
   DOCS_API_WRITE_BATCH_INVALID_ID_PATH(
       Response.Status.BAD_REQUEST, "ID path is invalid for document during batch write."),
+
   DOCS_API_WRITE_BATCH_FAILED(
       Response.Status.INTERNAL_SERVER_ERROR, "Write failed during batched document write."),
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCodeRuntimeException.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/exception/ErrorCodeRuntimeException.java
@@ -35,6 +35,12 @@ public class ErrorCodeRuntimeException extends RuntimeException {
     this.errorCode = errorCode;
   }
 
+  /** @see Exception#Exception(Throwable) */
+  public ErrorCodeRuntimeException(ErrorCode errorCode, Throwable cause) {
+    super(cause);
+    this.errorCode = errorCode;
+  }
+
   /** @see Exception#Exception(String, Throwable) */
   public ErrorCodeRuntimeException(ErrorCode errorCode, String message, Throwable cause) {
     super(message, cause);

--- a/restapi/src/main/java/io/stargate/web/docsapi/resources/ReactiveDocumentResourceV2.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/resources/ReactiveDocumentResourceV2.java
@@ -212,7 +212,8 @@ public class ReactiveDocumentResourceV2 {
   @ManagedAsync
   @ApiOperation(
       value = "Replace data at a path in a document",
-      notes = "Removes whatever was previously present at the path")
+      notes =
+          "Removes whatever was previously present at the path. Note that operation is not allowed if a JSON schema exist for a target collection.")
   @ApiResponses(
       value = {
         @ApiResponse(code = 200, message = "OK", response = WriteDocResponse.class),

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/ReactiveDocumentServiceTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/ReactiveDocumentServiceTest.java
@@ -523,6 +523,44 @@ class ReactiveDocumentServiceTest {
     }
 
     @Test
+    public void subDocumentWithSchemaCheck() throws Exception {
+      String documentId = RandomStringUtils.randomAlphanumeric(16);
+      String namespace = RandomStringUtils.randomAlphanumeric(16);
+      String collection = RandomStringUtils.randomAlphanumeric(16);
+      String path = RandomStringUtils.randomAlphanumeric(16);
+      List<String> subPath = Collections.singletonList(path);
+      ExecutionContext context = ExecutionContext.create(true);
+      String payload = "{}";
+      JsonNode schema = objectMapper.createObjectNode();
+
+      when(jsonSchemaHandler.getCachedJsonSchema(documentDB, namespace, collection))
+          .thenReturn(schema);
+
+      Single<DocumentResponseWrapper<Void>> result =
+          reactiveDocumentService.updateDocument(
+              documentDB, namespace, collection, documentId, subPath, payload, context);
+
+      result
+          .test()
+          .await()
+          .assertError(
+              e -> {
+                assertThat(e)
+                    .isInstanceOf(ErrorCodeRuntimeException.class)
+                    .hasFieldOrPropertyWithValue(
+                        "errorCode", ErrorCode.DOCS_API_JSON_SCHEMA_INVALID_PARTIAL_UPDATE);
+                return true;
+              });
+
+      verify(authService)
+          .authorizeDataWrite(authSubject, namespace, collection, Scope.MODIFY, SourceAPI.REST);
+      verify(authService)
+          .authorizeDataWrite(authSubject, namespace, collection, Scope.DELETE, SourceAPI.REST);
+      verify(jsonSchemaHandler).getCachedJsonSchema(documentDB, namespace, collection);
+      verifyNoMoreInteractions(writeService, authService, searchService, jsonSchemaHandler);
+    }
+
+    @Test
     public void malformedJson() throws Exception {
       String documentId = RandomStringUtils.randomAlphanumeric(16);
       String namespace = RandomStringUtils.randomAlphanumeric(16);


### PR DESCRIPTION
**What this PR does**:
Fixes a bug introduced in the #1572 which resulted in checking the JSON schema being valid on sub-document updates. This action should be forbidden. Note that the similar bug exists for the `PATCH` operation on a root document and that will be fixed in #1605.

@polandll I updated the Swagger annotations here to clarify this for the user.

**Which issue(s) this PR fixes**:
Relates to #1604 and fixes the update (`PUT`) operations.

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
