### PR TITLE
gRPC: Fix conversion of UDT field types

### DIFF
--- a/bridge/src/main/java/io/stargate/bridge/service/SchemaHandler.java
+++ b/bridge/src/main/java/io/stargate/bridge/service/SchemaHandler.java
@@ -100,8 +100,7 @@ class SchemaHandler {
       udtBuilder.setFrozen(udt.isFrozen());
       for (Column column : udt.columns()) {
         udtBuilder.putFields(
-            column.name(),
-            ValuesHelper.convertType(ValuesHelper.columnTypeNotNull(column).rawType()));
+            column.name(), ValuesHelper.convertType(ValuesHelper.columnTypeNotNull(column)));
       }
       describeResultBuilder.addTypes(udtBuilder.build());
     }
@@ -153,7 +152,7 @@ class SchemaHandler {
     }
 
     for (Column column : table.regularAndStaticColumns()) {
-      if (column.kind().equals(Column.Kind.Static)) {
+      if (column.kind() == Column.Kind.Static) {
         cqlTableBuilder.addStaticColumns(buildColumnSpec(column));
       } else {
         cqlTableBuilder.addColumns(buildColumnSpec(column));

--- a/grpc/src/main/java/io/stargate/grpc/service/ValuesHelper.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/ValuesHelper.java
@@ -253,7 +253,7 @@ public class ValuesHelper {
         TypeSpec.Udt.Builder udtBuilder = TypeSpec.Udt.newBuilder();
         udtBuilder.setName(udt.name());
         for (Column column : udt.columns()) {
-          udtBuilder.putFields(column.name(), convertType(columnTypeNotNull(column).rawType()));
+          udtBuilder.putFields(column.name(), convertType(columnTypeNotNull(column)));
         }
         udtBuilder.setFrozen(columnType.isFrozen());
         builder.setUdt(udtBuilder.build());


### PR DESCRIPTION
**What this PR does**:
Fix a bug that made gRPC operations fail if the response references a UDT that has fields with parameterized types (e.g. collections).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
