### PR TITLE
gRPC: Fix conversion of UDT field types

### DIFF
--- a/grpc/src/main/java/io/stargate/grpc/service/ValuesHelper.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/ValuesHelper.java
@@ -245,7 +245,7 @@ public class ValuesHelper {
         }
         TypeSpec.Udt.Builder udtBuilder = TypeSpec.Udt.newBuilder();
         for (Column column : udt.columns()) {
-          udtBuilder.putFields(column.name(), convertType(columnTypeNotNull(column).rawType()));
+          udtBuilder.putFields(column.name(), convertType(columnTypeNotNull(column)));
         }
         builder.setUdt(udtBuilder.build());
         break;


### PR DESCRIPTION
**What this PR does**:
Fix a bug that made gRPC operations fail if the response references a UDT that has fields with parameterized types (e.g. collections).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
