### PR TITLE
Add configuration property for Docs API port

### DIFF
--- a/restapi/src/main/java/io/stargate/web/impl/RestApiServerConfiguration.java
+++ b/restapi/src/main/java/io/stargate/web/impl/RestApiServerConfiguration.java
@@ -16,5 +16,23 @@
 package io.stargate.web.impl;
 
 import io.dropwizard.Configuration;
+import io.dropwizard.jetty.HttpConnectorFactory;
+import io.dropwizard.server.ServerFactory;
+import io.dropwizard.server.SimpleServerFactory;
 
-public class RestApiServerConfiguration extends Configuration {}
+public class RestApiServerConfiguration extends Configuration {
+  private int docsApiPortOverride = -1;
+
+  public void docsApiPortOverride(int port) {
+    docsApiPortOverride = port;
+    ServerFactory serverF = this.getServerFactory();
+    // It's actually "RestApiServerFactory" but that extends SimpleServerFactory so:
+    HttpConnectorFactory connF =
+        (HttpConnectorFactory) ((SimpleServerFactory) serverF).getConnector();
+    connF.setPort(port);
+  }
+
+  public int gocsApiPortOverride() {
+    return docsApiPortOverride;
+  }
+}

--- a/restapi/src/main/java/io/stargate/web/impl/RestApiServerConfiguration.java
+++ b/restapi/src/main/java/io/stargate/web/impl/RestApiServerConfiguration.java
@@ -20,6 +20,19 @@ import io.dropwizard.jetty.HttpConnectorFactory;
 import io.dropwizard.server.ServerFactory;
 import io.dropwizard.server.SimpleServerFactory;
 
+/**
+ * Configuration class for StargateV1 Docs API.
+ *
+ * <p>The only interesting thing is to apply Docs API port override via System properties:
+ *
+ * <pre>
+ *  -Ddw.docsApiPortOverride=8099
+ * </pre>
+ *
+ * (although technically it is also possible to add root-level value in {@code
+ * src/main/resources/config.yaml} that could simply use the regular YAML overide of
+ * "server.connector.port: 8099" instead)
+ */
 public class RestApiServerConfiguration extends Configuration {
   private int docsApiPortOverride = -1;
 

--- a/restapi/src/main/java/io/stargate/web/impl/RestApiServerConfiguration.java
+++ b/restapi/src/main/java/io/stargate/web/impl/RestApiServerConfiguration.java
@@ -45,7 +45,7 @@ public class RestApiServerConfiguration extends Configuration {
     connF.setPort(port);
   }
 
-  public int gocsApiPortOverride() {
+  public int getDocsApiPortOverride() {
     return docsApiPortOverride;
   }
 }


### PR DESCRIPTION
**What this PR does**:

Adds a workaround to allow re-defining "StargateV1" Documents API port number within StargateV2.
The problem worked around is that all different APIs rely on same system property overrides, as far
as DropWizard is concerned, so the usual:

```
-Ddw.server.connector.port=9090
```

cannot be used as that would change port numbers of ALL APIs. So instead an additional custom property:

```
-Ddw.docsApiPortOverride=9090
```

is supported instead.

**Which issue(s) this PR fixes**:

No issue filed.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
