### PR TITLE
Add delay when reconnecting to schema notifications

### DIFF
--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/impl/RestServiceServer.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/impl/RestServiceServer.java
@@ -112,7 +112,10 @@ public class RestServiceServer extends Application<RestServiceServerConfiguratio
     environment.jersey().register(new CreateGrpcStubFilter(grpcChannel));
 
     StargateBridgeClientFactory stargateBridgeClientFactory =
-        StargateBridgeClientFactory.newInstance(grpcChannel, BridgeConfig.ADMIN_TOKEN);
+        StargateBridgeClientFactory.newInstance(
+            grpcChannel,
+            BridgeConfig.ADMIN_TOKEN,
+            environment.lifecycle().scheduledExecutorService("bridge-factory").threads(1).build());
     environment
         .jersey()
         .register(new CreateStargateBridgeClientFilter(stargateBridgeClientFactory));

--- a/sgv2-restapi/src/main/resources/logback.xml
+++ b/sgv2-restapi/src/main/resources/logback.xml
@@ -11,4 +11,5 @@
   </root>
   <logger name="org.apache.cassandra" level="${stargate.logging.level.cassandra:-INFO}"/>
   <logger name="io.stargate.web" level="${stargate.logging.level.web:-INFO}"/>
+  <logger name="io.stargate.sgv2" level="${stargate.logging.level.web:-INFO}"/>
 </configuration>

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/DefaultStargateBridgeClientFactory.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/DefaultStargateBridgeClientFactory.java
@@ -17,15 +17,17 @@ package io.stargate.sgv2.common.grpc;
 
 import io.grpc.Channel;
 import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
 
 class DefaultStargateBridgeClientFactory implements StargateBridgeClientFactory {
 
   private final Channel channel;
   private final DefaultStargateBridgeSchema schema;
 
-  DefaultStargateBridgeClientFactory(Channel channel, String adminAuthToken) {
+  DefaultStargateBridgeClientFactory(
+      Channel channel, String adminAuthToken, ScheduledExecutorService executor) {
     this.channel = channel;
-    this.schema = new DefaultStargateBridgeSchema(channel, adminAuthToken);
+    this.schema = new DefaultStargateBridgeSchema(channel, adminAuthToken, executor);
   }
 
   @Override

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/DefaultStargateBridgeSchema.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/DefaultStargateBridgeSchema.java
@@ -32,6 +32,7 @@ import io.stargate.proto.StargateBridgeGrpc.StargateBridgeStub;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,6 +46,7 @@ class DefaultStargateBridgeSchema implements StargateBridgeSchema {
   private static final int DESCRIBE_KEYSPACE_TIMEOUT_SECONDS = 5;
   private static final GetSchemaNotificationsParams GET_SCHEMA_NOTIFICATIONS_PARAMS =
       GetSchemaNotificationsParams.newBuilder().build();
+  private static final long MAX_RECONNECT_DELAY_MS = TimeUnit.SECONDS.toMillis(5);
 
   private final Channel channel;
   private final StargateBearerToken adminCallCredentials;
@@ -53,8 +55,11 @@ class DefaultStargateBridgeSchema implements StargateBridgeSchema {
   // to ask for it will trigger the query. `CompletionStage<null>` means the keyspace does not
   // exist. Schema change notifications invalidate the entry to force a refresh.
   private final Cache<String, CompletionStage<CqlKeyspaceDescribe>> keyspaceCache;
+  private final ScheduledExecutorService executor;
+  private volatile long reconnectDelayMs = 0;
 
-  DefaultStargateBridgeSchema(Channel channel, String adminAuthToken) {
+  DefaultStargateBridgeSchema(
+      Channel channel, String adminAuthToken, ScheduledExecutorService executor) {
     this.channel = channel;
     this.adminCallCredentials = new StargateBearerToken(adminAuthToken);
     this.keyspaceCache =
@@ -62,6 +67,8 @@ class DefaultStargateBridgeSchema implements StargateBridgeSchema {
             .maximumSize(KEYSPACE_CACHE_SIZE)
             .expireAfterAccess(KEYSPACE_CACHE_TTL)
             .build();
+    this.executor = executor;
+
     registerChangeObserver();
   }
 
@@ -158,6 +165,8 @@ class DefaultStargateBridgeSchema implements StargateBridgeSchema {
       if (notification.hasReady()) {
         // In case we missed notifications while the stream was initializing:
         keyspaceCache.invalidateAll();
+        // Reset for next time we get disconnected:
+        reconnectDelayMs = 0;
       } else {
         SchemaChange change = notification.getChange();
         LOG.debug(
@@ -172,16 +181,31 @@ class DefaultStargateBridgeSchema implements StargateBridgeSchema {
 
     @Override
     public void onError(Throwable t) {
-      LOG.warn("Unexpected error in notification stream, trying to reconnect", t);
-      registerChangeObserver();
+      LOG.warn("Unexpected error in notification stream", t);
+      scheduleReconnect();
     }
 
     @Override
     public void onCompleted() {
       // This should never happen since the server implementation never completes.
       // Handle gracefully nonetheless.
-      LOG.warn("Unexpected onCompleted, trying to reconnect");
-      registerChangeObserver();
+      LOG.warn("Unexpected onCompleted");
+      scheduleReconnect();
     }
+  }
+
+  private void scheduleReconnect() {
+    executor.schedule(this::registerChangeObserver, getAndIncreaseDelayMs(), TimeUnit.MILLISECONDS);
+  }
+
+  private long getAndIncreaseDelayMs() {
+    long current = reconnectDelayMs;
+    if (current == 0) {
+      reconnectDelayMs = 100;
+    } else if (current < MAX_RECONNECT_DELAY_MS) {
+      reconnectDelayMs = Math.min(current * 2, MAX_RECONNECT_DELAY_MS);
+    }
+    LOG.debug("Scheduling reconnection in {} ms", current);
+    return current;
   }
 }

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/StargateBridgeClientFactory.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/StargateBridgeClientFactory.java
@@ -17,11 +17,13 @@ package io.stargate.sgv2.common.grpc;
 
 import io.grpc.Channel;
 import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
 
 public interface StargateBridgeClientFactory {
 
-  static StargateBridgeClientFactory newInstance(Channel channel, String adminToken) {
-    return new DefaultStargateBridgeClientFactory(channel, adminToken);
+  static StargateBridgeClientFactory newInstance(
+      Channel channel, String adminToken, ScheduledExecutorService executor) {
+    return new DefaultStargateBridgeClientFactory(channel, adminToken, executor);
   }
 
   StargateBridgeClient newClient(String authToken, Optional<String> tenantId);


### PR DESCRIPTION
**What this PR does**:
Add an exponential backoff if the schema cache loses connectivity with the bridge.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
