### PR TITLE
Add schema read authorizations to the bridge

### DIFF
--- a/bridge/pom.xml
+++ b/bridge/pom.xml
@@ -73,6 +73,7 @@
                             org.osgi.framework,
                             io.stargate.core.*,
                             io.stargate.auth,
+                            io.stargate.auth.*,
                             io.stargate.db,
                             io.stargate.db.*,
                             org.apache.cassandra.stargate,

--- a/bridge/src/main/java/io/stargate/bridge/BridgeActivator.java
+++ b/bridge/src/main/java/io/stargate/bridge/BridgeActivator.java
@@ -16,6 +16,7 @@
 package io.stargate.bridge;
 
 import io.stargate.auth.AuthenticationService;
+import io.stargate.auth.AuthorizationService;
 import io.stargate.bridge.impl.BridgeImpl;
 import io.stargate.core.activator.BaseActivator;
 import io.stargate.core.grpc.BridgeConfig;
@@ -34,6 +35,8 @@ public class BridgeActivator extends BaseActivator {
           AuthenticationService.class,
           "AuthIdentifier",
           System.getProperty("stargate.auth_id", "AuthTableBasedService"));
+  private final ServicePointer<AuthorizationService> authorization =
+      ServicePointer.create(AuthorizationService.class);
   private final ServicePointer<Persistence> persistence =
       ServicePointer.create(Persistence.class, "Identifier", DbActivator.PERSISTENCE_IDENTIFIER);
 
@@ -49,7 +52,11 @@ public class BridgeActivator extends BaseActivator {
     }
     bridge =
         new BridgeImpl(
-            persistence.get(), metrics.get(), authentication.get(), BridgeConfig.ADMIN_TOKEN);
+            persistence.get(),
+            metrics.get(),
+            authentication.get(),
+            authorization.get(),
+            BridgeConfig.ADMIN_TOKEN);
     bridge.start();
 
     return null;
@@ -66,6 +73,6 @@ public class BridgeActivator extends BaseActivator {
 
   @Override
   protected List<ServicePointer<?>> dependencies() {
-    return Arrays.asList(metrics, persistence, authentication);
+    return Arrays.asList(metrics, persistence, authentication, authorization);
   }
 }

--- a/bridge/src/main/java/io/stargate/bridge/impl/BridgeImpl.java
+++ b/bridge/src/main/java/io/stargate/bridge/impl/BridgeImpl.java
@@ -20,6 +20,7 @@ import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.micrometer.core.instrument.binder.grpc.MetricCollectingServerInterceptor;
 import io.stargate.auth.AuthenticationService;
+import io.stargate.auth.AuthorizationService;
 import io.stargate.bridge.service.BridgeService;
 import io.stargate.bridge.service.interceptors.BridgeNewConnectionInterceptor;
 import io.stargate.core.metrics.api.Metrics;
@@ -49,6 +50,7 @@ public class BridgeImpl {
       Persistence persistence,
       Metrics metrics,
       AuthenticationService authenticationService,
+      AuthorizationService authorizationService,
       String adminToken) {
 
     String listenAddress;
@@ -76,7 +78,7 @@ public class BridgeImpl {
             .intercept(
                 new BridgeNewConnectionInterceptor(persistence, authenticationService, adminToken))
             .intercept(new MetricCollectingServerInterceptor(metrics.getMeterRegistry()))
-            .addService(new BridgeService(persistence, executor))
+            .addService(new BridgeService(persistence, authorizationService, executor))
             .build();
   }
 

--- a/bridge/src/main/java/io/stargate/bridge/service/AuthorizationHandler.java
+++ b/bridge/src/main/java/io/stargate/bridge/service/AuthorizationHandler.java
@@ -45,7 +45,7 @@ class AuthorizationHandler {
     this.responseObserver = responseObserver;
   }
 
-  public void handle() {
+  void handle() {
     AuthorizeSchemaReadsResponse.Builder response = AuthorizeSchemaReadsResponse.newBuilder();
     AuthenticationSubject subject = getSubject();
     request

--- a/bridge/src/main/java/io/stargate/bridge/service/AuthorizationHandler.java
+++ b/bridge/src/main/java/io/stargate/bridge/service/AuthorizationHandler.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.bridge.service;
+
+import io.grpc.stub.StreamObserver;
+import io.stargate.auth.AuthenticationSubject;
+import io.stargate.auth.AuthorizationService;
+import io.stargate.auth.SourceAPI;
+import io.stargate.auth.UnauthorizedException;
+import io.stargate.auth.entity.ResourceKind;
+import io.stargate.db.Persistence.Connection;
+import io.stargate.proto.Schema.AuthorizeSchemaReadsRequest;
+import io.stargate.proto.Schema.AuthorizeSchemaReadsResponse;
+import io.stargate.proto.Schema.SchemaRead;
+import java.util.Collections;
+
+class AuthorizationHandler {
+
+  private final AuthorizeSchemaReadsRequest request;
+  private final Connection connection;
+  private final AuthorizationService authorizationService;
+  private final StreamObserver<AuthorizeSchemaReadsResponse> responseObserver;
+
+  AuthorizationHandler(
+      AuthorizeSchemaReadsRequest request,
+      Connection connection,
+      AuthorizationService authorizationService,
+      StreamObserver<AuthorizeSchemaReadsResponse> responseObserver) {
+    this.request = request;
+    this.connection = connection;
+    this.authorizationService = authorizationService;
+    this.responseObserver = responseObserver;
+  }
+
+  public void handle() {
+    AuthorizeSchemaReadsResponse.Builder response = AuthorizeSchemaReadsResponse.newBuilder();
+    AuthenticationSubject subject = getSubject();
+    request
+        .getSchemaReadsList()
+        .forEach(read -> response.addAuthorized(isAuthorized(subject, read)));
+    responseObserver.onNext(response.build());
+    responseObserver.onCompleted();
+  }
+
+  private boolean isAuthorized(AuthenticationSubject subject, SchemaRead read) {
+    try {
+      authorizationService.authorizeSchemaRead(
+          subject,
+          Collections.singletonList(read.getKeyspaceName()),
+          read.hasElementName()
+              ? Collections.singletonList(read.getElementName().getValue())
+              : Collections.emptyList(),
+          convertApi(read.getSourceApi()),
+          convertType(read.getElementType()));
+      return true;
+    } catch (UnauthorizedException e) {
+      return false;
+    }
+  }
+
+  private AuthenticationSubject getSubject() {
+    return connection
+        .loggedUser()
+        .map(AuthenticationSubject::of)
+        .orElseThrow(() -> new IllegalStateException("Must be authenticated"));
+  }
+
+  private ResourceKind convertType(SchemaRead.ElementType elementType) {
+    switch (elementType) {
+      case KEYSPACE:
+        return ResourceKind.KEYSPACE;
+      case TABLE:
+        return ResourceKind.TABLE;
+      case FUNCTION:
+        return ResourceKind.FUNCTION;
+      case TYPE:
+        return ResourceKind.TYPE;
+      case TRIGGER:
+        return ResourceKind.TRIGGER;
+      case AGGREGATE:
+        return ResourceKind.AGGREGATE;
+      case VIEW:
+        return ResourceKind.VIEW;
+      case INDEX:
+        return ResourceKind.INDEX;
+      case UNRECOGNIZED:
+      default:
+        throw new IllegalArgumentException("Unsupported element type " + elementType);
+    }
+  }
+
+  private SourceAPI convertApi(SchemaRead.SourceApi sourceApi) {
+    switch (sourceApi) {
+      case GRAPHQL:
+        return SourceAPI.GRAPHQL;
+      case REST:
+        return SourceAPI.REST;
+      case UNRECOGNIZED:
+      default:
+        throw new IllegalArgumentException("Unsupported source API " + sourceApi);
+    }
+  }
+}

--- a/bridge/src/test/java/io/stargate/bridge/service/BaseBridgeTest.java
+++ b/bridge/src/test/java/io/stargate/bridge/service/BaseBridgeTest.java
@@ -24,6 +24,7 @@ import io.grpc.Server;
 import io.grpc.ServerInterceptor;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
+import io.stargate.auth.AuthorizationService;
 import io.stargate.db.Persistence;
 import io.stargate.db.Persistence.Connection;
 import io.stargate.proto.StargateBridgeGrpc;
@@ -46,6 +47,7 @@ public class BaseBridgeTest {
   private ManagedChannel clientChannel;
 
   protected @Mock Persistence persistence;
+  protected @Mock AuthorizationService authorizationService;
 
   protected Connection connection = spy(mock(Connection.class));
 
@@ -86,7 +88,7 @@ public class BaseBridgeTest {
         InProcessServerBuilder.forName(SERVER_NAME)
             .directExecutor()
             .intercept(interceptor)
-            .addService(new BridgeService(persistence, executor, 2))
+            .addService(new BridgeService(persistence, authorizationService, executor, 2))
             .build();
     try {
       server.start();

--- a/grpc-proto/proto/bridge.proto
+++ b/grpc-proto/proto/bridge.proto
@@ -39,5 +39,8 @@ service StargateBridge {
 
   // Requests notification of schema changes.
   rpc GetSchemaNotifications(GetSchemaNotificationsParams) returns (stream SchemaNotification) {}
+
+  // Checks whether the client is authorized to describe one or more schema elements.
+  rpc AuthorizeSchemaReads(AuthorizeSchemaReadsRequest) returns (AuthorizeSchemaReadsResponse) {}
 }
 

--- a/grpc-proto/proto/schema.proto
+++ b/grpc-proto/proto/schema.proto
@@ -107,3 +107,39 @@ message SchemaNotification {
     SchemaChange change = 2;
   }
 }
+
+// A request to authorize a series of schema reads.
+message AuthorizeSchemaReadsRequest {
+  repeated SchemaRead schema_reads = 1;
+}
+
+message SchemaRead {
+  enum SourceApi {
+    GRAPHQL = 0;
+    REST = 1;
+  }
+  enum ElementType {
+    KEYSPACE = 0;
+    TABLE = 1;
+    FUNCTION = 2;
+    TYPE = 3;
+    TRIGGER = 4;
+    AGGREGATE = 5;
+    VIEW = 6;
+    INDEX = 7;
+  }
+
+  string keyspace_name = 1;
+  // The name of the element in the keyspace
+  google.protobuf.StringValue element_name = 2;
+  // The type of element (note that if element_name if absent, KEYSPACE is implied).
+  ElementType element_type = 3;
+  // The Stargate API that initiated the request
+  SourceApi source_api = 4;
+}
+
+// The response to an AuthorizeSchemaReadsRequest.
+// The elements are in the same order as those of the request.
+message AuthorizeSchemaReadsResponse {
+  repeated bool authorized = 1;
+}

--- a/grpc-proto/proto/schema.proto
+++ b/grpc-proto/proto/schema.proto
@@ -130,9 +130,9 @@ message SchemaRead {
   }
 
   string keyspace_name = 1;
-  // The name of the element in the keyspace
+  // The name of the element in the keyspace (empty if element_type = KEYSPACE)
   google.protobuf.StringValue element_name = 2;
-  // The type of element (note that if element_name if absent, KEYSPACE is implied).
+  // The type of element
   ElementType element_type = 3;
   // The Stargate API that initiated the request
   SourceApi source_api = 4;

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2KeyspacesResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2KeyspacesResourceImpl.java
@@ -23,6 +23,7 @@ import io.stargate.proto.Schema.CqlKeyspaceDescribe;
 import io.stargate.sgv2.common.cql.builder.QueryBuilder;
 import io.stargate.sgv2.common.cql.builder.Replication;
 import io.stargate.sgv2.common.grpc.StargateBridgeClient;
+import io.stargate.sgv2.common.grpc.UnauthorizedKeyspaceException;
 import io.stargate.sgv2.restsvc.models.Sgv2Keyspace;
 import io.stargate.sgv2.restsvc.models.Sgv2RESTResponse;
 import io.stargate.sgv2.restsvc.resources.CreateGrpcStub;
@@ -71,7 +72,12 @@ public class Sgv2KeyspacesResourceImpl extends ResourceBase implements Sgv2Keysp
       final String keyspaceName,
       final boolean raw) {
 
-    CqlKeyspaceDescribe keyspaceDescribe = stargateBridgeClient.getKeyspace(keyspaceName);
+    CqlKeyspaceDescribe keyspaceDescribe;
+    try {
+      keyspaceDescribe = stargateBridgeClient.getKeyspace(keyspaceName);
+    } catch (UnauthorizedKeyspaceException e) {
+      throw new WebApplicationException("not authorized to describe keyspace", Status.UNAUTHORIZED);
+    }
     if (keyspaceDescribe == null) {
       throw new WebApplicationException("unable to describe keyspace", Status.NOT_FOUND);
     }

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/SchemaReads.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/SchemaReads.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.common.grpc;
+
+import com.google.protobuf.StringValue;
+import io.stargate.proto.Schema.SchemaRead;
+import io.stargate.proto.Schema.SchemaRead.ElementType;
+import io.stargate.proto.Schema.SchemaRead.SourceApi;
+
+/** Helper methods to construct {@link SchemaRead} instances. */
+public class SchemaReads {
+
+  public static SchemaRead keyspace(String keyspaceName, SourceApi sourceApi) {
+    return SchemaRead.newBuilder()
+        .setSourceApi(sourceApi)
+        .setElementType(ElementType.KEYSPACE)
+        .setKeyspaceName(keyspaceName)
+        .build();
+  }
+
+  public static SchemaRead table(String keyspaceName, String tableName, SourceApi sourceApi) {
+    return SchemaRead.newBuilder()
+        .setSourceApi(sourceApi)
+        .setElementType(ElementType.TABLE)
+        .setKeyspaceName(keyspaceName)
+        .setElementName(StringValue.of(tableName))
+        .build();
+  }
+}

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/UnauthorizedKeyspaceException.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/UnauthorizedKeyspaceException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.common.grpc;
+
+public class UnauthorizedKeyspaceException extends Exception {
+  private final String keyspaceName;
+
+  public UnauthorizedKeyspaceException(String keyspaceName) {
+    super("Unauthorized keyspace: " + keyspaceName);
+    this.keyspaceName = keyspaceName;
+  }
+
+  public String getKeyspaceName() {
+    return keyspaceName;
+  }
+}


### PR DESCRIPTION
**What this PR does**:
Add an authorization operation to the bridge, so that the client can explicitly check DESCRIBE permission (since it caches that data).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
