### PR TITLE
Add host ID property, flag, and env var

### DIFF
--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Cassandra311Persistence.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Cassandra311Persistence.java
@@ -206,7 +206,11 @@ public class Cassandra311Persistence
 
     String hostId = System.getProperty("stargate.host_id");
     if (hostId != null) {
-      SystemKeyspace.setLocalHostId(UUID.fromString(hostId));
+      try {
+        SystemKeyspace.setLocalHostId(UUID.fromString(hostId));
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException("Invalid host ID", e);
+      }
     }
 
     executor =

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Cassandra311Persistence.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Cassandra311Persistence.java
@@ -205,11 +205,12 @@ public class Cassandra311Persistence
     }
 
     String hostId = System.getProperty("stargate.host_id");
-    if (hostId != null) {
+    if (hostId != null && !hostId.isEmpty()) {
       try {
         SystemKeyspace.setLocalHostId(UUID.fromString(hostId));
       } catch (IllegalArgumentException e) {
-        throw new IllegalArgumentException("Invalid host ID", e);
+        throw new IllegalArgumentException(
+            String.format("Invalid host ID '%s': not a valid UUID", hostId), e);
       }
     }
 

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Cassandra311Persistence.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Cassandra311Persistence.java
@@ -50,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -67,6 +68,7 @@ import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.cql3.statements.BatchStatement;
 import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.marshal.UserType;
 import org.apache.cassandra.exceptions.AuthenticationException;
 import org.apache.cassandra.gms.ApplicationState;
@@ -200,6 +202,11 @@ public class Cassandra311Persistence
       daemon.init(null);
     } catch (IOException e) {
       throw new RuntimeException("Unable to start Cassandra persistence layer", e);
+    }
+
+    String hostId = System.getProperty("stargate.host_id");
+    if (hostId != null) {
+      SystemKeyspace.setLocalHostId(UUID.fromString(hostId));
     }
 
     executor =

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Cassandra40Persistence.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Cassandra40Persistence.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -48,6 +49,7 @@ import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.cql3.statements.BatchStatement;
 import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.marshal.UserType;
 import org.apache.cassandra.exceptions.AuthenticationException;
 import org.apache.cassandra.gms.ApplicationState;
@@ -180,6 +182,11 @@ public class Cassandra40Persistence
       daemon.init(null);
     } catch (IOException e) {
       throw new RuntimeException("Unable to start Cassandra persistence layer", e);
+    }
+
+    String hostId = System.getProperty("stargate.host_id");
+    if (hostId != null) {
+      SystemKeyspace.setLocalHostId(UUID.fromString(hostId));
     }
 
     executor =

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Cassandra40Persistence.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Cassandra40Persistence.java
@@ -186,7 +186,11 @@ public class Cassandra40Persistence
 
     String hostId = System.getProperty("stargate.host_id");
     if (hostId != null) {
-      SystemKeyspace.setLocalHostId(UUID.fromString(hostId));
+      try {
+        SystemKeyspace.setLocalHostId(UUID.fromString(hostId));
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException("Invalid host ID", e);
+      }
     }
 
     executor =

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Cassandra40Persistence.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Cassandra40Persistence.java
@@ -185,11 +185,12 @@ public class Cassandra40Persistence
     }
 
     String hostId = System.getProperty("stargate.host_id");
-    if (hostId != null) {
+    if (hostId != null && !hostId.isEmpty()) {
       try {
         SystemKeyspace.setLocalHostId(UUID.fromString(hostId));
       } catch (IllegalArgumentException e) {
-        throw new IllegalArgumentException("Invalid host ID", e);
+        throw new IllegalArgumentException(
+            String.format("Invalid host ID '%s': not a valid UUID", hostId), e);
       }
     }
 

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -3,6 +3,7 @@ package io.stargate.db.dse.impl;
 import static io.stargate.db.dse.impl.Conversion.toPreparedMetadata;
 import static io.stargate.db.dse.impl.Conversion.toResultMetadata;
 
+import com.datastax.bdp.db.nodes.Nodes;
 import com.datastax.bdp.db.util.ProductType;
 import com.datastax.bdp.db.util.ProductVersion;
 import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
@@ -43,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -197,6 +199,12 @@ public class DsePersistence
     }
 
     DatabaseDescriptor.daemonInitialization(true, config);
+
+    String hostId = System.getProperty("stargate.host_id");
+    if (hostId != null) {
+      Nodes.local().update(l -> l.setHostId(UUID.fromString(hostId)), true);
+    }
+
     cassandraDaemon = new CassandraDaemon(true);
 
     // CassandraDaemon.activate() creates a thread that swallows exceptions that occur during

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -202,7 +202,11 @@ public class DsePersistence
 
     String hostId = System.getProperty("stargate.host_id");
     if (hostId != null) {
-      Nodes.local().update(l -> l.setHostId(UUID.fromString(hostId)), true);
+      try {
+        Nodes.local().update(l -> l.setHostId(UUID.fromString(hostId)), true);
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException("Invalid host ID", e);
+      }
     }
 
     cassandraDaemon = new CassandraDaemon(true);

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -201,11 +201,12 @@ public class DsePersistence
     DatabaseDescriptor.daemonInitialization(true, config);
 
     String hostId = System.getProperty("stargate.host_id");
-    if (hostId != null) {
+    if (hostId != null && !hostId.isEmpty()) {
       try {
         Nodes.local().update(l -> l.setHostId(UUID.fromString(hostId)), true);
       } catch (IllegalArgumentException e) {
-        throw new IllegalArgumentException("Invalid host ID", e);
+        throw new IllegalArgumentException(
+            String.format("Invalid host ID '%s': not a valid UUID", hostId), e);
       }
     }
 

--- a/starctl
+++ b/starctl
@@ -159,6 +159,10 @@ if [[ ${#STARGATE_ARGS[@]} -eq 0 ]]; then
     if [[ ! -z "$DISABLE_BUNDLES_WATCH" ]]; then
         STARGATE_ARGS+=("--disable-bundles-watch")
     fi
+
+    if [[ ! -z "$HOST_ID" ]]; then
+        STARGATE_ARGS+=("--host-id", "$HOST_ID")
+    fi
 fi
 
 declare -a CMD=(java -server)

--- a/stargate-starter/src/main/java/io/stargate/starter/Starter.java
+++ b/stargate-starter/src/main/java/io/stargate/starter/Starter.java
@@ -248,7 +248,7 @@ public class Starter {
   @Order(value = 22)
   @Option(
       name = {"--host-id"},
-      description = "The host ID to use for this node")
+      description = "The host ID to use for this node. Must be a valid UUID.")
   protected String hostId;
 
   @Order(value = 1000)
@@ -383,7 +383,7 @@ public class Starter {
     System.setProperty(
         "org.apache.cassandra.disable_mbean_registration",
         String.valueOf(disableMBeanRegistration));
-    if (hostId != null) {
+    if (hostId != null && !hostId.isEmpty()) {
       System.setProperty("stargate.host_id", hostId);
     }
 

--- a/stargate-starter/src/main/java/io/stargate/starter/Starter.java
+++ b/stargate-starter/src/main/java/io/stargate/starter/Starter.java
@@ -245,6 +245,12 @@ public class Starter {
       })
   protected boolean disableBundlesWatch = false;
 
+  @Order(value = 22)
+  @Option(
+      name = {"--host-id"},
+      description = "The host ID to use for this node")
+  protected String hostId;
+
   @Order(value = 1000)
   @Option(
       name = "--nodetool",
@@ -377,6 +383,9 @@ public class Starter {
     System.setProperty(
         "org.apache.cassandra.disable_mbean_registration",
         String.valueOf(disableMBeanRegistration));
+    if (hostId != null) {
+      System.setProperty("stargate.host_id", hostId);
+    }
 
     if (bindToListenAddressOnly) {
       // Restrict the listen address for Jersey endpoints

--- a/testing/src/main/java/io/stargate/it/cql/HostIdTest.java
+++ b/testing/src/main/java/io/stargate/it/cql/HostIdTest.java
@@ -1,0 +1,39 @@
+package io.stargate.it.cql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import io.stargate.it.BaseIntegrationTest;
+import io.stargate.it.driver.CqlSessionExtension;
+import io.stargate.it.storage.StargateParameters;
+import io.stargate.it.storage.StargateSpec;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@StargateSpec(nodes = 1, shared = false, parametersCustomizer = "buildParameters")
+@ExtendWith(CqlSessionExtension.class)
+public class HostIdTest extends BaseIntegrationTest {
+  private static final String hostId =
+      UUID.nameUUIDFromBytes("test123".getBytes(StandardCharsets.UTF_8)).toString();
+
+  @SuppressWarnings("unused") // referenced in @StargateSpec
+  public static void buildParameters(StargateParameters.Builder builder) {
+    builder.putSystemProperties("stargate.host_id", hostId);
+  }
+
+  @Test
+  @DisplayName(
+      "Should expose the host ID in system.local set using the property `stargate.host_id`")
+  public void queryHostId(CqlSession session) {
+    Row localRow =
+        session.execute(SimpleStatement.builder("SELECT host_id FROM system.local").build()).one();
+    assertThat(localRow).isNotNull();
+    UUID localHostId = localRow.getUuid("host_id");
+    assertThat(localHostId.toString()).isEqualTo(hostId);
+  }
+}


### PR DESCRIPTION
**What this PR does**:

This adds the ability to explicitly set the host ID used by a Stargate
node.

Property: `stargate.host_id`
Flag: `--host-id`
Env var: `HOST_ID`

**Which issue(s) this PR fixes**:

No issue.

**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
