### PR TITLE
Fix #1639: refactor Materialized View REST API ITs into separate test class

### DIFF
--- a/testing/src/main/java/io/stargate/it/BaseIntegrationTest.java
+++ b/testing/src/main/java/io/stargate/it/BaseIntegrationTest.java
@@ -55,6 +55,10 @@ public class BaseIntegrationTest {
         && Version.parse(backend.clusterVersion()).nextStable().compareTo(Version.V4_0_0) >= 0;
   }
 
+  public boolean backendSupportsSAI() {
+    return backend.supportsSAI();
+  }
+
   public static Instant now() {
     // Avoid using Instants with nanosecond precision as nanos may be lost on the server side
     return Instant.ofEpochMilli(System.currentTimeMillis());

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2MVTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2MVTest.java
@@ -1,0 +1,226 @@
+package io.stargate.it.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.stargate.auth.model.AuthTokenResponse;
+import io.stargate.it.BaseIntegrationTest;
+import io.stargate.it.driver.CqlSessionExtension;
+import io.stargate.it.driver.CqlSessionSpec;
+import io.stargate.it.http.models.Credentials;
+import io.stargate.it.storage.StargateConnectionInfo;
+import io.stargate.web.restapi.models.ColumnDefinition;
+import io.stargate.web.restapi.models.GetResponseWrapper;
+import io.stargate.web.restapi.models.PrimaryKey;
+import io.stargate.web.restapi.models.TableAdd;
+import io.stargate.web.restapi.models.TableResponse;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import net.jcip.annotations.NotThreadSafe;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Integration tests for REST API v2 that test Materialized View functionality. Separate from other
+ * tests to allow exclusion when testing backends that do not support MVs.
+ */
+@NotThreadSafe
+@ExtendWith(CqlSessionExtension.class)
+@CqlSessionSpec()
+public class RestApiv2MVTest extends BaseIntegrationTest {
+  private String keyspaceName;
+  private String tableName;
+  private static String authToken;
+  private String host;
+  private String restUrlBase;
+
+  static class ListOfMapsGetResponseWrapper extends GetResponseWrapper<List<Map<String, Object>>> {
+    public ListOfMapsGetResponseWrapper() {
+      super(-1, null, null);
+    }
+  }
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  @BeforeEach
+  void setup(TestInfo testInfo, StargateConnectionInfo cluster) throws IOException {
+    host = "http://" + cluster.seedAddress();
+    restUrlBase = host + ":8082";
+
+    String body =
+        RestUtils.post(
+            "",
+            String.format("%s:8081/v1/auth/token/generate", host),
+            objectMapper.writeValueAsString(new Credentials("cassandra", "cassandra")),
+            HttpStatus.SC_CREATED);
+
+    AuthTokenResponse authTokenResponse = objectMapper.readValue(body, AuthTokenResponse.class);
+    authToken = authTokenResponse.getAuthToken();
+    assertThat(authToken).isNotNull();
+
+    Optional<String> name = testInfo.getTestMethod().map(Method::getName);
+    assertThat(name).isPresent();
+    String testName = name.get();
+    keyspaceName = "ks_" + testName + "_" + System.currentTimeMillis();
+    tableName = "tbl_" + testName + "_" + System.currentTimeMillis();
+  }
+
+  /*
+  /************************************************************************
+  /* Test methods
+  /************************************************************************
+   */
+
+  @Test
+  public void getAllRowsFromMaterializedView(CqlSession session) throws IOException {
+    assumeThat(isCassandra4())
+        .as("Disabled because MVs are not enabled by default on a Cassandra 4 backend")
+        .isFalse();
+
+    createTestKeyspace(keyspaceName);
+    tableName = "tbl_mvread_" + System.currentTimeMillis();
+    createTestTable(
+        tableName,
+        Arrays.asList("id text", "firstName text", "lastName text"),
+        Collections.singletonList("id"),
+        null);
+
+    List<Map<String, String>> expRows =
+        insertTestTableRows(
+            Arrays.asList(
+                Arrays.asList("id 1", "firstName John", "lastName Doe"),
+                Arrays.asList("id 2", "firstName Sarah", "lastName Smith"),
+                Arrays.asList("id 3", "firstName Jane")));
+
+    String materializedViewName = "mv_test_" + System.currentTimeMillis();
+
+    ResultSet resultSet =
+        session.execute(
+            String.format(
+                "CREATE MATERIALIZED VIEW \"%s\".%s "
+                    + "AS SELECT id, \"firstName\", \"lastName\" "
+                    + "FROM \"%s\".%s "
+                    + "WHERE id IS NOT NULL "
+                    + "AND \"firstName\" IS NOT NULL "
+                    + "AND \"lastName\" IS NOT NULL "
+                    + "PRIMARY KEY (id, \"lastName\")",
+                keyspaceName, materializedViewName, keyspaceName, tableName));
+    assertThat(resultSet.wasApplied()).isTrue();
+
+    String body =
+        RestUtils.get(
+            authToken,
+            String.format(
+                "%s:8082/v2/keyspaces/%s/%s/rows", host, keyspaceName, materializedViewName),
+            HttpStatus.SC_OK);
+
+    ListOfMapsGetResponseWrapper getResponseWrapper =
+        objectMapper.readerFor(ListOfMapsGetResponseWrapper.class).readValue(body);
+    assertThat(getResponseWrapper.getCount()).isEqualTo(2);
+
+    // Alas, due to "id" as partition key, ordering is arbitrary; so need to
+    // convert from List to something like Set
+    List<Map<String, Object>> rows = getResponseWrapper.getData();
+
+    expRows.remove(2); // the MV should only return the rows with a lastName
+
+    assertThat(rows.size()).isEqualTo(2);
+    assertThat(new LinkedHashSet<>(rows)).isEqualTo(new LinkedHashSet<>(expRows));
+  }
+
+  /*
+  /************************************************************************
+  /* Helper methods for setting up tests
+  /************************************************************************
+   */
+
+  private void createTestKeyspace(String keyspaceName) {
+    String createKeyspaceRequest =
+        String.format("{\"name\": \"%s\", \"replicas\": 1}", keyspaceName);
+
+    try {
+      RestUtils.post(
+          authToken,
+          String.format("%s/v2/schemas/keyspaces", restUrlBase),
+          createKeyspaceRequest,
+          HttpStatus.SC_CREATED);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void createTestTable(
+      String tableName, List<String> columns, List<String> partitionKey, List<String> clusteringKey)
+      throws IOException {
+    TableAdd tableAdd = new TableAdd();
+    tableAdd.setName(tableName);
+
+    List<ColumnDefinition> columnDefinitions =
+        columns.stream()
+            .map(x -> x.split(" "))
+            .map(y -> new ColumnDefinition(y[0], y[1]))
+            .collect(Collectors.toList());
+    tableAdd.setColumnDefinitions(columnDefinitions);
+
+    PrimaryKey primaryKey = new PrimaryKey();
+    primaryKey.setPartitionKey(partitionKey);
+    if (clusteringKey != null) {
+      primaryKey.setClusteringKey(clusteringKey);
+    }
+    tableAdd.setPrimaryKey(primaryKey);
+
+    String body =
+        RestUtils.post(
+            authToken,
+            String.format("%s/v2/schemas/keyspaces/%s/tables", restUrlBase, keyspaceName),
+            objectMapper.writeValueAsString(tableAdd),
+            HttpStatus.SC_CREATED);
+
+    TableResponse tableResponse = objectMapper.readValue(body, TableResponse.class);
+    assertThat(tableResponse.getName()).isEqualTo(tableName);
+  }
+
+  /**
+   * Helper method for inserting table entries using so-called "Stringified" values for columns:
+   * this differs a bit from full JSON values and is mostly useful for simple String and number
+   * fields.
+   *
+   * @return {@code List} of entries to expect back for given definitions.
+   */
+  private List<Map<String, String>> insertTestTableRows(List<List<String>> rows)
+      throws IOException {
+    final List<Map<String, String>> insertedRows = new ArrayList<>();
+    for (List<String> row : rows) {
+      Map<String, String> rowMap = new HashMap<>();
+      for (String kv : row) {
+        // Split on first space, leave others in (with no limit we'd silently
+        // drop later space-separated parts)
+        String[] parts = kv.split(" ", 2);
+        rowMap.put(parts[0].trim(), parts[1].trim());
+      }
+      insertedRows.add(rowMap);
+
+      RestUtils.post(
+          authToken,
+          String.format("%s/v2/keyspaces/%s/%s", restUrlBase, keyspaceName, tableName),
+          objectMapper.writeValueAsString(rowMap),
+          HttpStatus.SC_CREATED);
+    }
+    return insertedRows;
+  }
+}

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2RowsTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2RowsTest.java
@@ -16,11 +16,8 @@
 package io.stargate.it.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.Assert.assertTrue;
 
-import com.datastax.oss.driver.api.core.CqlSession;
-import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JavaType;
@@ -702,63 +699,6 @@ public class RestApiv2RowsTest extends BaseIntegrationTest {
     List<Map<String, Object>> rows = getResponseWrapper.getData();
 
     assertThat(rows.size()).isEqualTo(4);
-    assertThat(new LinkedHashSet<>(rows)).isEqualTo(new LinkedHashSet<>(expRows));
-  }
-
-  @Test
-  public void getAllRowsFromMaterializedView(CqlSession session) throws IOException {
-    assumeThat(isCassandra4())
-        .as("Disabled because MVs are not enabled by default on a Cassandra 4 backend")
-        .isFalse();
-
-    createTestKeyspace(keyspaceName);
-    tableName = "tbl_mvread_" + System.currentTimeMillis();
-    createTestTable(
-        tableName,
-        Arrays.asList("id text", "firstName text", "lastName text"),
-        Collections.singletonList("id"),
-        null);
-
-    List<Map<String, String>> expRows =
-        insertTestTableRows(
-            Arrays.asList(
-                Arrays.asList("id 1", "firstName John", "lastName Doe"),
-                Arrays.asList("id 2", "firstName Sarah", "lastName Smith"),
-                Arrays.asList("id 3", "firstName Jane")));
-
-    String materializedViewName = "mv_test_" + System.currentTimeMillis();
-
-    ResultSet resultSet =
-        session.execute(
-            String.format(
-                "CREATE MATERIALIZED VIEW \"%s\".%s "
-                    + "AS SELECT id, \"firstName\", \"lastName\" "
-                    + "FROM \"%s\".%s "
-                    + "WHERE id IS NOT NULL "
-                    + "AND \"firstName\" IS NOT NULL "
-                    + "AND \"lastName\" IS NOT NULL "
-                    + "PRIMARY KEY (id, \"lastName\")",
-                keyspaceName, materializedViewName, keyspaceName, tableName));
-    assertThat(resultSet.wasApplied()).isTrue();
-
-    String body =
-        RestUtils.get(
-            authToken,
-            String.format(
-                "%s:8082/v2/keyspaces/%s/%s/rows", host, keyspaceName, materializedViewName),
-            HttpStatus.SC_OK);
-
-    ListOfMapsGetResponseWrapper getResponseWrapper =
-        LIST_OF_MAPS_GETRESPONSE_READER.readValue(body);
-    assertThat(getResponseWrapper.getCount()).isEqualTo(2);
-
-    // Alas, due to "id" as partition key, ordering is arbitrary; so need to
-    // convert from List to something like Set
-    List<Map<String, Object>> rows = getResponseWrapper.getData();
-
-    expRows.remove(2); // the MV should only return the rows with a lastName
-
-    assertThat(rows.size()).isEqualTo(2);
     assertThat(new LinkedHashSet<>(rows)).isEqualTo(new LinkedHashSet<>(expRows));
   }
 

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2SchemaTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2SchemaTest.java
@@ -1,7 +1,6 @@
 package io.stargate.it.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.Row;
@@ -22,7 +21,6 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1028,56 +1026,6 @@ public class RestApiv2SchemaTest extends BaseIntegrationTest {
             HttpStatus.SC_CREATED);
     successResponse = objectMapper.readValue(body, SuccessResponse.class);
     assertThat(successResponse.getSuccess()).isTrue();
-  }
-
-  @Test
-  public void indexCreateCustom(CqlSession session) throws IOException {
-    // TODO remove this when we figure out how to enable SAI indexes in Cassandra 4
-    assumeThat(isCassandra4())
-        .as(
-            "Disabled because it is currently not possible to enable SAI indexes "
-                + "on a Cassandra 4 backend")
-        .isFalse();
-
-    createTestKeyspace(keyspaceName);
-    tableName = "tbl_createtable_" + System.currentTimeMillis();
-    createTestTable(
-        tableName,
-        Arrays.asList("id text", "firstName text", "lastName text", "email list<text>"),
-        Collections.singletonList("id"),
-        null);
-
-    IndexAdd indexAdd = new IndexAdd();
-    String indexType = "org.apache.cassandra.index.sasi.SASIIndex";
-    indexAdd.setColumn("lastName");
-    indexAdd.setName("test_custom_idx");
-    indexAdd.setType(indexType);
-    indexAdd.setIfNotExists(false);
-    indexAdd.setKind(null);
-
-    Map<String, String> options = new HashMap<>();
-    options.put("mode", "CONTAINS");
-    indexAdd.setOptions(options);
-
-    String body =
-        RestUtils.post(
-            authToken,
-            String.format(
-                "%s/v2/schemas/keyspaces/%s/tables/%s/indexes",
-                restUrlBase, keyspaceName, tableName),
-            objectMapper.writeValueAsString(indexAdd),
-            HttpStatus.SC_CREATED);
-    SuccessResponse successResponse = objectMapper.readValue(body, SuccessResponse.class);
-    assertThat(successResponse.getSuccess()).isTrue();
-
-    Collection<Row> rows = session.execute("SELECT * FROM system_schema.indexes;").all();
-    Optional<Row> row =
-        rows.stream().filter(i -> "test_custom_idx".equals(i.getString("index_name"))).findFirst();
-    Map<String, String> optionsReturned = row.get().getMap("options", String.class, String.class);
-
-    assertThat(optionsReturned.get("class_name")).isEqualTo(indexType);
-    assertThat(optionsReturned.get("target")).isEqualTo("\"lastName\"");
-    assertThat(optionsReturned.get("mode")).isEqualTo("CONTAINS");
   }
 
   @Test

--- a/testing/src/main/java/io/stargate/it/http/restapi/RestApiTestBase.java
+++ b/testing/src/main/java/io/stargate/it/http/restapi/RestApiTestBase.java
@@ -8,18 +8,25 @@ import io.stargate.it.BaseIntegrationTest;
 import io.stargate.it.http.RestUtils;
 import io.stargate.it.http.models.Credentials;
 import io.stargate.it.storage.StargateConnectionInfo;
+import io.stargate.web.restapi.models.ColumnDefinition;
 import io.stargate.web.restapi.models.GetResponseWrapper;
+import io.stargate.web.restapi.models.PrimaryKey;
+import io.stargate.web.restapi.models.TableAdd;
+import io.stargate.web.restapi.models.TableResponse;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 
 /** Intermediate IT base class for use by REST API integration tests. */
-public class RestApiTestBase extends BaseIntegrationTest {
+abstract class RestApiTestBase extends BaseIntegrationTest {
   protected String keyspaceName;
   protected String tableName;
   protected static String authToken;
@@ -77,5 +84,65 @@ public class RestApiTestBase extends BaseIntegrationTest {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  protected void createTestTable(
+      String tableName, List<String> columns, List<String> partitionKey, List<String> clusteringKey)
+      throws IOException {
+    TableAdd tableAdd = new TableAdd();
+    tableAdd.setName(tableName);
+
+    List<ColumnDefinition> columnDefinitions =
+        columns.stream()
+            .map(x -> x.split(" "))
+            .map(y -> new ColumnDefinition(y[0], y[1]))
+            .collect(Collectors.toList());
+    tableAdd.setColumnDefinitions(columnDefinitions);
+
+    PrimaryKey primaryKey = new PrimaryKey();
+    primaryKey.setPartitionKey(partitionKey);
+    if (clusteringKey != null) {
+      primaryKey.setClusteringKey(clusteringKey);
+    }
+    tableAdd.setPrimaryKey(primaryKey);
+
+    String body =
+        RestUtils.post(
+            authToken,
+            String.format("%s/v2/schemas/keyspaces/%s/tables", restUrlBase, keyspaceName),
+            objectMapper.writeValueAsString(tableAdd),
+            HttpStatus.SC_CREATED);
+
+    TableResponse tableResponse = objectMapper.readValue(body, TableResponse.class);
+    assertThat(tableResponse.getName()).isEqualTo(tableName);
+  }
+
+  /**
+   * Helper method for inserting table entries using so-called "Stringified" values for columns:
+   * this differs a bit from full JSON values and is mostly useful for simple String and number
+   * fields.
+   *
+   * @return {@code List} of entries to expect back for given definitions.
+   */
+  protected List<Map<String, String>> insertTestTableRows(List<List<String>> rows)
+      throws IOException {
+    final List<Map<String, String>> insertedRows = new ArrayList<>();
+    for (List<String> row : rows) {
+      Map<String, String> rowMap = new HashMap<>();
+      for (String kv : row) {
+        // Split on first space, leave others in (with no limit we'd silently
+        // drop later space-separated parts)
+        String[] parts = kv.split(" ", 2);
+        rowMap.put(parts[0].trim(), parts[1].trim());
+      }
+      insertedRows.add(rowMap);
+
+      RestUtils.post(
+          authToken,
+          String.format("%s/v2/keyspaces/%s/%s", restUrlBase, keyspaceName, tableName),
+          objectMapper.writeValueAsString(rowMap),
+          HttpStatus.SC_CREATED);
+    }
+    return insertedRows;
   }
 }

--- a/testing/src/main/java/io/stargate/it/http/restapi/RestApiTestBase.java
+++ b/testing/src/main/java/io/stargate/it/http/restapi/RestApiTestBase.java
@@ -1,0 +1,81 @@
+package io.stargate.it.http.restapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.stargate.auth.model.AuthTokenResponse;
+import io.stargate.it.BaseIntegrationTest;
+import io.stargate.it.http.RestUtils;
+import io.stargate.it.http.models.Credentials;
+import io.stargate.it.storage.StargateConnectionInfo;
+import io.stargate.web.restapi.models.GetResponseWrapper;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+
+/** Intermediate IT base class for use by REST API integration tests. */
+public class RestApiTestBase extends BaseIntegrationTest {
+  protected String keyspaceName;
+  protected String tableName;
+  protected static String authToken;
+  private String host;
+  protected String restUrlBase;
+
+  protected static class ListOfMapsGetResponseWrapper
+      extends GetResponseWrapper<List<Map<String, Object>>> {
+    public ListOfMapsGetResponseWrapper() {
+      super(-1, null, null);
+    }
+  }
+
+  protected static final ObjectMapper objectMapper = new ObjectMapper();
+
+  @BeforeEach
+  void setup(TestInfo testInfo, StargateConnectionInfo cluster) throws IOException {
+    host = "http://" + cluster.seedAddress();
+    restUrlBase = host + ":8082";
+
+    String body =
+        RestUtils.post(
+            "",
+            String.format("%s:8081/v1/auth/token/generate", host),
+            objectMapper.writeValueAsString(new Credentials("cassandra", "cassandra")),
+            HttpStatus.SC_CREATED);
+
+    AuthTokenResponse authTokenResponse = objectMapper.readValue(body, AuthTokenResponse.class);
+    authToken = authTokenResponse.getAuthToken();
+    assertThat(authToken).isNotNull();
+
+    Optional<String> name = testInfo.getTestMethod().map(Method::getName);
+    assertThat(name).isPresent();
+    String testName = name.get();
+    keyspaceName = "ks_" + testName + "_" + System.currentTimeMillis();
+    tableName = "tbl_" + testName + "_" + System.currentTimeMillis();
+  }
+
+  /*
+  /************************************************************************
+  /* Shared helper methods for setting up tests
+  /************************************************************************
+   */
+
+  protected void createTestKeyspace(String keyspaceName) {
+    String createKeyspaceRequest =
+        String.format("{\"name\": \"%s\", \"replicas\": 1}", keyspaceName);
+
+    try {
+      RestUtils.post(
+          authToken,
+          String.format("%s/v2/schemas/keyspaces", restUrlBase),
+          createKeyspaceRequest,
+          HttpStatus.SC_CREATED);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/testing/src/main/java/io/stargate/it/http/restapi/RestApiv2SAITest.java
+++ b/testing/src/main/java/io/stargate/it/http/restapi/RestApiv2SAITest.java
@@ -34,11 +34,9 @@ public class RestApiv2SAITest extends RestApiTestBase {
   @Test
   public void indexCreateCustom(CqlSession session) throws IOException {
     // TODO remove this when we figure out how to enable SAI indexes in Cassandra 4
-    assumeThat(isCassandra4())
-        .as(
-            "Disabled because it is currently not possible to enable SAI indexes "
-                + "on a Cassandra 4 backend")
-        .isFalse();
+    assumeThat(backendSupportsSAI())
+        .as("Disabled because it is currently not possible to enable SAI indexes on this backend")
+        .isTrue();
 
     createTestKeyspace(keyspaceName);
     tableName = "tbl_createtable_" + System.currentTimeMillis();

--- a/testing/src/main/java/io/stargate/it/http/restapi/RestApiv2SAITest.java
+++ b/testing/src/main/java/io/stargate/it/http/restapi/RestApiv2SAITest.java
@@ -1,0 +1,83 @@
+package io.stargate.it.http.restapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.Row;
+import io.stargate.it.driver.CqlSessionExtension;
+import io.stargate.it.driver.CqlSessionSpec;
+import io.stargate.it.http.RestUtils;
+import io.stargate.web.restapi.models.IndexAdd;
+import io.stargate.web.restapi.models.SuccessResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import net.jcip.annotations.NotThreadSafe;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Integration tests for REST API v2 that test Storage-Attached Index (SAI) dependant functionality.
+ * Separate from other tests to allow exclusion when testing backends that test(s) would not work
+ * with.
+ */
+@NotThreadSafe
+@ExtendWith(CqlSessionExtension.class)
+@CqlSessionSpec()
+public class RestApiv2SAITest extends RestApiTestBase {
+  @Test
+  public void indexCreateCustom(CqlSession session) throws IOException {
+    // TODO remove this when we figure out how to enable SAI indexes in Cassandra 4
+    assumeThat(isCassandra4())
+        .as(
+            "Disabled because it is currently not possible to enable SAI indexes "
+                + "on a Cassandra 4 backend")
+        .isFalse();
+
+    createTestKeyspace(keyspaceName);
+    tableName = "tbl_createtable_" + System.currentTimeMillis();
+    createTestTable(
+        tableName,
+        Arrays.asList("id text", "firstName text", "lastName text", "email list<text>"),
+        Collections.singletonList("id"),
+        null);
+
+    IndexAdd indexAdd = new IndexAdd();
+    String indexType = "org.apache.cassandra.index.sasi.SASIIndex";
+    indexAdd.setColumn("lastName");
+    indexAdd.setName("test_custom_idx");
+    indexAdd.setType(indexType);
+    indexAdd.setIfNotExists(false);
+    indexAdd.setKind(null);
+
+    Map<String, String> options = new HashMap<>();
+    options.put("mode", "CONTAINS");
+    indexAdd.setOptions(options);
+
+    String body =
+        RestUtils.post(
+            authToken,
+            String.format(
+                "%s/v2/schemas/keyspaces/%s/tables/%s/indexes",
+                restUrlBase, keyspaceName, tableName),
+            objectMapper.writeValueAsString(indexAdd),
+            HttpStatus.SC_CREATED);
+    SuccessResponse successResponse = objectMapper.readValue(body, SuccessResponse.class);
+    assertThat(successResponse.getSuccess()).isTrue();
+
+    Collection<Row> rows = session.execute("SELECT * FROM system_schema.indexes;").all();
+    Optional<Row> row =
+        rows.stream().filter(i -> "test_custom_idx".equals(i.getString("index_name"))).findFirst();
+    Map<String, String> optionsReturned = row.get().getMap("options", String.class, String.class);
+
+    assertThat(optionsReturned.get("class_name")).isEqualTo(indexType);
+    assertThat(optionsReturned.get("target")).isEqualTo("\"lastName\"");
+    assertThat(optionsReturned.get("mode")).isEqualTo("CONTAINS");
+  }
+}


### PR DESCRIPTION
**What this PR does**:

Further refactors REST API v2 tests to move:

* Materialized View related tests into new class

The reason being that further testing by downstream projects has issues with a backend that does not (yet?) support Materialized Views, and test exclusion is easier with more granular division of tests methods into classes.

**Which issue(s) this PR fixes**:
Fixes #1639

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
