### PR TITLE
ability to add extra tags for each gRPC call

### DIFF
--- a/grpc/pom.xml
+++ b/grpc/pom.xml
@@ -130,7 +130,10 @@
                             !io.micrometer.core.instrument.binder.grpc,
                             io.micrometer.core.instrument
                         ]]></Import-Package>
-            <Export-Package>!*</Export-Package>
+            <Export-Package><![CDATA[
+                            io.grpc.*,
+                            io.stargate.grpc.metrics.*,
+                            ]]></Export-Package>
             <Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
           </instructions>

--- a/grpc/src/main/java/io/micrometer/core/instrument/binder/grpc/TaggingMetricCollectingServerInterceptor.java
+++ b/grpc/src/main/java/io/micrometer/core/instrument/binder/grpc/TaggingMetricCollectingServerInterceptor.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.micrometer.core.instrument.binder.grpc;
+
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.Status;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.stargate.grpc.metrics.api.GrpcMetricsTagProvider;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+/**
+ * Extension of the micrometer's {@link MetricCollectingServerInterceptor} that enables us to add
+ * extra tags on each {@link ServerCall}.
+ */
+public class TaggingMetricCollectingServerInterceptor extends MetricCollectingServerInterceptor {
+
+  /**
+   * The total number of requests received, same as
+   * MetricCollectingServerInterceptor#METRIC_NAME_SERVER_REQUESTS_RECEIVED.
+   */
+  private static final String METRIC_NAME_SERVER_REQUESTS_RECEIVED =
+      "grpc.server.requests.received";
+
+  /**
+   * The total number of responses sent, same as
+   * MetricCollectingServerInterceptor#METRIC_NAME_SERVER_RESPONSES_SENT.
+   */
+  private static final String METRIC_NAME_SERVER_RESPONSES_SENT = "grpc.server.responses.sent";
+
+  /**
+   * The total time taken for the server to complete the call, same as
+   * MetricCollectingServerInterceptor#METRIC_NAME_SERVER_PROCESSING_DURATION.
+   */
+  private static final String METRIC_NAME_SERVER_PROCESSING_DURATION =
+      "grpc.server.processing.duration";
+
+  /** Stargate {@link GrpcMetricsTagProvider} for extra tags on each call. */
+  private final GrpcMetricsTagProvider tagProvider;
+
+  public TaggingMetricCollectingServerInterceptor(
+      MeterRegistry registry, GrpcMetricsTagProvider tagProvider) {
+    super(registry);
+    this.tagProvider = tagProvider;
+  }
+
+  public TaggingMetricCollectingServerInterceptor(
+      MeterRegistry registry,
+      UnaryOperator<Counter.Builder> counterCustomizer,
+      UnaryOperator<Timer.Builder> timerCustomizer,
+      GrpcMetricsTagProvider tagProvider,
+      Status.Code... eagerInitializedCodes) {
+    super(registry, counterCustomizer, timerCustomizer, eagerInitializedCodes);
+    this.tagProvider = tagProvider;
+  }
+
+  @Override
+  public <Q, A> ServerCall.Listener<Q> interceptCall(
+      ServerCall<Q, A> call, Metadata requestHeaders, ServerCallHandler<Q, A> next) {
+    // only first line changed from the super impl
+    final MetricSet metrics = metricsFor(call);
+    final Consumer<Status.Code> responseStatusTiming =
+        metrics.newProcessingDurationTiming(this.registry);
+
+    final MetricCollectingServerCall<Q, A> monitoringCall =
+        new MetricCollectingServerCall<>(call, metrics.getResponseCounter());
+
+    return new MetricCollectingServerCallListener<>(
+        next.startCall(monitoringCall, requestHeaders),
+        metrics.getRequestCounter(),
+        monitoringCall::getResponseCode,
+        responseStatusTiming);
+  }
+
+  private MetricSet metricsFor(ServerCall<?, ?> call) {
+    MethodDescriptor<?, ?> method = call.getMethodDescriptor();
+    Tags callTags = tagProvider.getCallTags(call);
+
+    // check if there is any extension, if not return super
+    // otherwise use our implementation
+    if (Tags.empty().equals(callTags)) {
+      return super.metricsFor(method);
+    } else {
+      return new MetricSet(
+          newRequestCounterFor(method, callTags),
+          newResponseCounterFor(method, callTags),
+          newTimerFunction(method, callTags));
+    }
+  }
+
+  // copied from super, extending with Tags
+  private Counter newRequestCounterFor(final MethodDescriptor<?, ?> method, Tags tags) {
+    return this.counterCustomizer
+        .apply(
+            prepareCounterFor(
+                method,
+                METRIC_NAME_SERVER_REQUESTS_RECEIVED,
+                "The total number of requests received"))
+        .tags(tags)
+        .register(this.registry);
+  }
+
+  // copied from super, extending with Tags
+  private Counter newResponseCounterFor(final MethodDescriptor<?, ?> method, Tags tags) {
+    return this.counterCustomizer
+        .apply(
+            prepareCounterFor(
+                method, METRIC_NAME_SERVER_RESPONSES_SENT, "The total number of responses sent"))
+        .tags(tags)
+        .register(this.registry);
+  }
+
+  // copied from super, extending with Tags
+  private Function<Status.Code, Timer> newTimerFunction(
+      final MethodDescriptor<?, ?> method, Tags tags) {
+    return asTimerFunction(
+        () ->
+            this.timerCustomizer.apply(
+                prepareTimerFor(
+                        method,
+                        METRIC_NAME_SERVER_PROCESSING_DURATION,
+                        "The total time taken for the server to complete the call")
+                    .tags(tags)));
+  }
+}

--- a/grpc/src/main/java/io/stargate/grpc/metrics/api/GrpcMetricsTagProvider.java
+++ b/grpc/src/main/java/io/stargate/grpc/metrics/api/GrpcMetricsTagProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.grpc.metrics.api;
+
+import io.grpc.ServerCall;
+import io.micrometer.core.instrument.Tags;
+
+public interface GrpcMetricsTagProvider {
+
+  /**
+   * Returns tags for server side gRPC call.
+   *
+   * <p><b>IMPORTANT:</b> that the implementation must return constant amount of tags for any input.
+   * Prometheus does not allow different tags from the single process.
+   *
+   * @param call Server-side gRPC call
+   * @return Tags
+   */
+  Tags getCallTags(ServerCall<?, ?> call);
+}

--- a/grpc/src/main/java/io/stargate/grpc/metrics/api/NoopGrpcMetricsTagProvider.java
+++ b/grpc/src/main/java/io/stargate/grpc/metrics/api/NoopGrpcMetricsTagProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.grpc.metrics.api;
+
+import io.grpc.ServerCall;
+import io.micrometer.core.instrument.Tags;
+
+/** No-op implementation of the {@link GrpcMetricsTagProvider}, returns empty tags for any call. */
+public class NoopGrpcMetricsTagProvider implements GrpcMetricsTagProvider {
+
+  /** {@inheritDoc} */
+  @Override
+  public Tags getCallTags(ServerCall<?, ?> call) {
+    return Tags.empty();
+  }
+}

--- a/testing-services/pom.xml
+++ b/testing-services/pom.xml
@@ -28,6 +28,12 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>io.stargate.grpc</groupId>
+      <artifactId>grpc</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -51,7 +57,9 @@
               io.stargate.core.*,
               io.stargate.db,
               io.stargate.db.*,
+              io.stargate.grpc.metrics.*,
               io.micrometer.core.*,
+              io.grpc.*,
             ]]></Import-Package>
             <Export-Package>!*</Export-Package>
             <Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>

--- a/testing-services/src/main/java/io/stargate/testing/TestingServicesActivator.java
+++ b/testing-services/src/main/java/io/stargate/testing/TestingServicesActivator.java
@@ -19,7 +19,9 @@ import io.stargate.auth.AuthorizationProcessor;
 import io.stargate.core.activator.BaseActivator;
 import io.stargate.core.metrics.api.HttpMetricsTagProvider;
 import io.stargate.db.metrics.api.ClientInfoMetricsTagProvider;
+import io.stargate.grpc.metrics.api.GrpcMetricsTagProvider;
 import io.stargate.testing.auth.LoggingAuthorizationProcessorImpl;
+import io.stargate.testing.metrics.AuthorityGrpcMetricsTagProvider;
 import io.stargate.testing.metrics.FixedClientInfoTagProvider;
 import io.stargate.testing.metrics.TagMeHttpMetricsTagProvider;
 import java.util.ArrayList;
@@ -34,6 +36,9 @@ public class TestingServicesActivator extends BaseActivator {
 
   public static final String HTTP_TAG_PROVIDER_PROPERTY = "stargate.metrics.http_tag_provider.id";
   public static final String TAG_ME_HTTP_TAG_PROVIDER = "TagMeProvider";
+
+  public static final String GRPC_TAG_PROVIDER_PROPERTY = "stargate.metrics.grpc_tag_provider.id";
+  public static final String AUTHORITY_GRPC_TAG_PROVIDER = "AuthorityGrpcProvider";
 
   public static final String CLIENT_INFO_TAG_PROVIDER_PROPERTY =
       "stargate.metrics.client_info_tag_provider.id";
@@ -66,6 +71,12 @@ public class TestingServicesActivator extends BaseActivator {
       FixedClientInfoTagProvider tagProvider = new FixedClientInfoTagProvider();
 
       services.add(new ServiceAndProperties(tagProvider, ClientInfoMetricsTagProvider.class));
+    }
+
+    if (AUTHORITY_GRPC_TAG_PROVIDER.equals(System.getProperty(GRPC_TAG_PROVIDER_PROPERTY))) {
+      AuthorityGrpcMetricsTagProvider tagProvider = new AuthorityGrpcMetricsTagProvider();
+
+      services.add(new ServiceAndProperties(tagProvider, GrpcMetricsTagProvider.class));
     }
 
     return services;

--- a/testing-services/src/main/java/io/stargate/testing/metrics/AuthorityGrpcMetricsTagProvider.java
+++ b/testing-services/src/main/java/io/stargate/testing/metrics/AuthorityGrpcMetricsTagProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.testing.metrics;
+
+import io.grpc.ServerCall;
+import io.micrometer.core.instrument.Tags;
+import io.stargate.grpc.metrics.api.GrpcMetricsTagProvider;
+import java.util.Optional;
+
+/** Adds {@value AUTHORITY_KEY} as tag based on the gRPC call#getAuthority. */
+public class AuthorityGrpcMetricsTagProvider implements GrpcMetricsTagProvider {
+
+  public static final String AUTHORITY_KEY = "authority";
+
+  @Override
+  public Tags getCallTags(ServerCall<?, ?> call) {
+    return Optional.ofNullable(call.getAuthority())
+        .map(a -> Tags.of(AUTHORITY_KEY, a))
+        .orElseGet(() -> Tags.of(AUTHORITY_KEY, "UNKNOWN"));
+  }
+}

--- a/testing/src/main/java/io/stargate/it/grpc/MetricsGrpcIntTest.java
+++ b/testing/src/main/java/io/stargate/it/grpc/MetricsGrpcIntTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.it.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import io.stargate.it.driver.CqlSessionExtension;
+import io.stargate.it.driver.CqlSessionSpec;
+import io.stargate.it.driver.TestKeyspace;
+import io.stargate.it.http.RestUtils;
+import io.stargate.it.storage.StargateConnectionInfo;
+import io.stargate.it.storage.StargateParameters;
+import io.stargate.it.storage.StargateSpec;
+import io.stargate.proto.QueryOuterClass;
+import io.stargate.proto.StargateGrpc;
+import io.stargate.testing.TestingServicesActivator;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(CqlSessionExtension.class)
+@CqlSessionSpec(
+    initQueries = {
+      "CREATE TABLE IF NOT EXISTS test (k text, v int, PRIMARY KEY(k, v))",
+    })
+@StargateSpec(parametersCustomizer = "buildParameters")
+public class MetricsGrpcIntTest extends GrpcIntegrationTest {
+
+  private static String host;
+
+  public static void buildParameters(StargateParameters.Builder builder) {
+    builder.putSystemProperties(
+        TestingServicesActivator.GRPC_TAG_PROVIDER_PROPERTY,
+        TestingServicesActivator.AUTHORITY_GRPC_TAG_PROVIDER);
+  }
+
+  @BeforeAll
+  public static void setupHost(StargateConnectionInfo cluster) {
+    host = "http://" + cluster.seedAddress();
+  }
+
+  @Test
+  public void queryMetricsWithExtraTags(@TestKeyspace CqlIdentifier keyspace) {
+    // given
+    StargateGrpc.StargateBlockingStub stub = stubWithCallCredentials();
+
+    // when
+    QueryOuterClass.Response response =
+        stub.executeQuery(
+            cqlQuery("INSERT INTO test (k, v) VALUES ('a', 1)", queryParameters(keyspace)));
+
+    // then
+    assertThat(response).isNotNull();
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              String result =
+                  RestUtils.get("", String.format("%s:8084/metrics", host), HttpStatus.SC_OK);
+
+              // metered grpc request received lines
+              List<String> requestsReceived =
+                  Arrays.stream(result.split(System.getProperty("line.separator")))
+                      .filter(line -> line.startsWith("grpc_server_requests_received"))
+                      .collect(Collectors.toList());
+
+              assertThat(requestsReceived)
+                  .anySatisfy(
+                      metric ->
+                          assertThat(metric)
+                              .contains("authority=")
+                              .contains("method=\"ExecuteQuery\"")
+                              .contains("methodType=\"UNARY\"")
+                              .contains("service=\"stargate.Stargate\""));
+
+              // metered grpc responses sent lines
+              List<String> responsesSent =
+                  Arrays.stream(result.split(System.getProperty("line.separator")))
+                      .filter(line -> line.startsWith("grpc_server_responses_sent"))
+                      .collect(Collectors.toList());
+
+              assertThat(responsesSent)
+                  .anySatisfy(
+                      metric ->
+                          assertThat(metric)
+                              .contains("authority=")
+                              .contains("method=\"ExecuteQuery\"")
+                              .contains("methodType=\"UNARY\"")
+                              .contains("service=\"stargate.Stargate\""));
+
+              // metered grpc processing duration lines
+              List<String> processingDuration =
+                  Arrays.stream(result.split(System.getProperty("line.separator")))
+                      .filter(line -> line.startsWith("grpc_server_processing_duration"))
+                      .collect(Collectors.toList());
+
+              assertThat(processingDuration)
+                  .anySatisfy(
+                      metric ->
+                          assertThat(metric)
+                              .contains("authority=")
+                              .contains("statusCode=")
+                              .contains("method=\"ExecuteQuery\"")
+                              .contains("methodType=\"UNARY\"")
+                              .contains("service=\"stargate.Stargate\""));
+            });
+  }
+
+  @Test
+  public void batchMetricsWithExtraTags(@TestKeyspace CqlIdentifier keyspace) {
+    // given
+    StargateGrpc.StargateBlockingStub stub = stubWithCallCredentials();
+
+    // when
+    QueryOuterClass.Response response =
+        stub.executeBatch(
+            QueryOuterClass.Batch.newBuilder()
+                .addQueries(cqlBatchQuery("INSERT INTO test (k, v) VALUES ('a', 1)"))
+                .addQueries(cqlBatchQuery("INSERT INTO test (k, v) VALUES ('b', 2)"))
+                .setParameters(batchParameters(keyspace))
+                .build());
+
+    // then
+    assertThat(response).isNotNull();
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              String result =
+                  RestUtils.get("", String.format("%s:8084/metrics", host), HttpStatus.SC_OK);
+
+              // metered grpc request received lines
+              List<String> requestsReceived =
+                  Arrays.stream(result.split(System.getProperty("line.separator")))
+                      .filter(line -> line.startsWith("grpc_server_requests_received"))
+                      .collect(Collectors.toList());
+
+              assertThat(requestsReceived)
+                  .anySatisfy(
+                      metric ->
+                          assertThat(metric)
+                              .contains("authority=")
+                              .contains("method=\"ExecuteBatch\"")
+                              .contains("methodType=\"UNARY\"")
+                              .contains("service=\"stargate.Stargate\""));
+
+              // metered grpc responses sent lines
+              List<String> responsesSent =
+                  Arrays.stream(result.split(System.getProperty("line.separator")))
+                      .filter(line -> line.startsWith("grpc_server_responses_sent"))
+                      .collect(Collectors.toList());
+
+              assertThat(responsesSent)
+                  .anySatisfy(
+                      metric ->
+                          assertThat(metric)
+                              .contains("authority=")
+                              .contains("method=\"ExecuteBatch\"")
+                              .contains("methodType=\"UNARY\"")
+                              .contains("service=\"stargate.Stargate\""));
+
+              // metered grpc processing duration lines
+              List<String> processingDuration =
+                  Arrays.stream(result.split(System.getProperty("line.separator")))
+                      .filter(line -> line.startsWith("grpc_server_processing_duration"))
+                      .collect(Collectors.toList());
+
+              assertThat(processingDuration)
+                  .anySatisfy(
+                      metric ->
+                          assertThat(metric)
+                              .contains("authority=")
+                              .contains("statusCode=")
+                              .contains("method=\"ExecuteBatch\"")
+                              .contains("methodType=\"UNARY\"")
+                              .contains("service=\"stargate.Stargate\""));
+            });
+  }
+}


### PR DESCRIPTION
**What this PR does**:
Adds possibility to add extra tags for each gRPC server-side call. This extends the original Micrometer implementation, as that is not supported yet there.

There's nothing too interesting here, only new interceptor, OSGi gymnastics to make everything work and integration test to confirm everything. I am not sure if unit tests for the `TaggingMetricCollectingServerInterceptor` is needed here?

**Which issue(s) this PR fixes**:
Internal issue.

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated

