### PR TITLE
Trivial fix to avoid duplicate "Order" values; make sure name/desc separate

### DIFF
--- a/stargate-starter/src/main/java/io/stargate/starter/Starter.java
+++ b/stargate-starter/src/main/java/io/stargate/starter/Starter.java
@@ -226,28 +226,25 @@ public class Starter {
 
   @Order(value = 20)
   @Option(
-      name = {
-        "--disable-dynamic-snitch",
-        "Whether the dynamic snitch should wrap the actual snitch."
-      })
+      name = "--disable-dynamic-snitch",
+      description = "Whether the dynamic snitch should wrap the actual snitch.")
   protected boolean disableDynamicSnitch = false;
 
   @Order(value = 21)
   @Option(
-      name = {"--disable-mbean-registration", "Whether the mbean registration should be disabled"})
+      name = "--disable-mbean-registration",
+      description = "Whether the mbean registration should be disabled")
   protected boolean disableMBeanRegistration = false;
-
-  @Order(value = 21)
-  @Option(
-      name = {
-        "--disable-bundles-watch",
-        "Whether watching the bundle directory for new jars to load should be disabled"
-      })
-  protected boolean disableBundlesWatch = false;
 
   @Order(value = 22)
   @Option(
-      name = {"--host-id"},
+      name = "--disable-bundles-watch",
+      description = "Whether watching the bundle directory for new jars to load should be disabled")
+  protected boolean disableBundlesWatch = false;
+
+  @Order(value = 23)
+  @Option(
+      name = "--host-id",
       description = "The host ID to use for this node. Must be a valid UUID.")
   protected String hostId;
 


### PR DESCRIPTION
**What this PR does**:

Fixes duplicate `Order` for options in `Starter`; makes sure `name` and `description` are separate.

**Which issue(s) this PR fixes**:
No PR filed

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
