### PR TITLE
updating stargate-jars.zip to match expected structure

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -69,7 +69,7 @@ jobs:
           mvn -P dse -q -ff clean package -DskipTests
       - name: zip-up
         run: |
-          zip stargate-jars.zip starctl stargate-lib/logback.xml stargate-lib/*.jar
+          zip -r stargate-jars.zip starctl* start_all_local.sh stargate-lib
       - name: Retrieve stashed release URL
         uses: actions/download-artifact@v1
         with:


### PR DESCRIPTION
While testing ALPHA-3 release, I discovered that the `stargate-jars.zip` file did not have the intended structure. Specifically the new REST API service jar was omitted, should be `stargate-lib/rest/sgv2-rest-service-2.0.0-ALPHA-3.jar`

I fixed the zip in the release manually and this PR is to update the workflow to build the zip correctly next time.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
