### PR TITLE
grcp metric interceptor to be before the connection one

### DIFF
--- a/grpc/src/main/java/io/stargate/grpc/impl/GrpcImpl.java
+++ b/grpc/src/main/java/io/stargate/grpc/impl/GrpcImpl.java
@@ -73,10 +73,10 @@ public class GrpcImpl {
             // `Persistence` operations are done asynchronously so there isn't a need for a separate
             // thread pool for handling gRPC callbacks in `GrpcService`.
             .directExecutor()
-            .intercept(new NewConnectionInterceptor(persistence, authenticationService))
             .intercept(
                 new TaggingMetricCollectingServerInterceptor(
                     metrics.getMeterRegistry(), grpcMetricsTagProvider))
+            .intercept(new NewConnectionInterceptor(persistence, authenticationService))
             .addService(new GrpcService(persistence, executor))
             .build();
   }


### PR DESCRIPTION
**What this PR does**:
Makes the gRPC metrics interceptor before the connection interceptor.. This should enable us to correctly catch the unauthorized calls in the metrics..

**Which issue(s) this PR fixes**:
Internal.

@mpenick can you ack this is OK?