### PR TITLE
Specialize v2 QueryBuilder to generate gRPC Query

### DIFF
--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/ResourceBase.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/ResourceBase.java
@@ -36,6 +36,8 @@ public abstract class ResourceBase {
 
   protected static final BridgeProtoValueConverters PROTO_CONVERTERS =
       BridgeProtoValueConverters.instance();
+  protected static final QueryOuterClass.QueryParameters PARAMETERS_FOR_LOCAL_QUORUM =
+      parametersBuilderForLocalQuorum().build();
 
   // // // Helper methods for Schema access
 
@@ -70,30 +72,28 @@ public abstract class ResourceBase {
 
   // // // Helper methods for Bridge/gRPC query construction
 
-  protected static QueryOuterClass.QueryParameters parametersForLocalQuorum() {
-    return parametersBuilderForLocalQuorum().build();
-  }
-
-  protected static QueryOuterClass.QueryParameters.Builder parametersBuilderForLocalQuorum() {
+  private static QueryOuterClass.QueryParameters.Builder parametersBuilderForLocalQuorum() {
     return QueryOuterClass.QueryParameters.newBuilder()
         .setConsistency(
             QueryOuterClass.ConsistencyValue.newBuilder()
-                .setValue(QueryOuterClass.Consistency.LOCAL_QUORUM));
+                .setValue(QueryOuterClass.Consistency.LOCAL_QUORUM))
+        .setPageSize(Int32Value.of(DEFAULT_PAGE_SIZE));
   }
 
-  protected QueryOuterClass.QueryParameters.Builder parameters(
+  protected QueryOuterClass.QueryParameters parametersForPageSizeAndState(
       int pageSizeParam, String pageStateParam) {
+    if (isStringEmpty(pageStateParam) && pageSizeParam <= 0) {
+      return PARAMETERS_FOR_LOCAL_QUORUM;
+    }
     QueryOuterClass.QueryParameters.Builder paramsB = parametersBuilderForLocalQuorum();
     if (!isStringEmpty(pageStateParam)) {
       paramsB =
           paramsB.setPagingState(BytesValue.of(ByteString.copyFrom(decodeBase64(pageStateParam))));
     }
-    int pageSize = DEFAULT_PAGE_SIZE;
     if (pageSizeParam > 0) {
-      pageSize = pageSizeParam;
+      paramsB = paramsB.setPageSize(Int32Value.of(pageSizeParam));
     }
-    paramsB = paramsB.setPageSize(Int32Value.of(pageSize));
-    return paramsB;
+    return paramsB.build();
   }
 
   // // // Helper methods for Bridge/gRPC type manipulation

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/Sgv2RowsResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/Sgv2RowsResourceImpl.java
@@ -141,7 +141,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
         (tableDef) -> {
           final ToProtoConverter toProtoConverter = findProtoConverter(tableDef);
           final QueryOuterClass.Query query =
-              buildGetRowsByPKCQL(
+              buildGetRowsByPKQuery(
                   keyspaceName,
                   tableName,
                   path,
@@ -222,7 +222,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
 
           final QueryOuterClass.Query query;
           try {
-            query = buildAddRowCQL(keyspaceName, tableName, payloadMap, toProtoConverter);
+            query = buildAddRowQuery(keyspaceName, tableName, payloadMap, toProtoConverter);
           } catch (IllegalArgumentException e) {
             throw new WebApplicationException(e.getMessage(), Status.BAD_REQUEST);
           }
@@ -261,7 +261,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
           final ToProtoConverter toProtoConverter = findProtoConverter(tableDef);
 
           final QueryOuterClass.Query query =
-              buildDeleteRowsByPKCQL(keyspaceName, tableName, path, tableDef, toProtoConverter);
+              buildDeleteRowsByPKCQuery(keyspaceName, tableName, path, tableDef, toProtoConverter);
 
           /*QueryOuterClass.Response grpcResponse =*/
           bridge.executeQuery(query);
@@ -308,7 +308,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
           final QueryOuterClass.Query query;
           try {
             query =
-                buildUpdateRowCQL(
+                buildUpdateRowQuery(
                     keyspaceName, tableName, path, tableDef, payloadMap, toProtoConverter);
           } catch (IllegalArgumentException e) {
             throw new WebApplicationException(e.getMessage(), Status.BAD_REQUEST);
@@ -327,7 +327,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
   /////////////////////////////////////////////////////////////////////////
    */
 
-  protected QueryOuterClass.Query buildGetRowsByPKCQL(
+  protected QueryOuterClass.Query buildGetRowsByPKQuery(
       String keyspaceName,
       String tableName,
       List<PathSegment> pkValues,
@@ -369,7 +369,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
         .build();
   }
 
-  private QueryOuterClass.Query buildDeleteRowsByPKCQL(
+  private QueryOuterClass.Query buildDeleteRowsByPKCQuery(
       String keyspaceName,
       String tableName,
       List<PathSegment> pkValues,
@@ -418,7 +418,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
     return primaryKeys;
   }
 
-  protected QueryOuterClass.Query buildAddRowCQL(
+  protected QueryOuterClass.Query buildAddRowQuery(
       String keyspaceName,
       String tableName,
       Map<String, Object> payloadMap,
@@ -437,7 +437,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
         .build();
   }
 
-  protected QueryOuterClass.Query buildUpdateRowCQL(
+  protected QueryOuterClass.Query buildUpdateRowQuery(
       String keyspaceName,
       String tableName,
       List<PathSegment> pkValues,

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/Sgv2RowsResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/Sgv2RowsResourceImpl.java
@@ -95,7 +95,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
                     .from(keyspaceName, tableName)
                     .where(whereConditions)
                     .orderBy(sortOrder)
-                    .parameters(parameters(pageSizeParam, pageStateParam).build())
+                    .parameters(parametersForPageSizeAndState(pageSizeParam, pageStateParam))
                     .build();
           } else {
             query =
@@ -105,7 +105,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
                     .from(keyspaceName, tableName)
                     .where(whereConditions)
                     .orderBy(sortOrder)
-                    .parameters(parameters(pageSizeParam, pageStateParam).build())
+                    .parameters(parametersForPageSizeAndState(pageSizeParam, pageStateParam))
                     .build();
           }
           return fetchRows(bridge, query, raw);
@@ -182,7 +182,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
               .star()
               .from(keyspaceName, tableName)
               .orderBy(sortOrder)
-              .parameters(parameters(pageSizeParam, pageStateParam).build())
+              .parameters(parametersForPageSizeAndState(pageSizeParam, pageStateParam))
               .build();
     } else {
       query =
@@ -191,7 +191,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
               .column(columns)
               .from(keyspaceName, tableName)
               .orderBy(sortOrder)
-              .parameters(parameters(pageSizeParam, pageStateParam).build())
+              .parameters(parametersForPageSizeAndState(pageSizeParam, pageStateParam))
               .build();
     }
     return fetchRows(bridge, query, raw);
@@ -356,7 +356,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
           .from(keyspaceName, tableName)
           .where(whereConditions)
           .orderBy(sortOrder)
-          .parameters(parameters(pageSizeParam, pageStateParam).build())
+          .parameters(parametersForPageSizeAndState(pageSizeParam, pageStateParam))
           .build();
     }
     return new QueryBuilder()
@@ -365,7 +365,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
         .from(keyspaceName, tableName)
         .where(whereConditions)
         .orderBy(sortOrder)
-        .parameters(parameters(pageSizeParam, pageStateParam).build())
+        .parameters(parametersForPageSizeAndState(pageSizeParam, pageStateParam))
         .build();
   }
 
@@ -392,7 +392,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
         .delete()
         .from(keyspaceName, tableName)
         .where(whereConditions)
-        .parameters(parametersForLocalQuorum())
+        .parameters(PARAMETERS_FOR_LOCAL_QUORUM)
         .build();
   }
 
@@ -433,7 +433,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
     return new QueryBuilder()
         .insertInto(keyspaceName, tableName)
         .value(valueModifiers)
-        .parameters(parametersForLocalQuorum())
+        .parameters(PARAMETERS_FOR_LOCAL_QUORUM)
         .build();
   }
 
@@ -482,7 +482,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
         .update(keyspaceName, tableName)
         .value(valueModifiers)
         .where(whereConditions)
-        .parameters(parametersForLocalQuorum())
+        .parameters(PARAMETERS_FOR_LOCAL_QUORUM)
         .build();
   }
 

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/Sgv2RowsResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/Sgv2RowsResourceImpl.java
@@ -7,7 +7,7 @@ import io.stargate.sgv2.common.cql.builder.BuiltCondition;
 import io.stargate.sgv2.common.cql.builder.Column;
 import io.stargate.sgv2.common.cql.builder.Predicate;
 import io.stargate.sgv2.common.cql.builder.QueryBuilder;
-import io.stargate.sgv2.common.cql.builder.Value;
+import io.stargate.sgv2.common.cql.builder.Term;
 import io.stargate.sgv2.common.cql.builder.ValueModifier;
 import io.stargate.sgv2.common.grpc.StargateBridgeClient;
 import io.stargate.sgv2.common.http.CreateStargateBridgeClient;
@@ -480,7 +480,7 @@ public class Sgv2RowsResourceImpl extends ResourceBase implements Sgv2RowsResour
               ? ValueModifier.of(
                   ValueModifier.Target.column(columnName),
                   ValueModifier.Operation.INCREMENT,
-                  Value.marker())
+                  Term.marker())
               : ValueModifier.marker(columnName);
       valueModifiers.add(mod);
       valuesBuilder.addValues(

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/WhereParser.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/WhereParser.java
@@ -10,7 +10,7 @@ import io.stargate.proto.QueryOuterClass;
 import io.stargate.proto.Schema;
 import io.stargate.sgv2.common.cql.builder.BuiltCondition;
 import io.stargate.sgv2.common.cql.builder.Predicate;
-import io.stargate.sgv2.common.cql.builder.Value;
+import io.stargate.sgv2.common.cql.builder.Term;
 import io.stargate.sgv2.restsvc.grpc.ToProtoConverter;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -221,7 +221,7 @@ public class WhereParser {
         BuiltCondition.of(
             BuiltCondition.LHS.mapAccess(fieldName, rawKey),
             FilterOp.$CONTAINSENTRY.predicate,
-            Value.marker()));
+            Term.marker()));
     valuesBuilder.addValues(opContentValue);
   }
 

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/WhereParser.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/WhereParser.java
@@ -40,8 +40,7 @@ public class WhereParser {
     this.converter = converter;
   }
 
-  public List<BuiltCondition> parseWhere(
-      String whereParam, QueryOuterClass.Values.Builder valuesBuilder) {
+  public List<BuiltCondition> parseWhere(String whereParam) {
     JsonNode jsonTree;
     try {
       jsonTree = MAPPER.readTree(whereParam);
@@ -78,22 +77,22 @@ public class WhereParser {
 
         switch (operation) {
           case $IN:
-            addInOperation(conditions, fieldName, valueNode, valuesBuilder);
+            addInOperation(conditions, fieldName, valueNode);
             break;
           case $EXISTS:
-            addExistsOperation(conditions, fieldName, valueNode, valuesBuilder);
+            addExistsOperation(conditions, fieldName, valueNode);
             break;
           case $CONTAINS:
-            addContainsOperation(conditions, fieldName, valueNode, valuesBuilder);
+            addContainsOperation(conditions, fieldName, valueNode);
             break;
           case $CONTAINSKEY:
-            addContainsKeyOperation(conditions, fieldName, valueNode, valuesBuilder);
+            addContainsKeyOperation(conditions, fieldName, valueNode);
             break;
           case $CONTAINSENTRY:
-            addContainsEntryOperation(conditions, fieldName, valueNode, valuesBuilder);
+            addContainsEntryOperation(conditions, fieldName, valueNode);
             break;
           default: // GT, GTE, LT, LTE, EQ, NE
-            addSimpleOperation(conditions, fieldName, operation, valueNode, valuesBuilder);
+            addSimpleOperation(conditions, fieldName, operation, valueNode);
         }
       }
     }
@@ -106,46 +105,31 @@ public class WhereParser {
   }
 
   private void addSimpleOperation(
-      List<BuiltCondition> conditions,
-      String fieldName,
-      FilterOp filterOp,
-      JsonNode valueNode,
-      QueryOuterClass.Values.Builder valuesBuilder) {
+      List<BuiltCondition> conditions, String fieldName, FilterOp filterOp, JsonNode valueNode) {
     if (valueNode.isTextual()) {
-      addSingleSimpleOperation(
-          conditions, fieldName, filterOp, valueNode.textValue(), valuesBuilder);
+      addSingleSimpleOperation(conditions, fieldName, filterOp, valueNode.textValue());
     } else if (valueNode.isArray()) {
       for (JsonNode element : valueNode) {
-        addSingleSimpleOperation(
-            conditions, fieldName, filterOp, nodeToRawObject(element), valuesBuilder);
+        addSingleSimpleOperation(conditions, fieldName, filterOp, nodeToRawObject(element));
       }
     } else {
-      addSingleSimpleOperation(
-          conditions, fieldName, filterOp, nodeToRawObject(valueNode), valuesBuilder);
+      addSingleSimpleOperation(conditions, fieldName, filterOp, nodeToRawObject(valueNode));
     }
   }
 
   private void addSingleSimpleOperation(
-      List<BuiltCondition> conditions,
-      String fieldName,
-      FilterOp filterOp,
-      Object rawValue,
-      QueryOuterClass.Values.Builder valuesBuilder) {
+      List<BuiltCondition> conditions, String fieldName, FilterOp filterOp, Object rawValue) {
     final QueryOuterClass.Value opValue;
     if (rawValue instanceof String) {
       opValue = converter.protoValueFromStringified(fieldName, (String) rawValue);
     } else {
       opValue = converter.protoValueFromStrictlyTyped(fieldName, rawValue);
     }
-    conditions.add(BuiltCondition.ofMarker(fieldName, filterOp.predicate));
-    valuesBuilder.addValues(opValue);
+    conditions.add(BuiltCondition.of(fieldName, filterOp.predicate, opValue));
   }
 
   private void addContainsOperation(
-      List<BuiltCondition> conditions,
-      String fieldName,
-      JsonNode valueNode,
-      QueryOuterClass.Values.Builder valuesBuilder) {
+      List<BuiltCondition> conditions, String fieldName, JsonNode valueNode) {
     // First convert from JsonNode into "natural" Java Object (scalar, List, Map etc)
     final Object rawValue = nodeToRawObject(valueNode);
     // And then try to decode into "Content" value of Container type
@@ -159,15 +143,11 @@ public class WhereParser {
               "Field '%s' not of container type (list, map, set); has to be for operation %s",
               fieldName, FilterOp.$CONTAINS.rawValue));
     }
-    conditions.add(BuiltCondition.ofMarker(fieldName, FilterOp.$CONTAINS.predicate));
-    valuesBuilder.addValues(opValue);
+    conditions.add(BuiltCondition.of(fieldName, FilterOp.$CONTAINS.predicate, opValue));
   }
 
   private void addContainsKeyOperation(
-      List<BuiltCondition> conditions,
-      String fieldName,
-      JsonNode valueNode,
-      QueryOuterClass.Values.Builder valuesBuilder) {
+      List<BuiltCondition> conditions, String fieldName, JsonNode valueNode) {
     // First convert from JsonNode into "natural" Java Object (scalar, List, Map etc)
     final Object rawValue = nodeToRawObject(valueNode);
     // And then try to decode into "Key" value of Map type
@@ -181,15 +161,11 @@ public class WhereParser {
               "Field '%s' not of map type; has to be for operation %s",
               fieldName, FilterOp.$CONTAINSKEY.rawValue));
     }
-    conditions.add(BuiltCondition.ofMarker(fieldName, FilterOp.$CONTAINSKEY.predicate));
-    valuesBuilder.addValues(opValue);
+    conditions.add(BuiltCondition.of(fieldName, FilterOp.$CONTAINSKEY.predicate, opValue));
   }
 
   private void addContainsEntryOperation(
-      List<BuiltCondition> conditions,
-      String fieldName,
-      JsonNode entryNode,
-      QueryOuterClass.Values.Builder valuesBuilder) {
+      List<BuiltCondition> conditions, String fieldName, JsonNode entryNode) {
     // First: we need a JSON Object with "key" and "value"
     JsonNode keyNode = entryNode.get("key");
     JsonNode valueNode = entryNode.get("value");
@@ -221,15 +197,11 @@ public class WhereParser {
         BuiltCondition.of(
             BuiltCondition.LHS.mapAccess(fieldName, rawKey),
             FilterOp.$CONTAINSENTRY.predicate,
-            Term.marker()));
-    valuesBuilder.addValues(opContentValue);
+            Term.of(opContentValue)));
   }
 
   private void addInOperation(
-      List<BuiltCondition> conditions,
-      String fieldName,
-      JsonNode valueNode,
-      QueryOuterClass.Values.Builder valuesBuilder) {
+      List<BuiltCondition> conditions, String fieldName, JsonNode valueNode) {
     if (!valueNode.isArray() || valueNode.isEmpty()) {
       throw new IllegalArgumentException(
           String.format(
@@ -241,15 +213,11 @@ public class WhereParser {
       final Object rawElement = nodeToRawObject(element);
       inValues.add(converter.protoValueFromStrictlyTyped(fieldName, rawElement));
     }
-    conditions.add(BuiltCondition.ofMarker(fieldName, Predicate.IN));
-    valuesBuilder.addValues(Values.of(inValues));
+    conditions.add(BuiltCondition.of(fieldName, Predicate.IN, Values.of(inValues)));
   }
 
   private void addExistsOperation(
-      List<BuiltCondition> conditions,
-      String fieldName,
-      JsonNode valueNode,
-      QueryOuterClass.Values.Builder valuesBuilder) {
+      List<BuiltCondition> conditions, String fieldName, JsonNode valueNode) {
     if (!valueNode.isBoolean() || !valueNode.booleanValue()) {
       throw new IllegalArgumentException(
           String.format("`%s` only supports the value `true`.", FilterOp.$EXISTS.rawValue));
@@ -259,7 +227,7 @@ public class WhereParser {
     // 05-Jan-2022, tatu: As per [https://github.com/stargate/stargate/discussions/1519]
     //   behavior with REST API (vs Documents API) is problematic. We implement it the same way
     //   for StargateV2 as for V1, for compatibility reasons.
-    addSingleSimpleOperation(conditions, fieldName, FilterOp.$EXISTS, Boolean.TRUE, valuesBuilder);
+    addSingleSimpleOperation(conditions, fieldName, FilterOp.$EXISTS, Boolean.TRUE);
   }
 
   private Object nodeToRawObject(JsonNode valueNode) {

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2ColumnsResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2ColumnsResourceImpl.java
@@ -76,7 +76,7 @@ public class Sgv2ColumnsResourceImpl extends ResourceBase implements Sgv2Columns
                   .alter()
                   .table(keyspaceName, tableName)
                   .addColumn(columnDef)
-                  .parameters(parametersForLocalQuorum())
+                  .parameters(PARAMETERS_FOR_LOCAL_QUORUM)
                   .build();
           bridge.executeQuery(query);
 
@@ -147,7 +147,7 @@ public class Sgv2ColumnsResourceImpl extends ResourceBase implements Sgv2Columns
                     .alter()
                     .table(keyspaceName, tableName)
                     .renameColumn(columnName, newName)
-                    .parameters(parametersForLocalQuorum())
+                    .parameters(PARAMETERS_FOR_LOCAL_QUORUM)
                     .build();
             bridge.executeQuery(query);
           }
@@ -184,7 +184,7 @@ public class Sgv2ColumnsResourceImpl extends ResourceBase implements Sgv2Columns
                   .alter()
                   .table(keyspaceName, tableName)
                   .dropColumn(columnName)
-                  .parameters(parametersForLocalQuorum())
+                  .parameters(PARAMETERS_FOR_LOCAL_QUORUM)
                   .build();
           bridge.executeQuery(query);
           return Response.status(Response.Status.NO_CONTENT).build();

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2ColumnsResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2ColumnsResourceImpl.java
@@ -71,17 +71,14 @@ public class Sgv2ColumnsResourceImpl extends ResourceBase implements Sgv2Columns
                   .kind(kind)
                   .type(columnDefinition.getTypeDefinition())
                   .build();
-          String cql =
+          QueryOuterClass.Query query =
               new QueryBuilder()
                   .alter()
                   .table(keyspaceName, tableName)
                   .addColumn(columnDef)
+                  .parameters(parametersForLocalQuorum())
                   .build();
-          bridge.executeQuery(
-              QueryOuterClass.Query.newBuilder()
-                  .setParameters(parametersForLocalQuorum())
-                  .setCql(cql)
-                  .build());
+          bridge.executeQuery(query);
 
           return Response.status(Response.Status.CREATED)
               .entity(Collections.singletonMap("name", columnName))
@@ -145,17 +142,14 @@ public class Sgv2ColumnsResourceImpl extends ResourceBase implements Sgv2Columns
           }
           // Avoid call if there is no need to rename
           if (!columnName.equals(newName)) {
-            String cql =
+            QueryOuterClass.Query query =
                 new QueryBuilder()
                     .alter()
                     .table(keyspaceName, tableName)
                     .renameColumn(columnName, newName)
+                    .parameters(parametersForLocalQuorum())
                     .build();
-            bridge.executeQuery(
-                QueryOuterClass.Query.newBuilder()
-                    .setParameters(parametersForLocalQuorum())
-                    .setCql(cql)
-                    .build());
+            bridge.executeQuery(query);
           }
           return Response.status(Response.Status.OK)
               .entity(Collections.singletonMap("name", newName))
@@ -185,17 +179,14 @@ public class Sgv2ColumnsResourceImpl extends ResourceBase implements Sgv2Columns
                 String.format("column '%s' not found in table '%s'", columnName, tableName),
                 Response.Status.BAD_REQUEST);
           }
-          String cql =
+          QueryOuterClass.Query query =
               new QueryBuilder()
                   .alter()
                   .table(keyspaceName, tableName)
                   .dropColumn(columnName)
+                  .parameters(parametersForLocalQuorum())
                   .build();
-          bridge.executeQuery(
-              QueryOuterClass.Query.newBuilder()
-                  .setParameters(parametersForLocalQuorum())
-                  .setCql(cql)
-                  .build());
+          bridge.executeQuery(query);
           return Response.status(Response.Status.NO_CONTENT).build();
         });
   }

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2IndexesResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2IndexesResourceImpl.java
@@ -56,14 +56,15 @@ public class Sgv2IndexesResourceImpl extends ResourceBase implements Sgv2Indexes
     // check that we're authorized for the table
     bridge.getTable(keyspaceName, tableName);
 
-    String cql =
+    Query query =
         new QueryBuilder()
             .select()
             .from("system_schema", "indexes")
             .where("keyspace_name", Predicate.EQ, keyspaceName)
             .where("table_name", Predicate.EQ, tableName)
+            .parameters(parametersBuilderForLocalQuorum().build())
             .build();
-    return fetchRows(bridge, -1, null, true, cql, null);
+    return fetchRows(bridge, query, true);
   }
 
   @Override
@@ -96,7 +97,7 @@ public class Sgv2IndexesResourceImpl extends ResourceBase implements Sgv2Indexes
                     String.format("Column '%s' not found in table.", columnName),
                     Status.NOT_FOUND));
 
-    String cql =
+    Query query =
         new QueryBuilder()
             .create()
             .index(indexAdd.getName())
@@ -106,7 +107,7 @@ public class Sgv2IndexesResourceImpl extends ResourceBase implements Sgv2Indexes
             .indexingType(indexAdd.getKind())
             .custom(indexAdd.getType(), indexAdd.getOptions())
             .build();
-    bridge.executeQuery(Query.newBuilder().setCql(cql).build());
+    bridge.executeQuery(query);
 
     Map<String, Object> responsePayload = Collections.singletonMap("success", true);
     return Response.status(Status.CREATED).entity(responsePayload).build();
@@ -140,9 +141,9 @@ public class Sgv2IndexesResourceImpl extends ResourceBase implements Sgv2Indexes
           String.format("Index '%s' not found.", indexName), Status.NOT_FOUND);
     }
 
-    String cql =
+    Query query =
         new QueryBuilder().drop().index(keyspaceName, indexName).ifExists(ifExists).build();
-    bridge.executeQuery(Query.newBuilder().setCql(cql).build());
+    bridge.executeQuery(query);
 
     return Response.status(Status.NO_CONTENT).build();
   }

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2IndexesResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2IndexesResourceImpl.java
@@ -62,7 +62,7 @@ public class Sgv2IndexesResourceImpl extends ResourceBase implements Sgv2Indexes
             .from("system_schema", "indexes")
             .where("keyspace_name", Predicate.EQ, keyspaceName)
             .where("table_name", Predicate.EQ, tableName)
-            .parameters(parametersBuilderForLocalQuorum().build())
+            .parameters(PARAMETERS_FOR_LOCAL_QUORUM)
             .build();
     return fetchRows(bridge, query, true);
   }

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2KeyspacesResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2KeyspacesResourceImpl.java
@@ -88,9 +88,9 @@ public class Sgv2KeyspacesResourceImpl extends ResourceBase implements Sgv2Keysp
       throw new WebApplicationException(e.getMessage(), Status.BAD_REQUEST);
     }
     final String keyspaceName = ksCreateDef.name;
-    String cql;
+    Query query;
     if (ksCreateDef.datacenters == null) {
-      cql =
+      query =
           new QueryBuilder()
               .create()
               .keyspace(keyspaceName)
@@ -98,7 +98,7 @@ public class Sgv2KeyspacesResourceImpl extends ResourceBase implements Sgv2Keysp
               .withReplication(Replication.simpleStrategy(ksCreateDef.replicas))
               .build();
     } else {
-      cql =
+      query =
           new QueryBuilder()
               .create()
               .keyspace(keyspaceName)
@@ -107,7 +107,6 @@ public class Sgv2KeyspacesResourceImpl extends ResourceBase implements Sgv2Keysp
               .build();
     }
 
-    Query query = Query.newBuilder().setCql(cql).build();
     bridge.executeQuery(query);
 
     // No real contents; can ignore ResultSet it seems and only worry about exceptions
@@ -121,8 +120,7 @@ public class Sgv2KeyspacesResourceImpl extends ResourceBase implements Sgv2Keysp
       final StargateBridgeClient bridge,
       final String keyspaceName,
       final HttpServletRequest request) {
-    String cql = new QueryBuilder().drop().keyspace(keyspaceName).ifExists().build();
-    Query query = Query.newBuilder().setCql(cql).build();
+    Query query = new QueryBuilder().drop().keyspace(keyspaceName).ifExists().build();
     /*QueryOuterClass.Response grpcResponse =*/ bridge.executeQuery(query);
     return Response.status(Status.NO_CONTENT).build();
   }

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2TablesResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2TablesResourceImpl.java
@@ -112,7 +112,7 @@ public class Sgv2TablesResourceImpl extends ResourceBase implements Sgv2TablesRe
             .table(keyspaceName, tableAdd.getName())
             .ifNotExists(tableAdd.getIfNotExists())
             .column(columns)
-            .parameters(parametersForLocalQuorum())
+            .parameters(PARAMETERS_FOR_LOCAL_QUORUM)
             .build();
 
     bridge.executeQuery(query);
@@ -153,7 +153,7 @@ public class Sgv2TablesResourceImpl extends ResourceBase implements Sgv2TablesRe
                   .alter()
                   .table(keyspaceName, tableName)
                   .withDefaultTTL(options.getDefaultTimeToLive())
-                  .parameters(parametersForLocalQuorum())
+                  .parameters(PARAMETERS_FOR_LOCAL_QUORUM)
                   .build();
           bridge.executeQuery(query);
           return Response.status(Status.OK)

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2TablesResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2TablesResourceImpl.java
@@ -106,19 +106,16 @@ public class Sgv2TablesResourceImpl extends ResourceBase implements Sgv2TablesRe
       columns.add(column.build());
     }
 
-    String cql =
+    QueryOuterClass.Query query =
         new QueryBuilder()
             .create()
             .table(keyspaceName, tableAdd.getName())
             .ifNotExists(tableAdd.getIfNotExists())
             .column(columns)
+            .parameters(parametersForLocalQuorum())
             .build();
 
-    bridge.executeQuery(
-        QueryOuterClass.Query.newBuilder()
-            .setParameters(parametersForLocalQuorum())
-            .setCql(cql)
-            .build());
+    bridge.executeQuery(query);
 
     return Response.status(Status.CREATED)
         .entity(Collections.singletonMap("name", tableName))
@@ -151,17 +148,14 @@ public class Sgv2TablesResourceImpl extends ResourceBase implements Sgv2TablesRe
             throw new WebApplicationException(
                 "No update provided for defaultTTL", Status.BAD_REQUEST);
           }
-          String cql =
+          QueryOuterClass.Query query =
               new QueryBuilder()
                   .alter()
                   .table(keyspaceName, tableName)
                   .withDefaultTTL(options.getDefaultTimeToLive())
+                  .parameters(parametersForLocalQuorum())
                   .build();
-          bridge.executeQuery(
-              QueryOuterClass.Query.newBuilder()
-                  .setParameters(parametersForLocalQuorum())
-                  .setCql(cql)
-                  .build());
+          bridge.executeQuery(query);
           return Response.status(Status.OK)
               .entity(Collections.singletonMap("name", tableName))
               .build();
@@ -175,8 +169,8 @@ public class Sgv2TablesResourceImpl extends ResourceBase implements Sgv2TablesRe
       final String tableName,
       final HttpServletRequest request) {
     requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
-    String cql = new QueryBuilder().drop().table(keyspaceName, tableName).ifExists().build();
-    QueryOuterClass.Query query = QueryOuterClass.Query.newBuilder().setCql(cql).build();
+    QueryOuterClass.Query query =
+        new QueryBuilder().drop().table(keyspaceName, tableName).ifExists().build();
     /*QueryOuterClass.Response grpcResponse =*/ bridge.executeQuery(query);
     return Response.status(Status.NO_CONTENT).build();
   }

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceImpl.java
@@ -130,7 +130,7 @@ public class Sgv2UDTsResourceImpl extends ResourceBase implements Sgv2UDTsResour
             .type(keyspaceName, typeName)
             .ifNotExists(udtAdd.getIfNotExists())
             .column(columns2columns(udtAdd.getFields()))
-            .parameters(parametersForLocalQuorum())
+            .parameters(PARAMETERS_FOR_LOCAL_QUORUM)
             .build();
     try {
       bridge.executeQuery(query);

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceImpl.java
@@ -44,7 +44,7 @@ public class Sgv2UDTsResourceImpl extends ResourceBase implements Sgv2UDTsResour
       final HttpServletRequest request) {
     requireNonEmptyKeyspace(keyspaceName);
 
-    String cql =
+    QueryOuterClass.Query query =
         new QueryBuilder()
             .select()
             .column("type_name")
@@ -54,7 +54,6 @@ public class Sgv2UDTsResourceImpl extends ResourceBase implements Sgv2UDTsResour
             .where("keyspace_name", Predicate.EQ, keyspaceName)
             .build();
 
-    QueryOuterClass.Query query = QueryOuterClass.Query.newBuilder().setCql(cql).build();
     QueryOuterClass.Response grpcResponse = bridge.executeQuery(query);
 
     final QueryOuterClass.ResultSet rs = grpcResponse.getResultSet();
@@ -77,7 +76,7 @@ public class Sgv2UDTsResourceImpl extends ResourceBase implements Sgv2UDTsResour
     requireNonEmptyKeyspace(keyspaceName);
     requireNonEmptyTypename(typeName);
 
-    String cql =
+    QueryOuterClass.Query query =
         new QueryBuilder()
             .select()
             .column("type_name")
@@ -88,7 +87,6 @@ public class Sgv2UDTsResourceImpl extends ResourceBase implements Sgv2UDTsResour
             .where("type_name", Predicate.EQ, typeName)
             .build();
 
-    QueryOuterClass.Query query = QueryOuterClass.Query.newBuilder().setCql(cql).build();
     QueryOuterClass.Response grpcResponse = bridge.executeQuery(query);
 
     final QueryOuterClass.ResultSet rs = grpcResponse.getResultSet();
@@ -126,19 +124,16 @@ public class Sgv2UDTsResourceImpl extends ResourceBase implements Sgv2UDTsResour
     final String typeName = udtAdd.getName();
     requireNonEmptyTypename(typeName);
 
-    final String cql =
+    QueryOuterClass.Query query =
         new QueryBuilder()
             .create()
             .type(keyspaceName, typeName)
             .ifNotExists(udtAdd.getIfNotExists())
             .column(columns2columns(udtAdd.getFields()))
+            .parameters(parametersForLocalQuorum())
             .build();
     try {
-      bridge.executeQuery(
-          QueryOuterClass.Query.newBuilder()
-              .setParameters(parametersForLocalQuorum())
-              .setCql(cql)
-              .build());
+      bridge.executeQuery(query);
     } catch (StatusRuntimeException grpcE) {
       // For most failures pass and let default handler deal; but for specific case of
       // trying to create existing UDT without "if-not-exists", try to dig actual fail
@@ -168,7 +163,7 @@ public class Sgv2UDTsResourceImpl extends ResourceBase implements Sgv2UDTsResour
     requireNonEmptyKeyspace(keyspaceName);
     requireNonEmptyTypename(typeName);
 
-    String cql =
+    QueryOuterClass.Query query =
         new QueryBuilder()
             .drop()
             .type(keyspaceName, typeName)
@@ -176,7 +171,6 @@ public class Sgv2UDTsResourceImpl extends ResourceBase implements Sgv2UDTsResour
             //    seems inconsistent; would be good for idempotency
             // .ifExists()
             .build();
-    QueryOuterClass.Query query = QueryOuterClass.Query.newBuilder().setCql(cql).build();
     /*QueryOuterClass.Response grpcResponse =*/ bridge.executeQuery(query);
     return Response.status(Response.Status.NO_CONTENT).build();
   }
@@ -203,9 +197,8 @@ public class Sgv2UDTsResourceImpl extends ResourceBase implements Sgv2UDTsResour
 
     if (addFields != null && !addFields.isEmpty()) {
       List<Column> columns = columns2columns(addFields);
-      final String cql =
+      QueryOuterClass.Query query =
           new QueryBuilder().alter().type(keyspaceName, typeName).addColumn(columns).build();
-      QueryOuterClass.Query query = QueryOuterClass.Query.newBuilder().setCql(cql).build();
       /*QueryOuterClass.Response grpcResponse =*/ bridge.executeQuery(query);
     }
 
@@ -217,13 +210,12 @@ public class Sgv2UDTsResourceImpl extends ResourceBase implements Sgv2UDTsResour
                       Sgv2UDTUpdateRequest.FieldRename::getFrom,
                       Sgv2UDTUpdateRequest.FieldRename::getTo));
 
-      final String cql =
+      QueryOuterClass.Query query =
           new QueryBuilder()
               .alter()
               .type(keyspaceName, typeName)
               .renameColumn(columnRenames)
               .build();
-      QueryOuterClass.Query query = QueryOuterClass.Query.newBuilder().setCql(cql).build();
       /*QueryOuterClass.Response grpcResponse =*/ bridge.executeQuery(query);
     }
 

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/CqlStrings.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/CqlStrings.java
@@ -64,6 +64,14 @@ public class CqlStrings {
   }
 
   /**
+   * Quote the given string; double quotes are escaped. If the given string is null, this method
+   * returns a quoted empty string ({@code ""}).
+   */
+  public static String doubleQuote(String value) {
+    return quote(value, '\"');
+  }
+
+  /**
    * Quotes text and escapes any existing quotes in the text. {@code String.replace()} is a bit too
    * inefficient (see JAVA-67, JAVA-1262).
    *

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/BuiltCondition.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/BuiltCondition.java
@@ -28,17 +28,17 @@ public interface BuiltCondition {
 
   Predicate predicate();
 
-  Value<?> value();
+  Term<?> value();
 
   static BuiltCondition of(String columnName, Predicate predicate, Object value) {
-    return of(LHS.column(columnName), predicate, Value.of(value));
+    return of(LHS.column(columnName), predicate, Term.of(value));
   }
 
   static BuiltCondition ofMarker(String columnName, Predicate predicate) {
-    return of(LHS.column(columnName), predicate, Value.marker());
+    return of(LHS.column(columnName), predicate, Term.marker());
   }
 
-  static BuiltCondition of(LHS lhs, Predicate predicate, Value<?> value) {
+  static BuiltCondition of(LHS lhs, Predicate predicate, Term<?> value) {
     return ImmutableBuiltCondition.builder().lhs(lhs).predicate(predicate).value(value).build();
   }
 
@@ -60,11 +60,11 @@ public interface BuiltCondition {
     }
 
     public static LHS mapAccess(String columnName, Object key) {
-      return new MapElement(columnName, Value.of(key));
+      return new MapElement(columnName, Term.of(key));
     }
 
     public static LHS mapAccess(String columnName) {
-      return new MapElement(columnName, Value.marker());
+      return new MapElement(columnName, Term.marker());
     }
 
     public static LHS columnTuple(String... columnNames) {
@@ -81,7 +81,7 @@ public interface BuiltCondition {
 
     abstract String columnName();
 
-    Optional<Value<?>> value() {
+    Optional<Term<?>> value() {
       return Optional.empty();
     }
 
@@ -118,9 +118,9 @@ public interface BuiltCondition {
 
     static final class MapElement extends LHS {
       private final String columnName;
-      private final Value<?> keyValue;
+      private final Term<?> keyValue;
 
-      private MapElement(String columnName, Value<?> keyValue) {
+      private MapElement(String columnName, Term<?> keyValue) {
         this.columnName = columnName;
         this.keyValue = keyValue;
       }
@@ -130,12 +130,12 @@ public interface BuiltCondition {
         return columnName;
       }
 
-      Value<?> keyValue() {
+      Term<?> keyValue() {
         return keyValue;
       }
 
       @Override
-      Optional<Value<?>> value() {
+      Optional<Term<?>> value() {
         return Optional.of(keyValue);
       }
 

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/BuiltCondition.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/BuiltCondition.java
@@ -31,7 +31,11 @@ public interface BuiltCondition {
   Term<?> value();
 
   static BuiltCondition of(String columnName, Predicate predicate, Object value) {
-    return of(LHS.column(columnName), predicate, Term.of(value));
+    return of(columnName, predicate, Term.of(value));
+  }
+
+  static BuiltCondition of(String columnName, Predicate predicate, Term<?> value) {
+    return of(LHS.column(columnName), predicate, value);
   }
 
   static BuiltCondition ofMarker(String columnName, Predicate predicate) {
@@ -120,7 +124,7 @@ public interface BuiltCondition {
       private final String columnName;
       private final Term<?> keyValue;
 
-      private MapElement(String columnName, Term<?> keyValue) {
+      MapElement(String columnName, Term<?> keyValue) {
         this.columnName = columnName;
         this.keyValue = keyValue;
       }

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Literal.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Literal.java
@@ -23,12 +23,6 @@ class Literal<T> implements Term<T> {
     this.value = value;
   }
 
-  @Override
-  public boolean isMarker() {
-    return false;
-  }
-
-  @Override
   public T get() {
     return value;
   }

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Literal.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Literal.java
@@ -15,17 +15,21 @@
  */
 package io.stargate.sgv2.common.cql.builder;
 
-public interface Value<T> {
+class Literal<T> implements Term<T> {
 
-  static <T> Value<T> marker() {
-    return new Marker<>();
+  private final T value;
+
+  public Literal(T value) {
+    this.value = value;
   }
 
-  static <T> Value<T> of(T value) {
-    return new ConcreteValue<>(value);
+  @Override
+  public boolean isMarker() {
+    return false;
   }
 
-  boolean isMarker();
-
-  T get();
+  @Override
+  public T get() {
+    return value;
+  }
 }

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Marker.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Marker.java
@@ -15,15 +15,25 @@
  */
 package io.stargate.sgv2.common.cql.builder;
 
+import io.stargate.sgv2.common.cql.CqlStrings;
+
 class Marker<T> implements Term<T> {
 
-  @Override
-  public boolean isMarker() {
-    return true;
+  private final String name;
+
+  Marker(String name) {
+    this.name = name;
   }
 
-  @Override
-  public T get() {
-    throw new UnsupportedOperationException("Cannot get the value of a marker");
+  Marker() {
+    this(null);
+  }
+
+  boolean isAnonymous() {
+    return name == null;
+  }
+
+  String asCql() {
+    return name == null ? "?" : ":" + CqlStrings.doubleQuote(name);
   }
 }

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Marker.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Marker.java
@@ -15,7 +15,7 @@
  */
 package io.stargate.sgv2.common.cql.builder;
 
-class Marker<T> implements Value<T> {
+class Marker<T> implements Term<T> {
 
   @Override
   public boolean isMarker() {

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/QueryBuilderImpl.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/QueryBuilderImpl.java
@@ -117,8 +117,8 @@ public class QueryBuilderImpl {
   /** The IFs conditions for a conditional UPDATE or DELETE. */
   private final List<BuiltCondition> ifs = new ArrayList<>();
 
-  private Value<Integer> limit;
-  private Value<Integer> perPartitionLimit;
+  private Term<Integer> limit;
+  private Term<Integer> perPartitionLimit;
   private final List<String> groupBys = new ArrayList<>();
   private final Map<String, Column.Order> orders = new LinkedHashMap<>();
 
@@ -131,8 +131,8 @@ public class QueryBuilderImpl {
   private String indexCreateColumn;
   private String customIndexClass;
   private Map<String, String> customIndexOptions;
-  private Value<Integer> ttl;
-  private Value<Long> timestamp;
+  private Term<Integer> ttl;
+  private Term<Long> timestamp;
   private boolean allowFiltering;
 
   @DSLAction
@@ -604,25 +604,25 @@ public class QueryBuilderImpl {
 
   @DSLAction
   public void limit() {
-    this.limit = Value.marker();
+    this.limit = Term.marker();
   }
 
   @DSLAction
   public void limit(Integer limit) {
     if (limit != null) {
-      this.limit = Value.of(limit);
+      this.limit = Term.of(limit);
     }
   }
 
   @DSLAction
   public void perPartitionLimit() {
-    this.perPartitionLimit = Value.marker();
+    this.perPartitionLimit = Term.marker();
   }
 
   @DSLAction
   public void perPartitionLimit(Integer limit) {
     if (limit != null) {
-      this.perPartitionLimit = Value.of(limit);
+      this.perPartitionLimit = Term.of(limit);
     }
   }
 
@@ -659,25 +659,25 @@ public class QueryBuilderImpl {
 
   @DSLAction
   public void ttl() {
-    this.ttl = Value.marker();
+    this.ttl = Term.marker();
   }
 
   @DSLAction
   public void ttl(Integer ttl) {
     if (ttl != null) {
-      this.ttl = Value.of(ttl);
+      this.ttl = Term.of(ttl);
     }
   }
 
   @DSLAction
   public void timestamp() {
-    this.timestamp = Value.marker();
+    this.timestamp = Term.marker();
   }
 
   @DSLAction
   public void timestamp(Long timestamp) {
     if (timestamp != null) {
-      this.timestamp = Value.of(timestamp);
+      this.timestamp = Term.of(timestamp);
     }
   }
 
@@ -1104,11 +1104,11 @@ public class QueryBuilderImpl {
     return query.toString();
   }
 
-  static String formatValue(Value<?> value) {
+  static String formatValue(Term<?> value) {
     if (value instanceof Marker) {
       return "?";
-    } else if (value instanceof ConcreteValue) {
-      Object v = ((ConcreteValue<?>) value).get();
+    } else if (value instanceof Literal) {
+      Object v = ((Literal<?>) value).get();
       if (v instanceof CharSequence) {
         return CqlStrings.quote(v.toString());
       } else {
@@ -1136,7 +1136,7 @@ public class QueryBuilderImpl {
 
     String columnName = modifier.target().columnName();
     String fieldName = modifier.target().fieldName();
-    Value<?> mapKey = modifier.target().mapKey();
+    Term<?> mapKey = modifier.target().mapKey();
 
     String targetString;
     if (fieldName != null) {

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/QueryBuilderImpl.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/QueryBuilderImpl.java
@@ -21,23 +21,38 @@ import com.github.misberner.apcommons.util.AFModifier;
 import com.github.misberner.duzzt.annotations.DSLAction;
 import com.github.misberner.duzzt.annotations.GenerateEmbeddedDSL;
 import com.github.misberner.duzzt.annotations.SubExpr;
+import io.stargate.proto.QueryOuterClass.Query;
+import io.stargate.proto.QueryOuterClass.QueryParameters;
+import io.stargate.proto.QueryOuterClass.Value;
+import io.stargate.proto.QueryOuterClass.Values;
 import io.stargate.sgv2.common.cql.ColumnUtils;
 import io.stargate.sgv2.common.cql.CqlStrings;
+import io.stargate.sgv2.common.grpc.StargateBridgeClient;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-/** Convenience builder for creating queries. */
+/**
+ * Convenience builder for creating queries.
+ *
+ * <p>The generated CQL string is wrapped into a {@link Query} that can be passed directly to {@link
+ * StargateBridgeClient#executeQuery(Query)}. In addition, any time a {@link Value} is passed to the
+ * builder (via such methods as {@link #where(Column, Predicate, Object)}, {@link #value(Column,
+ * Object)}, etc.), it is automatically replaced with a named bind marker, and stored in {@link
+ * Query#getValues()}.
+ */
 @GenerateEmbeddedDSL(
     modifier = AFModifier.DEFAULT,
     autoVarArgs = false,
     name = "QueryBuilder",
-    syntax = "(<keyspace>|<table>|<insert>|<update>|<delete>|<select>|<index>|<type>) build",
+    syntax =
+        "(<keyspace>|<table>|<insert>|<update>|<delete>|<select>|<index>|<type>) parameters? build",
     where = {
       @SubExpr(
           name = "keyspace",
@@ -121,6 +136,7 @@ public class QueryBuilderImpl {
   private Term<Integer> perPartitionLimit;
   private final List<String> groupBys = new ArrayList<>();
   private final Map<String, Column.Order> orders = new LinkedHashMap<>();
+  private final Map<String, Value> boundValues = new HashMap<>();
 
   private Replication replication;
   private boolean ifNotExists;
@@ -134,6 +150,8 @@ public class QueryBuilderImpl {
   private Term<Integer> ttl;
   private Term<Long> timestamp;
   private boolean allowFiltering;
+  private QueryParameters parameters;
+  private boolean hasAnonymousMarkers;
 
   @DSLAction
   public void create() {
@@ -432,23 +450,32 @@ public class QueryBuilderImpl {
 
   @DSLAction
   public void value(String column, Object value) {
-    value(ValueModifier.set(column, value));
-  }
-
-  @DSLAction
-  public void value(String column) {
-    value(ValueModifier.marker(column));
-  }
-
-  public void value(Column column) {
-    value(column.name());
+    addModifier(ValueModifier.set(column, termFor(column, value)));
   }
 
   public void value(Column column, Object value) {
     value(column.name(), value);
   }
 
+  @DSLAction
+  public void value(String column) {
+    addModifier(ValueModifier.marker(column));
+  }
+
+  public void value(Column column) {
+    value(column.name());
+  }
+
   public void value(ValueModifier modifier) {
+    Term<?> newValue = bindGrpcValues(modifier.target().columnName(), modifier.value());
+    ValueModifier.Target newTarget = bindGrpcValues(modifier.target());
+    if (newValue != modifier.value() || newTarget != modifier.target()) {
+      modifier = ValueModifier.of(newTarget, modifier.operation(), newValue);
+    }
+    addModifier(modifier);
+  }
+
+  private void addModifier(ValueModifier modifier) {
     if (isInsert && (modifier.target().fieldName() != null || modifier.target().mapKey() != null)) {
       throw invalid("Can't reference fields or map elements in INSERT queries");
     }
@@ -465,19 +492,23 @@ public class QueryBuilderImpl {
     where(column.name(), predicate, value);
   }
 
+  public void where(String columnName, Predicate predicate, Object value) {
+    where(BuiltCondition.of(columnName, predicate, termFor(columnName, value)));
+  }
+
   public void where(Column column, Predicate predicate) {
     where(column.name(), predicate);
   }
 
-  public void where(String columnName, Predicate predicate, Object value) {
-    where(BuiltCondition.of(columnName, predicate, value));
-  }
-
   public void where(String columnName, Predicate predicate) {
-    where(BuiltCondition.ofMarker(columnName, predicate));
+    addWhere(BuiltCondition.ofMarker(columnName, predicate));
   }
 
   public void where(BuiltCondition where) {
+    addWhere(bindGrpcValues(where));
+  }
+
+  private void addWhere(BuiltCondition where) {
     wheres.add(where);
   }
 
@@ -489,14 +520,18 @@ public class QueryBuilderImpl {
   }
 
   public void ifs(String columnName, Predicate predicate, Object value) {
-    ifs(BuiltCondition.of(columnName, predicate, value));
+    addIf(BuiltCondition.of(columnName, predicate, termFor(columnName, value)));
   }
 
   public void ifs(String columnName, Predicate predicate) {
-    ifs(BuiltCondition.ofMarker(columnName, predicate));
+    addIf(BuiltCondition.ofMarker(columnName, predicate));
   }
 
   public void ifs(BuiltCondition condition) {
+    addIf(bindGrpcValues(condition));
+  }
+
+  private void addIf(BuiltCondition condition) {
     ifs.add(condition);
   }
 
@@ -615,6 +650,16 @@ public class QueryBuilderImpl {
   }
 
   @DSLAction
+  public void limit(Value limit) {
+    if (limit != null) {
+      if (limit.getInnerCase() != Value.InnerCase.INT) {
+        throw new IllegalArgumentException("Expected an int value");
+      }
+      this.limit = termFor("limit", limit);
+    }
+  }
+
+  @DSLAction
   public void perPartitionLimit() {
     this.perPartitionLimit = Term.marker();
   }
@@ -623,6 +668,16 @@ public class QueryBuilderImpl {
   public void perPartitionLimit(Integer limit) {
     if (limit != null) {
       this.perPartitionLimit = Term.of(limit);
+    }
+  }
+
+  @DSLAction
+  public void perPartitionLimit(Value limit) {
+    if (limit != null) {
+      if (limit.getInnerCase() != Value.InnerCase.INT) {
+        throw new IllegalArgumentException("Expected an int value");
+      }
+      this.perPartitionLimit = termFor("perPartitionLimit", limit);
     }
   }
 
@@ -670,6 +725,16 @@ public class QueryBuilderImpl {
   }
 
   @DSLAction
+  public void ttl(Value ttl) {
+    if (ttl != null) {
+      if (ttl.getInnerCase() != Value.InnerCase.INT) {
+        throw new IllegalArgumentException("Expected an int value");
+      }
+      this.ttl = termFor("ttl", ttl);
+    }
+  }
+
+  @DSLAction
   public void timestamp() {
     this.timestamp = Term.marker();
   }
@@ -682,7 +747,38 @@ public class QueryBuilderImpl {
   }
 
   @DSLAction
-  public String build() {
+  public void timestamp(Value timestamp) {
+    if (timestamp != null) {
+      if (timestamp.getInnerCase() != Value.InnerCase.INT) {
+        throw new IllegalArgumentException("Expected an int value");
+      }
+      this.timestamp = termFor("timestamp", timestamp);
+    }
+  }
+
+  @DSLAction
+  public void parameters(QueryParameters parameters) {
+    this.parameters = parameters;
+  }
+
+  @DSLAction
+  public Query build() {
+    Query.Builder query = Query.newBuilder().setCql(buildCql());
+    if (!boundValues.isEmpty()) {
+      Values.Builder values = Values.newBuilder();
+      for (Map.Entry<String, Value> entry : boundValues.entrySet()) {
+        values.addValueNames(entry.getKey());
+        values.addValues(entry.getValue());
+      }
+      query.setValues(values);
+    }
+    if (parameters != null) {
+      query.setParameters(parameters);
+    }
+    return query.build();
+  }
+
+  private String buildCql() {
     if (isKeyspace && isCreate) {
       return createKeyspace();
     }
@@ -1106,10 +1202,13 @@ public class QueryBuilderImpl {
 
   static String formatValue(Term<?> value) {
     if (value instanceof Marker) {
-      return "?";
+      return ((Marker<?>) value).asCql();
     } else if (value instanceof Literal) {
       Object v = ((Literal<?>) value).get();
-      if (v instanceof CharSequence) {
+      if (v instanceof Value) {
+        // This can only happen if we forgot to call termFor() somewhere
+        throw new IllegalStateException("gRPC value should have been converted to a marker");
+      } else if (v instanceof CharSequence) {
         return CqlStrings.quote(v.toString());
       } else {
         // This works for simple values. We assume that this will be good enough for our needs.
@@ -1216,12 +1315,14 @@ public class QueryBuilderImpl {
   }
 
   private String deleteQuery() {
-    StringBuilder builder =
-        new StringBuilder("DELETE ")
-            .append(
-                selection.stream().map(QueryBuilderImpl::cqlName).collect(Collectors.joining(", ")))
-            .append(" FROM ")
-            .append(maybeQualify(tableName));
+    StringBuilder builder = new StringBuilder("DELETE");
+    if (!selection.isEmpty()) {
+      builder.append(
+          selection.stream()
+              .map(QueryBuilderImpl::cqlName)
+              .collect(Collectors.joining(", ", " ", "")));
+    }
+    builder.append(" FROM ").append(maybeQualify(tableName));
     addUsingClause(builder);
     appendWheres(builder);
     appendIfs(builder);
@@ -1272,6 +1373,105 @@ public class QueryBuilderImpl {
     }
 
     return builder.toString();
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> Term<T> termFor(String name, Object value) {
+    if (value instanceof Marker) {
+      // We don't expose a public way to create named markers. If we change that, we'll need to
+      // adjust the code below, and also ensure that client-provided named markers do not clash with
+      // our generated ones.
+      assert ((Marker<?>) value).isAnonymous();
+
+      hasAnonymousMarkers = true;
+      checkNoMixedMarkers();
+      return ((Marker<T>) value);
+    } else if (value instanceof Value) {
+      String markerName = addBoundValue(name, ((Value) value));
+      checkNoMixedMarkers();
+      return new Marker<>(markerName);
+    } else {
+      return ((Term<T>) Term.of(value));
+    }
+  }
+
+  private void checkNoMixedMarkers() {
+    if (hasAnonymousMarkers && !boundValues.isEmpty()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Can't use anonymous and named markers in the same query (arguments of type "
+                  + "`%s` are automatically converted to named markers)",
+              Value.class.getName()));
+    }
+  }
+
+  private String addBoundValue(String name, Value value) {
+    String marker = name;
+    int i = 2;
+    while (boundValues.containsKey(marker)) {
+      marker = name + i++;
+    }
+    boundValues.put(marker, value);
+    return marker;
+  }
+
+  /**
+   * Inspects a client-provided term to check if it references a gRPC {@link Value}. If so, the
+   * value is automatically bound and a bind marker is returned. If not, the instance is returned
+   * unchanged.
+   */
+  private Term<?> bindGrpcValues(String name, Term<?> t) {
+    if (!(t instanceof Literal)) {
+      return t;
+    }
+    Object o = ((Literal<?>) t).get();
+    if (!(o instanceof Value)) {
+      return t;
+    }
+    return termFor(name, o);
+  }
+
+  /** @see #bindGrpcValues(String, Term) */
+  private ValueModifier.Target bindGrpcValues(ValueModifier.Target t) {
+    Term<?> mapKey = t.mapKey();
+    if (mapKey == null) {
+      return t;
+    }
+    if (!(mapKey instanceof Literal)) {
+      return t;
+    }
+    Object o = ((Literal<?>) mapKey).get();
+    if (!(o instanceof Value)) {
+      return t;
+    }
+    return ValueModifier.Target.mapValue(t.columnName(), termFor(t.columnName(), o));
+  }
+
+  /** @see #bindGrpcValues(String, Term) */
+  private BuiltCondition.LHS bindGrpcValues(BuiltCondition.LHS lhs) {
+    return lhs.value()
+        .filter(v -> v instanceof Literal)
+        .map(
+            v -> {
+              Term<?> newValue = termFor(lhs.columnName(), ((Literal<?>) v).get());
+              return (BuiltCondition.LHS)
+                  new BuiltCondition.LHS.MapElement(lhs.columnName(), newValue);
+            })
+        .orElse(lhs);
+  }
+
+  /** @see #bindGrpcValues(String, Term) */
+  private BuiltCondition bindGrpcValues(BuiltCondition where) {
+    BuiltCondition.LHS newLhs = bindGrpcValues(where.lhs());
+
+    // Will need to compute a different name if LHS.tuple() or token() are implemented
+    assert where.lhs().columnName() != null;
+    Term<?> newValue = bindGrpcValues(where.lhs().columnName(), where.value());
+
+    if (newValue != where.value() || newLhs != where.lhs()) {
+      where = BuiltCondition.of(newLhs, where.predicate(), newValue);
+    }
+    return where;
   }
 
   private static String formatFunctionCall(FunctionCall functionCall) {

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Term.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Term.java
@@ -15,21 +15,17 @@
  */
 package io.stargate.sgv2.common.cql.builder;
 
-class ConcreteValue<T> implements Value<T> {
+public interface Term<T> {
 
-  private final T value;
-
-  public ConcreteValue(T value) {
-    this.value = value;
+  static <T> Term<T> marker() {
+    return new Marker<>();
   }
 
-  @Override
-  public boolean isMarker() {
-    return false;
+  static <T> Term<T> of(T value) {
+    return new Literal<>(value);
   }
 
-  @Override
-  public T get() {
-    return value;
-  }
+  boolean isMarker();
+
+  T get();
 }

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Term.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Term.java
@@ -24,8 +24,4 @@ public interface Term<T> {
   static <T> Term<T> of(T value) {
     return new Literal<>(value);
   }
-
-  boolean isMarker();
-
-  T get();
 }

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/ValueModifier.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/ValueModifier.java
@@ -26,17 +26,17 @@ public interface ValueModifier {
 
   Operation operation();
 
-  Value<?> value();
+  Term<?> value();
 
   static ValueModifier set(String columnName, Object value) {
-    return of(Target.column(columnName), Operation.SET, Value.of(value));
+    return of(Target.column(columnName), Operation.SET, Term.of(value));
   }
 
   static ValueModifier marker(String columnName) {
-    return of(Target.column(columnName), Operation.SET, Value.marker());
+    return of(Target.column(columnName), Operation.SET, Term.marker());
   }
 
-  static ValueModifier of(Target target, Operation operation, Value<?> value) {
+  static ValueModifier of(Target target, Operation operation, Term<?> value) {
     return ImmutableValueModifier.builder()
         .target(target)
         .operation(operation)
@@ -63,7 +63,7 @@ public interface ValueModifier {
 
     /** only set for map value access */
     @Nullable
-    Value<?> mapKey();
+    Term<?> mapKey();
 
     static Target column(String columnName) {
       return ImmutableTarget.builder().columnName(columnName).build();
@@ -73,7 +73,7 @@ public interface ValueModifier {
       return ImmutableTarget.builder().columnName(columnName).fieldName(fieldName).build();
     }
 
-    static Target mapValue(String columnName, Value<?> mapKey) {
+    static Target mapValue(String columnName, Term<?> mapKey) {
       return ImmutableTarget.builder().columnName(columnName).mapKey(mapKey).build();
     }
   }

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/ValueModifier.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/ValueModifier.java
@@ -29,7 +29,11 @@ public interface ValueModifier {
   Term<?> value();
 
   static ValueModifier set(String columnName, Object value) {
-    return of(Target.column(columnName), Operation.SET, Term.of(value));
+    return set(columnName, Term.of(value));
+  }
+
+  static ValueModifier set(String columnName, Term<?> value) {
+    return of(Target.column(columnName), Operation.SET, value);
   }
 
   static ValueModifier marker(String columnName) {

--- a/sgv2-service-common/src/test/java/io/stargate/sgv2/common/cql/builder/QueryBuilderTest.java
+++ b/sgv2-service-common/src/test/java/io/stargate/sgv2/common/cql/builder/QueryBuilderTest.java
@@ -285,7 +285,7 @@ public class QueryBuilderTest {
                   ValueModifier.of(
                       ValueModifier.Target.column("c"),
                       ValueModifier.Operation.PREPEND,
-                      Value.marker()))
+                      Term.marker()))
               .where("k", Predicate.EQ)
               .ifs("v", Predicate.GT)
               .ifExists()

--- a/sgv2-service-common/src/test/java/io/stargate/sgv2/common/cql/builder/QueryBuilderTest.java
+++ b/sgv2-service-common/src/test/java/io/stargate/sgv2/common/cql/builder/QueryBuilderTest.java
@@ -40,7 +40,8 @@ public class QueryBuilderTest {
               .create()
               .keyspace("ks")
               .withReplication(Replication.simpleStrategy(1))
-              .build(),
+              .build()
+              .getCql(),
           "CREATE KEYSPACE ks "
               + "WITH replication = { 'class': 'SimpleStrategy', 'replication_factor': 1 }"),
       arguments(
@@ -48,7 +49,8 @@ public class QueryBuilderTest {
               .create()
               .keyspace("Ks")
               .withReplication(Replication.simpleStrategy(1))
-              .build(),
+              .build()
+              .getCql(),
           "CREATE KEYSPACE \"Ks\" "
               + "WITH replication = { 'class': 'SimpleStrategy', 'replication_factor': 1 }"),
       arguments(
@@ -57,7 +59,8 @@ public class QueryBuilderTest {
               .keyspace("ks")
               .ifNotExists()
               .withReplication(Replication.simpleStrategy(1))
-              .build(),
+              .build()
+              .getCql(),
           "CREATE KEYSPACE IF NOT EXISTS ks "
               + "WITH replication = { 'class': 'SimpleStrategy', 'replication_factor': 1 }"),
       arguments(
@@ -73,7 +76,8 @@ public class QueryBuilderTest {
                           put("dc2", 4);
                         }
                       }))
-              .build(),
+              .build()
+              .getCql(),
           "CREATE KEYSPACE IF NOT EXISTS ks "
               + "WITH replication = { 'class': 'NetworkTopologyStrategy', 'dc1': 3, 'dc2': 4 }"),
       arguments(
@@ -81,7 +85,8 @@ public class QueryBuilderTest {
               .alter()
               .keyspace("ks")
               .withReplication(Replication.simpleStrategy(1))
-              .build(),
+              .build()
+              .getCql(),
           "ALTER KEYSPACE ks "
               + "WITH replication = { 'class': 'SimpleStrategy', 'replication_factor': 1 }"),
       arguments(
@@ -90,34 +95,38 @@ public class QueryBuilderTest {
               .keyspace("ks")
               .withReplication(Replication.simpleStrategy(1))
               .andDurableWrites(false)
-              .build(),
+              .build()
+              .getCql(),
           "ALTER KEYSPACE ks "
               + "WITH replication = { 'class': 'SimpleStrategy', 'replication_factor': 1 } "
               + "AND durable_writes = false"),
-      arguments(new QueryBuilder().drop().keyspace("ks").build(), "DROP KEYSPACE ks"),
+      arguments(new QueryBuilder().drop().keyspace("ks").build().getCql(), "DROP KEYSPACE ks"),
       arguments(
-          new QueryBuilder().drop().keyspace("ks").ifExists().build(),
+          new QueryBuilder().drop().keyspace("ks").ifExists().build().getCql(),
           "DROP KEYSPACE IF EXISTS ks"),
       arguments(
           new QueryBuilder()
               .create()
               .table("ks", "tbl")
               .column("k", "int", Column.Kind.PARTITION_KEY)
-              .build(),
+              .build()
+              .getCql(),
           "CREATE TABLE ks.tbl (k int, PRIMARY KEY ((k)))"),
       arguments(
           new QueryBuilder()
               .create()
               .table("Ks", "Tbl")
               .column("k", "int", Column.Kind.PARTITION_KEY)
-              .build(),
+              .build()
+              .getCql(),
           "CREATE TABLE \"Ks\".\"Tbl\" (k int, PRIMARY KEY ((k)))"),
       arguments(
           new QueryBuilder()
               .create()
               .table("tbl")
               .column("k", "int", Column.Kind.PARTITION_KEY)
-              .build(),
+              .build()
+              .getCql(),
           "CREATE TABLE tbl (k int, PRIMARY KEY ((k)))"),
       arguments(
           new QueryBuilder()
@@ -125,7 +134,8 @@ public class QueryBuilderTest {
               .table("ks", "tbl")
               .ifNotExists()
               .column("k", "int", Column.Kind.PARTITION_KEY)
-              .build(),
+              .build()
+              .getCql(),
           "CREATE TABLE IF NOT EXISTS ks.tbl (k int, PRIMARY KEY ((k)))"),
       arguments(
           new QueryBuilder()
@@ -136,7 +146,8 @@ public class QueryBuilderTest {
               .column("cc", "text", Column.Kind.CLUSTERING, Column.Order.DESC)
               .column("v", "int")
               .column("s", "int", Column.Kind.STATIC)
-              .build(),
+              .build()
+              .getCql(),
           "CREATE TABLE IF NOT EXISTS ks.tbl "
               + "(k int, cc text, v int, s int STATIC, PRIMARY KEY ((k), cc)) "
               + "WITH CLUSTERING ORDER BY (cc DESC)"),
@@ -147,7 +158,8 @@ public class QueryBuilderTest {
               .column("k", "int", Column.Kind.PARTITION_KEY)
               .withComment("'test' comment")
               .withDefaultTTL(3600)
-              .build(),
+              .build()
+              .getCql(),
           "CREATE TABLE ks.tbl (k int, PRIMARY KEY ((k))) "
               + "WITH comment = '''test'' comment' "
               + "AND default_time_to_live = 3600"),
@@ -157,10 +169,17 @@ public class QueryBuilderTest {
               .table("ks", "tbl")
               .addColumn("c", "int")
               .addColumn("d", "int")
-              .build(),
+              .build()
+              .getCql(),
           "ALTER TABLE ks.tbl ADD (c int, d int)"),
       arguments(
-          new QueryBuilder().alter().table("ks", "tbl").dropColumn("c").dropColumn("d").build(),
+          new QueryBuilder()
+              .alter()
+              .table("ks", "tbl")
+              .dropColumn("c")
+              .dropColumn("d")
+              .build()
+              .getCql(),
           "ALTER TABLE ks.tbl DROP (c, d)"),
       arguments(
           new QueryBuilder()
@@ -168,18 +187,20 @@ public class QueryBuilderTest {
               .table("ks", "tbl")
               .renameColumn("c", "c2")
               .renameColumn("d", "d2")
-              .build(),
+              .build()
+              .getCql(),
           "ALTER TABLE ks.tbl RENAME c TO c2 AND d TO d2"),
-      arguments(new QueryBuilder().drop().table("ks", "tbl").build(), "DROP TABLE ks.tbl"),
+      arguments(new QueryBuilder().drop().table("ks", "tbl").build().getCql(), "DROP TABLE ks.tbl"),
       arguments(
-          new QueryBuilder().drop().table("ks", "tbl").ifExists().build(),
+          new QueryBuilder().drop().table("ks", "tbl").ifExists().build().getCql(),
           "DROP TABLE IF EXISTS ks.tbl"),
-      arguments(new QueryBuilder().truncate().table("ks", "tbl").build(), "TRUNCATE ks.tbl"),
       arguments(
-          new QueryBuilder().create().index().on("ks", "tbl").column("c").build(),
+          new QueryBuilder().truncate().table("ks", "tbl").build().getCql(), "TRUNCATE ks.tbl"),
+      arguments(
+          new QueryBuilder().create().index().on("ks", "tbl").column("c").build().getCql(),
           "CREATE INDEX ON ks.tbl (c)"),
       arguments(
-          new QueryBuilder().create().index("idx").on("ks", "tbl").column("c").build(),
+          new QueryBuilder().create().index("idx").on("ks", "tbl").column("c").build().getCql(),
           "CREATE INDEX idx ON ks.tbl (c)"),
       arguments(
           new QueryBuilder()
@@ -188,19 +209,48 @@ public class QueryBuilderTest {
               .ifNotExists()
               .on("ks", "tbl")
               .column("c")
-              .build(),
+              .build()
+              .getCql(),
           "CREATE INDEX IF NOT EXISTS idx ON ks.tbl (c)"),
       arguments(
-          new QueryBuilder().create().index().on("ks", "tbl").column("c").indexEntries().build(),
+          new QueryBuilder()
+              .create()
+              .index()
+              .on("ks", "tbl")
+              .column("c")
+              .indexEntries()
+              .build()
+              .getCql(),
           "CREATE INDEX ON ks.tbl (ENTRIES(c))"),
       arguments(
-          new QueryBuilder().create().index().on("ks", "tbl").column("c").indexFull().build(),
+          new QueryBuilder()
+              .create()
+              .index()
+              .on("ks", "tbl")
+              .column("c")
+              .indexFull()
+              .build()
+              .getCql(),
           "CREATE INDEX ON ks.tbl (FULL(c))"),
       arguments(
-          new QueryBuilder().create().index().on("ks", "tbl").column("c").indexKeys().build(),
+          new QueryBuilder()
+              .create()
+              .index()
+              .on("ks", "tbl")
+              .column("c")
+              .indexKeys()
+              .build()
+              .getCql(),
           "CREATE INDEX ON ks.tbl (KEYS(c))"),
       arguments(
-          new QueryBuilder().create().index().on("ks", "tbl").column("c").indexValues().build(),
+          new QueryBuilder()
+              .create()
+              .index()
+              .on("ks", "tbl")
+              .column("c")
+              .indexValues()
+              .build()
+              .getCql(),
           "CREATE INDEX ON ks.tbl (VALUES(c))"),
       arguments(
           new QueryBuilder()
@@ -209,11 +259,13 @@ public class QueryBuilderTest {
               .on("ks", "tbl")
               .column("c")
               .custom("IndexClass")
-              .build(),
+              .build()
+              .getCql(),
           "CREATE CUSTOM INDEX ON ks.tbl (c) USING 'IndexClass'"),
       arguments(
-          new QueryBuilder().drop().index("idx").ifExists().build(), "DROP INDEX IF EXISTS idx"),
-      arguments(new QueryBuilder().drop().index("ks", "idx").build(), "DROP INDEX ks.idx"),
+          new QueryBuilder().drop().index("idx").ifExists().build().getCql(),
+          "DROP INDEX IF EXISTS idx"),
+      arguments(new QueryBuilder().drop().index("ks", "idx").build().getCql(), "DROP INDEX ks.idx"),
       arguments(
           new QueryBuilder()
               .create()
@@ -223,7 +275,8 @@ public class QueryBuilderTest {
               .column("b")
               .column("c")
               .from("ks", "tbl")
-              .build(),
+              .build()
+              .getCql(),
           "CREATE MATERIALIZED VIEW ks.v "
               + "AS SELECT a, b, c "
               + "FROM ks.tbl "
@@ -232,13 +285,19 @@ public class QueryBuilderTest {
               + "AND c IS NOT NULL "
               + "PRIMARY KEY ((a))"),
       arguments(
-          new QueryBuilder().drop().materializedView("ks", "tbl").build(),
+          new QueryBuilder().drop().materializedView("ks", "tbl").build().getCql(),
           "DROP MATERIALIZED VIEW ks.tbl"),
       arguments(
-          new QueryBuilder().drop().materializedView("ks", "tbl").ifExists().build(),
+          new QueryBuilder().drop().materializedView("ks", "tbl").ifExists().build().getCql(),
           "DROP MATERIALIZED VIEW IF EXISTS ks.tbl"),
       arguments(
-          new QueryBuilder().create().type("ks", "t").column("a", "int").column("b", "int").build(),
+          new QueryBuilder()
+              .create()
+              .type("ks", "t")
+              .column("a", "int")
+              .column("b", "int")
+              .build()
+              .getCql(),
           "CREATE TYPE ks.t(a int, b int)"),
       arguments(
           new QueryBuilder()
@@ -246,25 +305,29 @@ public class QueryBuilderTest {
               .type("ks", "t")
               .renameColumn("a", "a2")
               .renameColumn("b", "b2")
-              .build(),
+              .build()
+              .getCql(),
           "ALTER TYPE ks.t RENAME a TO a2 AND b TO b2"),
-      arguments(new QueryBuilder().drop().type("ks", "t").build(), "DROP TYPE ks.t"),
+      arguments(new QueryBuilder().drop().type("ks", "t").build().getCql(), "DROP TYPE ks.t"),
       arguments(
-          new QueryBuilder().drop().type("ks", "t").ifExists().build(), "DROP TYPE IF EXISTS ks.t"),
+          new QueryBuilder().drop().type("ks", "t").ifExists().build().getCql(),
+          "DROP TYPE IF EXISTS ks.t"),
       arguments(
           new QueryBuilder()
               .alter()
               .type("ks", "t")
               .addColumn("c", "int")
               .addColumn("d", "int")
-              .build(),
+              .build()
+              .getCql(),
           "ALTER TYPE ks.t ADD c int, d int"),
       arguments(
           new QueryBuilder()
               .insertInto("ks", "tbl")
               .value("a", 1)
               .value(ValueModifier.marker("b"))
-              .build(),
+              .build()
+              .getCql(),
           "INSERT INTO ks.tbl (a, b) VALUES (1, ?)"),
       arguments(
           new QueryBuilder()
@@ -274,7 +337,8 @@ public class QueryBuilderTest {
               .ifNotExists()
               .ttl()
               .timestamp(1L)
-              .build(),
+              .build()
+              .getCql(),
           "INSERT INTO ks.tbl (a, b) VALUES ('text', ?) IF NOT EXISTS USING TTL ? AND TIMESTAMP 1"),
       arguments(
           new QueryBuilder()
@@ -289,7 +353,8 @@ public class QueryBuilderTest {
               .where("k", Predicate.EQ)
               .ifs("v", Predicate.GT)
               .ifExists()
-              .build(),
+              .build()
+              .getCql(),
           "UPDATE ks.tbl SET a = ?, "
               + "b = 'test', "
               + "c = ? + c "
@@ -303,14 +368,16 @@ public class QueryBuilderTest {
               .from("ks", "tbl")
               .where("k", Predicate.EQ)
               .ifs("v", Predicate.IN)
-              .build(),
+              .build()
+              .getCql(),
           "DELETE a, b, c FROM ks.tbl WHERE k = ? IF v IN ?"),
-      arguments(new QueryBuilder().select().from("ks", "tbl").build(), "SELECT * FROM ks.tbl"),
       arguments(
-          new QueryBuilder().select().column("a", "b", "c").from("ks", "tbl").build(),
+          new QueryBuilder().select().from("ks", "tbl").build().getCql(), "SELECT * FROM ks.tbl"),
+      arguments(
+          new QueryBuilder().select().column("a", "b", "c").from("ks", "tbl").build().getCql(),
           "SELECT a, b, c FROM ks.tbl"),
       arguments(
-          new QueryBuilder().select().count("a").from("ks", "tbl").build(),
+          new QueryBuilder().select().count("a").from("ks", "tbl").build().getCql(),
           "SELECT COUNT(a) FROM ks.tbl"),
       arguments(
           new QueryBuilder()
@@ -319,7 +386,8 @@ public class QueryBuilderTest {
               .from("ks", "tbl")
               .where("k", Predicate.EQ)
               .where("cc", Predicate.GT)
-              .build(),
+              .build()
+              .getCql(),
           "SELECT a, b, c FROM ks.tbl WHERE k = ? AND cc > ?"),
       arguments(
           new QueryBuilder()
@@ -332,7 +400,8 @@ public class QueryBuilderTest {
               .groupBy("cc2")
               .orderBy("cc1", Column.Order.ASC)
               .orderBy("cc2", Column.Order.DESC)
-              .build(),
+              .build()
+              .getCql(),
           "SELECT * FROM ks.tbl WHERE k > ? GROUP BY k, cc1, cc2 ORDER BY cc1 ASC, cc2 DESC"),
     };
   }

--- a/sgv2-service-common/src/test/java/io/stargate/sgv2/common/cql/builder/QueryBuilderValuesTest.java
+++ b/sgv2-service-common/src/test/java/io/stargate/sgv2/common/cql/builder/QueryBuilderValuesTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright DataStax, Inc. and/or The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.common.cql.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+
+import io.stargate.grpc.Values;
+import io.stargate.proto.QueryOuterClass;
+import io.stargate.proto.QueryOuterClass.Query;
+import io.stargate.proto.QueryOuterClass.Value;
+import io.stargate.sgv2.common.cql.builder.BuiltCondition.LHS;
+import org.junit.jupiter.api.Test;
+
+public class QueryBuilderValuesTest {
+
+  public static final Value INT_VALUE1 = Values.of(1);
+  public static final Value INT_VALUE2 = Values.of(10);
+  public static final Value TEXT_VALUE = Values.of("a");
+
+  @Test
+  public void shouldBindDirectInsertValues() {
+    Query query =
+        new QueryBuilder()
+            .insertInto("ks", "tbl")
+            .value("c1", INT_VALUE1)
+            .value("c2", TEXT_VALUE)
+            .value("c3", 3)
+            .build();
+
+    assertThat(query.getCql())
+        .isEqualTo("INSERT INTO ks.tbl (c1, c2, c3) VALUES (:\"c1\", :\"c2\", 3)");
+
+    QueryOuterClass.Values values = query.getValues();
+    assertThat(values.getValuesCount()).isEqualTo(2);
+    assertValue(values, "c1", INT_VALUE1);
+    assertValue(values, "c2", TEXT_VALUE);
+  }
+
+  @Test
+  public void shouldBindValueModifiers() {
+    Query query =
+        new QueryBuilder()
+            .update("ks", "tbl")
+            .value(ValueModifier.set("c1", INT_VALUE1))
+            .value(
+                ValueModifier.of(
+                    ValueModifier.Target.mapValue("c2", Term.of(TEXT_VALUE)),
+                    ValueModifier.Operation.APPEND,
+                    Term.of(1)))
+            .where("k", Predicate.EQ, 1)
+            .build();
+
+    assertThat(query.getCql())
+        .isEqualTo("UPDATE ks.tbl SET c1 = :\"c1\", c2[:\"c2\"] += 1 WHERE k = 1");
+
+    QueryOuterClass.Values values = query.getValues();
+    assertThat(values.getValuesCount()).isEqualTo(2);
+    assertValue(values, "c1", INT_VALUE1);
+    assertValue(values, "c2", TEXT_VALUE);
+  }
+
+  @Test
+  public void shouldBindDirectWhereValues() {
+    Query query =
+        new QueryBuilder()
+            .select()
+            .from("ks", "tbl")
+            .where("c1", Predicate.EQ, INT_VALUE1)
+            .where("c2", Predicate.EQ, TEXT_VALUE)
+            .where("c3", Predicate.EQ, 3)
+            .build();
+
+    assertThat(query.getCql())
+        .isEqualTo("SELECT * FROM ks.tbl WHERE c1 = :\"c1\" AND c2 = :\"c2\" AND c3 = 3");
+
+    QueryOuterClass.Values values = query.getValues();
+    assertThat(values.getValuesCount()).isEqualTo(2);
+    assertValue(values, "c1", INT_VALUE1);
+    assertValue(values, "c2", TEXT_VALUE);
+  }
+
+  @Test
+  public void shouldBindBuiltConditionsInWhere() {
+    Query query =
+        new QueryBuilder()
+            .select()
+            .from("ks", "tbl")
+            .where(BuiltCondition.of("c1", Predicate.EQ, INT_VALUE1))
+            .where(BuiltCondition.of(LHS.mapAccess("c2", TEXT_VALUE), Predicate.GT, Term.of(1)))
+            .build();
+
+    assertThat(query.getCql())
+        .isEqualTo("SELECT * FROM ks.tbl WHERE c1 = :\"c1\" AND c2[:\"c2\"] > 1");
+
+    QueryOuterClass.Values values = query.getValues();
+    assertThat(values.getValuesCount()).isEqualTo(2);
+    assertValue(values, "c1", INT_VALUE1);
+    assertValue(values, "c2", TEXT_VALUE);
+  }
+
+  @Test
+  public void shouldBindDirectIfValues() {
+    Query query =
+        new QueryBuilder()
+            .delete()
+            .from("ks", "tbl")
+            .where("k", Predicate.EQ, 1)
+            .ifs("c1", Predicate.EQ, INT_VALUE1)
+            .ifs("c2", Predicate.EQ, TEXT_VALUE)
+            .ifs("c3", Predicate.EQ, 3)
+            .build();
+
+    assertThat(query.getCql())
+        .isEqualTo("DELETE FROM ks.tbl WHERE k = 1 IF c1 = :\"c1\" AND c2 = :\"c2\" AND c3 = 3");
+
+    QueryOuterClass.Values values = query.getValues();
+    assertThat(values.getValuesCount()).isEqualTo(2);
+    assertValue(values, "c1", INT_VALUE1);
+    assertValue(values, "c2", TEXT_VALUE);
+  }
+
+  @Test
+  public void shouldBindBuiltConditionsInIfs() {
+    Query query =
+        new QueryBuilder()
+            .delete()
+            .from("ks", "tbl")
+            .where("k", Predicate.EQ, 1)
+            .ifs(BuiltCondition.of("c1", Predicate.EQ, INT_VALUE1))
+            .ifs(BuiltCondition.of(LHS.mapAccess("c2", TEXT_VALUE), Predicate.GT, Term.of(1)))
+            .build();
+
+    assertThat(query.getCql())
+        .isEqualTo("DELETE FROM ks.tbl WHERE k = 1 IF c1 = :\"c1\" AND c2[:\"c2\"] > 1");
+
+    QueryOuterClass.Values values = query.getValues();
+    assertThat(values.getValuesCount()).isEqualTo(2);
+    assertValue(values, "c1", INT_VALUE1);
+    assertValue(values, "c2", TEXT_VALUE);
+  }
+
+  @Test
+  public void shouldGenerateUniqueMarkerNames() {
+    Query query =
+        new QueryBuilder()
+            .delete()
+            .from("ks", "tbl")
+            .where("k", Predicate.GT, INT_VALUE1)
+            .where("k", Predicate.LTE, INT_VALUE2)
+            .build();
+
+    assertThat(query.getCql()).isEqualTo("DELETE FROM ks.tbl WHERE k > :\"k\" AND k <= :\"k2\"");
+
+    QueryOuterClass.Values values = query.getValues();
+    assertThat(values.getValuesCount()).isEqualTo(2);
+    assertValue(values, "k", INT_VALUE1);
+    assertValue(values, "k2", INT_VALUE2);
+  }
+
+  @Test
+  public void shouldNotAllowMixedMarkers() {
+    assertThatThrownBy(
+            () ->
+                new QueryBuilder()
+                    .select()
+                    .from("ks", "tbl")
+                    .where("c1", Predicate.EQ, INT_VALUE1)
+                    .where("c2", Predicate.EQ, Term.marker()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Can't use anonymous and named markers in the same query");
+    assertThatThrownBy(
+            () ->
+                new QueryBuilder()
+                    .select()
+                    .from("ks", "tbl")
+                    .where("c1", Predicate.EQ, Term.marker())
+                    .where("c2", Predicate.EQ, INT_VALUE1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Can't use anonymous and named markers in the same query");
+  }
+
+  @Test
+  public void shouldAllowAnonymousMarkersWhenNoValues() {
+    Query query =
+        new QueryBuilder()
+            .select()
+            .from("ks", "tbl")
+            .where("c1", Predicate.EQ, Term.marker())
+            .build();
+
+    assertThat(query.getCql()).isEqualTo("SELECT * FROM ks.tbl WHERE c1 = ?");
+  }
+
+  private void assertValue(QueryOuterClass.Values values, String name, Value value) {
+    for (int i = 0; i < values.getValueNamesCount(); i++) {
+      if (name.equals(values.getValueNames(i))) {
+        assertThat(values.getValues(i)).isEqualTo(value);
+        return;
+      }
+    }
+    fail("Did not find value name %s in %s", name, values.getValueNamesList());
+  }
+}


### PR DESCRIPTION
**What this PR does**:
Revisit v2's `QueryBuilderImpl` to build a `QueryOuterClass.Query` that can be directly passed to the bridge client.

In addition, detect when `QueryOuterClass.Value` are used, automatically replace them with bind markers, and store them in `Query.getValues()`.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
