### PR TITLE
closes #1659: proper handling of retries for unprepared errors in grpc

### DIFF
--- a/grpc/src/main/java/io/stargate/grpc/retries/DefaultRetryPolicy.java
+++ b/grpc/src/main/java/io/stargate/grpc/retries/DefaultRetryPolicy.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  * <p>This is a very conservative implementation: it triggers a maximum of one retry per request,
  * and only in cases that have a high chance of success (see the method javadocs for detailed
  * explanations of each case). The exception is the {@link
- * RetryPolicy#onUnprepared(PreparedQueryNotFoundException, int)}, which allows limitless retries.
+ * RetryPolicy#onUnprepared(PreparedQueryNotFoundException, int)}, which allows 2 retries.
  */
 @ThreadSafe
 public class DefaultRetryPolicy implements RetryPolicy {
@@ -115,14 +115,16 @@ public class DefaultRetryPolicy implements RetryPolicy {
   /**
    * {@inheritDoc}
    *
-   * <p>No limits on the retries when UNPREPARED occurs.
+   * <p>Two retries max when UNPREPARED occurs.
    */
   @Override
   public RetryDecision onUnprepared(PreparedQueryNotFoundException pe, int retryCount) {
-    if (LOG.isTraceEnabled()) {
+    RetryDecision decision = retryCount < 2 ? RetryDecision.RETRY : RetryDecision.RETHROW;
+
+    if (decision == RetryDecision.RETRY && LOG.isTraceEnabled()) {
       LOG.trace(RETRYING_ON_UNPREPARED, pe.id.toString(), retryCount);
     }
 
-    return RetryDecision.RETRY;
+    return decision;
   }
 }

--- a/grpc/src/main/java/io/stargate/grpc/retries/DefaultRetryPolicy.java
+++ b/grpc/src/main/java/io/stargate/grpc/retries/DefaultRetryPolicy.java
@@ -19,6 +19,7 @@ import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting
 import edu.umd.cs.findbugs.annotations.NonNull;
 import net.jcip.annotations.ThreadSafe;
 import org.apache.cassandra.stargate.db.WriteType;
+import org.apache.cassandra.stargate.exceptions.PreparedQueryNotFoundException;
 import org.apache.cassandra.stargate.exceptions.ReadTimeoutException;
 import org.apache.cassandra.stargate.exceptions.WriteTimeoutException;
 import org.slf4j.Logger;
@@ -29,7 +30,8 @@ import org.slf4j.LoggerFactory;
  *
  * <p>This is a very conservative implementation: it triggers a maximum of one retry per request,
  * and only in cases that have a high chance of success (see the method javadocs for detailed
- * explanations of each case).
+ * explanations of each case). The exception is the {@link
+ * RetryPolicy#onUnprepared(PreparedQueryNotFoundException, int)}, which allows limitless retries.
  */
 @ThreadSafe
 public class DefaultRetryPolicy implements RetryPolicy {
@@ -45,6 +47,10 @@ public class DefaultRetryPolicy implements RetryPolicy {
   public static final String RETRYING_ON_WRITE_TIMEOUT =
       "Retrying on write timeout (consistency: {}, write type: {}, "
           + "required acknowledgments: {}, received acknowledgments: {}, retries: {})";
+
+  @VisibleForTesting
+  public static final String RETRYING_ON_UNPREPARED =
+      "Retrying on unprepared (MD5 digest: {}, retries: {})";
 
   /**
    * {@inheritDoc}
@@ -104,5 +110,19 @@ public class DefaultRetryPolicy implements RetryPolicy {
           retryCount);
     }
     return decision;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>No limits on the retries when UNPREPARED occurs.
+   */
+  @Override
+  public RetryDecision onUnprepared(PreparedQueryNotFoundException pe, int retryCount) {
+    if (LOG.isTraceEnabled()) {
+      LOG.trace(RETRYING_ON_UNPREPARED, pe.id.toString(), retryCount);
+    }
+
+    return RetryDecision.RETRY;
   }
 }

--- a/grpc/src/main/java/io/stargate/grpc/retries/RetryPolicy.java
+++ b/grpc/src/main/java/io/stargate/grpc/retries/RetryPolicy.java
@@ -16,6 +16,7 @@
 package io.stargate.grpc.retries;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.apache.cassandra.stargate.exceptions.PreparedQueryNotFoundException;
 import org.apache.cassandra.stargate.exceptions.ReadTimeoutException;
 import org.apache.cassandra.stargate.exceptions.WriteTimeoutException;
 
@@ -50,4 +51,15 @@ public interface RetryPolicy {
    */
   RetryDecision onWriteTimeout(
       @NonNull WriteTimeoutException writeTimeoutException, int retryCount);
+
+  /**
+   * Whether to retry when the server replied with a {@code UNPREPARED} error; this indicates a
+   * <b>server-side</b> prepared query cache evicted a prepared statement during a query.
+   *
+   * @param preparedQueryNotFoundException the exception used to determine if the query should be
+   *     retried.
+   * @param retryCount how many times the retry policy has been invoked already for this request
+   */
+  RetryDecision onUnprepared(
+      PreparedQueryNotFoundException preparedQueryNotFoundException, int retryCount);
 }

--- a/grpc/src/main/java/io/stargate/grpc/service/MessageHandler.java
+++ b/grpc/src/main/java/io/stargate/grpc/service/MessageHandler.java
@@ -44,6 +44,7 @@ import java.util.concurrent.CompletionStage;
 import javax.annotation.Nullable;
 import org.apache.cassandra.stargate.db.ConsistencyLevel;
 import org.apache.cassandra.stargate.exceptions.PersistenceException;
+import org.apache.cassandra.stargate.exceptions.PreparedQueryNotFoundException;
 import org.apache.cassandra.stargate.exceptions.ReadTimeoutException;
 import org.apache.cassandra.stargate.exceptions.WriteTimeoutException;
 
@@ -121,7 +122,7 @@ public abstract class MessageHandler<MessageT extends GeneratedMessageV3, Prepar
     PersistenceException pe = cause.get();
     switch (pe.code()) {
       case UNPREPARED:
-        return RetryDecision.RETRY;
+        return retryPolicy.onUnprepared((PreparedQueryNotFoundException) pe, retryCount);
       case READ_TIMEOUT:
         return retryPolicy.onReadTimeout((ReadTimeoutException) pe, retryCount);
       case WRITE_TIMEOUT:


### PR DESCRIPTION
**What this PR does**:
Extends the grpc `RetryPolicy` in order to allow specific retries for the `UNPREPARED` error code. Currently allows limites retries, but we should agree in this PR if this is fine or not. See #1659 for more details.

**Which issue(s) this PR fixes**:
Fixes #1659

**Checklist**
- [x] Automated Tests added/updated
