### PR TITLE
closes #1660: non-api endpoint metrics to be reported with different …

### DIFF
--- a/graphqlapi/src/main/java/io/stargate/graphql/web/DropwizardServer.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/DropwizardServer.java
@@ -38,6 +38,7 @@ import io.stargate.graphql.web.resources.FilesResource;
 import io.stargate.graphql.web.resources.GraphqlCache;
 import io.stargate.graphql.web.resources.PlaygroundResource;
 import io.stargate.metrics.jersey.MetricsBinder;
+import java.util.Arrays;
 import java.util.EnumSet;
 import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration;
@@ -49,6 +50,9 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
 public class DropwizardServer extends Application<Configuration> {
+
+  public static final String[] NON_API_URI_REGEX =
+      new String[] {"^/playground$", "^/graphql-schema$"};
 
   private final Persistence persistence;
   private final AuthenticationService authenticationService;
@@ -155,7 +159,11 @@ public class DropwizardServer extends Application<Configuration> {
     enableCors(environment);
 
     MetricsBinder metricsBinder =
-        new MetricsBinder(metrics, httpMetricsTagProvider, GraphqlActivator.MODULE_NAME);
+        new MetricsBinder(
+            metrics,
+            httpMetricsTagProvider,
+            GraphqlActivator.MODULE_NAME,
+            Arrays.asList(NON_API_URI_REGEX));
     metricsBinder.register(environment.jersey());
 
     environment

--- a/graphqlapi/src/main/java/io/stargate/graphql/web/DropwizardServer.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/web/DropwizardServer.java
@@ -51,8 +51,7 @@ import org.osgi.framework.FrameworkUtil;
 
 public class DropwizardServer extends Application<Configuration> {
 
-  public static final String[] NON_API_URI_REGEX =
-      new String[] {"^/playground$", "^/graphql-schema$"};
+  public static final String[] NON_API_URI_REGEX = new String[] {"^/(playground|graphql-schema)$"};
 
   private final Persistence persistence;
   private final AuthenticationService authenticationService;

--- a/metrics-jersey/src/main/java/io/stargate/metrics/jersey/MetricsBinder.java
+++ b/metrics-jersey/src/main/java/io/stargate/metrics/jersey/MetricsBinder.java
@@ -32,9 +32,12 @@ import io.stargate.metrics.jersey.tags.DocsApiModuleTagsProvider;
 import io.stargate.metrics.jersey.tags.HeadersTagProvider;
 import io.stargate.metrics.jersey.tags.HttpCounterTagsProvider;
 import io.stargate.metrics.jersey.tags.HttpMeterTagsProvider;
+import io.stargate.metrics.jersey.tags.NonApiModuleTagsProvider;
 import io.stargate.metrics.jersey.tags.PathParametersTagsProvider;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -67,8 +70,22 @@ public class MetricsBinder {
   private final Metrics metrics;
   private final HttpMetricsTagProvider httpMetricsTagProvider;
   private final String module;
+  private final Collection<String> nonApiUriRegexes;
   private final MetricsListenerConfig meterListenerConfig;
   private final MetricsListenerConfig counterListenerConfig;
+
+  /**
+   * Default constructor with no non-APR URI regexes. Uses {@link SystemPropsMetricsListenerConfig}
+   * for metering and counting configuration.
+   *
+   * @param metrics {@link Metrics} instance.
+   * @param httpMetricsTagProvider Global {@link HttpMetricsTagProvider} registered in the OSGi
+   * @param module Module name
+   */
+  public MetricsBinder(
+      Metrics metrics, HttpMetricsTagProvider httpMetricsTagProvider, String module) {
+    this(metrics, httpMetricsTagProvider, module, Collections.emptyList());
+  }
 
   /**
    * Default constructor. Uses {@link SystemPropsMetricsListenerConfig} for metering and counting
@@ -77,13 +94,18 @@ public class MetricsBinder {
    * @param metrics {@link Metrics} instance.
    * @param httpMetricsTagProvider Global {@link HttpMetricsTagProvider} registered in the OSGi
    * @param module Module name
+   * @param nonApiUriRegexes List of regexes for URIs that should be tagged with #module-other tag.
    */
   public MetricsBinder(
-      Metrics metrics, HttpMetricsTagProvider httpMetricsTagProvider, String module) {
+      Metrics metrics,
+      HttpMetricsTagProvider httpMetricsTagProvider,
+      String module,
+      Collection<String> nonApiUriRegexes) {
     this(
         metrics,
         httpMetricsTagProvider,
         module,
+        nonApiUriRegexes,
         new SystemPropsMetricsListenerConfig("stargate.metrics.http_meter_listener"),
         new SystemPropsMetricsListenerConfig("stargate.metrics.http_counter_listener"));
   }
@@ -94,6 +116,7 @@ public class MetricsBinder {
    * @param metrics {@link Metrics} instance.
    * @param httpMetricsTagProvider Global {@link HttpMetricsTagProvider} registered in the OSGi
    * @param module Module name
+   * @param nonApiUriRegexes List of regexes for URIs that should be tagged with #module-other tag.
    * @param meterListenerConfig config for metering HTTP requests
    * @param counterListenerConfig config for counting HTTP requests
    */
@@ -101,11 +124,13 @@ public class MetricsBinder {
       Metrics metrics,
       HttpMetricsTagProvider httpMetricsTagProvider,
       String module,
+      Collection<String> nonApiUriRegexes,
       MetricsListenerConfig meterListenerConfig,
       MetricsListenerConfig counterListenerConfig) {
     this.metrics = metrics;
     this.httpMetricsTagProvider = httpMetricsTagProvider;
     this.module = module;
+    this.nonApiUriRegexes = nonApiUriRegexes;
     this.meterListenerConfig = meterListenerConfig;
     this.counterListenerConfig = counterListenerConfig;
   }
@@ -119,7 +144,8 @@ public class MetricsBinder {
   public void register(JerseyEnvironment jersey) {
     if (meterListenerConfig.isEnabled()) {
       JerseyTagsProvider meterTagsProvider =
-          getMeterTagsProvider(meterListenerConfig, metrics, httpMetricsTagProvider, module);
+          getMeterTagsProvider(
+              meterListenerConfig, metrics, httpMetricsTagProvider, module, nonApiUriRegexes);
       MetricsApplicationEventListener listener =
           new MetricsApplicationEventListener(
               metrics.getMeterRegistry(),
@@ -131,7 +157,8 @@ public class MetricsBinder {
 
     if (counterListenerConfig.isEnabled()) {
       JerseyTagsProvider counterTagsProvider =
-          getCounterTagsProvider(counterListenerConfig, metrics, httpMetricsTagProvider, module);
+          getCounterTagsProvider(
+              counterListenerConfig, metrics, httpMetricsTagProvider, module, nonApiUriRegexes);
       CounterApplicationEventListener listener =
           new CounterApplicationEventListener(
               metrics.getMeterRegistry(),
@@ -145,7 +172,8 @@ public class MetricsBinder {
       MetricsListenerConfig config,
       Metrics metrics,
       HttpMetricsTagProvider httpMetricsTagProvider,
-      String module) {
+      String module,
+      Collection<String> nonApiUriRegexes) {
     // resolve if http tag provider should be ignored or not
     HttpMeterTagsProvider resourceProvider =
         config.isIgnoreHttpMetricProvider()
@@ -154,7 +182,7 @@ public class MetricsBinder {
 
     // get default tags and add the meter provider
     List<JerseyTagsProvider> allProviders =
-        new ArrayList<>(getDefaultTagsProvider(metrics, module));
+        new ArrayList<>(getDefaultTagsProvider(metrics, module, nonApiUriRegexes));
     allProviders.add(resourceProvider);
 
     // return composite containing all the providers
@@ -165,7 +193,8 @@ public class MetricsBinder {
       MetricsListenerConfig config,
       Metrics metrics,
       HttpMetricsTagProvider httpMetricsTagProvider,
-      String module) {
+      String module,
+      Collection<String> nonApiUriRegexes) {
     // resolve if http tag provider should be ignored or not
     HttpCounterTagsProvider resourceProvider =
         config.isIgnoreHttpMetricProvider()
@@ -174,20 +203,27 @@ public class MetricsBinder {
 
     // get default tags and add the meter provider
     List<JerseyTagsProvider> allProviders =
-        new ArrayList<>(getDefaultTagsProvider(metrics, module));
+        new ArrayList<>(getDefaultTagsProvider(metrics, module, nonApiUriRegexes));
     allProviders.add(resourceProvider);
 
     // return composite containing all the providers
     return new CompositeJerseyTagsProvider(allProviders);
   }
 
-  private static List<JerseyTagsProvider> getDefaultTagsProvider(Metrics metrics, String module) {
+  private static List<JerseyTagsProvider> getDefaultTagsProvider(
+      Metrics metrics, String module, Collection<String> nonApiUriRegexes) {
     ConstantTagsProvider defaultProvider = new ConstantTagsProvider(metrics.tagsForModule(module));
     PathParametersTagsProvider pathParametersProvider = new PathParametersTagsProvider();
     HeadersTagProvider headersTagProvider = new HeadersTagProvider();
+    NonApiModuleTagsProvider nonApiModuleTagsProvider =
+        new NonApiModuleTagsProvider(metrics, module, nonApiUriRegexes);
     DocsApiModuleTagsProvider docsApiProvider = new DocsApiModuleTagsProvider(metrics);
 
     return Arrays.asList(
-        defaultProvider, pathParametersProvider, headersTagProvider, docsApiProvider);
+        defaultProvider,
+        pathParametersProvider,
+        headersTagProvider,
+        nonApiModuleTagsProvider,
+        docsApiProvider);
   }
 }

--- a/metrics-jersey/src/main/java/io/stargate/metrics/jersey/tags/NonApiModuleTagsProvider.java
+++ b/metrics-jersey/src/main/java/io/stargate/metrics/jersey/tags/NonApiModuleTagsProvider.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.metrics.jersey.tags;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.jersey2.server.JerseyTagsProvider;
+import io.stargate.core.metrics.api.Metrics;
+import java.util.Collection;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.glassfish.jersey.server.monitoring.RequestEvent;
+
+/**
+ * A simple tag provider that overwrites the module tag to <code>other</code> if URI matches one of
+ * the patterns.
+ */
+public class NonApiModuleTagsProvider implements JerseyTagsProvider {
+
+  public static final String NON_API_MODULE_EXTENSION = "other";
+
+  private final Tags tags;
+
+  private final Collection<Pattern> uriPatterns;
+
+  public NonApiModuleTagsProvider(Metrics metrics, String module, Collection<String> uriRegexes) {
+    this.tags = metrics.tagsForModule(module + "-" + NON_API_MODULE_EXTENSION);
+    this.uriPatterns = uriRegexes.stream().map(Pattern::compile).collect(Collectors.toList());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Iterable<Tag> httpRequestTags(RequestEvent event) {
+    return tagsInternal(event);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Iterable<Tag> httpLongRequestTags(RequestEvent event) {
+    return tagsInternal(event);
+  }
+
+  private Iterable<Tag> tagsInternal(RequestEvent event) {
+    if (isNonApiRequest(event.getUriInfo())) {
+      return tags;
+    }
+    return Tags.empty();
+  }
+
+  // we are on non-api if any pattern matches
+  private boolean isNonApiRequest(ExtendedUriInfo uriInfo) {
+    if (uriPatterns.isEmpty()) {
+      return false;
+    }
+
+    String path = uriInfo.getAbsolutePath().getPath();
+    return uriPatterns.stream().anyMatch(p -> p.matcher(path).matches());
+  }
+}

--- a/metrics-jersey/src/test/java/io/stargate/metrics/jersey/MetricsBinderTest.java
+++ b/metrics-jersey/src/test/java/io/stargate/metrics/jersey/MetricsBinderTest.java
@@ -30,6 +30,7 @@ import io.stargate.core.metrics.api.HttpMetricsTagProvider;
 import io.stargate.core.metrics.api.Metrics;
 import io.stargate.metrics.jersey.config.MetricsListenerConfig;
 import io.stargate.metrics.jersey.listener.CounterApplicationEventListener;
+import java.util.Collections;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -63,7 +64,12 @@ class MetricsBinderTest {
   public void init() {
     binder =
         new MetricsBinder(
-            metrics, httpMetricsTagProvider, MODULE, meterListenerConfig, counterListenerConfig);
+            metrics,
+            httpMetricsTagProvider,
+            MODULE,
+            Collections.emptyList(),
+            meterListenerConfig,
+            counterListenerConfig);
   }
 
   @Nested
@@ -82,6 +88,7 @@ class MetricsBinderTest {
       verify(jerseyEnvironment, times(2)).register(registerComponentCaptor.capture());
       verify(metrics, times(2)).getMeterRegistry();
       verify(metrics, times(2)).tagsForModule(MODULE);
+      verify(metrics, times(2)).tagsForModule(MODULE + "-other");
       verifyNoMoreInteractions(metrics, httpMetricsTagProvider);
       assertThat(registerComponentCaptor.getAllValues())
           .hasSize(2)

--- a/metrics-jersey/src/test/java/io/stargate/metrics/jersey/tags/NonApiModuleTagsProviderTest.java
+++ b/metrics-jersey/src/test/java/io/stargate/metrics/jersey/tags/NonApiModuleTagsProviderTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.metrics.jersey.tags;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.stargate.core.metrics.api.Metrics;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.glassfish.jersey.server.monitoring.RequestEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NonApiModuleTagsProviderTest {
+
+  NonApiModuleTagsProvider provider;
+
+  @Mock Metrics metrics;
+
+  @Mock RequestEvent requestEvent;
+
+  @Mock ExtendedUriInfo extendedUriInfo;
+
+  @BeforeEach
+  public void mockEvent() {
+    lenient().when(requestEvent.getUriInfo()).thenReturn(extendedUriInfo);
+  }
+
+  @Nested
+  class HttpRequestTags {
+
+    @Test
+    public void happyPath() throws Exception {
+      Tags tags = Tags.of("module", RandomStringUtils.randomAlphanumeric(16));
+      when(extendedUriInfo.getAbsolutePath()).thenReturn(new URI("/playground"));
+      when(metrics.tagsForModule("testing-other")).thenReturn(tags);
+
+      provider =
+          new NonApiModuleTagsProvider(metrics, "testing", Collections.singleton("^/playground$"));
+      Iterable<Tag> result = provider.httpRequestTags(requestEvent);
+
+      assertThat(result).containsAll(tags);
+      verify(metrics).tagsForModule("testing-other");
+      verifyNoMoreInteractions(metrics);
+    }
+
+    @Test
+    public void notMatched() throws Exception {
+      when(extendedUriInfo.getAbsolutePath()).thenReturn(new URI("/v1/keyspaces/my-keyspace"));
+
+      provider =
+          new NonApiModuleTagsProvider(
+              metrics, "testing", Arrays.asList("^/$", "^/playground$", "^/swagger.*"));
+      Iterable<Tag> result = provider.httpRequestTags(requestEvent);
+
+      assertThat(result).isEmpty();
+      verify(metrics).tagsForModule("testing-other");
+      verifyNoMoreInteractions(metrics);
+    }
+
+    @Test
+    public void emptyRegexes() {
+      provider = new NonApiModuleTagsProvider(metrics, "testing", Collections.emptyList());
+      Iterable<Tag> result = provider.httpRequestTags(requestEvent);
+
+      assertThat(result).isEmpty();
+      verify(metrics).tagsForModule("testing-other");
+      verifyNoMoreInteractions(metrics, extendedUriInfo);
+    }
+  }
+
+  @Nested
+  class HttpLongRequestTags {
+
+    @Test
+    public void happyPath() throws Exception {
+      Tags tags = Tags.of("module", RandomStringUtils.randomAlphanumeric(16));
+      when(extendedUriInfo.getAbsolutePath()).thenReturn(new URI("/playground"));
+      when(metrics.tagsForModule("testing-other")).thenReturn(tags);
+
+      provider =
+          new NonApiModuleTagsProvider(metrics, "testing", Collections.singleton("^/playground$"));
+      Iterable<Tag> result = provider.httpLongRequestTags(requestEvent);
+
+      assertThat(result).containsAll(tags);
+      verify(metrics).tagsForModule("testing-other");
+      verifyNoMoreInteractions(metrics);
+    }
+
+    @Test
+    public void notMatched() throws Exception {
+      when(extendedUriInfo.getAbsolutePath()).thenReturn(new URI("/v1/keyspaces/my-keyspace"));
+
+      provider =
+          new NonApiModuleTagsProvider(
+              metrics, "testing", Arrays.asList("^/$", "^/playground$", "^/swagger.*"));
+      Iterable<Tag> result = provider.httpLongRequestTags(requestEvent);
+
+      assertThat(result).isEmpty();
+      verify(metrics).tagsForModule("testing-other");
+      verifyNoMoreInteractions(metrics);
+    }
+
+    @Test
+    public void emptyRegexes() {
+      provider = new NonApiModuleTagsProvider(metrics, "testing", Collections.emptyList());
+      Iterable<Tag> result = provider.httpLongRequestTags(requestEvent);
+
+      assertThat(result).isEmpty();
+      verify(metrics).tagsForModule("testing-other");
+      verifyNoMoreInteractions(metrics, extendedUriInfo);
+    }
+  }
+}

--- a/metrics-jersey/src/test/java/io/stargate/metrics/jersey/tags/NonApiModuleTagsProviderTest.java
+++ b/metrics-jersey/src/test/java/io/stargate/metrics/jersey/tags/NonApiModuleTagsProviderTest.java
@@ -65,7 +65,8 @@ class NonApiModuleTagsProviderTest {
       when(metrics.tagsForModule("testing-other")).thenReturn(tags);
 
       provider =
-          new NonApiModuleTagsProvider(metrics, "testing", Collections.singleton("^/playground$"));
+          new NonApiModuleTagsProvider(
+              metrics, "testing", Collections.singleton("^/(playground|swagger)$"));
       Iterable<Tag> result = provider.httpRequestTags(requestEvent);
 
       assertThat(result).containsAll(tags);

--- a/restapi/src/main/java/io/stargate/web/impl/RestApiServer.java
+++ b/restapi/src/main/java/io/stargate/web/impl/RestApiServer.java
@@ -56,6 +56,7 @@ import io.swagger.jaxrs.config.DefaultJaxrsScanner;
 import io.swagger.jaxrs.listing.ApiListingResource;
 import io.swagger.jaxrs.listing.SwaggerSerializers;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.EnumSet;
 import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration;
@@ -67,6 +68,8 @@ import org.osgi.framework.FrameworkUtil;
 
 /** DropWizard {@code Application} that will serve both REST (v1, v2) and Document API endpoints. */
 public class RestApiServer extends Application<RestApiServerConfiguration> {
+
+  public static final String[] NON_API_URI_REGEX = new String[] {"^/$", "^/health$", "^/swagger.*"};
 
   private final AuthenticationService authenticationService;
   private final AuthorizationService authorizationService;
@@ -184,7 +187,11 @@ public class RestApiServer extends Application<RestApiServerConfiguration> {
     enableCors(environment);
 
     MetricsBinder metricsBinder =
-        new MetricsBinder(metrics, httpMetricsTagProvider, RestApiActivator.MODULE_NAME);
+        new MetricsBinder(
+            metrics,
+            httpMetricsTagProvider,
+            RestApiActivator.MODULE_NAME,
+            Arrays.asList(NON_API_URI_REGEX));
     metricsBinder.register(environment.jersey());
 
     // no html content

--- a/testing/src/main/java/io/stargate/it/http/MetricsTest.java
+++ b/testing/src/main/java/io/stargate/it/http/MetricsTest.java
@@ -136,6 +136,68 @@ public class MetricsTest extends BaseIntegrationTest {
   }
 
   @Test
+  public void restNonApiHttpRequestMetrics() throws IOException {
+    // call the rest api path with target header
+    String path = String.format("%s:8082", host);
+    OkHttpClient client = new OkHttpClient().newBuilder().build();
+    Request request = new Request.Builder().url(path).get().build();
+
+    int status = execute(client, request);
+
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              String result =
+                  RestUtils.get("", String.format("%s:8084/metrics", host), HttpStatus.SC_OK);
+
+              // metered http request lines
+              List<String> meterLines =
+                  Arrays.stream(result.split(System.getProperty("line.separator")))
+                      .filter(line -> line.startsWith("http_server_requests_seconds"))
+                      .collect(Collectors.toList());
+
+              assertThat(meterLines)
+                  .anySatisfy(
+                      metric ->
+                          assertThat(metric)
+                              .contains("method=\"GET\"")
+                              .contains("module=\"restapi-other\"")
+                              .contains("uri=\"root\"")
+                              .contains(String.format("status=\"%d\"", status))
+                              .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY)
+                              .contains("quantile=\"0.95\"")
+                              .doesNotContain("error"))
+                  .anySatisfy(
+                      metric ->
+                          assertThat(metric)
+                              .contains("method=\"GET\"")
+                              .contains("module=\"restapi-other\"")
+                              .contains("uri=\"root\"")
+                              .contains(String.format("status=\"%d\"", status))
+                              .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY)
+                              .contains("quantile=\"0.99\""))
+                  .doesNotContain("error");
+
+              // counted http request lines
+              List<String> counterLines =
+                  Arrays.stream(result.split(System.getProperty("line.separator")))
+                      .filter(line -> line.startsWith("http_server_requests_counter"))
+                      .collect(Collectors.toList());
+
+              assertThat(counterLines)
+                  .anySatisfy(
+                      metric ->
+                          assertThat(metric)
+                              .contains("error=\"false\"")
+                              .contains("module=\"restapi-other\"")
+                              .doesNotContain("method=\"GET\"")
+                              .doesNotContain("uri=\"root\"")
+                              .doesNotContain(String.format("status=\"%d\"", status)));
+            });
+  }
+
+  @Test
   public void docsApiHttpRequestMetrics() throws IOException {
     // call the rest api path with target header
     String path = String.format("%s:8082/v2/namespaces/some", host);
@@ -266,6 +328,66 @@ public class MetricsTest extends BaseIntegrationTest {
                               .doesNotContain(String.format("status=\"%d\"", status))
                               .doesNotContain(
                                   TagMeHttpMetricsTagProvider.TAG_ME_KEY + "=\"test-value\""));
+            });
+  }
+
+  @Test
+  public void graphqlNonApiHttpRequestMetrics() throws IOException {
+    // call the rest api path with target header
+    String path = String.format("%s:8080/playground", host);
+    OkHttpClient client = new OkHttpClient().newBuilder().build();
+    Request request = new Request.Builder().url(path).get().build();
+
+    int status = execute(client, request);
+
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              String result =
+                  RestUtils.get("", String.format("%s:8084/metrics", host), HttpStatus.SC_OK);
+
+              List<String> meteredLines =
+                  Arrays.stream(result.split(System.getProperty("line.separator")))
+                      .filter(line -> line.startsWith("http_server_requests_seconds"))
+                      .collect(Collectors.toList());
+
+              assertThat(meteredLines)
+                  .anySatisfy(
+                      metric ->
+                          assertThat(metric)
+                              .contains("method=\"GET\"")
+                              .contains("module=\"graphqlapi-other\"")
+                              .contains("uri=\"/playground\"")
+                              .contains(String.format("status=\"%d\"", status))
+                              .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY)
+                              .contains("quantile=\"0.95\"")
+                              .doesNotContain("error"))
+                  .anySatisfy(
+                      metric ->
+                          assertThat(metric)
+                              .contains("method=\"GET\"")
+                              .contains("module=\"graphqlapi-other\"")
+                              .contains("uri=\"/playground\"")
+                              .contains(String.format("status=\"%d\"", status))
+                              .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY)
+                              .contains("quantile=\"0.99\"")
+                              .doesNotContain("error"));
+
+              List<String> countedLines =
+                  Arrays.stream(result.split(System.getProperty("line.separator")))
+                      .filter(line -> line.startsWith("http_server_requests_counter"))
+                      .collect(Collectors.toList());
+
+              assertThat(countedLines)
+                  .anySatisfy(
+                      metric ->
+                          assertThat(metric)
+                              .contains("error=\"false\"")
+                              .contains("module=\"graphqlapi-other\"")
+                              .doesNotContain("method=\"GET\"")
+                              .doesNotContain("uri=\"/playground\"")
+                              .doesNotContain(String.format("status=\"%d\"", status)));
             });
   }
 


### PR DESCRIPTION
**What this PR does**:
Enables possibility to tag specific endpoints with a `module=basemodule-other` tag when reporting metrics. See #1660 for more information.

**Which issue(s) this PR fixes**:
Fixes #1660.

**Checklist**
- [x] Automated Tests added/updated
