### PR TITLE
closes #1220: json with empty field names not supported

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/service/JsonDocumentShredder.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/JsonDocumentShredder.java
@@ -165,6 +165,13 @@ public class JsonDocumentShredder {
             field -> {
               String fieldName = field.getKey();
 
+              if (fieldName.isEmpty()) {
+                String msg =
+                    "JSON objects containing empty field names are not supported at the moment.";
+                throw new ErrorCodeRuntimeException(
+                    ErrorCode.DOCS_API_GENERAL_INVALID_FIELD_NAME, msg);
+              }
+
               // check for valid field name
               if (DocsApiUtils.containsIllegalSequences(fieldName)) {
                 String msg =

--- a/restapi/src/test/java/io/stargate/web/docsapi/service/JsonDocumentShredderTest.java
+++ b/restapi/src/test/java/io/stargate/web/docsapi/service/JsonDocumentShredderTest.java
@@ -161,6 +161,17 @@ class JsonDocumentShredderTest {
     }
 
     @Test
+    public void emptyFieldName() {
+      ObjectNode payload = objectMapper.createObjectNode().put("", "text");
+
+      Throwable result = catchThrowable(() -> shredder.shred(payload, Collections.emptyList()));
+
+      assertThat(result)
+          .isInstanceOf(ErrorCodeRuntimeException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_GENERAL_INVALID_FIELD_NAME);
+    }
+
+    @Test
     public void emptyObject() {
       ObjectNode payload = objectMapper.createObjectNode();
 

--- a/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
+++ b/testing/src/main/java/io/stargate/it/http/docsapi/BaseDocumentApiV2Test.java
@@ -775,6 +775,17 @@ public abstract class BaseDocumentApiV2Test extends BaseIntegrationTest {
   }
 
   @Test
+  public void testJsonEmptyKey() throws IOException {
+    String json = "{\"\": \"value\", \"nested\": {\"\": \"value\"}}";
+
+    String resp = RestUtils.post(authToken, collectionPath, json, 400);
+
+    assertThat(resp)
+        .isEqualTo(
+            "{\"description\":\"JSON objects containing empty field names are not supported at the moment.\",\"code\":400}");
+  }
+
+  @Test
   public void testWriteManyDocs() throws IOException {
     // Create documents using multiExample that creates random ID's
     URL url = Resources.getResource("multiExample.json");


### PR DESCRIPTION
**What this PR does**:
As agreed with @EricBorczuk, allowing empty keys in JSON, although they are valid, would represent quite a challenge for us in the documents API. Thus, we decided that for now we explicitly forbid this and return `400` in case such document is written. We assumed this will not affect users, as empty JSON keys are an anti-pattern. The handling might change in future.

**Which issue(s) this PR fixes**:
Fixes #1220.
