### PR TITLE
Fix #1680: update Jackson dependency to 2.12.6

### DIFF
--- a/config-store-yaml/pom.xml
+++ b/config-store-yaml/pom.xml
@@ -28,7 +28,6 @@
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>2.11.4</version>
       </dependency>
       <dependency>
         <groupId>com.github.ben-manes.caffeine</groupId>

--- a/persistence-test/pom.xml
+++ b/persistence-test/pom.xml
@@ -53,11 +53,9 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
-    <!-- IMPORTANT: please note that this dependency must be in sync with the transitive version in the cassandra-all in persistence 3.11, 4.0 and DSE 6.8 projects -->
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.9.10</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -484,6 +484,17 @@
   </distributionManagement>
   <dependencyManagement>
     <dependencies>
+      <!-- To get a consistent set of Jackson components, use BOM:
+           will provide default version for all standard components
+          (but will not add actual dependencies)
+        -->
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>2.12.6</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.dropwizard</groupId>
         <artifactId>dropwizard-core</artifactId>

--- a/restapi/pom.xml
+++ b/restapi/pom.xml
@@ -52,6 +52,14 @@
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-core</artifactId>
     </dependency>
+    <!-- Since restapi serializes Java 8 date/time values, we must use
+         JSR-310 module. Version provided by parent.
+      -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>com.github.java-json-tools</groupId>
       <artifactId>json-schema-validator</artifactId>

--- a/restapi/src/main/java/io/stargate/web/resources/Converters.java
+++ b/restapi/src/main/java/io/stargate/web/resources/Converters.java
@@ -25,6 +25,8 @@ import com.datastax.oss.driver.shaded.guava.common.collect.Lists;
 import com.datastax.oss.driver.shaded.guava.common.collect.Maps;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.stargate.db.datastore.Row;
 import io.stargate.db.query.Modification.Operation;
 import io.stargate.db.query.Predicate;
@@ -70,8 +72,15 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class Converters {
-
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  static {
+    // For Java 8 date/time types we need, as per [stargate#1680]:
+    OBJECT_MAPPER.registerModule(new JavaTimeModule());
+    // and by default date/time values written as numbers but we prefer ISO-8601:
+    OBJECT_MAPPER.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+  }
+
   private static final Pattern UNQUOTED_IDENTIFIER = Pattern.compile("[a-z][a-z0-9_]*");
   private static final Pattern PATTERN_DOUBLE_QUOTE = Pattern.compile("\"", Pattern.LITERAL);
   private static final String ESCAPED_DOUBLE_QUOTE = Matcher.quoteReplacement("\"\"");

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2RowsTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2RowsTest.java
@@ -597,6 +597,7 @@ public class RestApiv2RowsTest extends BaseIntegrationTest {
     assertThat(data.size()).isEqualTo(1);
     assertThat(data.get(0).get("id")).isEqualTo("1");
     assertThat(data.get(0).get("firstName")).isEqualTo("John");
+    assertThat(data.get(0).get("created")).isEqualTo(timestamp);
   }
 
   @Test


### PR DESCRIPTION
**What this PR does**:

Adds managed dependency to `jackson-bom` version 2.12.6, which will default Jackson dependencies to that version throughout project.

**Which issue(s) this PR fixes**:

No issue filed; Snyk reported issues wrt Jackson 2.10.5 on another project.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated -- will rely on existing CI
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
