### PR TITLE
(WIP) Alternative Jackson 2.12.6 upgrade PR

### DIFF
--- a/config-store-yaml/pom.xml
+++ b/config-store-yaml/pom.xml
@@ -28,7 +28,6 @@
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>2.11.4</version>
       </dependency>
       <dependency>
         <groupId>com.github.ben-manes.caffeine</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -484,6 +484,18 @@
   </distributionManagement>
   <dependencyManagement>
     <dependencies>
+      <!-- To get a consistent set of Jackson components, use BOM:
+           will provide default version for all standard components
+           (but will not add actual dependencies)
+          NOTE: sub-modules MAY still override these defaults (see "persistence-test")
+        -->
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>2.12.6</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.dropwizard</groupId>
         <artifactId>dropwizard-core</artifactId>


### PR DESCRIPTION
DO NOT MERGE!

**What this PR does**:

Upgrades most of Jackson deps to 2.12.6 -- but unlike earlier PR #1681 leaves overrides for one module to see if that avoids test fails.

**Which issue(s) this PR fixes**:
Fixes #1680

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
