### PR TITLE
Fix #1685 handling of `timestamp` values on REST/json output

### DIFF
--- a/restapi/pom.xml
+++ b/restapi/pom.xml
@@ -52,6 +52,14 @@
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-core</artifactId>
     </dependency>
+    <!-- Since restapi serializes Java 8 date/time values, we must use
+         JSR-310 module. Version provided by parent.
+      -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>2.10.5</version>
+    </dependency>
     <dependency>
       <groupId>com.github.java-json-tools</groupId>
       <artifactId>json-schema-validator</artifactId>

--- a/restapi/src/main/java/io/stargate/web/resources/Converters.java
+++ b/restapi/src/main/java/io/stargate/web/resources/Converters.java
@@ -25,6 +25,8 @@ import com.datastax.oss.driver.shaded.guava.common.collect.Lists;
 import com.datastax.oss.driver.shaded.guava.common.collect.Maps;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.stargate.db.datastore.Row;
 import io.stargate.db.query.Modification.Operation;
 import io.stargate.db.query.Predicate;
@@ -72,6 +74,14 @@ import java.util.stream.Collectors;
 public class Converters {
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  static {
+    // For Java 8 date/time types we need:
+    OBJECT_MAPPER.registerModule(new JavaTimeModule());
+    // and by default date/time values written as numbers but we prefer ISO-8601:
+    OBJECT_MAPPER.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+  }
+
   private static final Pattern UNQUOTED_IDENTIFIER = Pattern.compile("[a-z][a-z0-9_]*");
   private static final Pattern PATTERN_DOUBLE_QUOTE = Pattern.compile("\"", Pattern.LITERAL);
   private static final String ESCAPED_DOUBLE_QUOTE = Matcher.quoteReplacement("\"\"");

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2RowsTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2RowsTest.java
@@ -597,6 +597,7 @@ public class RestApiv2RowsTest extends BaseIntegrationTest {
     assertThat(data.size()).isEqualTo(1);
     assertThat(data.get(0).get("id")).isEqualTo("1");
     assertThat(data.get(0).get("firstName")).isEqualTo("John");
+    assertThat(data.get(0).get("created")).isEqualTo(timestamp);
   }
 
   @Test


### PR DESCRIPTION
**What this PR does**:

Fixes json serialization of `timestamp` values: instead of meaningless JSON objects will be serialized as ISO-8601 Strings. Adds minor test extension to verify the fix; formerly no tests seem to verify actual value that comes back.

**Which issue(s) this PR fixes**:
Fixes #1685

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
