### PR TITLE
Use anonymous bind markers in v2 query builder

### DIFF
--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Literal.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Literal.java
@@ -15,15 +15,15 @@
  */
 package io.stargate.sgv2.common.cql.builder;
 
-class Literal<T> implements Term<T> {
+class Literal implements Term {
 
-  private final T value;
+  private final Object value;
 
-  public Literal(T value) {
+  public Literal(Object value) {
     this.value = value;
   }
 
-  public T get() {
+  public Object get() {
     return value;
   }
 }

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Marker.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Marker.java
@@ -15,25 +15,9 @@
  */
 package io.stargate.sgv2.common.cql.builder;
 
-import io.stargate.sgv2.common.cql.CqlStrings;
-
-class Marker<T> implements Term<T> {
-
-  private final String name;
-
-  Marker(String name) {
-    this.name = name;
-  }
-
-  Marker() {
-    this(null);
-  }
-
-  boolean isAnonymous() {
-    return name == null;
-  }
+class Marker implements Term {
 
   String asCql() {
-    return name == null ? "?" : ":" + CqlStrings.doubleQuote(name);
+    return "?";
   }
 }

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Term.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Term.java
@@ -15,13 +15,8 @@
  */
 package io.stargate.sgv2.common.cql.builder;
 
-public interface Term<T> {
-
-  static <T> Term<T> marker() {
-    return new Marker<>();
-  }
-
-  static <T> Term<T> of(T value) {
-    return new Literal<>(value);
+public interface Term {
+  static Term of(Object value) {
+    return new Literal(value);
   }
 }

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/ValueModifier.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/ValueModifier.java
@@ -26,21 +26,17 @@ public interface ValueModifier {
 
   Operation operation();
 
-  Term<?> value();
+  Term value();
 
   static ValueModifier set(String columnName, Object value) {
     return set(columnName, Term.of(value));
   }
 
-  static ValueModifier set(String columnName, Term<?> value) {
+  static ValueModifier set(String columnName, Term value) {
     return of(Target.column(columnName), Operation.SET, value);
   }
 
-  static ValueModifier marker(String columnName) {
-    return of(Target.column(columnName), Operation.SET, Term.marker());
-  }
-
-  static ValueModifier of(Target target, Operation operation, Term<?> value) {
+  static ValueModifier of(Target target, Operation operation, Term value) {
     return ImmutableValueModifier.builder()
         .target(target)
         .operation(operation)
@@ -67,7 +63,7 @@ public interface ValueModifier {
 
     /** only set for map value access */
     @Nullable
-    Term<?> mapKey();
+    Term mapKey();
 
     static Target column(String columnName) {
       return ImmutableTarget.builder().columnName(columnName).build();
@@ -77,7 +73,7 @@ public interface ValueModifier {
       return ImmutableTarget.builder().columnName(columnName).fieldName(fieldName).build();
     }
 
-    static Target mapValue(String columnName, Term<?> mapKey) {
+    static Target mapValue(String columnName, Term mapKey) {
       return ImmutableTarget.builder().columnName(columnName).mapKey(mapKey).build();
     }
   }

--- a/sgv2-service-common/src/test/java/io/stargate/sgv2/common/cql/builder/QueryBuilderTest.java
+++ b/sgv2-service-common/src/test/java/io/stargate/sgv2/common/cql/builder/QueryBuilderTest.java
@@ -322,56 +322,6 @@ public class QueryBuilderTest {
               .getCql(),
           "ALTER TYPE ks.t ADD c int, d int"),
       arguments(
-          new QueryBuilder()
-              .insertInto("ks", "tbl")
-              .value("a", 1)
-              .value(ValueModifier.marker("b"))
-              .build()
-              .getCql(),
-          "INSERT INTO ks.tbl (a, b) VALUES (1, ?)"),
-      arguments(
-          new QueryBuilder()
-              .insertInto("ks", "tbl")
-              .value("a", "text")
-              .value(ValueModifier.marker("b"))
-              .ifNotExists()
-              .ttl()
-              .timestamp(1L)
-              .build()
-              .getCql(),
-          "INSERT INTO ks.tbl (a, b) VALUES ('text', ?) IF NOT EXISTS USING TTL ? AND TIMESTAMP 1"),
-      arguments(
-          new QueryBuilder()
-              .update("ks", "tbl")
-              .value("a")
-              .value("b", "test")
-              .value(
-                  ValueModifier.of(
-                      ValueModifier.Target.column("c"),
-                      ValueModifier.Operation.PREPEND,
-                      Term.marker()))
-              .where("k", Predicate.EQ)
-              .ifs("v", Predicate.GT)
-              .ifExists()
-              .build()
-              .getCql(),
-          "UPDATE ks.tbl SET a = ?, "
-              + "b = 'test', "
-              + "c = ? + c "
-              + "WHERE k = ? "
-              + "IF EXISTS "
-              + "AND v > ?"),
-      arguments(
-          new QueryBuilder()
-              .delete()
-              .column("a", "b", "c")
-              .from("ks", "tbl")
-              .where("k", Predicate.EQ)
-              .ifs("v", Predicate.IN)
-              .build()
-              .getCql(),
-          "DELETE a, b, c FROM ks.tbl WHERE k = ? IF v IN ?"),
-      arguments(
           new QueryBuilder().select().from("ks", "tbl").build().getCql(), "SELECT * FROM ks.tbl"),
       arguments(
           new QueryBuilder().select().column("a", "b", "c").from("ks", "tbl").build().getCql(),
@@ -379,30 +329,6 @@ public class QueryBuilderTest {
       arguments(
           new QueryBuilder().select().count("a").from("ks", "tbl").build().getCql(),
           "SELECT COUNT(a) FROM ks.tbl"),
-      arguments(
-          new QueryBuilder()
-              .select()
-              .column("a", "b", "c")
-              .from("ks", "tbl")
-              .where("k", Predicate.EQ)
-              .where("cc", Predicate.GT)
-              .build()
-              .getCql(),
-          "SELECT a, b, c FROM ks.tbl WHERE k = ? AND cc > ?"),
-      arguments(
-          new QueryBuilder()
-              .select()
-              .star()
-              .from("ks", "tbl")
-              .where("k", Predicate.GT)
-              .groupBy("k")
-              .groupBy("cc1")
-              .groupBy("cc2")
-              .orderBy("cc1", Column.Order.ASC)
-              .orderBy("cc2", Column.Order.DESC)
-              .build()
-              .getCql(),
-          "SELECT * FROM ks.tbl WHERE k > ? GROUP BY k, cc1, cc2 ORDER BY cc1 ASC, cc2 DESC"),
     };
   }
 }

--- a/sgv2-service-common/src/test/java/io/stargate/sgv2/common/cql/builder/QueryBuilderValuesTest.java
+++ b/sgv2-service-common/src/test/java/io/stargate/sgv2/common/cql/builder/QueryBuilderValuesTest.java
@@ -16,11 +16,8 @@
 package io.stargate.sgv2.common.cql.builder;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 
 import io.stargate.grpc.Values;
-import io.stargate.proto.QueryOuterClass;
 import io.stargate.proto.QueryOuterClass.Query;
 import io.stargate.proto.QueryOuterClass.Value;
 import io.stargate.sgv2.common.cql.builder.BuiltCondition.LHS;
@@ -42,13 +39,8 @@ public class QueryBuilderValuesTest {
             .value("c3", 3)
             .build();
 
-    assertThat(query.getCql())
-        .isEqualTo("INSERT INTO ks.tbl (c1, c2, c3) VALUES (:\"c1\", :\"c2\", 3)");
-
-    QueryOuterClass.Values values = query.getValues();
-    assertThat(values.getValuesCount()).isEqualTo(2);
-    assertValue(values, "c1", INT_VALUE1);
-    assertValue(values, "c2", TEXT_VALUE);
+    assertThat(query.getCql()).isEqualTo("INSERT INTO ks.tbl (c1, c2, c3) VALUES (?, ?, 3)");
+    assertThat(query.getValues().getValuesList()).containsExactly(INT_VALUE1, TEXT_VALUE);
   }
 
   @Test
@@ -65,13 +57,8 @@ public class QueryBuilderValuesTest {
             .where("k", Predicate.EQ, 1)
             .build();
 
-    assertThat(query.getCql())
-        .isEqualTo("UPDATE ks.tbl SET c1 = :\"c1\", c2[:\"c2\"] += 1 WHERE k = 1");
-
-    QueryOuterClass.Values values = query.getValues();
-    assertThat(values.getValuesCount()).isEqualTo(2);
-    assertValue(values, "c1", INT_VALUE1);
-    assertValue(values, "c2", TEXT_VALUE);
+    assertThat(query.getCql()).isEqualTo("UPDATE ks.tbl SET c1 = ?, c2[?] += 1 WHERE k = 1");
+    assertThat(query.getValues().getValuesList()).containsExactly(INT_VALUE1, TEXT_VALUE);
   }
 
   @Test
@@ -85,13 +72,8 @@ public class QueryBuilderValuesTest {
             .where("c3", Predicate.EQ, 3)
             .build();
 
-    assertThat(query.getCql())
-        .isEqualTo("SELECT * FROM ks.tbl WHERE c1 = :\"c1\" AND c2 = :\"c2\" AND c3 = 3");
-
-    QueryOuterClass.Values values = query.getValues();
-    assertThat(values.getValuesCount()).isEqualTo(2);
-    assertValue(values, "c1", INT_VALUE1);
-    assertValue(values, "c2", TEXT_VALUE);
+    assertThat(query.getCql()).isEqualTo("SELECT * FROM ks.tbl WHERE c1 = ? AND c2 = ? AND c3 = 3");
+    assertThat(query.getValues().getValuesList()).containsExactly(INT_VALUE1, TEXT_VALUE);
   }
 
   @Test
@@ -104,13 +86,8 @@ public class QueryBuilderValuesTest {
             .where(BuiltCondition.of(LHS.mapAccess("c2", TEXT_VALUE), Predicate.GT, Term.of(1)))
             .build();
 
-    assertThat(query.getCql())
-        .isEqualTo("SELECT * FROM ks.tbl WHERE c1 = :\"c1\" AND c2[:\"c2\"] > 1");
-
-    QueryOuterClass.Values values = query.getValues();
-    assertThat(values.getValuesCount()).isEqualTo(2);
-    assertValue(values, "c1", INT_VALUE1);
-    assertValue(values, "c2", TEXT_VALUE);
+    assertThat(query.getCql()).isEqualTo("SELECT * FROM ks.tbl WHERE c1 = ? AND c2[?] > 1");
+    assertThat(query.getValues().getValuesList()).containsExactly(INT_VALUE1, TEXT_VALUE);
   }
 
   @Test
@@ -126,12 +103,8 @@ public class QueryBuilderValuesTest {
             .build();
 
     assertThat(query.getCql())
-        .isEqualTo("DELETE FROM ks.tbl WHERE k = 1 IF c1 = :\"c1\" AND c2 = :\"c2\" AND c3 = 3");
-
-    QueryOuterClass.Values values = query.getValues();
-    assertThat(values.getValuesCount()).isEqualTo(2);
-    assertValue(values, "c1", INT_VALUE1);
-    assertValue(values, "c2", TEXT_VALUE);
+        .isEqualTo("DELETE FROM ks.tbl WHERE k = 1 IF c1 = ? AND c2 = ? AND c3 = 3");
+    assertThat(query.getValues().getValuesList()).containsExactly(INT_VALUE1, TEXT_VALUE);
   }
 
   @Test
@@ -145,13 +118,8 @@ public class QueryBuilderValuesTest {
             .ifs(BuiltCondition.of(LHS.mapAccess("c2", TEXT_VALUE), Predicate.GT, Term.of(1)))
             .build();
 
-    assertThat(query.getCql())
-        .isEqualTo("DELETE FROM ks.tbl WHERE k = 1 IF c1 = :\"c1\" AND c2[:\"c2\"] > 1");
-
-    QueryOuterClass.Values values = query.getValues();
-    assertThat(values.getValuesCount()).isEqualTo(2);
-    assertValue(values, "c1", INT_VALUE1);
-    assertValue(values, "c2", TEXT_VALUE);
+    assertThat(query.getCql()).isEqualTo("DELETE FROM ks.tbl WHERE k = 1 IF c1 = ? AND c2[?] > 1");
+    assertThat(query.getValues().getValuesList()).containsExactly(INT_VALUE1, TEXT_VALUE);
   }
 
   @Test
@@ -164,55 +132,20 @@ public class QueryBuilderValuesTest {
             .where("k", Predicate.LTE, INT_VALUE2)
             .build();
 
-    assertThat(query.getCql()).isEqualTo("DELETE FROM ks.tbl WHERE k > :\"k\" AND k <= :\"k2\"");
-
-    QueryOuterClass.Values values = query.getValues();
-    assertThat(values.getValuesCount()).isEqualTo(2);
-    assertValue(values, "k", INT_VALUE1);
-    assertValue(values, "k2", INT_VALUE2);
+    assertThat(query.getCql()).isEqualTo("DELETE FROM ks.tbl WHERE k > ? AND k <= ?");
+    assertThat(query.getValues().getValuesList()).containsExactly(INT_VALUE1, INT_VALUE2);
   }
 
   @Test
-  public void shouldNotAllowMixedMarkers() {
-    assertThatThrownBy(
-            () ->
-                new QueryBuilder()
-                    .select()
-                    .from("ks", "tbl")
-                    .where("c1", Predicate.EQ, INT_VALUE1)
-                    .where("c2", Predicate.EQ, Term.marker()))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Can't use anonymous and named markers in the same query");
-    assertThatThrownBy(
-            () ->
-                new QueryBuilder()
-                    .select()
-                    .from("ks", "tbl")
-                    .where("c1", Predicate.EQ, Term.marker())
-                    .where("c2", Predicate.EQ, INT_VALUE1))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Can't use anonymous and named markers in the same query");
-  }
+  public void shouldBindValuesInQueryOrder() {
+    // This is a bit contrived, client code should not explicitly depend on generated classes like
+    // this:
+    QueryBuilder.QueryBuilder__21 select = new QueryBuilder().select().from("ks", "tbl");
+    select.limit(INT_VALUE2);
+    select.where(BuiltCondition.of("c1", Predicate.EQ, INT_VALUE1));
+    Query query = select.build();
 
-  @Test
-  public void shouldAllowAnonymousMarkersWhenNoValues() {
-    Query query =
-        new QueryBuilder()
-            .select()
-            .from("ks", "tbl")
-            .where("c1", Predicate.EQ, Term.marker())
-            .build();
-
-    assertThat(query.getCql()).isEqualTo("SELECT * FROM ks.tbl WHERE c1 = ?");
-  }
-
-  private void assertValue(QueryOuterClass.Values values, String name, Value value) {
-    for (int i = 0; i < values.getValueNamesCount(); i++) {
-      if (name.equals(values.getValueNames(i))) {
-        assertThat(values.getValues(i)).isEqualTo(value);
-        return;
-      }
-    }
-    fail("Did not find value name %s in %s", name, values.getValueNamesList());
+    assertThat(query.getCql()).isEqualTo("SELECT * FROM ks.tbl WHERE c1 = ? LIMIT ?");
+    assertThat(query.getValues().getValuesList()).containsExactly(INT_VALUE1, INT_VALUE2);
   }
 }


### PR DESCRIPTION
**What this PR does**:
See title.
This is required because named markers don't work in batch queries ([CASSANDRA-10246](https://issues.apache.org/jira/browse/CASSANDRA-10246)).


**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
