### PR TITLE
Fix eviction race for prepared statements on Cassandra 4.0

### DIFF
--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Cassandra40Persistence.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Cassandra40Persistence.java
@@ -7,6 +7,7 @@ import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.Iterables;
 import com.datastax.oss.driver.shaded.guava.common.util.concurrent.Uninterruptibles;
+import com.google.common.util.concurrent.Striped;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.core.util.TimeSource;
 import io.stargate.db.Authenticator;
@@ -38,6 +39,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -98,6 +100,13 @@ public class Cassandra40Persistence
         IndexMetadata,
         ViewMetadata> {
   private static final Logger logger = LoggerFactory.getLogger(Cassandra40Persistence.class);
+
+  // Locks for synchronizing prepared statements. This default uses the recommended number of locks
+  // suggested in the Java docs for CPU-bound tasks (which preparing a statement is).
+  private static final Striped<Lock> PREPARE_LOCKS =
+      Striped.lock(
+          Integer.getInteger(
+              "stargate.prepare_lock_count", Runtime.getRuntime().availableProcessors() * 4));
 
   private static final boolean USE_TRANSITIONAL_AUTH =
       Boolean.getBoolean("stargate.cql_use_transitional_auth");
@@ -500,12 +509,22 @@ public class Cassandra40Persistence
 
     @Override
     public CompletableFuture<Result.Prepared> prepare(String query, Parameters parameters) {
-      return executeRequestOnExecutor(
-          parameters,
-          // The queryStartNanoTime is not used by prepared message, so it doesn't really matter
-          // that it's only computed now.
-          System.nanoTime(),
-          () -> new PrepareMessage(query, parameters.defaultKeyspace().orElse(null)));
+      // The behavior of prepared statements was changed as part of CASSANDRA-15252
+      // (and CASSANDRA-17248) which can cause multiple prepares of the same query to evict each
+      // other from the prepared cache. A few Stargate APIs eagerly prepare queries which
+      // increases this chance and to avoid this we serialize prepares for similar queries.
+      Lock lock = PREPARE_LOCKS.get(parameters.defaultKeyspace().map(k -> query + k).orElse(query));
+      try {
+        lock.lock();
+        return executeRequestOnExecutor(
+            parameters,
+            // The queryStartNanoTime is not used by prepared message, so it doesn't really matter
+            // that it's only computed now.
+            System.nanoTime(),
+            () -> new PrepareMessage(query, parameters.defaultKeyspace().orElse(null)));
+      } finally {
+        lock.unlock();
+      }
     }
 
     @Override

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Cassandra40Persistence.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Cassandra40Persistence.java
@@ -513,7 +513,7 @@ public class Cassandra40Persistence
       // (and CASSANDRA-17248) which can cause multiple prepares of the same query to evict each
       // other from the prepared cache. A few Stargate APIs eagerly prepare queries which
       // increases this chance and to avoid this we serialize prepares for similar queries.
-      Lock lock = PREPARE_LOCKS.get(parameters.defaultKeyspace().map(k -> query + k).orElse(query));
+      Lock lock = PREPARE_LOCKS.get(query);
       try {
         lock.lock();
         return executeRequestOnExecutor(


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

CASSANDRA-15252 (and CASSANDRA-17248) changed the behavior of prepared
statements which can cause multiple prepares of the same query to evict
each other from the prepared cache. This manifest itself as
`PreparedQueryNotFoundException` exceptions when attempting to execute a
prepared statement that was just prepared then evicted by another
concurrent prepare.

This fix serializes prepares for similar queries by locking them;
allowing one prepare to finish completely to avoid the case where
simultaneous prepares evict each other. It uses lock striping to
hopefully avoid making prepares too slow for concurrent preparers.

**Which issue(s) this PR fixes**:
Fixes #1679

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [X] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
