### PR TITLE
gRPC: add support for CQL duration type

### DIFF
--- a/grpc-proto/proto/query.proto
+++ b/grpc-proto/proto/query.proto
@@ -78,6 +78,12 @@ message Decimal {
   bytes value = 3;
 }
 
+message Duration {
+  sint32 months = 1;
+  sint32 days = 2;
+  sint64 nanos = 3;
+}
+
 // A CQL value. This is used both in requests to bind parameterized query strings, and in responses
 // to represent the result data.
 message Value {
@@ -129,9 +135,7 @@ message Value {
     uint64 time = 12;
 
     // CQL types: duration
-    // The duration value's fields (months, days and nanos), encoded in Cassandra's [varint] format
-    // and concatenated together.
-    bytes duration = 17;
+    Duration duration = 17;
 
     // CQL types: list, set, map, tuple
     Collection collection = 13;

--- a/grpc-proto/proto/query.proto
+++ b/grpc-proto/proto/query.proto
@@ -128,6 +128,11 @@ message Value {
     // in the range 0 to 86399999999999 (inclusive).
     uint64 time = 12;
 
+    // CQL types: duration
+    // The duration value's fields (months, days and nanos), encoded in Cassandra's [varint] format
+    // and concatenated together.
+    bytes duration = 17;
+
     // CQL types: list, set, map, tuple
     Collection collection = 13;
 

--- a/grpc-proto/src/main/java/io/stargate/grpc/CqlDuration.java
+++ b/grpc-proto/src/main/java/io/stargate/grpc/CqlDuration.java
@@ -1,0 +1,681 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.grpc;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
+import java.io.DataInput;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Period;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAmount;
+import java.time.temporal.TemporalUnit;
+import java.time.temporal.UnsupportedTemporalTypeException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A duration, as defined in CQL.
+ *
+ * <p>It stores months, days, and seconds separately due to the fact that the number of days in a
+ * month varies, and a day can have 23 or 25 hours if a daylight saving is involved. As such, this
+ * type differs from {@link Duration} (which only represents an amount between two points in time,
+ * regardless of the calendar).
+ *
+ * <p>Note: this class was copied from the Datastax Java driver, also licensed under the Apache
+ * license version 2.0.
+ */
+public final class CqlDuration implements TemporalAmount {
+
+  static final long NANOS_PER_MICRO = 1000L;
+  static final long NANOS_PER_MILLI = 1000 * NANOS_PER_MICRO;
+  static final long NANOS_PER_SECOND = 1000 * NANOS_PER_MILLI;
+  static final long NANOS_PER_MINUTE = 60 * NANOS_PER_SECOND;
+  static final long NANOS_PER_HOUR = 60 * NANOS_PER_MINUTE;
+  static final int DAYS_PER_WEEK = 7;
+  static final int MONTHS_PER_YEAR = 12;
+
+  /** The Regexp used to parse the duration provided as String. */
+  private static final Pattern STANDARD_PATTERN =
+      Pattern.compile(
+          "\\G(\\d+)(y|Y|mo|MO|mO|Mo|w|W|d|D|h|H|s|S|ms|MS|mS|Ms|us|US|uS|Us|µs|µS|ns|NS|nS|Ns|m|M)");
+
+  /**
+   * The Regexp used to parse the duration when provided in the ISO 8601 format with designators.
+   */
+  private static final Pattern ISO8601_PATTERN =
+      Pattern.compile("P((\\d+)Y)?((\\d+)M)?((\\d+)D)?(T((\\d+)H)?((\\d+)M)?((\\d+)S)?)?");
+
+  /**
+   * The Regexp used to parse the duration when provided in the ISO 8601 format with designators.
+   */
+  private static final Pattern ISO8601_WEEK_PATTERN = Pattern.compile("P(\\d+)W");
+
+  /** The Regexp used to parse the duration when provided in the ISO 8601 alternative format. */
+  private static final Pattern ISO8601_ALTERNATIVE_PATTERN =
+      Pattern.compile("P(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})");
+
+  private static final ImmutableList<TemporalUnit> TEMPORAL_UNITS =
+      ImmutableList.of(ChronoUnit.MONTHS, ChronoUnit.DAYS, ChronoUnit.NANOS);
+
+  private final int months;
+  private final int days;
+  private final long nanoseconds;
+
+  private CqlDuration(int months, int days, long nanoseconds) {
+    // Makes sure that all the values are negative if one of them is
+    if ((months < 0 || days < 0 || nanoseconds < 0)
+        && (months > 0 || days > 0 || nanoseconds > 0)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "All values must be either negative or positive, got %d months, %d days, %d nanoseconds",
+              months, days, nanoseconds));
+    }
+    this.months = months;
+    this.days = days;
+    this.nanoseconds = nanoseconds;
+  }
+
+  /**
+   * Creates a duration with the given number of months, days and nanoseconds.
+   *
+   * <p>A duration can be negative. In this case, all the non zero values must be negative.
+   *
+   * @param months the number of months
+   * @param days the number of days
+   * @param nanoseconds the number of nanoseconds
+   * @throws IllegalArgumentException if the values are not all negative or all positive
+   */
+  public static CqlDuration newInstance(int months, int days, long nanoseconds) {
+    return new CqlDuration(months, days, nanoseconds);
+  }
+
+  /**
+   * Converts a <code>String</code> into a duration.
+   *
+   * <p>The accepted formats are:
+   *
+   * <ul>
+   *   <li>multiple digits followed by a time unit like: 12h30m where the time unit can be:
+   *       <ul>
+   *         <li>{@code y}: years
+   *         <li>{@code mo}: months
+   *         <li>{@code w}: weeks
+   *         <li>{@code d}: days
+   *         <li>{@code h}: hours
+   *         <li>{@code m}: minutes
+   *         <li>{@code s}: seconds
+   *         <li>{@code ms}: milliseconds
+   *         <li>{@code us} or {@code µs}: microseconds
+   *         <li>{@code ns}: nanoseconds
+   *       </ul>
+   *   <li>ISO 8601 format: P[n]Y[n]M[n]DT[n]H[n]M[n]S or P[n]W
+   *   <li>ISO 8601 alternative format: P[YYYY]-[MM]-[DD]T[hh]:[mm]:[ss]
+   * </ul>
+   *
+   * @param input the <code>String</code> to convert
+   */
+  public static CqlDuration from(String input) {
+    boolean isNegative = input.startsWith("-");
+    String source = isNegative ? input.substring(1) : input;
+
+    if (source.startsWith("P")) {
+      if (source.endsWith("W")) {
+        return parseIso8601WeekFormat(isNegative, source);
+      }
+      if (source.contains("-")) {
+        return parseIso8601AlternativeFormat(isNegative, source);
+      }
+      return parseIso8601Format(isNegative, source);
+    }
+    return parseStandardFormat(isNegative, source);
+  }
+
+  private static CqlDuration parseIso8601Format(boolean isNegative, String source) {
+    Matcher matcher = ISO8601_PATTERN.matcher(source);
+    if (!matcher.matches())
+      throw new IllegalArgumentException(
+          String.format("Unable to convert '%s' to a duration", source));
+
+    Builder builder = new Builder(isNegative);
+    if (matcher.group(1) != null) {
+      builder.addYears(groupAsLong(matcher, 2));
+    }
+    if (matcher.group(3) != null) {
+      builder.addMonths(groupAsLong(matcher, 4));
+    }
+    if (matcher.group(5) != null) {
+      builder.addDays(groupAsLong(matcher, 6));
+    }
+    // Checks if the String contains time information
+    if (matcher.group(7) != null) {
+      if (matcher.group(8) != null) {
+        builder.addHours(groupAsLong(matcher, 9));
+      }
+      if (matcher.group(10) != null) {
+        builder.addMinutes(groupAsLong(matcher, 11));
+      }
+      if (matcher.group(12) != null) {
+        builder.addSeconds(groupAsLong(matcher, 13));
+      }
+    }
+    return builder.build();
+  }
+
+  private static CqlDuration parseIso8601AlternativeFormat(boolean isNegative, String source) {
+    Matcher matcher = ISO8601_ALTERNATIVE_PATTERN.matcher(source);
+    if (!matcher.matches()) {
+      throw new IllegalArgumentException(
+          String.format("Unable to convert '%s' to a duration", source));
+    }
+    return new Builder(isNegative)
+        .addYears(groupAsLong(matcher, 1))
+        .addMonths(groupAsLong(matcher, 2))
+        .addDays(groupAsLong(matcher, 3))
+        .addHours(groupAsLong(matcher, 4))
+        .addMinutes(groupAsLong(matcher, 5))
+        .addSeconds(groupAsLong(matcher, 6))
+        .build();
+  }
+
+  private static CqlDuration parseIso8601WeekFormat(boolean isNegative, String source) {
+    Matcher matcher = ISO8601_WEEK_PATTERN.matcher(source);
+    if (!matcher.matches()) {
+      throw new IllegalArgumentException(
+          String.format("Unable to convert '%s' to a duration", source));
+    }
+    return new Builder(isNegative).addWeeks(groupAsLong(matcher, 1)).build();
+  }
+
+  private static CqlDuration parseStandardFormat(boolean isNegative, String source) {
+    Matcher matcher = STANDARD_PATTERN.matcher(source);
+    if (!matcher.find()) {
+      throw new IllegalArgumentException(
+          String.format("Unable to convert '%s' to a duration", source));
+    }
+    Builder builder = new Builder(isNegative);
+    boolean done;
+
+    do {
+      long number = groupAsLong(matcher, 1);
+      String symbol = matcher.group(2);
+      add(builder, number, symbol);
+      done = matcher.end() == source.length();
+    } while (matcher.find());
+
+    if (!done) {
+      throw new IllegalArgumentException(
+          String.format("Unable to convert '%s' to a duration", source));
+    }
+    return builder.build();
+  }
+
+  private static long groupAsLong(Matcher matcher, int group) {
+    return Long.parseLong(matcher.group(group));
+  }
+
+  private static Builder add(Builder builder, long number, String symbol) {
+    String s = symbol.toLowerCase(Locale.ROOT);
+    if (s.equals("y")) {
+      return builder.addYears(number);
+    } else if (s.equals("mo")) {
+      return builder.addMonths(number);
+    } else if (s.equals("w")) {
+      return builder.addWeeks(number);
+    } else if (s.equals("d")) {
+      return builder.addDays(number);
+    } else if (s.equals("h")) {
+      return builder.addHours(number);
+    } else if (s.equals("m")) {
+      return builder.addMinutes(number);
+    } else if (s.equals("s")) {
+      return builder.addSeconds(number);
+    } else if (s.equals("ms")) {
+      return builder.addMillis(number);
+    } else if (s.equals("us") || s.equals("µs")) {
+      return builder.addMicros(number);
+    } else if (s.equals("ns")) {
+      return builder.addNanos(number);
+    }
+    throw new IllegalArgumentException(String.format("Unknown duration symbol '%s'", symbol));
+  }
+
+  /**
+   * Appends the result of the division to the specified builder if the dividend is not zero.
+   *
+   * @param builder the builder to append to
+   * @param dividend the dividend
+   * @param divisor the divisor
+   * @param unit the time unit to append after the result of the division
+   * @return the remainder of the division
+   */
+  private static long append(StringBuilder builder, long dividend, long divisor, String unit) {
+    if (dividend == 0 || dividend < divisor) {
+      return dividend;
+    }
+    builder.append(dividend / divisor).append(unit);
+    return dividend % divisor;
+  }
+
+  public static CqlDuration decode(byte[] bytes) {
+    if (bytes == null || bytes.length == 0) {
+      return null;
+    } else {
+      DataInput in = ByteStreams.newDataInput(bytes);
+      try {
+        int months = (int) VIntCoding.readVInt(in);
+        int days = (int) VIntCoding.readVInt(in);
+        long nanoseconds = VIntCoding.readVInt(in);
+        return CqlDuration.newInstance(months, days, nanoseconds);
+      } catch (IOException e) {
+        // cannot happen
+        throw new AssertionError();
+      }
+    }
+  }
+
+  /**
+   * Returns the number of months in this duration.
+   *
+   * @return the number of months in this duration.
+   */
+  public int getMonths() {
+    return months;
+  }
+
+  /**
+   * Returns the number of days in this duration.
+   *
+   * @return the number of days in this duration.
+   */
+  public int getDays() {
+    return days;
+  }
+
+  /**
+   * Returns the number of nanoseconds in this duration.
+   *
+   * @return the number of months in this duration.
+   */
+  public long getNanoseconds() {
+    return nanoseconds;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation converts the months and days components to a {@link Period}, and the
+   * nanosecond component to a {@link Duration}, and adds those two amounts to the temporal object.
+   * Therefore the chronology of the temporal must be either the ISO chronology or null.
+   *
+   * @see Period#addTo(Temporal)
+   * @see Duration#addTo(Temporal)
+   */
+  @Override
+  public Temporal addTo(Temporal temporal) {
+    return temporal.plus(Period.of(0, months, days)).plus(Duration.ofNanos(nanoseconds));
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation converts the months and days components to a {@link Period}, and the
+   * nanosecond component to a {@link Duration}, and subtracts those two amounts to the temporal
+   * object. Therefore the chronology of the temporal must be either the ISO chronology or null.
+   *
+   * @see Period#subtractFrom(Temporal)
+   * @see Duration#subtractFrom(Temporal)
+   */
+  @Override
+  public Temporal subtractFrom(Temporal temporal) {
+    return temporal.minus(Period.of(0, months, days)).minus(Duration.ofNanos(nanoseconds));
+  }
+
+  @Override
+  public long get(TemporalUnit unit) {
+    if (unit == ChronoUnit.MONTHS) {
+      return months;
+    } else if (unit == ChronoUnit.DAYS) {
+      return days;
+    } else if (unit == ChronoUnit.NANOS) {
+      return nanoseconds;
+    } else {
+      throw new UnsupportedTemporalTypeException("Unsupported unit: " + unit);
+    }
+  }
+
+  @Override
+  public List<TemporalUnit> getUnits() {
+    return TEMPORAL_UNITS;
+  }
+
+  public byte[] encode() {
+    int size =
+        VIntCoding.computeVIntSize(months)
+            + VIntCoding.computeVIntSize(days)
+            + VIntCoding.computeVIntSize(nanoseconds);
+    ByteArrayDataOutput out = ByteStreams.newDataOutput(size);
+    try {
+      VIntCoding.writeVInt(months, out);
+      VIntCoding.writeVInt(days, out);
+      VIntCoding.writeVInt(nanoseconds, out);
+    } catch (IOException e) {
+      // cannot happen
+      throw new AssertionError();
+    }
+    return out.toByteArray();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    } else if (other instanceof CqlDuration) {
+      CqlDuration that = (CqlDuration) other;
+      return this.days == that.days
+          && this.months == that.months
+          && this.nanoseconds == that.nanoseconds;
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(days, months, nanoseconds);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+
+    if (months < 0 || days < 0 || nanoseconds < 0) {
+      builder.append('-');
+    }
+    long remainder = append(builder, Math.abs(months), MONTHS_PER_YEAR, "y");
+    append(builder, remainder, 1, "mo");
+
+    append(builder, Math.abs(days), 1, "d");
+
+    if (nanoseconds != 0) {
+      remainder = append(builder, Math.abs(nanoseconds), NANOS_PER_HOUR, "h");
+      remainder = append(builder, remainder, NANOS_PER_MINUTE, "m");
+      remainder = append(builder, remainder, NANOS_PER_SECOND, "s");
+      remainder = append(builder, remainder, NANOS_PER_MILLI, "ms");
+      remainder = append(builder, remainder, NANOS_PER_MICRO, "us");
+      append(builder, remainder, 1, "ns");
+    }
+    return builder.toString();
+  }
+
+  private static class Builder {
+    private final boolean isNegative;
+    private int months;
+    private int days;
+    private long nanoseconds;
+
+    /** We need to make sure that the values for each units are provided in order. */
+    private int currentUnitIndex;
+
+    public Builder(boolean isNegative) {
+      this.isNegative = isNegative;
+    }
+
+    /**
+     * Adds the specified amount of years.
+     *
+     * @param numberOfYears the number of years to add.
+     * @return this {@code Builder}
+     */
+    public Builder addYears(long numberOfYears) {
+      validateOrder(1);
+      validateMonths(numberOfYears, MONTHS_PER_YEAR);
+      // Cast to avoid http://errorprone.info/bugpattern/NarrowingCompoundAssignment
+      // We could also change the method to accept an int, but keeping long allows us to keep the
+      // calling code generic.
+      months += (int) numberOfYears * MONTHS_PER_YEAR;
+      return this;
+    }
+
+    /**
+     * Adds the specified amount of months.
+     *
+     * @param numberOfMonths the number of months to add.
+     * @return this {@code Builder}
+     */
+    public Builder addMonths(long numberOfMonths) {
+      validateOrder(2);
+      validateMonths(numberOfMonths, 1);
+      months += (int) numberOfMonths;
+      return this;
+    }
+
+    /**
+     * Adds the specified amount of weeks.
+     *
+     * @param numberOfWeeks the number of weeks to add.
+     * @return this {@code Builder}
+     */
+    public Builder addWeeks(long numberOfWeeks) {
+      validateOrder(3);
+      validateDays(numberOfWeeks, DAYS_PER_WEEK);
+      days += (int) numberOfWeeks * DAYS_PER_WEEK;
+      return this;
+    }
+
+    /**
+     * Adds the specified amount of days.
+     *
+     * @param numberOfDays the number of days to add.
+     * @return this {@code Builder}
+     */
+    public Builder addDays(long numberOfDays) {
+      validateOrder(4);
+      validateDays(numberOfDays, 1);
+      days += (int) numberOfDays;
+      return this;
+    }
+
+    /**
+     * Adds the specified amount of hours.
+     *
+     * @param numberOfHours the number of hours to add.
+     * @return this {@code Builder}
+     */
+    public Builder addHours(long numberOfHours) {
+      validateOrder(5);
+      validateNanos(numberOfHours, NANOS_PER_HOUR);
+      nanoseconds += numberOfHours * NANOS_PER_HOUR;
+      return this;
+    }
+
+    /**
+     * Adds the specified amount of minutes.
+     *
+     * @param numberOfMinutes the number of minutes to add.
+     * @return this {@code Builder}
+     */
+    public Builder addMinutes(long numberOfMinutes) {
+      validateOrder(6);
+      validateNanos(numberOfMinutes, NANOS_PER_MINUTE);
+      nanoseconds += numberOfMinutes * NANOS_PER_MINUTE;
+      return this;
+    }
+
+    /**
+     * Adds the specified amount of seconds.
+     *
+     * @param numberOfSeconds the number of seconds to add.
+     * @return this {@code Builder}
+     */
+    public Builder addSeconds(long numberOfSeconds) {
+      validateOrder(7);
+      validateNanos(numberOfSeconds, NANOS_PER_SECOND);
+      nanoseconds += numberOfSeconds * NANOS_PER_SECOND;
+      return this;
+    }
+
+    /**
+     * Adds the specified amount of milliseconds.
+     *
+     * @param numberOfMillis the number of milliseconds to add.
+     * @return this {@code Builder}
+     */
+    public Builder addMillis(long numberOfMillis) {
+      validateOrder(8);
+      validateNanos(numberOfMillis, NANOS_PER_MILLI);
+      nanoseconds += numberOfMillis * NANOS_PER_MILLI;
+      return this;
+    }
+
+    /**
+     * Adds the specified amount of microseconds.
+     *
+     * @param numberOfMicros the number of microseconds to add.
+     * @return this {@code Builder}
+     */
+    public Builder addMicros(long numberOfMicros) {
+      validateOrder(9);
+      validateNanos(numberOfMicros, NANOS_PER_MICRO);
+      nanoseconds += numberOfMicros * NANOS_PER_MICRO;
+      return this;
+    }
+
+    /**
+     * Adds the specified amount of nanoseconds.
+     *
+     * @param numberOfNanos the number of nanoseconds to add.
+     * @return this {@code Builder}
+     */
+    public Builder addNanos(long numberOfNanos) {
+      validateOrder(10);
+      validateNanos(numberOfNanos, 1);
+      nanoseconds += numberOfNanos;
+      return this;
+    }
+
+    /**
+     * Validates that the total number of months can be stored.
+     *
+     * @param units the number of units that need to be added
+     * @param monthsPerUnit the number of days per unit
+     */
+    private void validateMonths(long units, int monthsPerUnit) {
+      validate(units, (Integer.MAX_VALUE - months) / monthsPerUnit, "months");
+    }
+
+    /**
+     * Validates that the total number of days can be stored.
+     *
+     * @param units the number of units that need to be added
+     * @param daysPerUnit the number of days per unit
+     */
+    private void validateDays(long units, int daysPerUnit) {
+      validate(units, (Integer.MAX_VALUE - days) / daysPerUnit, "days");
+    }
+
+    /**
+     * Validates that the total number of nanoseconds can be stored.
+     *
+     * @param units the number of units that need to be added
+     * @param nanosPerUnit the number of nanoseconds per unit
+     */
+    private void validateNanos(long units, long nanosPerUnit) {
+      validate(units, (Long.MAX_VALUE - nanoseconds) / nanosPerUnit, "nanoseconds");
+    }
+
+    /**
+     * Validates that the specified amount is less than the limit.
+     *
+     * @param units the number of units to check
+     * @param limit the limit on the number of units
+     * @param unitName the unit name
+     */
+    private void validate(long units, long limit, String unitName) {
+      Preconditions.checkArgument(
+          units <= limit,
+          "Invalid duration. The total number of %s must be less or equal to %s",
+          unitName,
+          Integer.MAX_VALUE);
+    }
+
+    /**
+     * Validates that the duration values are added in the proper order.
+     *
+     * @param unitIndex the unit index (e.g. years=1, months=2, ...)
+     */
+    private void validateOrder(int unitIndex) {
+      if (unitIndex == currentUnitIndex) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Invalid duration. The %s are specified multiple times", getUnitName(unitIndex)));
+      }
+      if (unitIndex <= currentUnitIndex) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Invalid duration. The %s should be after %s",
+                getUnitName(currentUnitIndex), getUnitName(unitIndex)));
+      }
+      currentUnitIndex = unitIndex;
+    }
+
+    /**
+     * Returns the name of the unit corresponding to the specified index.
+     *
+     * @param unitIndex the unit index
+     * @return the name of the unit corresponding to the specified index.
+     */
+    private String getUnitName(int unitIndex) {
+      switch (unitIndex) {
+        case 1:
+          return "years";
+        case 2:
+          return "months";
+        case 3:
+          return "weeks";
+        case 4:
+          return "days";
+        case 5:
+          return "hours";
+        case 6:
+          return "minutes";
+        case 7:
+          return "seconds";
+        case 8:
+          return "milliseconds";
+        case 9:
+          return "microseconds";
+        case 10:
+          return "nanoseconds";
+        default:
+          throw new AssertionError("unknown unit index: " + unitIndex);
+      }
+    }
+
+    public CqlDuration build() {
+      return isNegative
+          ? new CqlDuration(-months, -days, -nanoseconds)
+          : new CqlDuration(months, days, nanoseconds);
+    }
+  }
+}

--- a/grpc-proto/src/main/java/io/stargate/grpc/CqlDuration.java
+++ b/grpc-proto/src/main/java/io/stargate/grpc/CqlDuration.java
@@ -17,10 +17,6 @@ package io.stargate.grpc;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.ByteArrayDataOutput;
-import com.google.common.io.ByteStreams;
-import java.io.DataInput;
-import java.io.IOException;
 import java.time.Duration;
 import java.time.Period;
 import java.time.temporal.ChronoUnit;
@@ -277,23 +273,6 @@ public final class CqlDuration implements TemporalAmount {
     return dividend % divisor;
   }
 
-  public static CqlDuration decode(byte[] bytes) {
-    if (bytes == null || bytes.length == 0) {
-      return null;
-    } else {
-      DataInput in = ByteStreams.newDataInput(bytes);
-      try {
-        int months = (int) VIntCoding.readVInt(in);
-        int days = (int) VIntCoding.readVInt(in);
-        long nanoseconds = VIntCoding.readVInt(in);
-        return CqlDuration.newInstance(months, days, nanoseconds);
-      } catch (IOException e) {
-        // cannot happen
-        throw new AssertionError();
-      }
-    }
-  }
-
   /**
    * Returns the number of months in this duration.
    *
@@ -367,23 +346,6 @@ public final class CqlDuration implements TemporalAmount {
   @Override
   public List<TemporalUnit> getUnits() {
     return TEMPORAL_UNITS;
-  }
-
-  public byte[] encode() {
-    int size =
-        VIntCoding.computeVIntSize(months)
-            + VIntCoding.computeVIntSize(days)
-            + VIntCoding.computeVIntSize(nanoseconds);
-    ByteArrayDataOutput out = ByteStreams.newDataOutput(size);
-    try {
-      VIntCoding.writeVInt(months, out);
-      VIntCoding.writeVInt(days, out);
-      VIntCoding.writeVInt(nanoseconds, out);
-    } catch (IOException e) {
-      // cannot happen
-      throw new AssertionError();
-    }
-    return out.toByteArray();
   }
 
   @Override

--- a/grpc-proto/src/main/java/io/stargate/grpc/VIntCoding.java
+++ b/grpc-proto/src/main/java/io/stargate/grpc/VIntCoding.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+package io.stargate.grpc;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * Variable length encoding inspired from Google <a
+ * href='https://developers.google.com/protocol-buffers/docs/encoding#varints'>varints</a>.
+ *
+ * <p>Cassandra vints are encoded with the most significant group first. The most significant byte
+ * will contains the information about how many extra bytes need to be read as well as the most
+ * significant bits of the integer. The number of extra bytes to read is encoded as 1 bit on the
+ * left side. For example, if we need to read 3 more bytes the first byte will start with 1110. If
+ * the encoded integer is 8 bytes long the vint will be encoded on 9 bytes and the first byte will
+ * be: 11111111
+ *
+ * <p>Signed integers are (like protocol buffer varints) encoded using the ZigZag encoding so that
+ * numbers with a small absolute value have a small vint encoded value too.
+ *
+ * <p>Note that there is also a type called {@code varint} in the CQL protocol specification. This
+ * is completely unrelated.
+ */
+class VIntCoding {
+
+  private static long readUnsignedVInt(DataInput input) throws IOException {
+    int firstByte = input.readByte();
+
+    // Bail out early if this is one byte, necessary or it fails later
+    if (firstByte >= 0) {
+      return firstByte;
+    }
+
+    int size = numberOfExtraBytesToRead(firstByte);
+    long retval = firstByte & firstByteValueMask(size);
+    for (int ii = 0; ii < size; ii++) {
+      byte b = input.readByte();
+      retval <<= 8;
+      retval |= b & 0xff;
+    }
+
+    return retval;
+  }
+
+  static long readVInt(DataInput input) throws IOException {
+    return decodeZigZag64(readUnsignedVInt(input));
+  }
+
+  // & this with the first byte to give the value part for a given extraBytesToRead encoded in the
+  // byte
+  private static int firstByteValueMask(int extraBytesToRead) {
+    // by including the known 0bit in the mask, we can use this for encodeExtraBytesToRead
+    return 0xff >> extraBytesToRead;
+  }
+
+  private static byte encodeExtraBytesToRead(int extraBytesToRead) {
+    // because we have an extra bit in the value mask, we just need to invert it
+    return (byte) ~firstByteValueMask(extraBytesToRead);
+  }
+
+  private static int numberOfExtraBytesToRead(int firstByte) {
+    // we count number of set upper bits; so if we simply invert all of the bits, we're golden
+    // this is aided by the fact that we only work with negative numbers, so when upcast to an int
+    // all
+    // of the new upper bits are also set, so by inverting we set all of them to zero
+    return Integer.numberOfLeadingZeros(~firstByte) - 24;
+  }
+
+  private static final ThreadLocal<byte[]> encodingBuffer =
+      ThreadLocal.withInitial(() -> new byte[9]);
+
+  private static void writeUnsignedVInt(long value, DataOutput output) throws IOException {
+    int size = VIntCoding.computeUnsignedVIntSize(value);
+    if (size == 1) {
+      output.write((int) value);
+      return;
+    }
+
+    output.write(VIntCoding.encodeVInt(value, size), 0, size);
+  }
+
+  private static byte[] encodeVInt(long value, int size) {
+    byte encodingSpace[] = encodingBuffer.get();
+    int extraBytes = size - 1;
+
+    for (int i = extraBytes; i >= 0; --i) {
+      encodingSpace[i] = (byte) value;
+      value >>= 8;
+    }
+    encodingSpace[0] |= encodeExtraBytesToRead(extraBytes);
+    return encodingSpace;
+  }
+
+  static void writeVInt(long value, DataOutput output) throws IOException {
+    writeUnsignedVInt(encodeZigZag64(value), output);
+  }
+
+  /**
+   * Decode a ZigZag-encoded 64-bit value. ZigZag encodes signed integers into values that can be
+   * efficiently encoded with varint. (Otherwise, negative values must be sign-extended to 64 bits
+   * to be varint encoded, thus always taking 10 bytes on the wire.)
+   *
+   * @param n an unsigned 64-bit integer, stored in a signed int because Java has no explicit
+   *     unsigned support.
+   * @return a signed 64-bit integer.
+   */
+  private static long decodeZigZag64(final long n) {
+    return (n >>> 1) ^ -(n & 1);
+  }
+
+  /**
+   * Encode a ZigZag-encoded 64-bit value. ZigZag encodes signed integers into values that can be
+   * efficiently encoded with varint. (Otherwise, negative values must be sign-extended to 64 bits
+   * to be varint encoded, thus always taking 10 bytes on the wire.)
+   *
+   * @param n a signed 64-bit integer.
+   * @return an unsigned 64-bit integer, stored in a signed int because Java has no explicit
+   *     unsigned support.
+   */
+  private static long encodeZigZag64(final long n) {
+    // Note:  the right-shift must be arithmetic
+    return (n << 1) ^ (n >> 63);
+  }
+
+  /** Compute the number of bytes that would be needed to encode a varint. */
+  static int computeVIntSize(final long param) {
+    return computeUnsignedVIntSize(encodeZigZag64(param));
+  }
+
+  /** Compute the number of bytes that would be needed to encode an unsigned varint. */
+  private static int computeUnsignedVIntSize(final long value) {
+    int magnitude =
+        Long.numberOfLeadingZeros(
+            value | 1); // | with 1 to ensure magnitude <= 63, so (63 - 1) / 7 <= 8
+    return (639 - magnitude * 9) >> 6;
+  }
+}

--- a/grpc-proto/src/main/java/io/stargate/grpc/Values.java
+++ b/grpc-proto/src/main/java/io/stargate/grpc/Values.java
@@ -101,7 +101,13 @@ public class Values {
   }
 
   public static Value of(CqlDuration duration) {
-    return Value.newBuilder().setDuration(ByteString.copyFrom(duration.encode())).build();
+    return Value.newBuilder()
+        .setDuration(
+            QueryOuterClass.Duration.newBuilder()
+                .setMonths(duration.getMonths())
+                .setDays(duration.getDays())
+                .setNanos(duration.getNanoseconds()))
+        .build();
   }
 
   public static Value of(BigInteger value) {
@@ -311,7 +317,8 @@ public class Values {
   public static CqlDuration duration(Value value) {
     checkInnerCase(value, InnerCase.DURATION);
 
-    return CqlDuration.decode(value.getDuration().toByteArray());
+    QueryOuterClass.Duration duration = value.getDuration();
+    return CqlDuration.newInstance(duration.getMonths(), duration.getDays(), duration.getNanos());
   }
 
   private static void checkInnerCase(Value value, InnerCase expected) {

--- a/grpc-proto/src/main/java/io/stargate/grpc/Values.java
+++ b/grpc-proto/src/main/java/io/stargate/grpc/Values.java
@@ -100,6 +100,10 @@ public class Values {
     return Value.newBuilder().setTime(value.toNanoOfDay()).build();
   }
 
+  public static Value of(CqlDuration duration) {
+    return Value.newBuilder().setDuration(ByteString.copyFrom(duration.encode())).build();
+  }
+
   public static Value of(BigInteger value) {
     return Value.newBuilder()
         .setVarint(
@@ -302,6 +306,12 @@ public class Values {
     checkInnerCase(value, InnerCase.TIME);
 
     return LocalTime.ofNanoOfDay(value.getTime());
+  }
+
+  public static CqlDuration duration(Value value) {
+    checkInnerCase(value, InnerCase.DURATION);
+
+    return CqlDuration.decode(value.getDuration().toByteArray());
   }
 
   private static void checkInnerCase(Value value, InnerCase expected) {

--- a/grpc-proto/src/test/java/io/stargate/grpc/CqlDurationTest.java
+++ b/grpc-proto/src/test/java/io/stargate/grpc/CqlDurationTest.java
@@ -1,0 +1,192 @@
+package io.stargate.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.UnsupportedTemporalTypeException;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class CqlDurationTest {
+
+  @ParameterizedTest
+  @MethodSource("locales")
+  public void should_parse_from_string_with_standard_pattern(Locale locale) {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(locale);
+      assertThat(CqlDuration.from("1y2mo")).isEqualTo(CqlDuration.newInstance(14, 0, 0));
+      assertThat(CqlDuration.from("-1y2mo")).isEqualTo(CqlDuration.newInstance(-14, 0, 0));
+      assertThat(CqlDuration.from("1Y2MO")).isEqualTo(CqlDuration.newInstance(14, 0, 0));
+      assertThat(CqlDuration.from("2w")).isEqualTo(CqlDuration.newInstance(0, 14, 0));
+      assertThat(CqlDuration.from("2d10h"))
+          .isEqualTo(CqlDuration.newInstance(0, 2, 10 * CqlDuration.NANOS_PER_HOUR));
+      assertThat(CqlDuration.from("2d")).isEqualTo(CqlDuration.newInstance(0, 2, 0));
+      assertThat(CqlDuration.from("30h"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 30 * CqlDuration.NANOS_PER_HOUR));
+      assertThat(CqlDuration.from("30h20m"))
+          .isEqualTo(
+              CqlDuration.newInstance(
+                  0, 0, 30 * CqlDuration.NANOS_PER_HOUR + 20 * CqlDuration.NANOS_PER_MINUTE));
+      assertThat(CqlDuration.from("20m"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 20 * CqlDuration.NANOS_PER_MINUTE));
+      assertThat(CqlDuration.from("56s"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 56 * CqlDuration.NANOS_PER_SECOND));
+      assertThat(CqlDuration.from("567ms"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 567 * CqlDuration.NANOS_PER_MILLI));
+      assertThat(CqlDuration.from("1950us"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 1950 * CqlDuration.NANOS_PER_MICRO));
+      assertThat(CqlDuration.from("1950µs"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 1950 * CqlDuration.NANOS_PER_MICRO));
+      assertThat(CqlDuration.from("1950000ns")).isEqualTo(CqlDuration.newInstance(0, 0, 1950000));
+      assertThat(CqlDuration.from("1950000NS")).isEqualTo(CqlDuration.newInstance(0, 0, 1950000));
+      assertThat(CqlDuration.from("-1950000ns")).isEqualTo(CqlDuration.newInstance(0, 0, -1950000));
+      assertThat(CqlDuration.from("1y3mo2h10m"))
+          .isEqualTo(CqlDuration.newInstance(15, 0, 130 * CqlDuration.NANOS_PER_MINUTE));
+    } finally {
+      Locale.setDefault(def);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("locales")
+  public void should_parse_from_string_with_iso8601_pattern(Locale locale) {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(locale);
+      assertThat(CqlDuration.from("P1Y2D")).isEqualTo(CqlDuration.newInstance(12, 2, 0));
+      assertThat(CqlDuration.from("P1Y2M")).isEqualTo(CqlDuration.newInstance(14, 0, 0));
+      assertThat(CqlDuration.from("P2W")).isEqualTo(CqlDuration.newInstance(0, 14, 0));
+      assertThat(CqlDuration.from("P1YT2H"))
+          .isEqualTo(CqlDuration.newInstance(12, 0, 2 * CqlDuration.NANOS_PER_HOUR));
+      assertThat(CqlDuration.from("-P1Y2M")).isEqualTo(CqlDuration.newInstance(-14, 0, 0));
+      assertThat(CqlDuration.from("P2D")).isEqualTo(CqlDuration.newInstance(0, 2, 0));
+      assertThat(CqlDuration.from("PT30H"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 30 * CqlDuration.NANOS_PER_HOUR));
+      assertThat(CqlDuration.from("PT30H20M"))
+          .isEqualTo(
+              CqlDuration.newInstance(
+                  0, 0, 30 * CqlDuration.NANOS_PER_HOUR + 20 * CqlDuration.NANOS_PER_MINUTE));
+      assertThat(CqlDuration.from("PT20M"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 20 * CqlDuration.NANOS_PER_MINUTE));
+      assertThat(CqlDuration.from("PT56S"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 56 * CqlDuration.NANOS_PER_SECOND));
+      assertThat(CqlDuration.from("P1Y3MT2H10M"))
+          .isEqualTo(CqlDuration.newInstance(15, 0, 130 * CqlDuration.NANOS_PER_MINUTE));
+    } finally {
+      Locale.setDefault(def);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("locales")
+  public void should_parse_from_string_with_iso8601_alternative_pattern(Locale locale) {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(locale);
+      assertThat(CqlDuration.from("P0001-00-02T00:00:00"))
+          .isEqualTo(CqlDuration.newInstance(12, 2, 0));
+      assertThat(CqlDuration.from("P0001-02-00T00:00:00"))
+          .isEqualTo(CqlDuration.newInstance(14, 0, 0));
+      assertThat(CqlDuration.from("P0001-00-00T02:00:00"))
+          .isEqualTo(CqlDuration.newInstance(12, 0, 2 * CqlDuration.NANOS_PER_HOUR));
+      assertThat(CqlDuration.from("-P0001-02-00T00:00:00"))
+          .isEqualTo(CqlDuration.newInstance(-14, 0, 0));
+      assertThat(CqlDuration.from("P0000-00-02T00:00:00"))
+          .isEqualTo(CqlDuration.newInstance(0, 2, 0));
+      assertThat(CqlDuration.from("P0000-00-00T30:00:00"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 30 * CqlDuration.NANOS_PER_HOUR));
+      assertThat(CqlDuration.from("P0000-00-00T30:20:00"))
+          .isEqualTo(
+              CqlDuration.newInstance(
+                  0, 0, 30 * CqlDuration.NANOS_PER_HOUR + 20 * CqlDuration.NANOS_PER_MINUTE));
+      assertThat(CqlDuration.from("P0000-00-00T00:20:00"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 20 * CqlDuration.NANOS_PER_MINUTE));
+      assertThat(CqlDuration.from("P0000-00-00T00:00:56"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 56 * CqlDuration.NANOS_PER_SECOND));
+      assertThat(CqlDuration.from("P0001-03-00T02:10:00"))
+          .isEqualTo(CqlDuration.newInstance(15, 0, 130 * CqlDuration.NANOS_PER_MINUTE));
+    } finally {
+      Locale.setDefault(def);
+    }
+  }
+
+  @Test
+  public void should_fail_to_parse_invalid_durations() {
+    assertInvalidDuration(
+        Long.MAX_VALUE + "d",
+        "Invalid duration. The total number of days must be less or equal to 2147483647");
+    assertInvalidDuration("2µ", "Unable to convert '2µ' to a duration");
+    assertInvalidDuration("-2µ", "Unable to convert '2µ' to a duration");
+    assertInvalidDuration("12.5s", "Unable to convert '12.5s' to a duration");
+    assertInvalidDuration("2m12.5s", "Unable to convert '2m12.5s' to a duration");
+    assertInvalidDuration("2m-12s", "Unable to convert '2m-12s' to a duration");
+    assertInvalidDuration("12s3s", "Invalid duration. The seconds are specified multiple times");
+    assertInvalidDuration("12s3m", "Invalid duration. The seconds should be after minutes");
+    assertInvalidDuration("1Y3M4D", "Invalid duration. The minutes should be after days");
+    assertInvalidDuration("P2Y3W", "Unable to convert 'P2Y3W' to a duration");
+    assertInvalidDuration("P0002-00-20", "Unable to convert 'P0002-00-20' to a duration");
+  }
+
+  private void assertInvalidDuration(String duration, String expectedErrorMessage) {
+    try {
+      CqlDuration.from(duration);
+      fail("Expected RuntimeException");
+    } catch (RuntimeException e) {
+      assertThat(e.getMessage()).isEqualTo(expectedErrorMessage);
+    }
+  }
+
+  @Test
+  public void should_get_by_unit() {
+    CqlDuration duration = CqlDuration.from("3mo2d15s");
+    assertThat(duration.get(ChronoUnit.MONTHS)).isEqualTo(3);
+    assertThat(duration.get(ChronoUnit.DAYS)).isEqualTo(2);
+    assertThat(duration.get(ChronoUnit.NANOS)).isEqualTo(15 * CqlDuration.NANOS_PER_SECOND);
+    assertThatThrownBy(() -> duration.get(ChronoUnit.YEARS))
+        .isInstanceOf(UnsupportedTemporalTypeException.class);
+  }
+
+  @Test
+  public void should_add_to_temporal() {
+    ZonedDateTime dateTime = ZonedDateTime.parse("2018-10-04T00:00-07:00[America/Los_Angeles]");
+    assertThat(dateTime.plus(CqlDuration.from("1mo")))
+        .isEqualTo("2018-11-04T00:00-07:00[America/Los_Angeles]");
+    assertThat(dateTime.plus(CqlDuration.from("1mo1h10s")))
+        .isEqualTo("2018-11-04T01:00:10-07:00[America/Los_Angeles]");
+    // 11-04 2:00 is daylight saving time end
+    assertThat(dateTime.plus(CqlDuration.from("1mo3h")))
+        .isEqualTo("2018-11-04T02:00-08:00[America/Los_Angeles]");
+  }
+
+  @Test
+  public void should_subtract_from_temporal() {
+    ZonedDateTime dateTime = ZonedDateTime.parse("2018-10-04T00:00-07:00[America/Los_Angeles]");
+    assertThat(dateTime.minus(CqlDuration.from("2mo")))
+        .isEqualTo("2018-08-04T00:00-07:00[America/Los_Angeles]");
+    assertThat(dateTime.minus(CqlDuration.from("1h15s15ns")))
+        .isEqualTo("2018-10-03T22:59:44.999999985-07:00[America/Los_Angeles]");
+  }
+
+  public static Arguments[] locales() {
+    return new Arguments[] {
+      arguments(Locale.US),
+      // non-latin alphabets
+      arguments(Locale.CHINA),
+      arguments(Locale.JAPAN),
+      arguments(Locale.KOREA),
+      arguments(new Locale("gr") /* greek */),
+      arguments(new Locale("ar") /* arabic */),
+      // latin-based alphabets with extended character sets
+      arguments(new Locale("vi") /* vietnamese */),
+      arguments(new Locale("tr") /* turkish*/),
+    };
+  }
+}

--- a/grpc/src/main/java/io/stargate/grpc/codec/DurationCodec.java
+++ b/grpc/src/main/java/io/stargate/grpc/codec/DurationCodec.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.grpc.codec;
+
+import com.google.protobuf.ByteString;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.stargate.db.schema.Column.ColumnType;
+import io.stargate.proto.QueryOuterClass.Value;
+import io.stargate.proto.QueryOuterClass.Value.InnerCase;
+import java.nio.ByteBuffer;
+
+public class DurationCodec implements ValueCodec {
+  @Override
+  public ByteBuffer encode(@NonNull Value value, @NonNull ColumnType type) {
+    if (value.getInnerCase() != InnerCase.DURATION) {
+      throw new IllegalArgumentException("Expected varint type");
+    }
+    return ByteBuffer.wrap(value.getDuration().toByteArray());
+  }
+
+  @Override
+  public Value decode(@NonNull ByteBuffer bytes, @NonNull ColumnType type) {
+    if (bytes.remaining() == 0) {
+      throw new IllegalArgumentException(
+          "Invalid duration value, expecting non-empty Bytes but got 0");
+    }
+
+    return Value.newBuilder().setDuration(ByteString.copyFrom(bytes.duplicate())).build();
+  }
+}

--- a/grpc/src/main/java/io/stargate/grpc/codec/VIntCoding.java
+++ b/grpc/src/main/java/io/stargate/grpc/codec/VIntCoding.java
@@ -42,7 +42,7 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-package io.stargate.grpc;
+package io.stargate.grpc.codec;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -110,9 +110,6 @@ class VIntCoding {
     return Integer.numberOfLeadingZeros(~firstByte) - 24;
   }
 
-  private static final ThreadLocal<byte[]> encodingBuffer =
-      ThreadLocal.withInitial(() -> new byte[9]);
-
   private static void writeUnsignedVInt(long value, DataOutput output) throws IOException {
     int size = VIntCoding.computeUnsignedVIntSize(value);
     if (size == 1) {
@@ -124,7 +121,7 @@ class VIntCoding {
   }
 
   private static byte[] encodeVInt(long value, int size) {
-    byte encodingSpace[] = encodingBuffer.get();
+    byte[] encodingSpace = new byte[9];
     int extraBytes = size - 1;
 
     for (int i = extraBytes; i >= 0; --i) {

--- a/grpc/src/main/java/io/stargate/grpc/codec/ValueCodecs.java
+++ b/grpc/src/main/java/io/stargate/grpc/codec/ValueCodecs.java
@@ -35,6 +35,7 @@ public class ValueCodecs {
               .put(Type.Date, new DateCodec())
               .put(Type.Decimal, new DecimalCodec())
               .put(Type.Double, new DoubleCodec())
+              .put(Type.Duration, new DurationCodec())
               .put(Type.Float, new FloatCodec())
               .put(Type.Int, new IntCodec())
               .put(Type.Inet, new InetCodec())


### PR DESCRIPTION
**What this PR does**:
Add `CqlDuration` type to represent durations on the client. 
Add missing bits to bind duration values and read duration columns.

Note: this is based on v2.0.0 because I started it in the context of GraphQL v2, but it can be backported to v1.

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
