### PR TITLE
Add testing of Duration/CqlDuration values wrt REST API

### DIFF
--- a/restapi/src/test/java/io/stargate/web/resources/ConvertersTest.java
+++ b/restapi/src/test/java/io/stargate/web/resources/ConvertersTest.java
@@ -310,10 +310,7 @@ public class ConvertersTest {
           Type.Timestamp,
           "\"a\"",
           "Invalid Timestamp value: Text 'a' could not be parsed at index 0"),
-      arguments(
-              Type.Duration,
-              "\"a\"",
-              "Invalid Duration value 'a': cannot parse"),
+      arguments(Type.Duration, "\"a\"", "Invalid Duration value 'a': cannot parse"),
       arguments(
           Type.List.of(Type.Int), "1", "Invalid List value '1': expected a JSON array or a string"),
       arguments(

--- a/restapi/src/test/java/io/stargate/web/resources/ConvertersTest.java
+++ b/restapi/src/test/java/io/stargate/web/resources/ConvertersTest.java
@@ -311,6 +311,10 @@ public class ConvertersTest {
           "\"a\"",
           "Invalid Timestamp value: Text 'a' could not be parsed at index 0"),
       arguments(
+              Type.Duration,
+              "\"a\"",
+              "Invalid Duration value 'a': cannot parse"),
+      arguments(
           Type.List.of(Type.Int), "1", "Invalid List value '1': expected a JSON array or a string"),
       arguments(
           Type.List.of(Type.Int),

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2RowsTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2RowsTest.java
@@ -602,28 +602,27 @@ public class RestApiv2RowsTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void getRowsWithDurationValue() throws IOException
-  {
+  public void getRowsWithDurationValue() throws IOException {
     createTestKeyspace(keyspaceName);
     createTestTable(
-            tableName,
-            Arrays.asList("id text", "firstName text", "time duration"),
-            Collections.singletonList("id"),
-            Collections.singletonList("firstName"));
+        tableName,
+        Arrays.asList("id text", "firstName text", "time duration"),
+        Collections.singletonList("id"),
+        Collections.singletonList("firstName"));
 
     CqlDuration expDuration = CqlDuration.from("2w");
     insertTestTableRows(
-            Arrays.asList(
-                    Arrays.asList("id 1", "firstName John", "time 2d"),
-                    Arrays.asList("id 2", "firstName Sarah", "time "+expDuration),
-                    Arrays.asList("id 3", "firstName Jane", "time 30h20m")));
+        Arrays.asList(
+            Arrays.asList("id 1", "firstName John", "time 2d"),
+            Arrays.asList("id 2", "firstName Sarah", "time " + expDuration),
+            Arrays.asList("id 3", "firstName Jane", "time 30h20m")));
 
     String body =
-            RestUtils.get(
-                    authToken,
-                    String.format(
-                            "%s/v2/keyspaces/%s/%s/%s?raw=true", restUrlBase, keyspaceName, tableName, "2"),
-                    HttpStatus.SC_OK);
+        RestUtils.get(
+            authToken,
+            String.format(
+                "%s/v2/keyspaces/%s/%s/%s?raw=true", restUrlBase, keyspaceName, tableName, "2"),
+            HttpStatus.SC_OK);
     JsonNode json = objectMapper.readTree(body);
     assertThat(json.size()).isEqualTo(1);
     assertThat(json.at("/0/firstName").asText()).isEqualTo("Sarah");

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2RowsTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2RowsTest.java
@@ -18,6 +18,7 @@ package io.stargate.it.http;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import com.datastax.oss.driver.api.core.data.CqlDuration;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JavaType;
@@ -598,6 +599,36 @@ public class RestApiv2RowsTest extends BaseIntegrationTest {
     assertThat(data.get(0).get("id")).isEqualTo("1");
     assertThat(data.get(0).get("firstName")).isEqualTo("John");
     assertThat(data.get(0).get("created")).isEqualTo(timestamp);
+  }
+
+  @Test
+  public void getRowsWithDurationValue() throws IOException
+  {
+    createTestKeyspace(keyspaceName);
+    createTestTable(
+            tableName,
+            Arrays.asList("id text", "firstName text", "time duration"),
+            Collections.singletonList("id"),
+            Collections.singletonList("firstName"));
+
+    CqlDuration expDuration = CqlDuration.from("2w");
+    insertTestTableRows(
+            Arrays.asList(
+                    Arrays.asList("id 1", "firstName John", "time 2d"),
+                    Arrays.asList("id 2", "firstName Sarah", "time "+expDuration),
+                    Arrays.asList("id 3", "firstName Jane", "time 30h20m")));
+
+    String body =
+            RestUtils.get(
+                    authToken,
+                    String.format(
+                            "%s/v2/keyspaces/%s/%s/%s?raw=true", restUrlBase, keyspaceName, tableName, "2"),
+                    HttpStatus.SC_OK);
+    JsonNode json = objectMapper.readTree(body);
+    assertThat(json.size()).isEqualTo(1);
+    assertThat(json.at("/0/firstName").asText()).isEqualTo("Sarah");
+    // NOTE: "2 weeks" may become "14 days" (or vice versa); so let's compare CqlDuration equality
+    assertThat(CqlDuration.from(json.at("/0/time").asText())).isEqualTo(expDuration);
   }
 
   @Test


### PR DESCRIPTION
**What this PR does**:

Adds testing of Duration value handling in REST API (based on findings for other APIs like gRPC see #1690).
This should especially help Stargate V2 / REST since value conversion handling was rewritten and may have gaps.

**Which issue(s) this PR fixes**:
Fixes #1693

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
