### PR TITLE
Add support for Duration/CqlDuration for REST API, SGv2

### DIFF
--- a/restapi/src/test/java/io/stargate/web/resources/ConvertersTest.java
+++ b/restapi/src/test/java/io/stargate/web/resources/ConvertersTest.java
@@ -310,6 +310,7 @@ public class ConvertersTest {
           Type.Timestamp,
           "\"a\"",
           "Invalid Timestamp value: Text 'a' could not be parsed at index 0"),
+      arguments(Type.Duration, "\"a\"", "Invalid Duration value 'a': cannot parse"),
       arguments(
           Type.List.of(Type.Int), "1", "Invalid List value '1': expected a JSON array or a string"),
       arguments(

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/FromProtoValueCodecs.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/FromProtoValueCodecs.java
@@ -430,9 +430,14 @@ public class FromProtoValueCodecs {
   protected static final class DurationCodec extends FromProtoValueCodec {
     @Override
     public Object fromProtoValue(QueryOuterClass.Value value) {
-      return (value.getInnerCase() == QueryOuterClass.Value.InnerCase.NULL)
-          ? null
-          : Values.duration(value);
+      if (value.getInnerCase() == QueryOuterClass.Value.InnerCase.NULL) {
+        return null;
+      }
+      // 16-Mar-2022, tatu: Two ways to go; either return CqlDuration and expect
+      //    caller to deal with it (requires custom Json serializer), or convert
+      //    here. Latter seems easier and safer for now since caller has no need
+      //    for actual full type. May be changed later if there is need to retain type.
+      return Values.duration(value).toString();
     }
 
     @Override

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/FromProtoValueCodecs.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/FromProtoValueCodecs.java
@@ -42,6 +42,7 @@ public class FromProtoValueCodecs {
   private static final TimestampCodec CODEC_TIMESTAMP = new TimestampCodec();
   private static final DateCodec CODEC_DATE = new DateCodec();
   private static final TimeCodec CODEC_TIME = new TimeCodec();
+  private static final DurationCodec CODEC_DURATION = new DurationCodec();
   private static final InetCodec CODEC_INET = new InetCodec();
   private static final BlobCodec CODEC_BLOB = new BlobCodec();
 
@@ -127,6 +128,8 @@ public class FromProtoValueCodecs {
         return CODEC_DATE;
       case TIME:
         return CODEC_TIME;
+      case DURATION:
+        return CODEC_DURATION;
       case INET:
         return CODEC_INET;
       case BLOB:
@@ -421,6 +424,22 @@ public class FromProtoValueCodecs {
       return (value.getInnerCase() == QueryOuterClass.Value.InnerCase.NULL)
           ? jsonNodeFactory.nullNode()
           : jsonNodeFactory.textNode(Values.time(value).toString());
+    }
+  }
+
+  protected static final class DurationCodec extends FromProtoValueCodec {
+    @Override
+    public Object fromProtoValue(QueryOuterClass.Value value) {
+      return (value.getInnerCase() == QueryOuterClass.Value.InnerCase.NULL)
+          ? null
+          : Values.duration(value);
+    }
+
+    @Override
+    public JsonNode jsonNodeFrom(QueryOuterClass.Value value) {
+      return (value.getInnerCase() == QueryOuterClass.Value.InnerCase.NULL)
+          ? jsonNodeFactory.nullNode()
+          : jsonNodeFactory.textNode(Values.duration(value).toString());
     }
   }
 

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/ToProtoValueCodecs.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/grpc/ToProtoValueCodecs.java
@@ -1,6 +1,7 @@
 package io.stargate.sgv2.restsvc.grpc;
 
 import io.stargate.core.util.ByteBufferUtils;
+import io.stargate.grpc.CqlDuration;
 import io.stargate.grpc.Values;
 import io.stargate.proto.QueryOuterClass;
 import java.math.BigDecimal;
@@ -42,6 +43,7 @@ public class ToProtoValueCodecs {
   protected static final TimestampCodec CODEC_TIMESTAMP = new TimestampCodec();
   protected static final DateCodec CODEC_DATE = new DateCodec();
   protected static final TimeCodec CODEC_TIME = new TimeCodec();
+  protected static final DurationCodec CODEC_DURATION = new DurationCodec();
   protected static final InetCodec CODEC_INET = new InetCodec();
   protected static final BlobCodec CODEC_BLOB = new BlobCodec();
 
@@ -120,6 +122,8 @@ public class ToProtoValueCodecs {
         return CODEC_DATE;
       case TIME:
         return CODEC_TIME;
+      case DURATION:
+        return CODEC_DURATION;
       case INET:
         return CODEC_INET;
       case BLOB:
@@ -641,6 +645,29 @@ public class ToProtoValueCodecs {
     public QueryOuterClass.Value protoValueFromStringified(String value) {
       try {
         return Values.of(LocalTime.parse(value));
+      } catch (IllegalArgumentException e) {
+        return invalidStringValue(value);
+      }
+    }
+  }
+
+  protected static final class DurationCodec extends ToProtoScalarCodecBase {
+    public DurationCodec() {
+      super("TypeSpec.Basic.DURATION");
+    }
+
+    @Override
+    public QueryOuterClass.Value protoValueFromStrictlyTyped(Object value) {
+      if (value instanceof String) {
+        return protoValueFromStringified((String) value);
+      }
+      return cannotCoerce(value);
+    }
+
+    @Override
+    public QueryOuterClass.Value protoValueFromStringified(String value) {
+      try {
+        return Values.of(CqlDuration.from(value));
       } catch (IllegalArgumentException e) {
         return invalidStringValue(value);
       }

--- a/sgv2-restapi/src/test/java/io/stargate/sgv2/restsvc/grpc/ToProtoConverterTest.java
+++ b/sgv2-restapi/src/test/java/io/stargate/sgv2/restsvc/grpc/ToProtoConverterTest.java
@@ -3,6 +3,7 @@ package io.stargate.sgv2.restsvc.grpc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import io.stargate.grpc.CqlDuration;
 import io.stargate.grpc.Values;
 import io.stargate.proto.QueryOuterClass;
 import io.stargate.proto.QueryOuterClass.ColumnSpec;
@@ -24,13 +25,14 @@ public class ToProtoConverterTest {
     return new Arguments[] {
       arguments(123, basicType(TypeSpec.Basic.INT), Values.of(123)),
       arguments(-4567L, basicType(TypeSpec.Basic.BIGINT), Values.of(-4567L)),
-      arguments("abc", basicType(TypeSpec.Basic.TEXT), Values.of("abc")),
+      arguments("abc", basicType(TypeSpec.Basic.VARCHAR), Values.of("abc")),
       arguments("/w==", basicType(TypeSpec.Basic.BLOB), Values.of(new byte[] {(byte) 0xFF})),
+      arguments("3d", basicType(TypeSpec.Basic.DURATION), Values.of(CqlDuration.from("3d"))),
 
       // Lists, Sets
       arguments(
           Arrays.asList("foo", "bar"),
-          listType(TypeSpec.Basic.TEXT),
+          listType(TypeSpec.Basic.VARCHAR),
           Values.of(Arrays.asList(Values.of("foo"), Values.of("bar")))),
       arguments(
           Arrays.asList(123, 456),
@@ -38,7 +40,7 @@ public class ToProtoConverterTest {
           Values.of(Arrays.asList(Values.of(123), Values.of(456)))),
       arguments(
           Arrays.asList("foo", "bar"),
-          setType(TypeSpec.Basic.TEXT),
+          setType(TypeSpec.Basic.VARCHAR),
           Values.of(Arrays.asList(Values.of("foo"), Values.of("bar")))),
       arguments(
           Arrays.asList(123, 456),
@@ -48,7 +50,7 @@ public class ToProtoConverterTest {
       // Maps
       arguments(
           Collections.singletonMap("foo", "bar"),
-          mapType(TypeSpec.Basic.TEXT, TypeSpec.Basic.TEXT),
+          mapType(TypeSpec.Basic.VARCHAR, TypeSpec.Basic.VARCHAR),
           // since internal representation is just as Collection...
           Values.of(Arrays.asList(Values.of("foo"), Values.of("bar")))),
       arguments(
@@ -74,14 +76,17 @@ public class ToProtoConverterTest {
     return new Arguments[] {
       arguments("123", basicType(TypeSpec.Basic.INT), Values.of(123)),
       arguments("-4567", basicType(TypeSpec.Basic.BIGINT), Values.of(-4567L)),
-      arguments("abc", basicType(TypeSpec.Basic.TEXT), Values.of("abc")),
-      arguments("'abc'", basicType(TypeSpec.Basic.TEXT), Values.of("abc")),
-      arguments("'quoted=''value'''", basicType(TypeSpec.Basic.TEXT), Values.of("quoted='value'")),
+      arguments("abc", basicType(TypeSpec.Basic.VARCHAR), Values.of("abc")),
+      arguments("'abc'", basicType(TypeSpec.Basic.VARCHAR), Values.of("abc")),
+      arguments(
+          "'quoted=''value'''", basicType(TypeSpec.Basic.VARCHAR), Values.of("quoted='value'")),
+      arguments("2d", basicType(TypeSpec.Basic.DURATION), Values.of(CqlDuration.from("2d"))),
+      arguments("'2d'", basicType(TypeSpec.Basic.DURATION), Values.of(CqlDuration.from("2d"))),
 
       // Lists, Sets
       arguments(
           "['foo','bar']",
-          listType(TypeSpec.Basic.TEXT),
+          listType(TypeSpec.Basic.VARCHAR),
           Values.of(Arrays.asList(Values.of("foo"), Values.of("bar")))),
       arguments(
           "[123, 456]",
@@ -90,7 +95,7 @@ public class ToProtoConverterTest {
       // Maps
       arguments(
           "{'foo': 'bar'}",
-          mapType(TypeSpec.Basic.TEXT, TypeSpec.Basic.TEXT),
+          mapType(TypeSpec.Basic.VARCHAR, TypeSpec.Basic.VARCHAR),
           // since internal representation is just as Collection...
           Values.of(Arrays.asList(Values.of("foo"), Values.of("bar")))),
       arguments(

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2RowsTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2RowsTest.java
@@ -643,8 +643,7 @@ public class RestApiv2RowsTest extends BaseRestApiTest {
     // cases could try to write JSON Object:
     assertThat(actualDuration).isInstanceOf(TextNode.class);
     // NOTE: "2 weeks" may become "14 days" (or vice versa); so let's compare CqlDuration equality
-    assertThat(actualDuration.textValue())
-            .isEqualTo(expDuration.toString());
+    assertThat(actualDuration.textValue()).isEqualTo(expDuration.toString());
   }
 
   @Test

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2RowsTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2RowsTest.java
@@ -26,7 +26,9 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.node.TextNode;
 import io.stargate.auth.model.AuthTokenResponse;
+import io.stargate.grpc.CqlDuration;
 import io.stargate.it.driver.CqlSessionExtension;
 import io.stargate.it.driver.CqlSessionSpec;
 import io.stargate.it.http.models.Credentials;
@@ -609,6 +611,40 @@ public class RestApiv2RowsTest extends BaseRestApiTest {
     assertThat(data.get(0).get("id")).isEqualTo("1");
     assertThat(data.get(0).get("firstname")).isEqualTo("John");
     assertThat(data.get(0).get("created")).isEqualTo(timestamp);
+  }
+
+  @Test
+  public void getRowsWithDurationValue() throws IOException {
+    createTestKeyspace(keyspaceName);
+    createTestTable(
+        tableName,
+        Arrays.asList("id text", "firstName text", "time duration"),
+        Collections.singletonList("id"),
+        Collections.singletonList("firstName"));
+
+    CqlDuration expDuration = CqlDuration.from("2w");
+    insertTestTableRows(
+        Arrays.asList(
+            Arrays.asList("id 1", "firstName John", "time 2d"),
+            Arrays.asList("id 2", "firstName Sarah", "time " + expDuration),
+            Arrays.asList("id 3", "firstName Jane", "time 30h20m")));
+
+    String body =
+        RestUtils.get(
+            authToken,
+            String.format(
+                "%s/v2/keyspaces/%s/%s/%s?raw=true", restUrlBase, keyspaceName, tableName, "2"),
+            HttpStatus.SC_OK);
+    JsonNode json = objectMapper.readTree(body);
+    assertThat(json.size()).isEqualTo(1);
+    assertThat(json.at("/0/firstName").asText()).isEqualTo("Sarah");
+    final JsonNode actualDuration = json.at("/0/time");
+    // There seem to be issues with serialization; we expect JSON String but in some
+    // cases could try to write JSON Object:
+    assertThat(actualDuration).isInstanceOf(TextNode.class);
+    // NOTE: "2 weeks" may become "14 days" (or vice versa); so let's compare CqlDuration equality
+    assertThat(actualDuration.textValue())
+            .isEqualTo(expDuration.toString());
   }
 
   @Test


### PR DESCRIPTION
**What this PR does**:

Fixes a gap in SGv2/REST wherein `Duration` type (`CqlDuration`) not supported as input or output.
Continuation of #1693.

NOTE: contains changes from #1693 (newly added REST integration test for Duration values).

**Which issue(s) this PR fixes**:
Fixes #1696

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
