### PR TITLE
closes #1692: updates DSE version to 6.8.21

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -48,6 +48,6 @@ RUN git clone --branch master --single-branch https://github.com/riptano/ccm.git
 # Create clusters to pre-download necessary artifacts
 RUN ccm create -v 4.0.3 stargate_40 && ccm remove stargate_40
 RUN ccm create -v 3.11.12 stargate_311 && ccm remove stargate_311
-RUN ccm create -v 6.8.20 --dse stargate_dse68 && ccm remove stargate_dse68
+RUN ccm create -v 6.8.21 --dse stargate_dse68 && ccm remove stargate_dse68
 
 CMD ["/bin/bash"]

--- a/persistence-dse-6.8/README.md
+++ b/persistence-dse-6.8/README.md
@@ -5,10 +5,10 @@ the DSE (DataStax Enterprise cassandra) `6.8.x` version.
 
 ## Cassandra version update
 
-The current Cassandra version this module depends on is `6.8.20`.
+The current Cassandra version this module depends on is `6.8.21`.
 In order to update to a newer patch version, please follow the guidelines below:
 
-* Update the `cassandra.version` property in the [pom.xml](pom.xml).
+* Update the `dse.version` property in the [pom.xml](pom.xml).
 * Update the `ccm.version` property (`it-dse-6.8` profile section) in [testing/pom.xml](testing/pom.xml)
 * Update the [CI Dockerfile](../ci/Dockerfile) and set the new version in the `ccm create` command related to DSE 6.8.
 Note that this will have no effect until the docker image is rebuilt and pushed to the remote repository, thus creating an issue for that would be a good idea.

--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -10,7 +10,7 @@
   <groupId>io.stargate.db.dse</groupId>
   <artifactId>persistence-dse-6.8</artifactId>
   <properties>
-    <dse.version>6.8.20</dse.version>
+    <dse.version>6.8.21</dse.version>
   </properties>
   <repositories>
     <repository>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -436,7 +436,7 @@
                 <configuration>
                   <systemPropertyVariables>
                     <ccm.dse>true</ccm.dse>
-                    <ccm.version>6.8.20</ccm.version>
+                    <ccm.version>6.8.21</ccm.version>
                     <stargate.test.nodes>1</stargate.test.nodes>
                   </systemPropertyVariables>
                   <failIfNoTests>true</failIfNoTests>


### PR DESCRIPTION
**What this PR does**:
Updates the DSE to `6.8.21`. Important as this version has solved the issue with warnings map memory leak.

**Which issue(s) this PR fixes**:
Fixes #1692
