### PR TITLE
updating version of nimbus-jose-jwt library

### DIFF
--- a/auth-jwt-service/pom.xml
+++ b/auth-jwt-service/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
-      <version>9.0.1</version>
+      <version>9.21</version>
     </dependency>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
Update the version of nimbus-jose-jwt library used in the JWT-based authentication module from 9.0.1 to 9.21

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
