### PR TITLE
update slf4j library version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     -->
     <jetty.version>9.4.44.v20210927</jetty.version>
     <!-- Logging framework likewise in sync -->
-    <slf4j.version>1.7.32</slf4j.version>
+    <slf4j.version>1.7.36</slf4j.version>
     <logback.version>1.2.8</logback.version>
 
     <!-- And then other 3rd party version dependencies, compile/runtime -->


### PR DESCRIPTION
Update the version of slf4j libraries used in Stargate from 1.7.32 to 1.7.36

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
