### PR TITLE
Add `makePagingState` to grpc bridge

### DIFF
--- a/bridge/src/main/java/io/stargate/bridge/service/BridgeService.java
+++ b/bridge/src/main/java/io/stargate/bridge/service/BridgeService.java
@@ -112,4 +112,11 @@ public class BridgeService extends StargateBridgeGrpc.StargateBridgeImplBase {
             request, GrpcService.CONNECTION_KEY.get(), authorizationService, responseObserver)
         .handle();
   }
+
+  @Override
+  public void makePagingState(
+      Schema.MakePagingStateParams request, StreamObserver<Schema.PagingState> responseObserver) {
+    PagingStateHandler.makePagingState(
+        request, GrpcService.CONNECTION_KEY.get(), persistence, responseObserver);
+  }
 }

--- a/bridge/src/main/java/io/stargate/bridge/service/PagingStateHandler.java
+++ b/bridge/src/main/java/io/stargate/bridge/service/PagingStateHandler.java
@@ -1,0 +1,112 @@
+package io.stargate.bridge.service;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.BytesValue;
+import io.grpc.stub.StreamObserver;
+import io.stargate.db.ClientInfo;
+import io.stargate.db.ImmutableParameters;
+import io.stargate.db.PagingPosition;
+import io.stargate.db.Parameters;
+import io.stargate.db.Persistence;
+import io.stargate.db.schema.Column;
+import io.stargate.grpc.service.GrpcService;
+import io.stargate.proto.QueryOuterClass;
+import io.stargate.proto.Schema;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.cassandra.stargate.db.ConsistencyLevel;
+
+public class PagingStateHandler {
+
+  public static void makePagingState(
+      Schema.MakePagingStateParams params,
+      Persistence.Connection connection,
+      Persistence persistence,
+      StreamObserver<Schema.PagingState> responseObserver) {
+    QueryOuterClass.QueryParameters qParams = params.getParameters();
+    String keyspace = params.getPosition().getKeyspaceName();
+    String decoratedKeyspace =
+        persistence.decorateKeyspaceName(keyspace, GrpcService.HEADERS_KEY.get());
+    String table = params.getPosition().getTableName();
+    Map<String, ByteString> rowMap = params.getPosition().getCurrentRowMap();
+    Map<Column, ByteBuffer> currentRow = new HashMap<>();
+    List<Column> cols = persistence.schema().keyspace(keyspace).table(table).columns();
+
+    PagingPosition pos =
+        new PagingPosition() {
+          @Override
+          public Map<Column, ByteBuffer> currentRow() {
+            for (Map.Entry<String, ByteString> entry : rowMap.entrySet()) {
+              Column c =
+                  cols.stream().filter(col -> col.name().equals(entry.getKey())).findFirst().get();
+              currentRow.put(c, entry.getValue().asReadOnlyByteBuffer());
+            }
+            return currentRow;
+          }
+
+          @Override
+          public ResumeMode resumeFrom() {
+            return ResumeMode.NEXT_ROW;
+          }
+        };
+    ByteBuffer pagingState =
+        connection.makePagingState(
+            pos, makeParameters(qParams, decoratedKeyspace, connection.clientInfo()));
+    responseObserver.onNext(
+        Schema.PagingState.newBuilder()
+            .setPagingState(
+                BytesValue.newBuilder().setValue(ByteString.copyFrom(pagingState.array())).build())
+            .build());
+    responseObserver.onCompleted();
+  }
+
+  private static Parameters makeParameters(
+      QueryOuterClass.QueryParameters parameters,
+      String decoratedKeyspace,
+      Optional<ClientInfo> clientInfo) {
+    ImmutableParameters.Builder builder = ImmutableParameters.builder();
+
+    builder.consistencyLevel(
+        parameters.hasConsistency()
+            ? ConsistencyLevel.fromCode(parameters.getConsistency().getValue().getNumber())
+            : GrpcService.DEFAULT_CONSISTENCY);
+
+    if (decoratedKeyspace != null) {
+      builder.defaultKeyspace(decoratedKeyspace);
+    }
+
+    builder.pageSize(
+        parameters.hasPageSize()
+            ? parameters.getPageSize().getValue()
+            : GrpcService.DEFAULT_PAGE_SIZE);
+
+    if (parameters.hasPagingState()) {
+      builder.pagingState(ByteBuffer.wrap(parameters.getPagingState().getValue().toByteArray()));
+    }
+
+    builder.serialConsistencyLevel(
+        parameters.hasSerialConsistency()
+            ? ConsistencyLevel.fromCode(parameters.getSerialConsistency().getValue().getNumber())
+            : GrpcService.DEFAULT_SERIAL_CONSISTENCY);
+
+    if (parameters.hasTimestamp()) {
+      builder.defaultTimestamp(parameters.getTimestamp().getValue());
+    }
+
+    if (parameters.hasNowInSeconds()) {
+      builder.nowInSeconds(parameters.getNowInSeconds().getValue());
+    }
+
+    clientInfo.ifPresent(
+        c -> {
+          Map<String, ByteBuffer> customPayload = new HashMap<>();
+          c.storeAuthenticationData(customPayload);
+          builder.customPayload(customPayload);
+        });
+
+    return builder.tracingRequested(parameters.getTracing()).build();
+  }
+}

--- a/grpc-proto/proto/bridge.proto
+++ b/grpc-proto/proto/bridge.proto
@@ -40,6 +40,9 @@ service StargateBridge {
   // Requests notification of schema changes.
   rpc GetSchemaNotifications(GetSchemaNotificationsParams) returns (stream SchemaNotification) {}
 
+  // Generates a paging state using the required parameters
+  rpc MakePagingState(MakePagingStateParams) returns (PagingState) {}
+
   // Checks whether the client is authorized to describe one or more schema elements.
   rpc AuthorizeSchemaReads(AuthorizeSchemaReadsRequest) returns (AuthorizeSchemaReadsResponse) {}
 }

--- a/grpc-proto/proto/schema.proto
+++ b/grpc-proto/proto/schema.proto
@@ -100,6 +100,22 @@ message DescribeTableQuery {
   string table_name = 2;
 }
 
+message PagingState {
+  google.protobuf.BytesValue paging_state = 1;
+}
+
+message PagingPosition {
+  string keyspace_name = 1;
+  string table_name = 2;
+  // A map of column name to bytes
+  map<string, bytes> current_row = 3;
+}
+
+message MakePagingStateParams {
+  PagingPosition position = 1;
+  QueryParameters parameters = 2;
+}
+
 // Note: the existing Response type is designed for both DML and DDL (schema) queries
 
 // The arguments to a `getSchemaNotifications` query.

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/DefaultStargateBridgeClient.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/DefaultStargateBridgeClient.java
@@ -15,6 +15,7 @@
  */
 package io.stargate.sgv2.common.grpc;
 
+import com.google.protobuf.ByteString;
 import com.google.protobuf.BytesValue;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -33,9 +34,11 @@ import io.stargate.proto.Schema;
 import io.stargate.proto.Schema.AuthorizeSchemaReadsRequest;
 import io.stargate.proto.Schema.CqlKeyspace;
 import io.stargate.proto.Schema.CqlKeyspaceDescribe;
+import io.stargate.proto.Schema.MakePagingStateParams;
 import io.stargate.proto.Schema.SchemaRead;
 import io.stargate.proto.Schema.SchemaRead.SourceApi;
 import io.stargate.proto.StargateBridgeGrpc;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -174,6 +177,16 @@ class DefaultStargateBridgeClient implements StargateBridgeClient {
             callOptions,
             AuthorizeSchemaReadsRequest.newBuilder().addAllSchemaReads(schemaReads).build())
         .getAuthorizedList();
+  }
+
+  @Override
+  public ByteBuffer makePagingState(MakePagingStateParams params) {
+    ByteString res =
+        ClientCalls.blockingUnaryCall(
+                channel, StargateBridgeGrpc.getMakePagingStateMethod(), callOptions, params)
+            .getPagingState()
+            .getValue();
+    return ByteBuffer.wrap(res.toByteArray());
   }
 
   private List<String> getKeyspaceNames(List<String> accumulator, BytesValue pagingState) {

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/StargateBridgeClient.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/StargateBridgeClient.java
@@ -20,7 +20,9 @@ import io.stargate.proto.QueryOuterClass.Query;
 import io.stargate.proto.QueryOuterClass.Response;
 import io.stargate.proto.Schema.CqlKeyspaceDescribe;
 import io.stargate.proto.Schema.CqlTable;
+import io.stargate.proto.Schema.MakePagingStateParams;
 import io.stargate.proto.Schema.SchemaRead;
+import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -92,4 +94,11 @@ public interface StargateBridgeClient {
   default boolean authorizeSchemaRead(SchemaRead schemaRead) {
     return authorizeSchemaReads(Collections.singletonList(schemaRead)).get(0);
   }
+
+  /**
+   * Generates a paging state.
+   *
+   * @see MakePagingStateParams
+   */
+  ByteBuffer makePagingState(MakePagingStateParams pagingStateParams);
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds makePagingState as a function to grpc bridge, allowing someone who has the keyspace, table, and column byte state of a row to make a paging state from it. I've been trying to find a way to manually test, but any advice on how to test would be welcome...

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
