### PR TITLE
Change numbus-jose-jwt version to be "managed" to change version globally

### DIFF
--- a/auth-jwt-service/pom.xml
+++ b/auth-jwt-service/pom.xml
@@ -33,7 +33,6 @@
     <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
-      <version>9.21</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <commons-io.version>2.7</commons-io.version>
     <grpc.version>1.42.1</grpc.version>
     <immutables.version>2.8.8</immutables.version>
+    <jackson.version>2.12.6</jackson.version>
     <javatuples.version>1.2</javatuples.version>
     <!-- Make sure micrometer and prometheus versions are in sync  -->
     <micrometer.version>1.7.3</micrometer.version>
@@ -491,7 +492,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.12.6</version>
+        <version>${jackson.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -701,6 +702,12 @@
         <artifactId>javax.servlet-api</artifactId>
         <version>4.0.1</version>
       </dependency>
+      <dependency>
+        <groupId>com.nimbusds</groupId>
+        <artifactId>nimbus-jose-jwt</artifactId>
+        <version>9.21</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
   <repositories>


### PR DESCRIPTION
**What this PR does**:

Moves version of `nimbus-jose-jwt` to main `managedDependency` section so it should apply everywhere where parent pom is used.

**Which issue(s) this PR fixes**:

No issue

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)

