### PR TITLE
gRPC: Optimize DescribeKeyspace when metadata hasn't changed

### DIFF
--- a/bridge/src/main/java/io/stargate/bridge/service/BridgeService.java
+++ b/bridge/src/main/java/io/stargate/bridge/service/BridgeService.java
@@ -15,9 +15,12 @@
  */
 package io.stargate.bridge.service;
 
+import io.grpc.Status;
+import io.grpc.StatusException;
 import io.grpc.stub.StreamObserver;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.db.Persistence;
+import io.stargate.db.schema.Keyspace;
 import io.stargate.grpc.service.GrpcService;
 import io.stargate.grpc.service.SingleBatchHandler;
 import io.stargate.grpc.service.SingleExceptionHandler;
@@ -31,6 +34,9 @@ import io.stargate.proto.StargateBridgeGrpc;
 import java.util.concurrent.ScheduledExecutorService;
 
 public class BridgeService extends StargateBridgeGrpc.StargateBridgeImplBase {
+
+  private static final Schema.CqlKeyspaceDescribe EMPTY_KEYSPACE_DESCRIPTION =
+      Schema.CqlKeyspaceDescribe.newBuilder().build();
 
   private final Persistence persistence;
   private final AuthorizationService authorizationService;
@@ -88,7 +94,27 @@ public class BridgeService extends StargateBridgeGrpc.StargateBridgeImplBase {
   public void describeKeyspace(
       Schema.DescribeKeyspaceQuery request,
       StreamObserver<Schema.CqlKeyspaceDescribe> responseObserver) {
-    SchemaHandler.describeKeyspace(request, persistence, responseObserver);
+
+    String decoratedName =
+        persistence.decorateKeyspaceName(request.getKeyspaceName(), GrpcService.HEADERS_KEY.get());
+
+    Keyspace keyspace = persistence.schema().keyspace(decoratedName);
+    if (keyspace == null) {
+      responseObserver.onError(
+          Status.NOT_FOUND.withDescription("Keyspace not found").asException());
+    } else if (request.hasHash() && request.getHash().getValue() == keyspace.hashCode()) {
+      // Client already has the latest version, don't resend
+      responseObserver.onNext(EMPTY_KEYSPACE_DESCRIPTION);
+      responseObserver.onCompleted();
+    } else {
+      try {
+        Schema.CqlKeyspaceDescribe description = SchemaHandler.buildKeyspaceDescription(keyspace);
+        responseObserver.onNext(description);
+        responseObserver.onCompleted();
+      } catch (StatusException e) {
+        responseObserver.onError(e);
+      }
+    }
   }
 
   @Override

--- a/bridge/src/main/java/io/stargate/bridge/service/SchemaHandler.java
+++ b/bridge/src/main/java/io/stargate/bridge/service/SchemaHandler.java
@@ -69,7 +69,8 @@ class SchemaHandler {
 
   static CqlKeyspaceDescribe buildKeyspaceDescription(Keyspace keyspace) throws StatusException {
 
-    CqlKeyspaceDescribe.Builder describeResultBuilder = CqlKeyspaceDescribe.newBuilder();
+    CqlKeyspaceDescribe.Builder describeResultBuilder =
+        CqlKeyspaceDescribe.newBuilder().setHash(keyspace.hashCode());
     CqlKeyspace.Builder cqlKeyspaceBuilder = CqlKeyspace.newBuilder();
     cqlKeyspaceBuilder.setName(keyspace.name());
 

--- a/grpc-proto/proto/schema.proto
+++ b/grpc-proto/proto/schema.proto
@@ -85,6 +85,11 @@ message CqlKeyspace {
 
 message DescribeKeyspaceQuery {
   string keyspace_name = 1;
+  // The value of `CqlKeyspaceDescribe.hash` the last time the client described that keyspace.
+  // - if it matches the current hash on the server, the server will return an empty response, to
+  //   indicate that the client can continue using the last known value.
+  // - if it doesn't match, or is not provided, the server will return a regular response.
+  google.protobuf.Int32Value hash = 2;
 }
 
 message CqlKeyspaceDescribe {
@@ -93,6 +98,8 @@ message CqlKeyspaceDescribe {
   repeated CqlTable tables = 3;
   repeated CqlIndex indexes = 4;
   repeated CqlMaterializedView materialized_views = 5;
+  // A hash of the metadata (see `DescribeKeyspaceQuery.hash`).
+  sint32 hash = 6;
 }
 
 message DescribeTableQuery {


### PR DESCRIPTION
**What this PR does**:
Allow client to send a hash of their known version when describing a keyspace. If the metadata hasn't changed, the bridge will return an empty response.

**Checklist**
- [x] Changes manually tested
