### PR TITLE
Fix prepared query not found in Cassandra 4.0 by adding lock to StargateQueryHandler

### DIFF
--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Cassandra40Persistence.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Cassandra40Persistence.java
@@ -7,7 +7,6 @@ import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.Iterables;
 import com.datastax.oss.driver.shaded.guava.common.util.concurrent.Uninterruptibles;
-import com.google.common.util.concurrent.Striped;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.core.util.TimeSource;
 import io.stargate.db.Authenticator;
@@ -39,7 +38,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.Lock;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -100,13 +98,6 @@ public class Cassandra40Persistence
         IndexMetadata,
         ViewMetadata> {
   private static final Logger logger = LoggerFactory.getLogger(Cassandra40Persistence.class);
-
-  // Locks for synchronizing prepared statements. This default uses the recommended number of locks
-  // suggested in the Java docs for CPU-bound tasks (which preparing a statement is).
-  private static final Striped<Lock> PREPARE_LOCKS =
-      Striped.lock(
-          Integer.getInteger(
-              "stargate.prepare_lock_count", Runtime.getRuntime().availableProcessors() * 4));
 
   private static final boolean USE_TRANSITIONAL_AUTH =
       Boolean.getBoolean("stargate.cql_use_transitional_auth");
@@ -509,22 +500,13 @@ public class Cassandra40Persistence
 
     @Override
     public CompletableFuture<Result.Prepared> prepare(String query, Parameters parameters) {
-      // The behavior of prepared statements was changed as part of CASSANDRA-15252
-      // (and CASSANDRA-17248) which can cause multiple prepares of the same query to evict each
-      // other from the prepared cache. A few Stargate APIs eagerly prepare queries which
-      // increases this chance and to avoid this we serialize prepares for similar queries.
-      Lock lock = PREPARE_LOCKS.get(query);
-      try {
-        lock.lock();
-        return executeRequestOnExecutor(
-            parameters,
-            // The queryStartNanoTime is not used by prepared message, so it doesn't really matter
-            // that it's only computed now.
-            System.nanoTime(),
-            () -> new PrepareMessage(query, parameters.defaultKeyspace().orElse(null)));
-      } finally {
-        lock.unlock();
-      }
+      return executeRequestOnExecutor(
+          parameters,
+          // The queryStartNanoTime is not used by prepared message, so it doesn't really
+          // matter
+          // that it's only computed now.
+          System.nanoTime(),
+          () -> new PrepareMessage(query, parameters.defaultKeyspace().orElse(null)));
     }
 
     @Override

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/StargateQueryHandler.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/StargateQueryHandler.java
@@ -17,6 +17,7 @@
  */
 package io.stargate.db.cassandra.impl;
 
+import com.google.common.util.concurrent.Striped;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.auth.Scope;
@@ -33,6 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
 import org.apache.cassandra.auth.IResource;
 import org.apache.cassandra.auth.RoleResource;
 import org.apache.cassandra.cql3.BatchQueryOptions;
@@ -94,6 +96,14 @@ import org.slf4j.LoggerFactory;
 public class StargateQueryHandler implements QueryHandler {
 
   private static final Logger logger = LoggerFactory.getLogger(StargateQueryHandler.class);
+
+  // Locks for synchronizing prepared statements. This default uses the recommended number of locks
+  // suggested in the Java docs for CPU-bound tasks (which preparing a statement is).
+  private static final Striped<Lock> PREPARE_LOCKS =
+      Striped.lock(
+          Integer.getInteger(
+              "stargate.prepare_lock_count", Runtime.getRuntime().availableProcessors() * 4));
+
   private final List<QueryInterceptor> interceptors = new CopyOnWriteArrayList<>();
   private AtomicReference<AuthorizationService> authorizationService;
 
@@ -149,7 +159,19 @@ public class StargateQueryHandler implements QueryHandler {
   public ResultMessage.Prepared prepare(
       String s, ClientState clientState, Map<String, ByteBuffer> map)
       throws RequestValidationException {
-    ResultMessage.Prepared prepare = QueryProcessor.instance.prepare(s, clientState, map);
+    // The behavior of prepared statements was changed as part of CASSANDRA-15252
+    // (and CASSANDRA-17248) which can cause multiple prepares of the same query to evict each
+    // other from the prepared cache. A few Stargate APIs eagerly prepare queries which
+    // increases this chance and to avoid this we serialize prepares for similar queries.
+    Lock lock = PREPARE_LOCKS.get(s);
+    ResultMessage.Prepared prepare;
+    try {
+      lock.lock();
+      prepare = QueryProcessor.instance.prepare(s, clientState, map);
+    } finally {
+      lock.unlock();
+    }
+
     CQLStatement statement =
         Optional.ofNullable(QueryProcessor.instance.getPrepared(prepare.statementId))
             .map(p -> p.statement)

--- a/testing/src/main/java/io/stargate/it/grpc/streaming/ExecuteBatchStreamingTest.java
+++ b/testing/src/main/java/io/stargate/it/grpc/streaming/ExecuteBatchStreamingTest.java
@@ -43,7 +43,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang3.RandomUtils;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -118,7 +117,7 @@ public class ExecuteBatchStreamingTest extends GrpcIntegrationTest {
                     rowOf(Values.of("c"), Values.of(3)))));
   }
 
-  @RepeatedTest(1000)
+  @Test
   public void manyStreamingBatch(@TestKeyspace CqlIdentifier keyspace) {
     List<StreamingResponse> responses = new CopyOnWriteArrayList<>();
 

--- a/testing/src/main/java/io/stargate/it/grpc/streaming/ExecuteBatchStreamingTest.java
+++ b/testing/src/main/java/io/stargate/it/grpc/streaming/ExecuteBatchStreamingTest.java
@@ -153,7 +153,7 @@ public class ExecuteBatchStreamingTest extends GrpcIntegrationTest {
 
     // make sure all queries where executed, and we got not errors back
     Awaitility.await()
-        .atMost(5, TimeUnit.SECONDS)
+        .atMost(30, TimeUnit.SECONDS)
         .untilAsserted(
             () -> {
               assertThat(responses).hasSize(queries);

--- a/testing/src/main/java/io/stargate/it/grpc/streaming/ExecuteBatchStreamingTest.java
+++ b/testing/src/main/java/io/stargate/it/grpc/streaming/ExecuteBatchStreamingTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang3.RandomUtils;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -117,7 +118,7 @@ public class ExecuteBatchStreamingTest extends GrpcIntegrationTest {
                     rowOf(Values.of("c"), Values.of(3)))));
   }
 
-  @Test
+  @RepeatedTest(1000)
   public void manyStreamingBatch(@TestKeyspace CqlIdentifier keyspace) {
     List<StreamingResponse> responses = new CopyOnWriteArrayList<>();
 
@@ -153,7 +154,7 @@ public class ExecuteBatchStreamingTest extends GrpcIntegrationTest {
 
     // make sure all queries where executed, and we got not errors back
     Awaitility.await()
-        .atMost(30, TimeUnit.SECONDS)
+        .atMost(5, TimeUnit.SECONDS)
         .untilAsserted(
             () -> {
               assertThat(responses).hasSize(queries);


### PR DESCRIPTION
We are regularly getting test failures with condition timeout on `ExecuteBatchStreamingTest.manyStreamingBatch`

```
Step #4 - "cassandra-4.0": [INFO] Results:
Step #4 - "cassandra-4.0": [INFO] 
Step #4 - "cassandra-4.0": [ERROR] Errors: 
Step #4 - "cassandra-4.0": [ERROR]   ExecuteBatchStreamingTest.manyStreamingBatch:157 ? ConditionTimeout Assertion ...
```

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
