### PR TITLE
Upgrade java driver 4.9 -> 4.10, to make gremlin dep optional

### DIFF
--- a/auth-jwt-service/src/test/java/io/stargate/auth/jwt/PlainTextJwtTokenSaslNegotiatorTest.java
+++ b/auth-jwt-service/src/test/java/io/stargate/auth/jwt/PlainTextJwtTokenSaslNegotiatorTest.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import org.apache.cassandra.stargate.exceptions.AuthenticationException;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
 class PlainTextJwtTokenSaslNegotiatorTest {
@@ -132,7 +131,7 @@ class PlainTextJwtTokenSaslNegotiatorTest {
 
   @Test
   public void tokenGreaterThanMaxLength() throws IOException {
-    final String tooLongToken = StringUtils.repeat("a", TOKEN_MAX_LENGTH + 1);
+    final String tooLongToken = new String(new char[TOKEN_MAX_LENGTH + 1]).replace('\0', 'a');
 
     SaslNegotiator wrappedNegotiator = mock(SaslNegotiator.class);
     when(wrappedNegotiator.isComplete()).thenReturn(false);

--- a/auth-table-based-service/src/test/java/io/stargate/auth/table/PlainTextTableBasedTokenSaslNegotiatorTest.java
+++ b/auth-table-based-service/src/test/java/io/stargate/auth/table/PlainTextTableBasedTokenSaslNegotiatorTest.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import org.apache.cassandra.stargate.exceptions.AuthenticationException;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
 class PlainTextTableBasedTokenSaslNegotiatorTest {
@@ -124,7 +123,7 @@ class PlainTextTableBasedTokenSaslNegotiatorTest {
 
   @Test
   public void tokenGreaterThanMaxLength() throws IOException {
-    final String tooLongToken = StringUtils.repeat("a", TOKEN_MAX_LENGTH + 1);
+    final String tooLongToken = new String(new char[TOKEN_MAX_LENGTH + 1]).replace('\0', 'a');
 
     SaslNegotiator wrappedNegotiator = mock(SaslNegotiator.class);
     when(wrappedNegotiator.isComplete()).thenReturn(false);

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.scm.id>github</project.scm.id>
     <doclint>none</doclint>
-    <driver.version>4.9.0</driver.version>
+    <driver.version>4.10.0</driver.version>
     <xml-format.skip>true</xml-format.skip>
 
     <!-- First DropWizard version and things it directly depends on that make sense to sync -->


### PR DESCRIPTION
**What this PR does**:

Updates java-driver-core version from 4.9 to 4.10 to update dependencies

**Which issue(s) this PR fixes**:

No public issue filed

**Checklist**
- [x] Changes manually tested -- relying on existing ITs, build
- [] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
