### PR TITLE
Remove `auto-factory` dependency if possible; or if not, update version from pre-1.0 to 1.0.1

### DIFF
--- a/persistence-cassandra-4.0/pom.xml
+++ b/persistence-cassandra-4.0/pom.xml
@@ -96,7 +96,6 @@
     <dependency>
       <groupId>com.google.auto.factory</groupId>
       <artifactId>auto-factory</artifactId>
-      <version>1.0-beta7</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.guava</groupId>

--- a/persistence-cassandra-4.0/pom.xml
+++ b/persistence-cassandra-4.0/pom.xml
@@ -94,16 +94,6 @@
       <artifactId>metrics-graphite</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.auto.factory</groupId>
-      <artifactId>auto-factory</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>com.github.akarnokd</groupId>
       <artifactId>rxjava2-extensions</artifactId>
       <version>0.20.10</version>

--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -150,7 +150,6 @@
     <dependency>
       <groupId>com.google.auto.factory</groupId>
       <artifactId>auto-factory</artifactId>
-      <version>1.0-beta7</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.guava</groupId>

--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -148,16 +148,6 @@
       <artifactId>metrics-graphite</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.auto.factory</groupId>
-      <artifactId>auto-factory</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>com.github.akarnokd</groupId>
       <artifactId>rxjava2-extensions</artifactId>
       <version>0.20.10</version>

--- a/pom.xml
+++ b/pom.xml
@@ -649,11 +649,6 @@
         <version>25.1-jre</version>
       </dependency>
       <dependency>
-        <groupId>com.google.auto.factory</groupId>
-        <artifactId>auto-factory</artifactId>
-        <version>1.0.1</version>
-      </dependency>
-      <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
         <version>${errorprone.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -644,6 +644,11 @@
         <version>25.1-jre</version>
       </dependency>
       <dependency>
+        <groupId>com.google.auto.factory</groupId>
+        <artifactId>auto-factory</artifactId>
+        <version>1.0.1</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
         <version>${errorprone.version}</version>


### PR DESCRIPTION
**What this PR does**:

Removes dependencies by Cassandra-4.0 and DSE backends to `com.google.auto.factory:auto-factory`.
(if this was not possibly, would increase dependency version from 1.0-b7 (pre-1.0) to 1.0.1).

**Which issue(s) this PR fixes**:
No issue filed

**Checklist**
- [x] Changes manually tested -- rely on build, CI
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
