### PR TITLE
Update jackson-databind to 2.12.6.1 (via jackson-bom) for CVE-2020-36518

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,12 @@
     <commons-io.version>2.7</commons-io.version>
     <grpc.version>1.42.1</grpc.version>
     <immutables.version>2.8.8</immutables.version>
-    <jackson.version>2.12.6</jackson.version>
+    <!-- 28-Mar-2022, tatu: BOM for "micro-patch" 2.12.6.1 of jackson-databind
+        is bit unusual wrt version; normally would be "x.y.z": when updating see:
+          https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom
+        for available versions
+      -->
+    <jackson.version>2.12.6.20220326</jackson.version>
     <javatuples.version>1.2</javatuples.version>
     <!-- Make sure micrometer and prometheus versions are in sync  -->
     <micrometer.version>1.7.3</micrometer.version>


### PR DESCRIPTION
**What this PR does**:

Upgrades `jackson-databind` from 2.12.6 to 2.12.6.1 to address CVE-2020-36518
(see https://github.com/FasterXML/jackson-databind/issues/2816) 

**Which issue(s) this PR fixes**:
No issue filed

**Checklist**
- [x] Changes manually tested -- rely on CI/build
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
