### PR TITLE
Force C*4 persistence to use latest Netty (4.1.75-final)

### DIFF
--- a/persistence-cassandra-4.0/pom.xml
+++ b/persistence-cassandra-4.0/pom.xml
@@ -18,6 +18,20 @@
     -->
     <cassandra.bundled-driver.version>3.11.0</cassandra.bundled-driver.version>
   </properties>
+  <dependencyManagement>
+    <dependencies>
+      <!-- 29-Mar-2022, tatu: Need to force Netty overrides here
+        -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <!-- Stargate component dependencies -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -516,16 +516,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!-- 29-Mar-2022, tatu: And same for Netty; force newer version
-              and hope it all works out
-        -->
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-bom</artifactId>
-        <version>${netty.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <dependency>
         <groupId>io.dropwizard</groupId>
         <artifactId>dropwizard-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -516,6 +516,16 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- 29-Mar-2022, tatu: And same for Netty; force newer version
+              and hope it all works out
+        -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.dropwizard</groupId>
         <artifactId>dropwizard-core</artifactId>


### PR DESCRIPTION
**What this PR does**:

Adds managed Netty dependency (using netty-bom) to force use of the latest Netty version by Cassandra-4.0 backend.
Could do the same for 3.11, likely; but NOT for dse backend (uses forked Netty so that would need to be upgraded).

The reason for upgrade is security scan that shows some problems with older Netty jars.

**Which issue(s) this PR fixes**:
No issue filed (yet).

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated -- relies on CI/IT to verify that things still work
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
