### PR TITLE
Upgrade Java driver 4.10->4.13

### DIFF
--- a/persistence-api/src/test/java/io/stargate/db/datastore/PersistenceBackedResultSetTest.java
+++ b/persistence-api/src/test/java/io/stargate/db/datastore/PersistenceBackedResultSetTest.java
@@ -40,8 +40,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class PersistenceBackedResultSetTest {
   private Connection connection;

--- a/persistence-api/src/test/java/io/stargate/db/datastore/PersistenceBackedResultSetTest.java
+++ b/persistence-api/src/test/java/io/stargate/db/datastore/PersistenceBackedResultSetTest.java
@@ -38,17 +38,12 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class PersistenceBackedResultSetTest {
-
-  private static final Logger log = LoggerFactory.getLogger(PersistenceBackedResultSetTest.class);
-
   private Connection connection;
   private Rows rowsSameUser;
   private Rows rowsDifferentUser;
@@ -770,7 +765,6 @@ class PersistenceBackedResultSetTest {
 
   private Predicate<Row> createAuthFilter(Map<String, String> claims) {
     String STARGATE_PREFIX = "x-stargate-";
-    JSONObject stargateClaims = new JSONObject(claims);
 
     return row -> {
       if (row == null) {
@@ -778,15 +772,8 @@ class PersistenceBackedResultSetTest {
       }
 
       for (Column col : row.columns()) {
-        if (stargateClaims.has(STARGATE_PREFIX + col.name())) {
-
-          String stargateClaimValue;
-          try {
-            stargateClaimValue = stargateClaims.getString(STARGATE_PREFIX + col.name());
-          } catch (JSONException e) {
-            log.warn("Unable to get stargate claim for " + STARGATE_PREFIX + col.name());
-            return false;
-          }
+        if (claims.containsKey(STARGATE_PREFIX + col.name())) {
+          String stargateClaimValue = claims.get(STARGATE_PREFIX + col.name());
           String columnValue = row.getString(col.name());
           if (!stargateClaimValue.equals(columnValue)) {
             return false;

--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -104,15 +104,6 @@
       <artifactId>dse-java-driver-core</artifactId>
       <version>1.10.0-dse+20210424</version>
     </dependency>
-
-    <!-- Prior to java-driver-core 4.14, this was compile-time but was
-         change to optional. So:
-      -->
-    <dependency>
-      <groupId>com.esri.geometry</groupId>
-      <artifactId>esri-geometry-api</artifactId>
-      <version>1.2.1</version>
-    </dependency>
     <dependency>
       <groupId>com.datastax.dse</groupId>
       <artifactId>dse-commons</artifactId>

--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -104,6 +104,15 @@
       <artifactId>dse-java-driver-core</artifactId>
       <version>1.10.0-dse+20210424</version>
     </dependency>
+
+    <!-- Prior to java-driver-core 4.14, this was compile-time but was
+         change to optional. So:
+      -->
+    <dependency>
+      <groupId>com.esri.geometry</groupId>
+      <artifactId>esri-geometry-api</artifactId>
+      <version>1.2.1</version>
+    </dependency>
     <dependency>
       <groupId>com.datastax.dse</groupId>
       <artifactId>dse-commons</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.scm.id>github</project.scm.id>
     <doclint>none</doclint>
-    <driver.version>4.14.0</driver.version>
+    <driver.version>4.13.0</driver.version>
     <xml-format.skip>true</xml-format.skip>
 
     <!-- First DropWizard version and things it directly depends on that make sense to sync -->

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.scm.id>github</project.scm.id>
     <doclint>none</doclint>
-    <driver.version>4.10.0</driver.version>
+    <driver.version>4.14.0</driver.version>
     <xml-format.skip>true</xml-format.skip>
 
     <!-- First DropWizard version and things it directly depends on that make sense to sync -->

--- a/restapi/pom.xml
+++ b/restapi/pom.xml
@@ -56,6 +56,14 @@
          JSR-310 module. Version provided by parent.
       -->
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>

--- a/restapi/src/main/java/io/stargate/web/docsapi/models/BuiltInApiFunction.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/models/BuiltInApiFunction.java
@@ -3,17 +3,14 @@ package io.stargate.web.docsapi.models;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.stargate.web.docsapi.exception.ErrorCode;
 import io.stargate.web.docsapi.exception.ErrorCodeRuntimeException;
-import org.codehaus.jackson.annotate.JsonProperty;
 
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum BuiltInApiFunction {
   ARRAY_PUSH("$push", "Appends data to the end of an array"),
   ARRAY_POP("$pop", "Removes data from the end of an array, returning it");
 
-  @JsonProperty("name")
   public String name;
 
-  @JsonProperty("description")
   public String description;
 
   public boolean requiresValue() {

--- a/restapi/src/main/java/io/stargate/web/docsapi/models/ExecutionProfile.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/models/ExecutionProfile.java
@@ -15,11 +15,11 @@
  */
 package io.stargate.web.docsapi.models;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.List;
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
 import org.immutables.value.Value;
 
 @JsonSerialize(as = ImmutableExecutionProfile.class)


### PR DESCRIPTION
**What this PR does**:

After initial increase in Cassandra Java driver to 4.10, let's try to go all the way to 4.13 (was: 4.14 initially).
(4.14 was a bridge too far initially, with an odd `esri-geometry-api` dependency miss problem).

Found couple of minor issues:

* org.json transitive dependency assumed, but library not really needed (code is operating on Maps)
* Accidental use of Jackson 1.x annotations instead of 2.x
* Missing Jackson dependency for `restapi` (not breaking since a few things bring it transitively, but good practice to be explicit)

NOTE: as a follow-up 4.13->4.14 it looks like DSE persistence module will need dependency to this:

```
<dependency>
  <groupId>com.esri.geometry</groupId>
  <artifactId>esri-geometry-api</artifactId>
  <version>1.2.1</version>
</dependency>
 ```

which 4.13 has strict dependency to; 4.14 defines as `optional`. But adding direct dependency from `persistence-dse-6.8/pom.xml` did NOT resolve the IT failure so there seems to be need to do something else.

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
