### PR TITLE
updating to dropwizard 2.0.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,12 +20,12 @@
     <xml-format.skip>true</xml-format.skip>
 
     <!-- First DropWizard version and things it directly depends on that make sense to sync -->
-    <dropwizard.version>2.0.27</dropwizard.version>
+    <dropwizard.version>2.0.28</dropwizard.version>
     <!--
       Note that this is currently aligned with the metrics version that DropWizard transitively depends on.
       It's probably a good idea to keep the two versions in sync.
     -->
-    <dropwizard.metrics.version>4.1.28</dropwizard.metrics.version>
+    <dropwizard.metrics.version>4.1.29</dropwizard.metrics.version>
     <!--
       Note that this is currently aligned with the Jetty version that DropWizard transitively depends on.
       It's probably a good idea to keep the two versions in sync.


### PR DESCRIPTION
Update dropwizard to latest 2.0.28 and associated dropwizard metrics version 4.1.29

See: https://github.com/dropwizard/dropwizard/releases/tag/v2.0.28

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
