### PR TITLE
Netty version update to 4.1.75.Final

### DIFF
--- a/persistence-api/pom.xml
+++ b/persistence-api/pom.xml
@@ -15,6 +15,21 @@
       <url>https://repo.maven.apache.org/maven2</url>
     </repository>
   </repositories>
+  <dependencyManagement>
+    <dependencies>
+      <!-- 30-Mar-2022, tatu: Need to force Netty overrides here so
+	   they propagate to most modules but NOT to persistence where
+	   DSE at least requires different versions (3.11 may or may not)
+        -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <!-- Stargate component dependencies -->
     <dependency>

--- a/persistence-cassandra-3.11/pom.xml
+++ b/persistence-cassandra-3.11/pom.xml
@@ -18,6 +18,20 @@
     -->
     <cassandra.bundled-driver.version>3.0.1</cassandra.bundled-driver.version>
   </properties>
+  <dependencyManagement>
+    <dependencies>
+      <!-- 30-Mar-2022, tatu: Need to force Netty overrides here since
+	   it cannot be done in parent pom (due to DSE backend)
+        -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <!-- Stargate component dependencies -->
     <dependency>


### PR DESCRIPTION
**What this PR does**:

Updates version of Netty used as dependency, to address CVEs/vulns reported for some Netty versions.
This should update all modules expected for `persistence-dse-6.8` (which is known to have issues with upgrade) to the currently latest Netty version, `4.1.75.Final`

**Which issue(s) this PR fixes**:
No issue for this repo

**Checklist**
- [x] Changes manually tested -- rely on CI for existing unit, integration tests
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
