### PR TITLE
Upgrade json-path 2.5.0->2.7.0 to get json-smart upgrade

### DIFF
--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -206,7 +206,7 @@
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
-      <version>2.5.0</version>
+      <version>2.7.0</version>
     </dependency>
     <dependency>
       <groupId>io.projectreactor</groupId>


### PR DESCRIPTION
**What this PR does**:

Updates "json-path" dependency from `2.5.0` to `2.7.0` to upgrade transitive dependency of "json-smart" parser package (to address a reported vuln).

**Which issue(s) this PR fixes**:
No public issue filed

**Checklist**
- [x] Changes manually tested -- verified dependency chain, but mostly rely on existing CI/IT
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
