### PR TITLE
Add bridge method to get supported persistence features

### DIFF
--- a/bridge/src/main/java/io/stargate/bridge/service/BridgeService.java
+++ b/bridge/src/main/java/io/stargate/bridge/service/BridgeService.java
@@ -37,6 +37,7 @@ public class BridgeService extends StargateBridgeGrpc.StargateBridgeImplBase {
 
   private final ScheduledExecutorService executor;
   private final int schemaAgreementRetries;
+  private final Schema.SupportedFeaturesResponse supportedFeaturesResponse;
 
   public BridgeService(
       Persistence persistence,
@@ -54,6 +55,12 @@ public class BridgeService extends StargateBridgeGrpc.StargateBridgeImplBase {
     this.authorizationService = authorizationService;
     this.executor = executor;
     this.schemaAgreementRetries = schemaAgreementRetries;
+    this.supportedFeaturesResponse =
+        Schema.SupportedFeaturesResponse.newBuilder()
+            .setSecondaryIndexes(persistence.supportsSecondaryIndex())
+            .setSai(persistence.supportsSAI())
+            .setLoggedBatches(persistence.supportsLoggedBatches())
+            .build();
   }
 
   @Override
@@ -98,5 +105,13 @@ public class BridgeService extends StargateBridgeGrpc.StargateBridgeImplBase {
     new AuthorizationHandler(
             request, GrpcService.CONNECTION_KEY.get(), authorizationService, responseObserver)
         .handle();
+  }
+
+  @Override
+  public void getSupportedFeatures(
+      Schema.SupportedFeaturesRequest request,
+      StreamObserver<Schema.SupportedFeaturesResponse> responseObserver) {
+    responseObserver.onNext(supportedFeaturesResponse);
+    responseObserver.onCompleted();
   }
 }

--- a/bridge/src/test/java/io/stargate/bridge/service/SupportedFeaturesTest.java
+++ b/bridge/src/test/java/io/stargate/bridge/service/SupportedFeaturesTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.bridge.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.when;
+
+import io.stargate.proto.Schema.SupportedFeaturesRequest;
+import io.stargate.proto.Schema.SupportedFeaturesResponse;
+import io.stargate.proto.StargateBridgeGrpc;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class SupportedFeaturesTest extends BaseBridgeTest {
+
+  @ParameterizedTest
+  @MethodSource("getSupportedFeatures")
+  public void shouldGetSupportedFeatures(
+      boolean secondaryIndexes, boolean sai, boolean loggedBatches) {
+    // Given
+    StargateBridgeGrpc.StargateBridgeBlockingStub stub = makeBlockingStub();
+    when(persistence.supportsSecondaryIndex()).thenReturn(secondaryIndexes);
+    when(persistence.supportsSAI()).thenReturn(sai);
+    when(persistence.supportsLoggedBatches()).thenReturn(loggedBatches);
+
+    startServer(persistence);
+
+    // When
+    SupportedFeaturesResponse response =
+        stub.getSupportedFeatures(SupportedFeaturesRequest.newBuilder().build());
+
+    // Then
+    assertThat(response.getSecondaryIndexes()).isEqualTo(secondaryIndexes);
+    assertThat(response.getSai()).isEqualTo(sai);
+    assertThat(response.getLoggedBatches()).isEqualTo(loggedBatches);
+  }
+
+  public static Arguments[] getSupportedFeatures() {
+    return new Arguments[] {
+      arguments(false, false, false),
+      arguments(false, false, true),
+      arguments(false, true, false),
+      arguments(false, true, true),
+      arguments(true, false, false),
+      arguments(true, false, true),
+      arguments(true, true, false),
+      arguments(true, true, true),
+    };
+  }
+}

--- a/grpc-proto/proto/bridge.proto
+++ b/grpc-proto/proto/bridge.proto
@@ -41,5 +41,8 @@ service StargateBridge {
 
   // Checks whether the client is authorized to describe one or more schema elements.
   rpc AuthorizeSchemaReads(AuthorizeSchemaReadsRequest) returns (AuthorizeSchemaReadsResponse) {}
+
+  // Checks which features are supported by the persistence backend.
+  rpc GetSupportedFeatures(SupportedFeaturesRequest) returns (SupportedFeaturesResponse) {}
 }
 

--- a/grpc-proto/proto/schema.proto
+++ b/grpc-proto/proto/schema.proto
@@ -141,3 +141,20 @@ message SchemaRead {
 message AuthorizeSchemaReadsResponse {
   repeated bool authorized = 1;
 }
+
+// The arguments to a GetSupportedFeatures call.
+// Intentionally empty, there are no arguments at this time but this is intended for future
+// extensibility.
+message SupportedFeaturesRequest {}
+
+// The response to a GetSupportedFeatures call.
+message SupportedFeaturesResponse {
+  // Whether the persistence backend supports regular Cassandra secondary indexes.
+  bool secondary_indexes = 1;
+
+  // Whether the persistence backend supports Storage Attached Indexes.
+  bool sai = 2;
+
+  // Whether the persistence backend supports logged CQL batches.
+  bool logged_batches = 3;
+}

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/LazyReference.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/LazyReference.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.common.grpc;
+
+import java.util.function.Supplier;
+
+/**
+ * A references that memoizes a value, but the computation function is provided by callers of {@link
+ * #get(Supplier)}.
+ */
+class LazyReference<T> {
+
+  private volatile T value;
+
+  T get(Supplier<T> initializer) {
+    T result = value;
+    if (result != null) {
+      return result;
+    }
+    synchronized (this) {
+      if (value == null) {
+        value = initializer.get();
+      }
+      return value;
+    }
+  }
+}

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/StargateBridgeClient.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/StargateBridgeClient.java
@@ -22,6 +22,7 @@ import io.stargate.proto.Schema;
 import io.stargate.proto.Schema.CqlKeyspaceDescribe;
 import io.stargate.proto.Schema.CqlTable;
 import io.stargate.proto.Schema.SchemaRead;
+import io.stargate.proto.Schema.SupportedFeaturesResponse;
 import io.stargate.sgv2.common.futures.Futures;
 import java.util.Collections;
 import java.util.List;
@@ -165,5 +166,11 @@ public interface StargateBridgeClient {
    */
   default boolean authorizeSchemaRead(SchemaRead schemaRead) {
     return authorizeSchemaReads(Collections.singletonList(schemaRead)).get(0);
+  }
+
+  CompletionStage<SupportedFeaturesResponse> getSupportedFeaturesAsync();
+
+  default SupportedFeaturesResponse getSupportedFeatures() {
+    return Futures.getUninterruptibly(getSupportedFeaturesAsync());
   }
 }

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/StargateBridgeClient.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/StargateBridgeClient.java
@@ -168,8 +168,10 @@ public interface StargateBridgeClient {
     return authorizeSchemaReads(Collections.singletonList(schemaRead)).get(0);
   }
 
+  /** Checks which features are supported by the persistence backend. */
   CompletionStage<SupportedFeaturesResponse> getSupportedFeaturesAsync();
 
+  /** @see #getSupportedFeaturesAsync() */
   default SupportedFeaturesResponse getSupportedFeatures() {
     return Futures.getUninterruptibly(getSupportedFeaturesAsync());
   }

--- a/sgv2-service-common/src/test/java/io/stargate/sgv2/common/grpc/DefaultStargateBridgeClientTest.java
+++ b/sgv2-service-common/src/test/java/io/stargate/sgv2/common/grpc/DefaultStargateBridgeClientTest.java
@@ -408,7 +408,7 @@ public class DefaultStargateBridgeClientTest {
 
   private DefaultStargateBridgeClient newClient() {
     return new DefaultStargateBridgeClient(
-        channel, AUTH_TOKEN, Optional.empty(), keyspaceCache, SOURCE_API);
+        channel, AUTH_TOKEN, Optional.empty(), keyspaceCache, new LazyReference<>(), SOURCE_API);
   }
 
   void mockAuthorizations(Map<SchemaRead, Boolean> authorizations) {

--- a/sgv2-service-common/src/test/java/io/stargate/sgv2/common/grpc/DefaultStargateBridgeClientTest.java
+++ b/sgv2-service-common/src/test/java/io/stargate/sgv2/common/grpc/DefaultStargateBridgeClientTest.java
@@ -18,6 +18,7 @@ package io.stargate.sgv2.common.grpc;
 import static io.stargate.sgv2.common.grpc.DefaultStargateBridgeClient.SELECT_KEYSPACE_NAMES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -50,6 +51,7 @@ import io.stargate.proto.Schema.CqlTable;
 import io.stargate.proto.Schema.DescribeKeyspaceQuery;
 import io.stargate.proto.Schema.SchemaRead;
 import io.stargate.proto.Schema.SchemaRead.SourceApi;
+import io.stargate.proto.Schema.SupportedFeaturesResponse;
 import io.stargate.proto.StargateBridgeGrpc.StargateBridgeImplBase;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -63,6 +65,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -372,6 +377,35 @@ public class DefaultStargateBridgeClientTest {
     assertThat(tables).extracting(CqlTable::getName).contains("tbl1", "tbl3");
   }
 
+  @ParameterizedTest
+  @MethodSource("getSupportedFeatures")
+  public void shouldGetSupportedFeatures(
+      boolean secondaryIndexes, boolean sai, boolean loggedBatches) {
+    // Given
+    mockSupportedFeatures(secondaryIndexes, sai, loggedBatches);
+
+    // When
+    SupportedFeaturesResponse response = newClient().getSupportedFeatures();
+
+    // Then
+    assertThat(response.getSecondaryIndexes()).isEqualTo(secondaryIndexes);
+    assertThat(response.getSai()).isEqualTo(sai);
+    assertThat(response.getLoggedBatches()).isEqualTo(loggedBatches);
+  }
+
+  public static Arguments[] getSupportedFeatures() {
+    return new Arguments[] {
+      arguments(false, false, false),
+      arguments(false, false, true),
+      arguments(false, true, false),
+      arguments(false, true, true),
+      arguments(true, false, false),
+      arguments(true, false, true),
+      arguments(true, true, false),
+      arguments(true, true, true),
+    };
+  }
+
   private DefaultStargateBridgeClient newClient() {
     return new DefaultStargateBridgeClient(
         channel, AUTH_TOKEN, Optional.empty(), keyspaceCache, SOURCE_API);
@@ -463,6 +497,20 @@ public class DefaultStargateBridgeClientTest {
 
   private void mockBatch(Batch batch, List<Row> rows) {
     doAnswer(i -> mockRows(i, rows)).when(service).executeBatch(eq(batch), any());
+  }
+
+  private void mockSupportedFeatures(boolean secondaryIndexes, boolean sai, boolean loggedBatches) {
+    doAnswer(
+            i ->
+                mockResponse(
+                    i,
+                    SupportedFeaturesResponse.newBuilder()
+                        .setSecondaryIndexes(secondaryIndexes)
+                        .setSai(sai)
+                        .setLoggedBatches(loggedBatches)
+                        .build()))
+        .when(service)
+        .getSupportedFeatures(any(), any());
   }
 
   private Void mockRows(InvocationOnMock i, List<Row> rows) {


### PR DESCRIPTION
**What this PR does**:
Trivial change to expose `Persistence.supports*` methods through the bridge. This will be needed for both GraphQL and Docs API.

**Which issue(s) this PR fixes**:
/

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
