### PR TITLE
Upgrade io.grpc dependencies from 1.42.1 to 1.45.1, use grpc-bom

### DIFF
--- a/grpc-examples/pom.xml
+++ b/grpc-examples/pom.xml
@@ -18,7 +18,6 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
-            <version>${grpc.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/grpc-proto/pom.xml
+++ b/grpc-proto/pom.xml
@@ -25,12 +25,10 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
-      <version>${grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
-      <version>${grpc.version}</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/grpc/pom.xml
+++ b/grpc/pom.xml
@@ -38,17 +38,14 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
-      <version>${grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
-      <version>${grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
-      <version>${grpc.version}</version>
     </dependency>
 
     <!-- 3rd party dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <caffeine.version>2.9.3</caffeine.version>
     <commons-io.version>2.7</commons-io.version>
-    <grpc.version>1.42.1</grpc.version>
+    <grpc.version>1.45.1</grpc.version>
     <immutables.version>2.8.8</immutables.version>
     <!-- 28-Mar-2022, tatu: BOM for "micro-patch" 2.12.6.1 of jackson-databind
         is bit unusual wrt version; normally would be "x.y.z": when updating see:
@@ -594,6 +594,15 @@
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>jersey-bom</artifactId>
         <version>2.34</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- BOM for gRPC as well -->
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-bom</artifactId>
+        <version>${grpc.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -91,17 +91,14 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
-      <version>${grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
-      <version>${grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
-      <version>${grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>com.apollographql.apollo</groupId>


### PR DESCRIPTION
**What this PR does**:

Start using "grpc-bom" to get a consistent set of `io.grpc` components; upgrade version to use from 1.42.1 to 1.45.1 (latest released at this point): goal being to get newer version of `protobuf-java` (3.17.2 -> 3.19.2) to address a security vuln ([CVE-2021-22569](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22569))

**Which issue(s) this PR fixes**:
No public issue.

**Checklist**
- [x] Changes manually tested -- verified dependency graph; otherwise CI/IT verifies compatibility
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
