### PR TITLE
Remove bridge token references

### DIFF
--- a/docker-compose/cassandra-3.11/.env
+++ b/docker-compose/cassandra-3.11/.env
@@ -1,3 +1,2 @@
 COMPOSE_PROJECT_NAME=cass311-stargate
 CASSTAG=3.11.11
-BRIDGE_TOKEN=sample-bridge-token

--- a/docker-compose/cassandra-3.11/docker-compose-dev-mode.yml
+++ b/docker-compose/cassandra-3.11/docker-compose-dev-mode.yml
@@ -20,7 +20,6 @@ services:
       - DATACENTER_NAME=datacenter1
       - ENABLE_AUTH=true
       - DEVELOPER_MODE=true
-      - BRIDGE_TOKEN=${BRIDGE_TOKEN}
   restapi:
     image: stargateio/restapi:${SGTAG}
     depends_on:
@@ -34,6 +33,5 @@ services:
       - STARGATE_BRIDGE_HOST=coordinator
       - STARGATE_BRIDGE_PORT=8091
       - STARGATE_REST_PORT=8082
-      - BRIDGE_TOKEN=${BRIDGE_TOKEN}
 networks:
   stargate:

--- a/docker-compose/cassandra-3.11/docker-compose.yml
+++ b/docker-compose/cassandra-3.11/docker-compose.yml
@@ -55,7 +55,6 @@ services:
       - RACK_NAME=rack1
       - DATACENTER_NAME=datacenter1
       - ENABLE_AUTH=true
-      - BRIDGE_TOKEN=${BRIDGE_TOKEN}
   restapi:
     image: stargateio/restapi:${SGTAG}
     depends_on:
@@ -69,6 +68,5 @@ services:
       - STARGATE_BRIDGE_HOST=coordinator
       - STARGATE_BRIDGE_PORT=8091
       - STARGATE_REST_PORT=8082
-      - BRIDGE_TOKEN=${BRIDGE_TOKEN}
 networks:
   stargate:

--- a/docker-compose/cassandra-4.0/.env
+++ b/docker-compose/cassandra-4.0/.env
@@ -1,3 +1,2 @@
 COMPOSE_PROJECT_NAME=cass40-stargate
 CASSTAG=4.0.1
-BRIDGE_TOKEN=sample-bridge-token

--- a/docker-compose/cassandra-4.0/docker-compose-dev-mode.yml
+++ b/docker-compose/cassandra-4.0/docker-compose-dev-mode.yml
@@ -20,7 +20,6 @@ services:
       - DATACENTER_NAME=datacenter1
       - ENABLE_AUTH=true
       - DEVELOPER_MODE=true
-      - BRIDGE_TOKEN=${BRIDGE_TOKEN}
   restapi:
     image: stargateio/restapi:${SGTAG}
     depends_on:
@@ -34,6 +33,5 @@ services:
       - STARGATE_BRIDGE_HOST=coordinator
       - STARGATE_BRIDGE_PORT=8091
       - STARGATE_REST_PORT=8082
-      - BRIDGE_TOKEN=${BRIDGE_TOKEN}
 networks:
   stargate:

--- a/docker-compose/cassandra-4.0/docker-compose.yml
+++ b/docker-compose/cassandra-4.0/docker-compose.yml
@@ -55,7 +55,6 @@ services:
       - RACK_NAME=rack1
       - DATACENTER_NAME=datacenter1
       - ENABLE_AUTH=true
-      - BRIDGE_TOKEN=${BRIDGE_TOKEN}
   restapi:
     image: stargateio/restapi:${SGTAG}
     depends_on:
@@ -69,6 +68,5 @@ services:
       - STARGATE_BRIDGE_HOST=coordinator
       - STARGATE_BRIDGE_PORT=8091
       - STARGATE_REST_PORT=8082
-      - BRIDGE_TOKEN=${BRIDGE_TOKEN}
 networks:
   stargate:

--- a/docker-compose/dse-6.8/.env
+++ b/docker-compose/dse-6.8/.env
@@ -1,3 +1,2 @@
 COMPOSE_PROJECT_NAME=dse68-stargate
 DSETAG=6.8.16
-BRIDGE_TOKEN=sample-bridge-token

--- a/docker-compose/dse-6.8/docker-compose-dev-mode.yml
+++ b/docker-compose/dse-6.8/docker-compose-dev-mode.yml
@@ -21,7 +21,6 @@ services:
       - DATACENTER_NAME=dc1
       - ENABLE_AUTH=true
       - DEVELOPER_MODE=true
-      - BRIDGE_TOKEN=${BRIDGE_TOKEN}
   restapi:
     image: stargateio/restapi:${SGTAG}
     depends_on:
@@ -35,6 +34,5 @@ services:
       - STARGATE_BRIDGE_HOST=coordinator
       - STARGATE_BRIDGE_PORT=8091
       - STARGATE_REST_PORT=8082
-      - BRIDGE_TOKEN=${BRIDGE_TOKEN}
 networks:
   stargate:

--- a/docker-compose/dse-6.8/docker-compose.yml
+++ b/docker-compose/dse-6.8/docker-compose.yml
@@ -64,7 +64,6 @@ services:
       - RACK_NAME=rack1
       - DATACENTER_NAME=dc1
       - ENABLE_AUTH=true
-      - BRIDGE_TOKEN=${BRIDGE_TOKEN}
   restapi:
     image: stargateio/restapi:${SGTAG}
     depends_on:
@@ -78,6 +77,5 @@ services:
       - STARGATE_BRIDGE_HOST=coordinator
       - STARGATE_BRIDGE_PORT=8091
       - STARGATE_REST_PORT=8082
-      - BRIDGE_TOKEN=${BRIDGE_TOKEN}
 networks:
   stargate:

--- a/starctl
+++ b/starctl
@@ -13,15 +13,11 @@ done
 cd -P -- "$(dirname -- "$0")" # switch to this dir
 echo $PWD
 
-if [ -z $BRIDGE_TOKEN ]; then
-  export BRIDGE_TOKEN=mockAdminToken
-fi
-
 # start REST API service
 ./starctl-service-rest &
 
 # pass along same arguments to script to start coordinator
-./starctl-coordinator "$@" --bridge-token="$BRIDGE_TOKEN" &
+./starctl-coordinator "$@" &
 
 wait
 

--- a/starctl-coordinator
+++ b/starctl-coordinator
@@ -164,9 +164,6 @@ if [[ ${#STARGATE_ARGS[@]} -eq 0 ]]; then
         STARGATE_ARGS+=("--host-id", "$HOST_ID")
     fi
 
-    if [[ ! -z "$BRIDGE_TOKEN" ]]; then
-        STARGATE_ARGS+=("--bridge-token" "$BRIDGE_TOKEN")
-    fi
 fi
 
 declare -a CMD=(java -server)

--- a/starctl-service-rest
+++ b/starctl-service-rest
@@ -42,13 +42,6 @@ fi
 
 eval declare -a JAVA_OPTS=("$JAVA_OPTS")
 
-if [ ! "x$BRIDGE_TOKEN" == "x" ]; then
-  JAVA_OPTS+=(-Dstargate.bridge.admin_token="$BRIDGE_TOKEN")
-else
-  echo "BRIDGE_TOKEN not found"
-  exit 2
-fi
-
 if [ ! "x$STARGATE_BRIDGE_HOST" == "x" ]; then
   JAVA_OPTS+=(-Ddw.stargate.bridge.host="$STARGATE_BRIDGE_HOST")
 else

--- a/stargate-starter/src/main/java/io/stargate/starter/Starter.java
+++ b/stargate-starter/src/main/java/io/stargate/starter/Starter.java
@@ -248,12 +248,6 @@ public class Starter {
       description = "The host ID to use for this node. Must be a valid UUID.")
   protected String hostId;
 
-  @Order(value = 24)
-  @Option(
-      name = "--bridge-token",
-      description = "Token that API services will use to authenticate to the bridge (required) ")
-  protected String bridgeToken;
-
   @Order(value = 1000)
   @Option(
       name = "--nodetool",
@@ -294,8 +288,7 @@ public class Starter {
       boolean dse,
       boolean isSimpleSnitch,
       int cqlPort,
-      int jmxPort,
-      String bridgeToken) {
+      int jmxPort) {
     this.clusterName = clusterName;
     this.version = version;
     this.listenHostStr = listenHostStr;
@@ -310,7 +303,6 @@ public class Starter {
     // bind to listen address only to allow multiple starters to start on the same host
     this.bindToListenAddressOnly = true;
     this.jmxPort = jmxPort;
-    this.bridgeToken = bridgeToken;
     this.disableDynamicSnitch = true;
     this.disableMBeanRegistration = true;
   }
@@ -322,10 +314,6 @@ public class Starter {
 
     if (clusterName == null || clusterName.trim().isEmpty()) {
       throw new IllegalArgumentException("--cluster-name must be specified");
-    }
-
-    if (bridgeToken == null || bridgeToken.trim().isEmpty()) {
-      throw new IllegalArgumentException("--bridge-token must be specified");
     }
 
     if (!InetAddressValidator.getInstance().isValid(listenHostStr)) {
@@ -395,7 +383,6 @@ public class Starter {
     if (hostId != null && !hostId.isEmpty()) {
       System.setProperty("stargate.host_id", hostId);
     }
-    System.setProperty("stargate.bridge.admin_token", bridgeToken);
 
     if (bindToListenAddressOnly) {
       // Restrict the listen address for Jersey endpoints

--- a/stargate-starter/src/test/java/io/stargate/starter/StarterTest.java
+++ b/stargate-starter/src/test/java/io/stargate/starter/StarterTest.java
@@ -37,7 +37,6 @@ class StarterTest {
     starter.clusterName = "foo";
     starter.version = "3.11";
     starter.seedList = Arrays.asList("127.0.0.1", "127.0.0.2");
-    starter.bridgeToken = "sample-bridge-token";
   }
 
   @Test
@@ -149,19 +148,6 @@ class StarterTest {
         IllegalArgumentException.class,
         starter::setStargateProperties,
         "At least one seed node address is required.");
-  }
-
-  @Test
-  void testSetStargatePropertiesMissingBridgeToken() {
-    starter.bridgeToken = null;
-
-    RuntimeException thrown =
-        assertThrows(
-            IllegalArgumentException.class,
-            starter::setStargateProperties,
-            "Expected setStargateProperties() to throw RuntimeException");
-
-    assertThat(thrown.getMessage()).isEqualTo("--bridge-token must be specified");
   }
 
   @Test

--- a/testing/src/main/java/io/stargate/it/http/ApiServiceExtension.java
+++ b/testing/src/main/java/io/stargate/it/http/ApiServiceExtension.java
@@ -210,7 +210,6 @@ public class ApiServiceExtension
       cmd.addArgument("-D" + params.servicePortPropertyName() + "=" + params.servicePort());
       cmd.addArgument("-D" + params.bridgeHostPropertyName() + "=" + connectionInfo.seedAddress());
       cmd.addArgument("-D" + params.bridgePortPropertyName() + "=" + connectionInfo.bridgePort());
-      cmd.addArgument("-D" + params.bridgeTokenPropertyName() + "=" + connectionInfo.bridgeToken());
 
       for (Entry<String, String> e : params.systemProperties().entrySet()) {
         cmd.addArgument("-D" + e.getKey() + "=" + e.getValue());

--- a/testing/src/main/java/io/stargate/it/http/ApiServiceParameters.java
+++ b/testing/src/main/java/io/stargate/it/http/ApiServiceParameters.java
@@ -79,12 +79,6 @@ public interface ApiServiceParameters {
   // example: "dw.stargate.bridge.port"
   String bridgePortPropertyName();
 
-  @Value.Default
-  // standard value
-  default String bridgeTokenPropertyName() {
-    return "stargate.bridge.admin_token";
-  }
-
   static Builder builder() {
     return ImmutableApiServiceParameters.builder();
   }
@@ -110,8 +104,6 @@ public interface ApiServiceParameters {
     Builder bridgeHostPropertyName(String bridgeHostPropertyName);
 
     Builder bridgePortPropertyName(String bridgePortPropertyName);
-
-    Builder bridgeTokenPropertyName(String bridgeTokenPropertyName);
 
     ApiServiceParameters build();
   }

--- a/testing/src/main/java/io/stargate/it/storage/StargateConnectionInfo.java
+++ b/testing/src/main/java/io/stargate/it/storage/StargateConnectionInfo.java
@@ -24,8 +24,6 @@ public interface StargateConnectionInfo {
 
   int bridgePort();
 
-  String bridgeToken();
-
   int jmxPort();
 
   String clusterName();

--- a/testing/src/main/java/io/stargate/it/storage/StargateExtension.java
+++ b/testing/src/main/java/io/stargate/it/storage/StargateExtension.java
@@ -348,7 +348,6 @@ public class StargateExtension extends ExternalResource<StargateSpec, StargateEx
     private final CommandLine cmd;
     private final int cqlPort;
     private final int bridgePort;
-    private final String bridgeToken;
     private final int jmxPort;
     private final String datacenter;
     private final String rack;
@@ -366,7 +365,6 @@ public class StargateExtension extends ExternalResource<StargateSpec, StargateEx
       this.listenAddress = env.listenAddress(nodeIndex);
       this.cqlPort = env.cqlPort();
       this.bridgePort = env.bridgePort();
-      this.bridgeToken = env.bridgeToken();
       this.jmxPort = env.jmxPort(nodeIndex);
       this.clusterName = backend.clusterName();
       this.datacenter = backend.datacenter();
@@ -423,8 +421,6 @@ public class StargateExtension extends ExternalResource<StargateSpec, StargateEx
       cmd.addArgument(String.valueOf(cqlPort));
       cmd.addArgument("--jmx-port");
       cmd.addArgument(String.valueOf(jmxPort));
-      cmd.addArgument("--bridge-token");
-      cmd.addArgument(bridgeToken);
 
       addStdOutListener(
           (node, line) -> {
@@ -479,11 +475,6 @@ public class StargateExtension extends ExternalResource<StargateSpec, StargateEx
     }
 
     @Override
-    public String bridgeToken() {
-      return bridgeToken;
-    }
-
-    @Override
     public int jmxPort() {
       return jmxPort;
     }
@@ -535,10 +526,6 @@ public class StargateExtension extends ExternalResource<StargateSpec, StargateEx
 
     private int bridgePort() {
       return 8091;
-    }
-
-    private String bridgeToken() {
-      return "mockAdminToken";
     }
 
     public File cacheDir(int nodeIndex) throws IOException {


### PR DESCRIPTION
Requirement to use the bridge token was recently removed under #1711, this PR is to remove other references to the bridge token from starter, testing, scripts, and Docker-related files.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
