### PR TITLE
[WIP] closes #1772: reference to the google api common protos

### DIFF
--- a/grpc-proto/pom.xml
+++ b/grpc-proto/pom.xml
@@ -30,6 +30,11 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-common-protos</artifactId>
+      <version>2.8.2</version>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>


### PR DESCRIPTION
**What this PR does**:
Potential fix for the #1772, adds `proto-google-common-protos` due to the missing `google/rpc/status.proto` reference in the `query.proto`. 

**Which issue(s) this PR fixes**:
Fixes #1172
