### PR TITLE
closes #1719: added generic Quarkus observability for Document API V2

### DIFF
--- a/sgv2-docsapi/.gitignore
+++ b/sgv2-docsapi/.gitignore
@@ -37,3 +37,6 @@ nb-configuration.xml
 
 # Local environment
 .env
+
+# jaeger in-memory storage
+badger/

--- a/sgv2-docsapi/README.md
+++ b/sgv2-docsapi/README.md
@@ -68,6 +68,14 @@ Below is the list of currently available properties.
 | `stargate.header-based-auth.enabled`     | `boolean` | `true`              | If the header based auth is enabled. |
 | `stargate.header-based-auth.header-name` | `String`  | `X-Cassandra-Token` | Name of the authentication header.   |
 
+#### [Metrics configuration](src/main/java/io/stargate/sgv2/docsapi/config/MetricsConfig.java)
+*Configuration mapping for the additional metrics properties.*
+
+| Property                                   | Type                 | Default | Description                                             |
+|--------------------------------------------|----------------------|---------|---------------------------------------------------------|
+| `stargate.metrics.global-tags`             | `Map<String,String>` | unset   | Map of global tags that will be applied to every meter. |
+
+
 #### [Multi-tenancy configuration](src/main/java/io/stargate/sgv2/docsapi/config/TenantResolverConfig.java)
 *Configuration mapping for the tenant resolving.*
 
@@ -199,6 +207,35 @@ In order to pass the request context information to the Bridge, the client shoul
 [Related guide](https://quarkus.io/guides/validation)
 
 Enables validation of configuration, beans, REST endpoints, etc.
+
+### `quarkus-micrometer-registry-prometheus`
+[Related guide](https://quarkus.io/guides/micrometer)
+
+Enables out-of-the-box metrics collection and the Prometheus exporter.
+Metrics are exported at the Prometheus default `/metrics` endpoint.
+All non-application endpoints are ignored from the collection.
+
+### `quarkus-opentelemetry-exporter-otlp`
+[Related guide](https://quarkus.io/guides/opentelemetry)
+
+Enables the [OpenTelemetry](https://opentelemetry.io/) tracing support.
+In order to activate the tracing, you need to supply the OTLP gRPC endpoint using the JVM parameter `-Dquarkus.opentelemetry.tracer.exporter.otlp.endpoint=http://localhost:55680`.
+The easiest way to locally collect and visualize traces is to use the [jaegertracing/opentelemetry-all-in-one](https://www.jaegertracing.io/docs/1.21/opentelemetry/) docker image with [in-memory](https://www.jaegertracing.io/docs/1.21/deployment/#badger---local-storage) storage:
+
+```shell
+docker run \
+  --rm \
+  -e SPAN_STORAGE_TYPE=badger \
+  -e BADGER_EPHEMERAL=false \
+  -e BADGER_DIRECTORY_VALUE=/badger/data \
+  -e BADGER_DIRECTORY_KEY=/badger/key \
+  -v badger:/badger \
+  -p 55680:55680 \
+  -p 16686:16686 \
+  jaegertracing/opentelemetry-all-in-one
+```
+
+You can then visualize traces using Jaeger UI started on http://localhost:16686.
 
 ### `quarkus-resteasy-reactive`
 [Related guide](https://quarkus.io/guides/resteasy-reactive)

--- a/sgv2-docsapi/README.md
+++ b/sgv2-docsapi/README.md
@@ -222,7 +222,7 @@ All non-application endpoints are ignored from the collection.
 [Related guide](https://quarkus.io/guides/opentelemetry)
 
 Enables the [OpenTelemetry](https://opentelemetry.io/) tracing support.
-In order to activate the tracing, you need to supply the OTLP gRPC endpoint using the JVM parameter `-Dquarkus.opentelemetry.tracer.exporter.otlp.endpoint=http://localhost:55680`.
+In order to activate the tracing, you need to supply the OTLP gRPC endpoint using the JVM parameters `-Dquarkus.opentelemetry.tracer.exporter.otlp.enabled=true -Dquarkus.opentelemetry.tracer.exporter.otlp.endpoint=http://localhost:55680`.
 The easiest way to locally collect and visualize traces is to use the [jaegertracing/opentelemetry-all-in-one](https://www.jaegertracing.io/docs/1.21/opentelemetry/) docker image with [in-memory](https://www.jaegertracing.io/docs/1.21/deployment/#badger---local-storage) storage:
 
 ```shell

--- a/sgv2-docsapi/README.md
+++ b/sgv2-docsapi/README.md
@@ -71,10 +71,13 @@ Below is the list of currently available properties.
 #### [Metrics configuration](src/main/java/io/stargate/sgv2/docsapi/config/MetricsConfig.java)
 *Configuration mapping for the additional metrics properties.*
 
-| Property                                   | Type                 | Default | Description                                             |
-|--------------------------------------------|----------------------|---------|---------------------------------------------------------|
-| `stargate.metrics.global-tags`             | `Map<String,String>` | unset   | Map of global tags that will be applied to every meter. |
-
+| Property                                              | Type                 | Default                        | Description                                                             |
+|-------------------------------------------------------|----------------------|--------------------------------|-------------------------------------------------------------------------|
+| `stargate.metrics.global-tags`                        | `Map<String,String>` | unset                          | Map of global tags that will be applied to every meter.                 |
+| `stargate.metrics.tenant-request-counter.enabled`     | `boolean`            | `true`                         | If extra metric for counting the request per tenant should be recorded. |
+| `stargate.metrics.tenant-request-counter.metric-name` | `String`             | `http.server.requests.counter` | Name of the metric.                                                     |
+| `stargate.metrics.tenant-request-counter.tenant-tag`  | `String`             | `tenant`                       | The tag key for tenant id.                                              |
+| `stargate.metrics.tenant-request-counter.error-tag`   | `String`             | `error`                        | The tag key for the request error flag (true/false).                    |
 
 #### [Multi-tenancy configuration](src/main/java/io/stargate/sgv2/docsapi/config/TenantResolverConfig.java)
 *Configuration mapping for the tenant resolving.*

--- a/sgv2-docsapi/pom.xml
+++ b/sgv2-docsapi/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.stargate</groupId>
   <artifactId>sgv2-docsapi</artifactId>
@@ -85,6 +86,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>
@@ -146,17 +151,16 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
-      <!-- formatting plugins -->
       <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
         <version>2.13</version>
         <executions>
           <execution>
+            <phase>process-sources</phase>
             <goals>
               <goal>check</goal>
             </goals>
-            <phase>process-sources</phase>
           </execution>
         </executions>
       </plugin>

--- a/sgv2-docsapi/pom.xml
+++ b/sgv2-docsapi/pom.xml
@@ -90,6 +90,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>

--- a/sgv2-docsapi/pom.xml
+++ b/sgv2-docsapi/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.stargate</groupId>
   <artifactId>sgv2-docsapi</artifactId>

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/metrics/TenantRequestMetricsFilter.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/metrics/TenantRequestMetricsFilter.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.api.common.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.stargate.sgv2.docsapi.api.common.StargateRequestInfo;
+import io.stargate.sgv2.docsapi.config.MetricsConfig;
+import org.jboss.resteasy.reactive.server.ServerResponseFilter;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerResponseContext;
+
+/**
+ * The filter for counting HTTP requests per tenant. Controlled by {@link MetricsConfig.TenantRequestCounterConfig}.
+ */
+@ApplicationScoped
+public class TenantRequestMetricsFilter {
+
+    /**
+     * The {@link MeterRegistry} to report to.
+     */
+    private final MeterRegistry meterRegistry;
+
+    /**
+     * The configuration for metrics.
+     */
+    private final MetricsConfig.TenantRequestCounterConfig config;
+
+    /**
+     * The request info bean.
+     */
+    private final StargateRequestInfo requestInfo;
+
+    /**
+     * The tag for error being true, created only once.
+     */
+    private final Tag errorTrue;
+
+    /**
+     * The tag for error being false, created only once.
+     */
+    private final Tag errorFalse;
+
+    /**
+     * The tag for tenant being unknown, created only once.
+     */
+    Tag tenantUnknown;
+
+    /**
+     * Default constructor.
+     */
+    @Inject
+    public TenantRequestMetricsFilter(MeterRegistry meterRegistry, StargateRequestInfo requestInfo, MetricsConfig metricsConfig) {
+        this.meterRegistry = meterRegistry;
+        this.requestInfo = requestInfo;
+        this.config = metricsConfig.tenantRequestCounter();
+        errorTrue = Tag.of(config.errorTag(), "true");
+        errorFalse = Tag.of(config.errorTag(), "false");
+        tenantUnknown = Tag.of(config.tenantTag(), "UNKNOWN");
+    }
+
+    /**
+     * Filter that this bean produces.
+     *
+     * @param context ContainerResponseContext
+     * @see https://quarkus.io/guides/resteasy-reactive#request-or-response-filters
+     */
+    @ServerResponseFilter
+    public void record(ContainerResponseContext context) {
+        // only if enabled
+        if (config.enabled()) {
+
+            // resolve tenant
+            Tag tenantTag = requestInfo.getTenantId()
+                    .map(id -> Tag.of(config.tenantTag(), id))
+                    .orElse(tenantUnknown);
+
+            // resolve error
+            boolean error = context.getStatus() >= 500;
+            Tag errorTag = error ? errorTrue : errorFalse;
+
+            // record
+            meterRegistry.counter(config.metricName(), Tags.of(tenantTag, errorTag)).increment();
+        }
+    }
+
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/metrics/configuration/MicrometerConfiguration.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/metrics/configuration/MicrometerConfiguration.java
@@ -21,38 +21,33 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.stargate.sgv2.docsapi.config.MetricsConfig;
-
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
 import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
 
-/**
- * Configuration of all {@link MeterFilter}s used.
- */
+/** Configuration of all {@link MeterFilter}s used. */
 public class MicrometerConfiguration {
 
-    /**
-     * @return Produces meter filter that takes care of the global tags
-     */
-    @Produces
-    @Singleton
-    public MeterFilter globalTagsFilters(MetricsConfig config) {
-        Map<String, String> globalTags = config.globalTags();
+  /** @return Produces meter filter that takes care of the global tags */
+  @Produces
+  @Singleton
+  public MeterFilter globalTagsFilters(MetricsConfig config) {
+    Map<String, String> globalTags = config.globalTags();
 
-        // if we have no global tags, use empty
-        if (null == globalTags) {
-            return MeterFilter.commonTags(Tags.empty());
-        }
-
-        // transform to tags
-        Collection<Tag> tags = globalTags.entrySet()
-                .stream()
-                .map(e -> Tag.of(e.getKey(), e.getValue()))
-                .collect(Collectors.toList());
-
-        // return all
-        return MeterFilter.commonTags(Tags.of(tags));
+    // if we have no global tags, use empty
+    if (null == globalTags) {
+      return MeterFilter.commonTags(Tags.empty());
     }
+
+    // transform to tags
+    Collection<Tag> tags =
+        globalTags.entrySet().stream()
+            .map(e -> Tag.of(e.getKey(), e.getValue()))
+            .collect(Collectors.toList());
+
+    // return all
+    return MeterFilter.commonTags(Tags.of(tags));
+  }
 }

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/metrics/configuration/MicrometerConfiguration.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/metrics/configuration/MicrometerConfiguration.java
@@ -17,7 +17,6 @@
 
 package io.stargate.sgv2.docsapi.api.common.metrics.configuration;
 
-import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.config.MeterFilter;
@@ -51,7 +50,4 @@ public class MicrometerConfiguration {
     // return all
     return MeterFilter.commonTags(Tags.of(tags));
   }
-
-
-
 }

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/metrics/configuration/MicrometerConfiguration.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/metrics/configuration/MicrometerConfiguration.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.api.common.metrics.configuration;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.stargate.sgv2.docsapi.config.MetricsConfig;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Configuration of all {@link MeterFilter}s used.
+ */
+public class MicrometerConfiguration {
+
+    /**
+     * @return Produces meter filter that takes care of the global tags
+     */
+    @Produces
+    @Singleton
+    public MeterFilter globalTagsFilters(MetricsConfig config) {
+        Map<String, String> globalTags = config.globalTags();
+
+        // if we have no global tags, use empty
+        if (null == globalTags) {
+            return MeterFilter.commonTags(Tags.empty());
+        }
+
+        // transform to tags
+        Collection<Tag> tags = globalTags.entrySet()
+                .stream()
+                .map(e -> Tag.of(e.getKey(), e.getValue()))
+                .collect(Collectors.toList());
+
+        // return all
+        return MeterFilter.commonTags(Tags.of(tags));
+    }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/metrics/configuration/MicrometerConfiguration.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/metrics/configuration/MicrometerConfiguration.java
@@ -17,6 +17,7 @@
 
 package io.stargate.sgv2.docsapi.api.common.metrics.configuration;
 
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.config.MeterFilter;
@@ -33,12 +34,12 @@ public class MicrometerConfiguration {
   /** @return Produces meter filter that takes care of the global tags */
   @Produces
   @Singleton
-  public MeterFilter globalTagsFilters(MetricsConfig config) {
+  public MeterFilter globalTagsMeterFilter(MetricsConfig config) {
     Map<String, String> globalTags = config.globalTags();
 
     // if we have no global tags, use empty
-    if (null == globalTags) {
-      return MeterFilter.commonTags(Tags.empty());
+    if (null == globalTags || globalTags.isEmpty()) {
+      return new MeterFilter() {};
     }
 
     // transform to tags
@@ -50,4 +51,7 @@ public class MicrometerConfiguration {
     // return all
     return MeterFilter.commonTags(Tags.of(tags));
   }
+
+
+
 }

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/config/MetricsConfig.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/config/MetricsConfig.java
@@ -18,19 +18,12 @@
 package io.stargate.sgv2.docsapi.config;
 
 import io.smallrye.config.ConfigMapping;
-import io.smallrye.config.WithDefault;
-import io.stargate.sgv2.docsapi.config.constants.Constants;
-
-import javax.validation.constraints.NotBlank;
 import java.util.Map;
 
 /** Extra, Stargate related configuration for the metrics. */
 @ConfigMapping(prefix = "stargate.metrics")
 public interface MetricsConfig {
 
-  /**
-   * @return Global tags attached to each metric being recorded.
-   */
+  /** @return Global tags attached to each metric being recorded. */
   Map<String, String> globalTags();
-
 }

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/config/MetricsConfig.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/config/MetricsConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.config;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.stargate.sgv2.docsapi.config.constants.Constants;
+
+import javax.validation.constraints.NotBlank;
+import java.util.Map;
+
+/** Extra, Stargate related configuration for the metrics. */
+@ConfigMapping(prefix = "stargate.metrics")
+public interface MetricsConfig {
+
+  /**
+   * @return Global tags attached to each metric being recorded.
+   */
+  Map<String, String> globalTags();
+
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/config/MetricsConfig.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/config/MetricsConfig.java
@@ -18,6 +18,11 @@
 package io.stargate.sgv2.docsapi.config;
 
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.util.Map;
 
 /** Extra, Stargate related configuration for the metrics. */
@@ -26,4 +31,42 @@ public interface MetricsConfig {
 
   /** @return Global tags attached to each metric being recorded. */
   Map<String, String> globalTags();
+
+  /**
+   * @return Setup for the tenant request counting.
+   */
+  @NotNull
+  @Valid
+  TenantRequestCounterConfig tenantRequestCounter();
+
+  interface TenantRequestCounterConfig {
+
+    /**
+     * @return If tenant request counter is enabled.
+     */
+    boolean enabled();
+
+    /**
+     * @return The metric name for the counter, defaults to <code>http.server.requests.counter</code>.
+     */
+    @NotBlank
+    @WithDefault("http.server.requests.counter")
+    String metricName();
+
+    /**
+     * @return The tag key for tenant-id, defaults to <code>tenant</code>.
+     */
+    @NotBlank
+    @WithDefault("tenant")
+    String tenantTag();
+
+    /**
+     * @return The tag key for error flag, defaults to <code>error</code>.
+     */
+    @NotBlank
+    @WithDefault("error")
+    String errorTag();
+
+  }
+
 }

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/config/MetricsConfig.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/config/MetricsConfig.java
@@ -19,11 +19,10 @@ package io.stargate.sgv2.docsapi.config;
 
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
-
+import java.util.Map;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import java.util.Map;
 
 /** Extra, Stargate related configuration for the metrics. */
 @ConfigMapping(prefix = "stargate.metrics")
@@ -32,41 +31,32 @@ public interface MetricsConfig {
   /** @return Global tags attached to each metric being recorded. */
   Map<String, String> globalTags();
 
-  /**
-   * @return Setup for the tenant request counting.
-   */
+  /** @return Setup for the tenant request counting. */
   @NotNull
   @Valid
   TenantRequestCounterConfig tenantRequestCounter();
 
   interface TenantRequestCounterConfig {
 
-    /**
-     * @return If tenant request counter is enabled.
-     */
+    /** @return If tenant request counter is enabled. */
     boolean enabled();
 
     /**
-     * @return The metric name for the counter, defaults to <code>http.server.requests.counter</code>.
+     * @return The metric name for the counter, defaults to <code>http.server.requests.counter
+     *     </code>.
      */
     @NotBlank
     @WithDefault("http.server.requests.counter")
     String metricName();
 
-    /**
-     * @return The tag key for tenant-id, defaults to <code>tenant</code>.
-     */
+    /** @return The tag key for tenant-id, defaults to <code>tenant</code>. */
     @NotBlank
     @WithDefault("tenant")
     String tenantTag();
 
-    /**
-     * @return The tag key for error flag, defaults to <code>error</code>.
-     */
+    /** @return The tag key for error flag, defaults to <code>error</code>. */
     @NotBlank
     @WithDefault("error")
     String errorTag();
-
   }
-
 }

--- a/sgv2-docsapi/src/main/resources/application-prod.yaml
+++ b/sgv2-docsapi/src/main/resources/application-prod.yaml
@@ -1,0 +1,12 @@
+---
+# production configuration
+# please keep properties in the alphabetical order
+
+quarkus:
+
+  # OpenTelemetry configuration
+  opentelemetry:
+    tracer:
+      # in the prod env use the sampler that samples 1% of all requests
+      sampler:
+        ratio: 0.01

--- a/sgv2-docsapi/src/main/resources/application.yaml
+++ b/sgv2-docsapi/src/main/resources/application.yaml
@@ -12,6 +12,12 @@ stargate:
   header-based-auth:
     enabled: true
 
+  # metrics properties
+  # see io.stargate.sgv2.docsapi.config.MetricsConfig for all config properties and options
+  metrics:
+    global-tags:
+      module: docsapi
+
   # the tenant resolver to use
   # see io.stargate.sgv2.docsapi.config.TenantResolverConfig for all config properties and options
   tenant-resolver:
@@ -57,6 +63,26 @@ quarkus:
         default:
           paths: /api/v2/*
           policy: authenticated
+
+  # built-in micrometer properties
+  micrometer:
+    binder:
+      http-server:
+        # ignore all non-application uris, as well as the custom set
+        suppress-non-application-uris: true
+        ignore-patterns:
+          - /
+          - /metrics
+          - /swagger-ui.*
+          - .*\.html
+        # due to the https://github.com/quarkusio/quarkus/issues/24938
+        # we need to define uri templating on our own for now
+        match-patterns:
+          - /api/v2/example/keyspace-exists/[a-z]+=/api/v2/example/keyspace-exists/{name}
+
+    export:
+      prometheus:
+        path: /metrics
 
   # information for the generated Open API definitions
   smallrye-openapi:

--- a/sgv2-docsapi/src/main/resources/application.yaml
+++ b/sgv2-docsapi/src/main/resources/application.yaml
@@ -92,9 +92,10 @@ quarkus:
       # in the dev env use the sampler that samples all requests
       sampler:
         ratio: 1.0
-      # the OTPL endpoint should be specified in order to report traces
+      # the OTPL should be enabled and endpoint should be specified in order to report traces
       exporter:
         otlp:
+          enabled: false
           endpoint:
 
   # information for the generated Open API definitions

--- a/sgv2-docsapi/src/main/resources/application.yaml
+++ b/sgv2-docsapi/src/main/resources/application.yaml
@@ -72,15 +72,11 @@ quarkus:
       http-server:
         # ignore all non-application uris, as well as the custom set
         suppress-non-application-uris: true
-        ignore-patterns:
-          - /
-          - /metrics
-          - /swagger-ui.*
-          - .*\.html
+        ignore-patterns: /,/metrics,/swagger-ui.*,.*\.html
+
         # due to the https://github.com/quarkusio/quarkus/issues/24938
         # we need to define uri templating on our own for now
-        match-patterns:
-          - /api/v2/example/keyspace-exists/[a-z]+=/api/v2/example/keyspace-exists/{name}
+        match-patterns: /api/v2/example/keyspace-exists/[a-z]+=/api/v2/example/keyspace-exists/{name}
     # exports at prometheus default path
     export:
       prometheus:

--- a/sgv2-docsapi/src/main/resources/application.yaml
+++ b/sgv2-docsapi/src/main/resources/application.yaml
@@ -17,6 +17,8 @@ stargate:
   metrics:
     global-tags:
       module: docsapi
+    tenant-request-counter:
+      enabled: true
 
   # the tenant resolver to use
   # see io.stargate.sgv2.docsapi.config.TenantResolverConfig for all config properties and options

--- a/sgv2-docsapi/src/main/resources/application.yaml
+++ b/sgv2-docsapi/src/main/resources/application.yaml
@@ -79,10 +79,21 @@ quarkus:
         # we need to define uri templating on our own for now
         match-patterns:
           - /api/v2/example/keyspace-exists/[a-z]+=/api/v2/example/keyspace-exists/{name}
-
+    # exports at prometheus default path
     export:
       prometheus:
         path: /metrics
+
+  # OpenTelemetry configuration
+  opentelemetry:
+    tracer:
+      # in the dev env use the sampler that samples all requests
+      sampler:
+        ratio: 1.0
+      # the OTPL endpoint should be specified in order to report traces
+      exporter:
+        otlp:
+          endpoint:
 
   # information for the generated Open API definitions
   smallrye-openapi:

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/metrics/TenantRequestMetricsFilterTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/metrics/TenantRequestMetricsFilterTest.java
@@ -1,0 +1,71 @@
+package io.stargate.sgv2.docsapi.api.common.metrics;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.docsapi.testprofiles.FixedTenantTestProfile;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(TenantRequestMetricsFilterTest.Profile.class)
+class TenantRequestMetricsFilterTest {
+
+  public static class Profile extends FixedTenantTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      Map<String, String> configOverrides = super.getConfigOverrides();
+
+      return ImmutableMap.<String, String>builder()
+          .putAll(configOverrides)
+          .put("stargate.metrics.tenant-request-counter.metric-name", "test.metrics")
+          .put("stargate.metrics.tenant-request-counter.tenant-tag", "tenantTag")
+          .put("stargate.metrics.tenant-request-counter.error-tag", "errorTag")
+          .build();
+    }
+  }
+
+  // simple testing endpoint, helps in testing metrics
+  @Path("testing")
+  public static class TestingResource {
+
+    @GET
+    @Produces("text/plain")
+    public String greet() {
+      return "hello";
+    }
+  }
+
+  @Test
+  public void record() {
+    // call endpoint
+    given().when().get("/testing").then().statusCode(200);
+
+    // collect metrics
+    String result = given().when().get("/metrics").then().statusCode(200).extract().asString();
+
+    // find target metrics
+    List<String> meteredLines =
+        Arrays.stream(result.split(System.getProperty("line.separator")))
+            .filter(line -> line.startsWith("test_metrics_total"))
+            .collect(Collectors.toList());
+
+    assertThat(meteredLines)
+        .anySatisfy(
+            metric ->
+                assertThat(metric)
+                    .contains("tenantTag=\"" + FixedTenantTestProfile.TENANT_ID + "\"")
+                    .contains("errorTag=\"false\"")
+                    .contains("module=\"test-module\""));
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/metrics/TenantRequestMetricsFilterTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/metrics/TenantRequestMetricsFilterTest.java
@@ -65,7 +65,6 @@ class TenantRequestMetricsFilterTest {
             metric ->
                 assertThat(metric)
                     .contains("tenantTag=\"" + FixedTenantTestProfile.TENANT_ID + "\"")
-                    .contains("errorTag=\"false\"")
-                    .contains("module=\"test-module\""));
+                    .contains("errorTag=\"false\""));
   }
 }

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/metrics/configuration/MicrometerConfigurationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/metrics/configuration/MicrometerConfigurationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.api.common.metrics.configuration;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(MicrometerConfigurationTest.Profile.class)
+class MicrometerConfigurationTest {
+
+  public static class Profile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return ImmutableMap.<String, String>builder()
+          .put("stargate.metrics.global-tags.module", "test-module")
+          .put("stargate.metrics.global-tags.extra-tag", "extra-value")
+          .build();
+    }
+  }
+
+  @Test
+  public void globalTags() {
+    // collect metrics
+    String result = given().when().get("/metrics").then().statusCode(200).extract().asString();
+
+    List<String> meteredLines =
+        Arrays.stream(result.split(System.getProperty("line.separator")))
+            .collect(Collectors.toList());
+
+    // confirm existence in one, not all support global tags
+    assertThat(meteredLines)
+        .anySatisfy(
+            metric ->
+                assertThat(metric)
+                    .contains("module=\"test-module\"")
+                    .contains("extra_tag=\"extra-value\""));
+  }
+}


### PR DESCRIPTION
**What this PR does**:
Add support for the observability in Quarkus DocsApi V2 project. As always, hit `README.MD` for all the information.

Features added:
* micrometer metrics with Prometheus exporter
   * global tags setup via configuration
   * tenant based request counting
* tracing with OpenTelemetry 

Features missing from V1:
* percentiles configuration
    * depends on https://github.com/quarkusio/quarkus/issues/24944 for easy and clean impl 
* path parameters as the tags
    * not so easy at the moment and probably also depending on few Quarkus issues being resolved 
    
**Which issue(s) this PR fixes**:
Fixes #1719

**Checklist**
- [x] Ticket for percentiles and path params
- [x] Tests for custom support we added

