### PR TITLE
relates to #1717: correct grpc proto generation, exclude grpc-proto deps

### DIFF
--- a/sgv2-docsapi/pom.xml
+++ b/sgv2-docsapi/pom.xml
@@ -13,7 +13,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.container-image.group>stargateio</quarkus.container-image.group>
     <quarkus.container-image.name>docsapi</quarkus.container-image.name>
-    <quarkus.generate-code.grpc.scan-for-proto>io.stargate.grpc:grpc-proto,com.google.api.grpc:proto-google-common-protos</quarkus.generate-code.grpc.scan-for-proto>
+    <quarkus.generate-code.grpc.scan-for-proto>io.stargate.grpc:grpc-proto</quarkus.generate-code.grpc.scan-for-proto>
+    <quarkus.generate-code.grpc.scan-for-imports>com.google.protobuf:protobuf-java,com.google.api.grpc:proto-google-common-protos</quarkus.generate-code.grpc.scan-for-imports>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>2.8.0.Final</quarkus.platform.version>
@@ -35,6 +36,12 @@
       <groupId>io.stargate.grpc</groupId>
       <artifactId>grpc-proto</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
**What this PR does**:

Thanks to @olim7t who figured out the correct way of generating from the `grpc-proto` protos.. I am also excluding any dependency in the `io.stargate.grpc:grpc-proto` as I want only dependency to proto files.. The grpc version will be resolved by Quarkus, thus we maintain Quarkus version and it's depending grpc version in sync.


**Which issue(s) this PR fixes**:

Followup for #1717.
