### PR TITLE
Fix Values.byteBuffer to return non-empty buffer (fixes #1676)

### DIFF
--- a/grpc-proto/src/main/java/io/stargate/grpc/Values.java
+++ b/grpc-proto/src/main/java/io/stargate/grpc/Values.java
@@ -78,6 +78,10 @@ public class Values {
     return Value.newBuilder().setBytes(ByteString.copyFrom(value)).build();
   }
 
+  /**
+   * Note that this method "consumes" its argument: after the call, {@code value} will have its
+   * position set to its limit, and thus appear empty.
+   */
   public static Value of(ByteBuffer value) {
     return Value.newBuilder().setBytes(ByteString.copyFrom(value)).build();
   }
@@ -232,9 +236,7 @@ public class Values {
   public static ByteBuffer byteBuffer(Value value) {
     checkInnerCase(value, InnerCase.BYTES);
 
-    ByteBuffer bytes = ByteBuffer.allocate(value.getBytes().size());
-    value.getBytes().copyTo(bytes);
-    return bytes;
+    return value.getBytes().asReadOnlyByteBuffer();
   }
 
   public static byte[] bytes(Value value) {

--- a/grpc-proto/src/test/java/io/stargate/grpc/ValuesTest.java
+++ b/grpc-proto/src/test/java/io/stargate/grpc/ValuesTest.java
@@ -223,7 +223,7 @@ public class ValuesTest {
     @Test
     public void encodeDecodeByteBuffer() {
       ByteBuffer expected = ByteBuffer.wrap(new byte[] {1, 2, 3});
-      assertThat(Values.byteBuffer(Values.of(expected))).isEqualTo(expected);
+      assertThat(Values.byteBuffer(Values.of(expected.duplicate()))).isEqualTo(expected);
     }
 
     @Test


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #1676

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
