### PR TITLE
Update Duzzt dependency, indirect StringTemplate, jacoco (for Java 9+ support)

### DIFF
--- a/persistence-api/pom.xml
+++ b/persistence-api/pom.xml
@@ -28,6 +28,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- To upgrade StringTemplate version Duzzt uses, easiest to force here
+        -->
+      <dependency>
+        <groupId>org.antlr</groupId>
+        <artifactId>ST4</artifactId>
+        <version>4.3.3</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -64,7 +71,7 @@
     <dependency>
       <groupId>com.github.misberner.duzzt</groupId>
       <artifactId>duzzt-processor</artifactId>
-      <version>0.0.2</version>
+      <version>0.1.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         but build fails with newer versions so keeping at this level
       -->
     <errorprone.version>2.3.4</errorprone.version>
-    <jacoco.version>0.8.6</jacoco.version>
+    <jacoco.version>0.8.8</jacoco.version>
     <junit.version>5.8.2</junit.version>
     <mockito.version>3.12.4</mockito.version>
     <assertj.version>3.21.0</assertj.version>


### PR DESCRIPTION
**What this PR does**:

Updates dependency versions for:

* jacoco (0.8.6 -> 0.8.8)
* Duzzt (0.0.2 -> 0.1.0)
* StringTemplate -- transitive dependency of Duzzt -- (4.0.7 -> 4.3.4)

This is aimed to resolve possible issues components have on Java 9 and later

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Changes manually tested -- tested via CI, ensuring no regression
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
