### PR TITLE
Update maven-compiler-plugin 3.8.1->3.10.1 (for post-Java-8 builds)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -420,7 +420,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
+          <version>3.10.1</version>
           <configuration>
             <compilerId>javac-with-errorprone</compilerId>
             <forceJavacCompilerUse>true</forceJavacCompilerUse>
@@ -486,11 +486,11 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M3</version>
+          <version>3.0.0-M6</version>
         </plugin>
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.0.0-M3</version>
+          <version>3.0.0-M6</version>
         </plugin>
         <plugin>
           <artifactId>maven-wrapper-plugin</artifactId>


### PR DESCRIPTION
**What this PR does**:

Updates `maven-compiler-plugin` version from 3.8 to 3.10: this is needed for builds using JDKs beyond 8 (or at least kind we have), and won't break current JDK 8 build.
Also updates test plugins to latest based on some other research (was needed for toolchains support it seems).

**Which issue(s) this PR fixes**:

Does not fix it but would be part of #1785 if that was implemented

**Checklist**
- [x] Changes manually tested -- should pass CI
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
