### PR TITLE
Add exception message in ErrorCodeRuntimeException for inclusion in Response

### DIFF
--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocsShredder.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocsShredder.java
@@ -142,13 +142,13 @@ public class DocsShredder {
           je.getClass().getName(),
           je.getMessage());
       throw new ErrorCodeRuntimeException(
-          ErrorCode.DOCS_API_INVALID_JSON_VALUE, "Malformed JSON object found during read.", je);
+          ErrorCode.DOCS_API_INVALID_JSON_VALUE, "Malformed JSON object found during read: " + je, je);
     } catch (RuntimeException e) {
       // We don't actually know it IS malformed JSON (perhaps we got NPE?) but this is what
       // has been reported so far so keep consistent. And log the stack trace.
-      logger.error("Error occurred during JSON read", e);
+      logger.error("Error occurred during JSON read: "+e, e);
       throw new ErrorCodeRuntimeException(
-          ErrorCode.DOCS_API_INVALID_JSON_VALUE, "Malformed JSON object found during read.", e);
+          ErrorCode.DOCS_API_INVALID_JSON_VALUE, "Malformed JSON object found during read: " + e, e);
     }
   }
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/DocsShredder.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/DocsShredder.java
@@ -142,13 +142,17 @@ public class DocsShredder {
           je.getClass().getName(),
           je.getMessage());
       throw new ErrorCodeRuntimeException(
-          ErrorCode.DOCS_API_INVALID_JSON_VALUE, "Malformed JSON object found during read: " + je, je);
+          ErrorCode.DOCS_API_INVALID_JSON_VALUE,
+          "Malformed JSON object found during read: " + je,
+          je);
     } catch (RuntimeException e) {
       // We don't actually know it IS malformed JSON (perhaps we got NPE?) but this is what
       // has been reported so far so keep consistent. And log the stack trace.
-      logger.error("Error occurred during JSON read: "+e, e);
+      logger.error("Error occurred during JSON read: " + e, e);
       throw new ErrorCodeRuntimeException(
-          ErrorCode.DOCS_API_INVALID_JSON_VALUE, "Malformed JSON object found during read: " + e, e);
+          ErrorCode.DOCS_API_INVALID_JSON_VALUE,
+          "Malformed JSON object found during read: " + e,
+          e);
     }
   }
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/JsonSchemaHandler.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/JsonSchemaHandler.java
@@ -121,7 +121,7 @@ public class JsonSchemaHandler {
       tree = mapper.readTree(value);
     } catch (JsonProcessingException e) {
       throw new ErrorCodeRuntimeException(
-          ErrorCode.DOCS_API_INVALID_JSON_VALUE, "Malformed JSON object found during read: "+e);
+          ErrorCode.DOCS_API_INVALID_JSON_VALUE, "Malformed JSON object found during read: " + e);
     }
     validate(schema, tree);
   }

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/JsonSchemaHandler.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/JsonSchemaHandler.java
@@ -116,12 +116,14 @@ public class JsonSchemaHandler {
   }
 
   public void validate(JsonNode schema, String value) throws ProcessingException {
+    final JsonNode tree;
     try {
-      validate(schema, mapper.readTree(value));
+      tree = mapper.readTree(value);
     } catch (JsonProcessingException e) {
       throw new ErrorCodeRuntimeException(
-          ErrorCode.DOCS_API_INVALID_JSON_VALUE, "Malformed JSON object found during read.");
+          ErrorCode.DOCS_API_INVALID_JSON_VALUE, "Malformed JSON object found during read: "+e);
     }
+    validate(schema, tree);
   }
 
   public void validate(JsonNode schema, JsonNode jsonValue) throws ProcessingException {

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
@@ -1308,7 +1308,7 @@ public class ReactiveDocumentService {
       return objectMapper.readTree(payload);
     } catch (JsonProcessingException e) {
       throw new ErrorCodeRuntimeException(
-          ErrorCode.DOCS_API_INVALID_JSON_VALUE, "Malformed JSON object found during read.", e);
+          ErrorCode.DOCS_API_INVALID_JSON_VALUE, "Malformed JSON object found during read: " + e, e);
     }
   }
 

--- a/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
+++ b/restapi/src/main/java/io/stargate/web/docsapi/service/ReactiveDocumentService.java
@@ -1308,7 +1308,9 @@ public class ReactiveDocumentService {
       return objectMapper.readTree(payload);
     } catch (JsonProcessingException e) {
       throw new ErrorCodeRuntimeException(
-          ErrorCode.DOCS_API_INVALID_JSON_VALUE, "Malformed JSON object found during read: " + e, e);
+          ErrorCode.DOCS_API_INVALID_JSON_VALUE,
+          "Malformed JSON object found during read: " + e,
+          e);
     }
   }
 


### PR DESCRIPTION
**What this PR does**:

Currently response message for invalid JSON for Docs API looks something like this from client end:

```
{"error":"did not receive correct status code","level":"error","msg":"response body: {\"description\":\"Malformed JSON object found during read.\",\"code\":400}","source":"client.go:81","time":"2022-04-26T16:21:27.276Z"}
   msg: response body: {"description":"Malformed JSON object found during read.","code":400}
```

where "description" does not contain anything useful. This PR adds `exception.toString()` after "Malformed ..." to likely indicate what is wrong with the JSON content, to help troubleshooting.

**Which issue(s) this PR fixes**:

No issue filed, problem encountered during troubleshooting

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
