### PR TITLE
Revisit value handling in the query builder

### DIFF
--- a/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/schema/cqlfirst/dml/fetchers/DataTypeMapping.java
+++ b/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/schema/cqlfirst/dml/fetchers/DataTypeMapping.java
@@ -47,15 +47,12 @@ import java.util.stream.Collectors;
 /** Provides the logic for adapting values from graphql to DB and vice versa. */
 class DataTypeMapping {
 
-  private static final Value NULL_VALUE =
-      Value.newBuilder().setNull(Value.Null.newBuilder()).build();
-
   /**
    * Converts a value coming from the GraphQL runtime into a value that can be sent to the bridge.
    */
   static Value toGrpcValue(TypeSpec type, Object graphQLValue, NameMapping nameMapping) {
     if (graphQLValue == null) {
-      return NULL_VALUE;
+      return Values.NULL;
     }
     switch (type.getSpecCase()) {
       case LIST:

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/WhereParser.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/WhereParser.java
@@ -180,22 +180,15 @@ public class WhereParser {
     final Object rawKey = nodeToRawObject(keyNode);
     final Object rawValue = nodeToRawObject(valueNode);
 
-    // Looks like we cannot pass Key as bound parameter, so no need to convert.
-    // But we do want to check field is of Map type anyway so
-    // And then try to decode Key and Value to match
-    if (converter.getCodec(fieldName).getKeyCodec() == null) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Field '%s' not of map type; has to be for operation %s",
-              fieldName, FilterOp.$CONTAINSENTRY.rawValue));
-    }
-    // But we can pass value via placeholder
+    // Convert into gRPC values
+    final QueryOuterClass.Value opKeyValue =
+        converter.keyProtoValueFromLooselyTyped(fieldName, rawKey);
     final QueryOuterClass.Value opContentValue =
         converter.contentProtoValueFromLooselyTyped(fieldName, rawValue);
 
     conditions.add(
         BuiltCondition.of(
-            BuiltCondition.LHS.mapAccess(fieldName, rawKey),
+            BuiltCondition.LHS.mapAccess(fieldName, opKeyValue),
             FilterOp.$CONTAINSENTRY.predicate,
             Term.of(opContentValue)));
   }

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2IndexesResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2IndexesResourceImpl.java
@@ -15,6 +15,7 @@
  */
 package io.stargate.sgv2.restsvc.resources.schemas;
 
+import io.stargate.bridge.grpc.Values;
 import io.stargate.bridge.proto.QueryOuterClass.Query;
 import io.stargate.bridge.proto.Schema;
 import io.stargate.bridge.proto.Schema.CqlTable;
@@ -63,8 +64,8 @@ public class Sgv2IndexesResourceImpl extends ResourceBase implements Sgv2Indexes
         new QueryBuilder()
             .select()
             .from("system_schema", "indexes")
-            .where("keyspace_name", Predicate.EQ, keyspaceName)
-            .where("table_name", Predicate.EQ, tableName)
+            .where("keyspace_name", Predicate.EQ, Values.of(keyspaceName))
+            .where("table_name", Predicate.EQ, Values.of(tableName))
             .parameters(PARAMETERS_FOR_LOCAL_QUORUM)
             .build();
     return fetchRows(bridge, query, true);

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2UDTsResourceImpl.java
@@ -5,6 +5,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.grpc.StatusRuntimeException;
+import io.stargate.bridge.grpc.Values;
 import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.common.cql.builder.Column;
 import io.stargate.sgv2.common.cql.builder.ImmutableColumn;
@@ -51,7 +52,7 @@ public class Sgv2UDTsResourceImpl extends ResourceBase implements Sgv2UDTsResour
             .column("field_names")
             .column("field_types")
             .from("system_schema", "types")
-            .where("keyspace_name", Predicate.EQ, keyspaceName)
+            .where("keyspace_name", Predicate.EQ, Values.of(keyspaceName))
             .build();
 
     QueryOuterClass.Response grpcResponse = bridge.executeQuery(query);
@@ -83,8 +84,8 @@ public class Sgv2UDTsResourceImpl extends ResourceBase implements Sgv2UDTsResour
             .column("field_names")
             .column("field_types")
             .from("system_schema", "types")
-            .where("keyspace_name", Predicate.EQ, keyspaceName)
-            .where("type_name", Predicate.EQ, typeName)
+            .where("keyspace_name", Predicate.EQ, Values.of(keyspaceName))
+            .where("type_name", Predicate.EQ, Values.of(typeName))
             .build();
 
     QueryOuterClass.Response grpcResponse = bridge.executeQuery(query);

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/BuiltCondition.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/BuiltCondition.java
@@ -15,6 +15,7 @@
  */
 package io.stargate.sgv2.common.cql.builder;
 
+import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.bridge.proto.QueryOuterClass.Value;
 import io.stargate.sgv2.common.cql.ColumnUtils;
 import java.util.List;
@@ -34,7 +35,7 @@ public interface BuiltCondition {
 
   Term value();
 
-  static BuiltCondition of(String columnName, Predicate predicate, Object value) {
+  static BuiltCondition of(String columnName, Predicate predicate, QueryOuterClass.Value value) {
     return of(columnName, predicate, Term.of(value));
   }
 
@@ -42,7 +43,7 @@ public interface BuiltCondition {
     return of(LHS.column(columnName), predicate, value);
   }
 
-  static BuiltCondition of(LHS lhs, Predicate predicate, Object value) {
+  static BuiltCondition of(LHS lhs, Predicate predicate, QueryOuterClass.Value value) {
     return of(lhs, predicate, Term.of(value));
   }
 
@@ -67,7 +68,7 @@ public interface BuiltCondition {
       return new ColumnName(columnName);
     }
 
-    public static LHS mapAccess(String columnName, Object key) {
+    public static LHS mapAccess(String columnName, QueryOuterClass.Value key) {
       return new MapElement(columnName, Term.of(key));
     }
 

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Literal.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Literal.java
@@ -15,15 +15,20 @@
  */
 package io.stargate.sgv2.common.cql.builder;
 
-class Literal implements Term {
+import io.stargate.bridge.proto.QueryOuterClass.Value;
+import java.util.Objects;
 
-  private final Object value;
+public class Literal implements Term {
 
-  public Literal(Object value) {
-    this.value = value;
+  static final String NULL_ERROR_MESSAGE = "Use Values.NULL to bind a null CQL value";
+
+  private final Value value;
+
+  public Literal(Value value) {
+    this.value = Objects.requireNonNull(value, NULL_ERROR_MESSAGE);
   }
 
-  public Object get() {
+  public Value get() {
     return value;
   }
 }

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Marker.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Marker.java
@@ -15,7 +15,7 @@
  */
 package io.stargate.sgv2.common.cql.builder;
 
-class Marker implements Term {
+public class Marker implements Term {
 
   String asCql() {
     return "?";

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/QueryBuilderImpl.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/QueryBuilderImpl.java
@@ -633,7 +633,7 @@ public class QueryBuilderImpl {
 
   @DSLAction
   public void limit(Value limit) {
-    this.limitTerm = termFor(limit);
+    this.limitTerm = limit == null ? null : termFor(limit);
     this.limitInt = null;
   }
 
@@ -651,7 +651,7 @@ public class QueryBuilderImpl {
 
   @DSLAction
   public void perPartitionLimit(Value perPartitionLimit) {
-    this.perPartitionLimitTerm = termFor(perPartitionLimit);
+    this.perPartitionLimitTerm = perPartitionLimit == null ? null : termFor(perPartitionLimit);
     this.perPartitionLimitInt = null;
   }
 
@@ -700,7 +700,7 @@ public class QueryBuilderImpl {
 
   @DSLAction
   public void ttl(Value ttl) {
-    this.ttlTerm = termFor(ttl);
+    this.ttlTerm = ttl == null ? null : termFor(ttl);
     this.ttlInt = null;
   }
 
@@ -718,7 +718,7 @@ public class QueryBuilderImpl {
 
   @DSLAction
   public void timestamp(Value timestamp) {
-    this.timestampTerm = termFor(timestamp);
+    this.timestampTerm = timestamp == null ? null : termFor(timestamp);
     this.timestampLong = null;
   }
 

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/QueryBuilderImpl.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/QueryBuilderImpl.java
@@ -492,6 +492,10 @@ public class QueryBuilderImpl {
     where(column.name(), predicate, value);
   }
 
+  public void where(Column column, Predicate predicate) {
+    where(column.name(), predicate, Term.marker());
+  }
+
   public void where(String columnName, Predicate predicate, Object value) {
     where(BuiltCondition.of(columnName, predicate, termFor(value)));
   }

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Term.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/Term.java
@@ -15,8 +15,14 @@
  */
 package io.stargate.sgv2.common.cql.builder;
 
+import io.stargate.bridge.proto.QueryOuterClass.Value;
+
 public interface Term {
-  static Term of(Object value) {
+  static Term of(Value value) {
     return new Literal(value);
+  }
+
+  static Term marker() {
+    return new Marker();
   }
 }

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/ValueModifier.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/ValueModifier.java
@@ -15,6 +15,7 @@
  */
 package io.stargate.sgv2.common.cql.builder;
 
+import io.stargate.bridge.proto.QueryOuterClass;
 import javax.annotation.Nullable;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
@@ -28,12 +29,20 @@ public interface ValueModifier {
 
   Term value();
 
-  static ValueModifier set(String columnName, Object value) {
+  static ValueModifier set(String columnName, QueryOuterClass.Value value) {
     return set(columnName, Term.of(value));
   }
 
   static ValueModifier set(String columnName, Term value) {
     return of(Target.column(columnName), Operation.SET, value);
+  }
+
+  static ValueModifier marker(String columnName) {
+    return of(Target.column(columnName), Operation.SET, Term.marker());
+  }
+
+  static ValueModifier of(Target target, Operation operation, QueryOuterClass.Value value) {
+    return of(target, operation, Term.of(value));
   }
 
   static ValueModifier of(Target target, Operation operation, Term value) {

--- a/sgv2-service-common/src/test/java/io/stargate/sgv2/common/cql/builder/QueryBuilderTest.java
+++ b/sgv2-service-common/src/test/java/io/stargate/sgv2/common/cql/builder/QueryBuilderTest.java
@@ -18,6 +18,7 @@ package io.stargate.sgv2.common.cql.builder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import io.stargate.bridge.grpc.Values;
 import java.util.LinkedHashMap;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -329,6 +330,21 @@ public class QueryBuilderTest {
       arguments(
           new QueryBuilder().select().count("a").from("ks", "tbl").build().getCql(),
           "SELECT COUNT(a) FROM ks.tbl"),
+      arguments(
+          new QueryBuilder().select().count("a").from("ks", "tbl").limit(1).build().getCql(),
+          "SELECT COUNT(a) FROM ks.tbl LIMIT 1"),
+      arguments(
+          new QueryBuilder()
+              .select()
+              .count("a")
+              .from("ks", "tbl")
+              .limit(Values.of(1))
+              .build()
+              .getCql(),
+          "SELECT COUNT(a) FROM ks.tbl LIMIT ?"),
+      arguments(
+          new QueryBuilder().select().count("a").from("ks", "tbl").limit().build().getCql(),
+          "SELECT COUNT(a) FROM ks.tbl LIMIT ?"),
     };
   }
 }


### PR DESCRIPTION
- only allow QueryOuterClass.Value as literals
- allow explicit bind markers
