### PR TITLE
DEV_GUIDE: Add MacOS loopback address

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -350,6 +350,7 @@ do
     sudo /sbin/ifconfig lo0 alias 127.0.2.$i;
 done
 
+sudo /sbin/ifconfig lo0 alias 127.0.3.1;
 ```
 
 Set access of the script:


### PR DESCRIPTION
127.0.3.1 as a loopback address is added in ce4e9f, but
the DEV_GUIDE is not updated. This commit adds this address
to the MacOS script.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
