### PR TITLE
relates to #1737: setup for the integration tests in docs api v2 

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -50,10 +50,17 @@ mvn -B install verify --file pom.xml \
 -P default \
 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
+echoinfo "Building docker images"
+
+./build_docker_images.sh
+
 echoinfo "Testing Java 17 projects"
 
 cd sgv2-docsapi/
 JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./mvnw -B verify --file ./pom.xml \
+-P \${C3}cassandra-311 \
+-P \${C4}cassandra-40 \
+-P \${DSE}dse-68 \
 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 cd ../
 

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -50,17 +50,11 @@ mvn -B install verify --file pom.xml \
 -P default \
 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
-echoinfo "Building docker images"
-
-./build_docker_images.sh
-
 echoinfo "Testing Java 17 projects"
 
 cd sgv2-docsapi/
 JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./mvnw -B verify --file ./pom.xml \
--P \${C3}cassandra-311 \
--P \${C4}cassandra-40 \
--P \${DSE}dse-68 \
+-P \!int-tests \
 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 cd ../
 

--- a/sgv2-docsapi/README.md
+++ b/sgv2-docsapi/README.md
@@ -13,8 +13,9 @@ All issues related to the Docs API V2 are marked with the `stargate-v2` and `doc
    * [Multi-tenancy](#multi-tenancy) 
 * [Configuration properties](#configuration-properties)  
 * [Development guide](#development-guide)  
-   * [Running the application in dev mode](#running-the-application-in-dev-mode) 
-   * [Running the application in dev mode](#packaging-and-running-the-application) 
+   * [Running the application in dev mode](#running-the-application-in-dev-mode)
+   * [Running integration tests](#running-integration-tests)
+   * [Packaging and running the application](#packaging-and-running-the-application) 
    * [Creating a native executable](#creating-a-native-executable) 
    * [Creating a docker image](#creating-a-docker-image) 
 * [Quarkus Extensions](#quarkus-extensions)  
@@ -79,6 +80,48 @@ You can attach the debugger at any point, the simplest option would be from Inte
 If you wish to debug from the start of the application, start with `-Ddebug=client` and create a debug configuration in a *Listen to remote JVM* mode.
 
 See [Debugging](https://quarkus.io/guides/maven-tooling#debugging) for more information.
+
+### Running integration tests
+
+Integration tests are using the [Testcontainers](https://www.testcontainers.org/) library in order to set up all needed dependencies, a Stargate coordinator and a Cassandra data store. 
+They are separated from the unit tests and are running as part of the `integration-test` and `verify` Maven phases:
+```shell script
+./mvnw integration-test
+```
+
+#### Data store selection
+
+Depending on the active profile, integration tests will target different Cassandra version as the data store.
+The available profiles are:
+
+* `cassandra-40` (enabled by default) - runs integration tests with [Cassandra 4.0](https://cassandra.apache.org/doc/4.0/index.html) as the data store
+* `cassandra-311` - runs integration tests with [Cassandra 3.11](https://cassandra.apache.org/doc/3.11/index.html) as the data store
+* `dse-68` - runs integration tests with [DataStax Enterprise (DSE) 6.8](https://docs.datastax.com/en/dse/6.8/dse-dev/index.html) as the data store
+
+The required profile can be activated using the `-P` option:
+
+```shell script
+./mvnw integration-test -P cassandra-311
+```
+
+#### Running from IDE
+
+Running integration tests from IDE is supported out of the box.
+The tests will use the Cassandra 4.0 as the data store by default.
+Running a test with a different version of the data store or the Stargate coordinator, requires changing the run configuration and specifying the following system properties:
+
+* `testing.containers.cassandra-image` - version of the Cassandra docker image to use, for example: `cassandra:4.0.3`
+* `testing.containers.stargate-image` - version of the Stargate coordinator docker image to use, for example: `stargateio/coordinator-4_0:v2.0.0-ALPHA-10-SNAPSHOT` (must be V2 coordinator for the target data store)
+* `testing.containers.cluster-version` - version of the cluster, for example: `4.0` (should be one of `3.11`, `4.0` or `6.8`)
+* `testing.containers.cluster-dse` - optional and only needed if DSE is used
+
+#### Skipping integration tests
+
+You can skip the integration tests during the maven build by disabling the `int-tests` profile:
+
+```shell script
+./mvnw verify -P \!int-tests
+```
 
 ### Packaging and running the application
 

--- a/sgv2-docsapi/README.md
+++ b/sgv2-docsapi/README.md
@@ -83,6 +83,8 @@ See [Debugging](https://quarkus.io/guides/maven-tooling#debugging) for more info
 
 ### Running integration tests
 
+> **_PREREQUISITES:_**  You need to build the coordinator docker image(s) first. In the root Stargate repo directory run `./mvnw clean install -P dse -DskipTests && ./build_docker_images.sh`
+
 Integration tests are using the [Testcontainers](https://www.testcontainers.org/) library in order to set up all needed dependencies, a Stargate coordinator and a Cassandra data store. 
 They are separated from the unit tests and are running as part of the `integration-test` and `verify` Maven phases:
 ```shell script
@@ -105,6 +107,9 @@ The required profile can be activated using the `-P` option:
 ```
 
 #### Running from IDE
+
+> **_PREREQUISITES:_**  You need to build the coordinator docker image(s) first and tag them with `latest` tag. In the root Stargate repo directory run `./mvnw clean install -P dse -DskipTests && ./build_docker_images.sh -t latest`
+
 
 Running integration tests from IDE is supported out of the box.
 The tests will use the Cassandra 4.0 as the data store by default.

--- a/sgv2-docsapi/README.md
+++ b/sgv2-docsapi/README.md
@@ -83,7 +83,10 @@ See [Debugging](https://quarkus.io/guides/maven-tooling#debugging) for more info
 
 ### Running integration tests
 
-> **_PREREQUISITES:_**  You need to build the coordinator docker image(s) first. In the root Stargate repo directory run `./mvnw clean install -P dse -DskipTests && ./build_docker_images.sh`
+> **_PREREQUISITES:_**  You need to build the coordinator docker image(s) first. In the root Stargate repo directory run:
+> ```
+> ./mvnw clean install -P dse -DskipTests && ./build_docker_images.sh
+> ```
 
 Integration tests are using the [Testcontainers](https://www.testcontainers.org/) library in order to set up all needed dependencies, a Stargate coordinator and a Cassandra data store. 
 They are separated from the unit tests and are running as part of the `integration-test` and `verify` Maven phases:
@@ -108,8 +111,10 @@ The required profile can be activated using the `-P` option:
 
 #### Running from IDE
 
-> **_PREREQUISITES:_**  You need to build the coordinator docker image(s) first and tag them with `latest` tag. In the root Stargate repo directory run `./mvnw clean install -P dse -DskipTests && ./build_docker_images.sh -t latest`
-
+> **_PREREQUISITES:_**  You need to build the coordinator docker image(s) first and tag them with `latest` tag. In the root Stargate repo directory run:
+> ```
+> ./mvnw clean install -P dse -DskipTests && ./build_docker_images.sh -t latest
+> ```
 
 Running integration tests from IDE is supported out of the box.
 The tests will use the Cassandra 4.0 as the data store by default.

--- a/sgv2-docsapi/pom.xml
+++ b/sgv2-docsapi/pom.xml
@@ -352,7 +352,6 @@
                   </systemPropertyVariables>
                   <includes>
                     <include>**/*IntegrationTest.*</include>
-                    <include>**/*EndToEndTest.*</include>
                   </includes>
                 </configuration>
               </execution>

--- a/sgv2-docsapi/pom.xml
+++ b/sgv2-docsapi/pom.xml
@@ -140,6 +140,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>${assertj.version}</version>
@@ -202,6 +207,10 @@
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <maven.home>${maven.home}</maven.home>
           </systemPropertyVariables>
+          <excludes>
+            <exclude>**/*IntegrationTest.*</exclude>
+            <exclude>**/*EndToEndTest.*</exclude>
+          </excludes>
         </configuration>
       </plugin>
       <plugin>
@@ -274,6 +283,83 @@
         <quarkus.package.type>native</quarkus.package.type>
         <quarkus.native.native-image-xmx>6G</quarkus.native.native-image-xmx>
       </properties>
+    </profile>
+    <profile>
+      <id>cassandra-40</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <!-- Please maintain default values for int-test in sync with io.stargate.sgv2.docsapi.testresource.StargateTestResource.Defaults -->
+        <stargate.int-test.cassandra.image>cassandra</stargate.int-test.cassandra.image>
+        <stargate.int-test.cassandra.image-tag>4.0.3</stargate.int-test.cassandra.image-tag>
+        <stargate.int-test.coordinator.image>stargateio/coordinator-4_0</stargate.int-test.coordinator.image>
+        <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
+        <stargate.int-test.cluster.name>cass-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
+        <stargate.int-test.cluster.version>4.0</stargate.int-test.cluster.version>
+        <stargate.int-test.cluster.dse>false</stargate.int-test.cluster.dse>
+      </properties>
+    </profile>
+    <profile>
+      <id>cassandra-311</id>
+      <properties>
+        <stargate.int-test.cassandra.image>cassandra</stargate.int-test.cassandra.image>
+        <stargate.int-test.cassandra.image-tag>3.11.12</stargate.int-test.cassandra.image-tag>
+        <stargate.int-test.coordinator.image>stargateio/coordinator-3_11</stargate.int-test.coordinator.image>
+        <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
+        <stargate.int-test.cluster.name>cass-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
+        <stargate.int-test.cluster.version>3.11</stargate.int-test.cluster.version>
+        <stargate.int-test.cluster.dse>false</stargate.int-test.cluster.dse>
+      </properties>
+    </profile>
+    <profile>
+      <id>dse-68</id>
+      <properties>
+        <stargate.int-test.cassandra.image>datastax/dse-server</stargate.int-test.cassandra.image>
+        <stargate.int-test.cassandra.image-tag>6.8.21</stargate.int-test.cassandra.image-tag>
+        <stargate.int-test.coordinator.image>stargateio/coordinator-dse-68</stargate.int-test.coordinator.image>
+        <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
+        <stargate.int-test.cluster.name>dse-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
+        <stargate.int-test.cluster.version>6.8</stargate.int-test.cluster.version>
+        <stargate.int-test.cluster.dse>true</stargate.int-test.cluster.dse>
+      </properties>
+    </profile>
+    <profile>
+      <id>int-tests</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>${surefire-plugin.version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <systemPropertyVariables>
+                    <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    <maven.home>${maven.home}</maven.home>
+                    <testing.containers.cassandra-image>${stargate.int-test.cassandra.image}:${stargate.int-test.cassandra.image-tag}</testing.containers.cassandra-image>
+                    <testing.containers.stargate-image>${stargate.int-test.coordinator.image}:${stargate.int-test.coordinator.image-tag}</testing.containers.stargate-image>
+                    <testing.containers.cluster-name>${stargate.int-test.cluster.name}</testing.containers.cluster-name>
+                    <testing.containers.cluster-version>${stargate.int-test.cluster.version}</testing.containers.cluster-version>
+                    <testing.containers.cluster-dse>${stargate.int-test.cluster.dse}</testing.containers.cluster-dse>
+                  </systemPropertyVariables>
+                  <includes>
+                    <include>**/*IntegrationTest.*</include>
+                    <include>**/*EndToEndTest.*</include>
+                  </includes>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/example/ExampleResourceIntegrationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/example/ExampleResourceIntegrationTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.api.v2.example;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.docsapi.testprofiles.IntegrationTestProfile;
+import io.stargate.sgv2.docsapi.testresource.StargateTestResource;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@QuarkusTestResource(StargateTestResource.class)
+@TestProfile(IntegrationTestProfile.class)
+class ExampleResourceIntegrationTest {
+
+  @Test
+  public void resourceLoads() {}
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/example/ExampleResourceIntegrationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/example/ExampleResourceIntegrationTest.java
@@ -17,15 +17,12 @@
 
 package io.stargate.sgv2.docsapi.api.v2.example;
 
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.stargate.sgv2.docsapi.testprofiles.IntegrationTestProfile;
-import io.stargate.sgv2.docsapi.testresource.StargateTestResource;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@QuarkusTestResource(StargateTestResource.class)
 @TestProfile(IntegrationTestProfile.class)
 class ExampleResourceIntegrationTest {
 

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/testprofiles/IntegrationTestProfile.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/testprofiles/IntegrationTestProfile.java
@@ -1,6 +1,17 @@
 package io.stargate.sgv2.docsapi.testprofiles;
 
 import io.quarkus.test.junit.QuarkusTestProfile;
+import io.stargate.sgv2.docsapi.testresource.StargateTestResource;
+import java.util.Collections;
+import java.util.List;
 
-/** Test profile for marking integration tests. */
-public class IntegrationTestProfile implements QuarkusTestProfile {}
+/** Test profile for integration tests. Includes the {@link StargateTestResource}. */
+public class IntegrationTestProfile implements QuarkusTestProfile {
+
+  /** Adds StargateTestResource to the test resources. */
+  @Override
+  public List<TestResourceEntry> testResources() {
+    TestResourceEntry stargateResource = new TestResourceEntry(StargateTestResource.class);
+    return Collections.singletonList(stargateResource);
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/testprofiles/IntegrationTestProfile.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/testprofiles/IntegrationTestProfile.java
@@ -1,0 +1,6 @@
+package io.stargate.sgv2.docsapi.testprofiles;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+/** Test profile for marking integration tests. */
+public class IntegrationTestProfile implements QuarkusTestProfile {}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/testresource/StargateTestResource.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/testresource/StargateTestResource.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.testresource;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.common.DevServicesContext;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.stargate.sgv2.docsapi.testprofiles.IntegrationTestProfile;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+
+/**
+ * Quarkus test resource that starts Cassandra/DSE and Stargate Coordinator using test containers.
+ *
+ * <p>Should be used in the integration tests, that should be explicitly annotated with {@link
+ * IntegrationTestProfile} class: <code>@TestProfile(IntegrationTestProfile.class)</code>
+ *
+ * <p>When run from IDE, by default it uses container versions specified in {@link Defaults}. If you
+ * wish to run locally with different Cassandra version or the DSE, please set up following system
+ * properties:
+ *
+ * <ol>
+ *   <li><code>testing.containers.cassandra-image</code>
+ *   <li><code>testing.containers.stargate-image</code>
+ *   <li><code>testing.containers.cluster-version</code>
+ *   <li><code>testing.containers.cluster-dse</code>
+ * </ol>
+ *
+ * <p>Note that this resource fetches the auth token and sets it via the properties, using the
+ * {@link io.stargate.sgv2.docsapi.api.common.token.impl.FixedTokenResolver}.
+ */
+public class StargateTestResource
+    implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
+
+  /** Set of defaults for the integration tests, usually used when running from IDE. */
+  interface Defaults {
+
+    String CASSANDRA_IMAGE = "cassandra";
+    String CASSANDRA_IMAGE_TAG = "4.0.3";
+
+    String STARGATE_IMAGE = "stargateio/coordinator-4_0";
+    String STARGATE_IMAGE_TAG = "latest";
+
+    String CLUSTER_NAME = "int-test-cluster";
+    String CLUSTER_VERSION = "4.0";
+
+    String CLUSTER_DSE = null;
+  }
+
+  private static final Logger LOG = LoggerFactory.getLogger(StargateTestResource.class);
+
+  private boolean enabled;
+
+  private Optional<String> containerNetworkId;
+
+  private Network network;
+
+  private GenericContainer<?> cassandraContainer;
+
+  private GenericContainer<?> stargateContainer;
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p><i>Note: container network ID will be present if resource is used
+   * with @QuarkusIntegrationTest</i>
+   */
+  @Override
+  public void setIntegrationTestContext(DevServicesContext context) {
+    containerNetworkId = context.containerNetworkId();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p><i>Note: only enable if IntegrationTestProfile is active profile</i>
+   */
+  @Override
+  public void setContext(Context context) {
+    String testProfile = context.testProfile();
+    String expectedProfile = IntegrationTestProfile.class.getName();
+    this.enabled = Objects.equals(testProfile, expectedProfile);
+  }
+
+  @Override
+  public Map<String, String> start() {
+    if (!enabled) {
+      return Collections.emptyMap();
+    }
+
+    // TODO make reusable after https://github.com/testcontainers/testcontainers-java/pull/4777
+    // boolean reuse = containerNetworkId.isEmpty();
+    boolean reuse = false;
+
+    cassandraContainer =
+        new GenericContainer<>(getCassandraImage())
+            .withEnv("HEAP_NEWSIZE", "512M")
+            .withEnv("MAX_HEAP_SIZE", "2048M")
+            .withEnv("CASSANDRA_CGROUP_MEMORY_LIMIT", "true")
+            .withEnv(
+                "JVM_EXTRA_OPTS",
+                "-Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.load_ring_state=false -Dcassandra.initial_token=1")
+            .withNetworkAliases("cassandra")
+            .withExposedPorts(7000)
+            .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("cassandra-docker")))
+            .waitingFor(Wait.forLogMessage(".*Created default superuser role.*\\n", 1))
+            .withStartupTimeout(Duration.ofMinutes(2))
+            .withReuse(reuse);
+    if (isDse()) {
+      cassandraContainer.withEnv("CLUSTER_NAME", getClusterName()).withEnv("DS_LICENSE", "accept");
+
+    } else {
+      cassandraContainer.withEnv("CASSANDRA_CLUSTER_NAME", getClusterName());
+    }
+    if (containerNetworkId.isPresent()) {
+      cassandraContainer.withNetworkMode(containerNetworkId.get());
+    } else {
+      cassandraContainer.withNetwork(network());
+    }
+    // resolve the network based on the mode
+    cassandraContainer.start();
+
+    stargateContainer =
+        new GenericContainer<>(getStargateImage())
+            .withEnv("JAVA_OPTS", "-Xmx1G")
+            .withEnv("CLUSTER_NAME", getClusterName())
+            .withEnv("CLUSTER_VERSION", getClusterVersion())
+            .withEnv("SEED", "cassandra")
+            .withEnv("SIMPLE_SNITCH", "true")
+            .withEnv("ENABLE_AUTH", "true")
+            .withNetworkAliases("coordinator")
+            .withExposedPorts(8091, 8081, 8084)
+            .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("coordinator-docker")))
+            .waitingFor(Wait.forHttp("/checker/readiness").forPort(8084).forStatusCode(200))
+            .withStartupTimeout(Duration.ofMinutes(2))
+            .withReuse(reuse);
+    // enable DSE if needed
+    if (isDse()) {
+      stargateContainer.withEnv("DSE", "1");
+    }
+    // resolve the network based on the mode
+    if (containerNetworkId.isPresent()) {
+      stargateContainer.withNetworkMode(containerNetworkId.get());
+    } else {
+      stargateContainer.withNetwork(network());
+    }
+    stargateContainer.start();
+
+    Integer authPort = stargateContainer.getMappedPort(8081);
+    Integer bridgePort = stargateContainer.getMappedPort(8091);
+
+    // get auth token
+    String token = getAuthToken("localhost", authPort);
+    LOG.info("Using auth token %s for integration tests.".formatted(token));
+
+    // return a map containing the configuration the application needs to use the service
+    ImmutableMap.Builder<String, String> propsBuilder = ImmutableMap.builder();
+    propsBuilder.put("stargate.auth.token-resolver.type", "fixed");
+    propsBuilder.put("stargate.auth.token-resolver.fixed.token", token);
+
+    if (containerNetworkId.isPresent()) {
+      propsBuilder.put("quarkus.grpc.clients.bridge.host", "coordinator");
+    } else {
+      propsBuilder.put("quarkus.grpc.clients.bridge.port", String.valueOf(bridgePort));
+    }
+
+    ImmutableMap<String, String> props = propsBuilder.build();
+    LOG.info("Using props map for the integration tests: %s".formatted(props));
+    return props;
+  }
+
+  @Override
+  public void stop() {
+    if (null != cassandraContainer && !cassandraContainer.isShouldBeReused()) {
+      cassandraContainer.stop();
+    }
+    if (null != stargateContainer && !stargateContainer.isShouldBeReused()) {
+      stargateContainer.stop();
+    }
+  }
+
+  private Network network() {
+    if (null == network) {
+      network = Network.newNetwork();
+    }
+    return network;
+  }
+
+  private String getCassandraImage() {
+    String image = System.getProperty("testing.containers.cassandra-image");
+    if (null == image) {
+      return Defaults.CASSANDRA_IMAGE + ":" + Defaults.CASSANDRA_IMAGE_TAG;
+    } else {
+      return image;
+    }
+  }
+
+  private String getStargateImage() {
+    String image = System.getProperty("testing.containers.stargate-image");
+    if (null == image) {
+      return Defaults.STARGATE_IMAGE + ":" + Defaults.STARGATE_IMAGE_TAG;
+    } else {
+      return image;
+    }
+  }
+
+  private String getClusterName() {
+    return System.getProperty("testing.containers.cluster-name", Defaults.CLUSTER_NAME);
+  }
+
+  private String getClusterVersion() {
+    return System.getProperty("testing.containers.cluster-version", Defaults.CLUSTER_VERSION);
+  }
+
+  private boolean isDse() {
+    String dse = System.getProperty("testing.containers.cluster-dse", Defaults.CLUSTER_DSE);
+    return "true".equals(dse);
+  }
+
+  private String getAuthToken(String host, int authPort) {
+    try {
+      // make call to the coordinator auth api
+      String json =
+          """
+              {
+                "username":"cassandra",
+                "password":"cassandra"
+              }
+              """;
+      URI authUri = new URI("http://%s:%d/v1/auth".formatted(host, authPort));
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(authUri)
+              .header("Content-Type", "application/json")
+              .POST(HttpRequest.BodyPublishers.ofString(json))
+              .build();
+      HttpResponse<String> response =
+          HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+
+      // map to response and read token
+      ObjectMapper objectMapper = new ObjectMapper();
+      AuthResponse authResponse = objectMapper.readValue(response.body(), AuthResponse.class);
+      return authResponse.authToken;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to get Cassandra token for integration tests.", e);
+    }
+  }
+
+  record AuthResponse(String authToken) {}
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/testresource/StargateTestResource.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/testresource/StargateTestResource.java
@@ -26,9 +26,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,8 +81,6 @@ public class StargateTestResource
 
   private static final Logger LOG = LoggerFactory.getLogger(StargateTestResource.class);
 
-  private boolean enabled;
-
   private Optional<String> containerNetworkId;
 
   private Network network;
@@ -104,24 +100,8 @@ public class StargateTestResource
     containerNetworkId = context.containerNetworkId();
   }
 
-  /**
-   * {@inheritDoc}
-   *
-   * <p><i>Note: only enable if IntegrationTestProfile is active profile</i>
-   */
-  @Override
-  public void setContext(Context context) {
-    String testProfile = context.testProfile();
-    String expectedProfile = IntegrationTestProfile.class.getName();
-    this.enabled = Objects.equals(testProfile, expectedProfile);
-  }
-
   @Override
   public Map<String, String> start() {
-    if (!enabled) {
-      return Collections.emptyMap();
-    }
-
     // TODO make reusable after https://github.com/testcontainers/testcontainers-java/pull/4777
     // boolean reuse = containerNetworkId.isEmpty();
     boolean reuse = false;


### PR DESCRIPTION
**What this PR does**:

Container based integration tests for the docs API v2. Note that this does not enable integration tests in the CI!

**Which issue(s) this PR fixes**:
Relates to #1737.

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
