### PR TITLE
closes #1722: collection resource impl

### DIFF
--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/StargateDocsApi.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/StargateDocsApi.java
@@ -1,25 +1,192 @@
 package io.stargate.sgv2.docsapi;
 
+import io.stargate.sgv2.docsapi.api.common.exception.model.dto.ApiError;
 import io.stargate.sgv2.docsapi.config.constants.Constants;
+import io.stargate.sgv2.docsapi.config.constants.OpenApiConstants;
 import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
 import org.eclipse.microprofile.openapi.annotations.Components;
 import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
+import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
 import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeIn;
 import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeType;
 import org.eclipse.microprofile.openapi.annotations.info.Info;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 @OpenAPIDefinition(
     // note that info is defined via the properties
     info = @Info(title = "", version = ""),
     components =
         @Components(
+
+            // security schemes
             securitySchemes = {
               @SecurityScheme(
-                  securitySchemeName = Constants.OPEN_API_DEFAULT_SECURITY_SCHEME,
+                  securitySchemeName = OpenApiConstants.SecuritySchemes.TOKEN,
                   type = SecuritySchemeType.APIKEY,
                   in = SecuritySchemeIn.HEADER,
                   apiKeyName = Constants.AUTHENTICATION_TOKEN_HEADER_NAME)
+            },
+
+            // reusable parameters
+            parameters = {
+              @Parameter(
+                  in = ParameterIn.PATH,
+                  name = OpenApiConstants.Parameters.NAMESPACE,
+                  required = true,
+                  schema = @Schema(implementation = String.class, pattern = "\\w+"),
+                  description = "The namespace where the collection is located.",
+                  example = "cycling"),
+              @Parameter(
+                  in = ParameterIn.PATH,
+                  name = OpenApiConstants.Parameters.COLLECTION,
+                  required = true,
+                  schema = @Schema(implementation = String.class, pattern = "\\w+"),
+                  description = "The name of the collection.",
+                  example = "events"),
+              @Parameter(
+                  in = ParameterIn.QUERY,
+                  name = OpenApiConstants.Parameters.RAW,
+                  description = "Unwrap results.",
+                  schema = @Schema(implementation = boolean.class)),
+            },
+
+            // reusable examples
+            examples = {
+              @ExampleObject(
+                  name = OpenApiConstants.Examples.GENERAL_BAD_REQUEST,
+                  value =
+                      """
+                      {
+                          "code": 400,
+                          "description": "Request invalid: payload not provided."
+                      }
+                      """),
+              @ExampleObject(
+                  name = OpenApiConstants.Examples.GENERAL_UNAUTHORIZED,
+                  value =
+                      """
+                      {
+                          "code": 401,
+                          "description": "Unauthorized operation.",
+                          "grpcStatus": "PERMISSION_DENIED"
+                      }
+                      """),
+              @ExampleObject(
+                  name = OpenApiConstants.Examples.GENERAL_MISSING_TOKEN,
+                  value =
+                      """
+                      {
+                          "code": 401,
+                          "description": "Missing token."
+                      }
+                      """),
+              @ExampleObject(
+                  name = OpenApiConstants.Examples.GENERAL_SERVER_SIDE_ERROR,
+                  value =
+                      """
+                      {
+                          "code": 500,
+                          "description": "Internal server error."
+                      }
+                      """),
+              @ExampleObject(
+                  name = OpenApiConstants.Examples.GENERAL_SERVICE_UNAVAILABLE,
+                  value =
+                      """
+                      {
+                          "code": 503,
+                          "description": "gRPC service unavailable (UNAVAILABLE->Service Unavailable): UNAVAILABLE: io exception",
+                          "grpcStatus": "UNAVAILABLE"
+                      }
+                      """),
+              @ExampleObject(
+                  name = OpenApiConstants.Examples.NAMESPACE_DOES_NOT_EXIST,
+                  value =
+                      """
+                      {
+                          "code": 404,
+                          "description": "Unknown namespace cycling, you must create it first."
+                      }
+                      """),
+              @ExampleObject(
+                  name = OpenApiConstants.Examples.COLLECTION_DOES_NOT_EXIST,
+                  value =
+                      """
+                      {
+                          "code": 404,
+                          "description": "Collection 'events' not found."
+                      }
+                      """),
+            },
+
+            // reusable response
+            responses = {
+              @APIResponse(
+                  name = OpenApiConstants.Responses.GENERAL_400,
+                  responseCode = "400",
+                  description = "Bad request.",
+                  content =
+                      @Content(
+                          mediaType = MediaType.APPLICATION_JSON,
+                          examples = {
+                            @ExampleObject(ref = OpenApiConstants.Examples.GENERAL_BAD_REQUEST)
+                          },
+                          schema =
+                              @org.eclipse.microprofile.openapi.annotations.media.Schema(
+                                  implementation = ApiError.class))),
+              @APIResponse(
+                  name = OpenApiConstants.Responses.GENERAL_401,
+                  responseCode = "401",
+                  description = "Unauthorized.",
+                  content =
+                      @Content(
+                          mediaType = MediaType.APPLICATION_JSON,
+                          examples = {
+                            @ExampleObject(ref = OpenApiConstants.Examples.GENERAL_UNAUTHORIZED),
+                            @ExampleObject(ref = OpenApiConstants.Examples.GENERAL_MISSING_TOKEN),
+                          },
+                          schema =
+                              @org.eclipse.microprofile.openapi.annotations.media.Schema(
+                                  implementation = ApiError.class))),
+              @APIResponse(
+                  name = OpenApiConstants.Responses.GENERAL_500,
+                  responseCode = "500",
+                  description = "Unexpected server-side error.",
+                  content =
+                      @Content(
+                          mediaType = MediaType.APPLICATION_JSON,
+                          examples = {
+                            @ExampleObject(
+                                ref = OpenApiConstants.Examples.GENERAL_SERVER_SIDE_ERROR),
+                          },
+                          schema =
+                              @org.eclipse.microprofile.openapi.annotations.media.Schema(
+                                  implementation = ApiError.class))),
+              @APIResponse(
+                  name = OpenApiConstants.Responses.GENERAL_503,
+                  responseCode = "503",
+                  description = "Data store service is not available.",
+                  content =
+                      @Content(
+                          mediaType = MediaType.APPLICATION_JSON,
+                          examples = {
+                            @ExampleObject(
+                                ref = OpenApiConstants.Examples.GENERAL_SERVICE_UNAVAILABLE),
+                          },
+                          schema =
+                              @org.eclipse.microprofile.openapi.annotations.media.Schema(
+                                  implementation = ApiError.class))),
             }),
-    tags = {})
+    tags = {
+      @Tag(
+          name = OpenApiConstants.Tags.COLLECTIONS,
+          description = "Collection management operations.")
+    })
 public class StargateDocsApi extends Application {}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/exception/JsonParseExceptionMapper.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/exception/JsonParseExceptionMapper.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.api.common.exception;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import io.stargate.sgv2.docsapi.api.common.exception.model.dto.ApiError;
+import javax.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+
+/** Simple exception mapper for the {@link JsonParseException}. */
+public class JsonParseExceptionMapper {
+
+  @ServerExceptionMapper
+  public RestResponse<ApiError> jsonParseException(JsonParseException exception) {
+    // enrich the message with the exception message
+    // this gives more details to the user
+    int code = Response.Status.BAD_REQUEST.getStatusCode();
+    String msg = "Unable to process JSON: %s".formatted(exception.getMessage());
+    ApiError error = new ApiError(msg, code);
+    return RestResponse.ResponseBuilder.create(Response.Status.BAD_REQUEST, error).build();
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/exception/JsonParseExceptionMapper.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/exception/JsonParseExceptionMapper.java
@@ -31,7 +31,7 @@ public class JsonParseExceptionMapper {
     // enrich the message with the exception message
     // this gives more details to the user
     int code = Response.Status.BAD_REQUEST.getStatusCode();
-    String msg = "Unable to process JSON: %s".formatted(exception.getMessage());
+    String msg = "Unable to process JSON: %s.".formatted(exception.getMessage());
     ApiError error = new ApiError(msg, code);
     return RestResponse.ResponseBuilder.create(Response.Status.BAD_REQUEST, error).build();
   }

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/exception/model/dto/ApiError.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/exception/model/dto/ApiError.java
@@ -24,6 +24,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
  *
  * @param description A human-readable description of the error state.
  * @param code The internal number referencing the error state.
+ * @param grpcStatus Status of a GRPC call, if this fails.
  * @param internalTxId The internal tracking number of the request.
  */
 public record ApiError(
@@ -34,7 +35,12 @@ public record ApiError(
         String description,
     @Schema(description = "The internal number referencing the error state.", example = "22000")
         int code,
-    @Schema(description = "The gRPC response status", example = "ABORTED") String grpcStatus,
+    @Schema(
+            description =
+                "The gRPC response status in case a gRPC request to the datastore failed.",
+            nullable = true,
+            example = "ABORTED")
+        String grpcStatus,
 
     // TODO Is this still needed and used? This was not part of the public API.
     @Schema(hidden = true) String internalTxId) {

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/example/ExampleResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/example/ExampleResource.java
@@ -26,7 +26,7 @@ import io.stargate.sgv2.docsapi.api.common.exception.model.dto.ApiError;
 import io.stargate.sgv2.docsapi.api.common.properties.datastore.DataStoreProperties;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.api.v2.example.model.dto.KeyspaceExistsResponse;
-import io.stargate.sgv2.docsapi.config.constants.Constants;
+import io.stargate.sgv2.docsapi.config.constants.OpenApiConstants;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
 /** Example resource showcasing the OpenAPI v3 annotations and the reactive implementation. */
 @Path("/v2/example")
 @Produces(MediaType.APPLICATION_JSON)
-@SecurityRequirement(name = Constants.OPEN_API_DEFAULT_SECURITY_SCHEME)
+@SecurityRequirement(name = OpenApiConstants.SecuritySchemes.TOKEN)
 public class ExampleResource {
 
   private static final Logger LOG = LoggerFactory.getLogger(ExampleResource.class);

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/model/dto/DocumentResponseWrapper.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/model/dto/DocumentResponseWrapper.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.api.v2.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.stargate.sgv2.docsapi.models.ExecutionProfile;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * Response wrapper used for most Document API endpoints, where {@code documentId} and {@code
+ * pageState} are to be returned along with wrapped response.
+ *
+ * @param <T> Type of response wrapped
+ * @see SimpleResponseWrapper
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DocumentResponseWrapper<T>(
+
+    // doc id
+    @Schema(
+            description = "The id of the document.",
+            example = "822dc277-9121-4791-8b01-da8154e67d5d")
+        String documentId,
+
+    // page state
+    @Schema(
+            description =
+                "A string representing the paging state to be used on future paging requests. Can be missing in case page state is exhausted.",
+            nullable = true,
+            example = "c29tZS1leGFtcGxlLXN0YXRl")
+        String pageState,
+
+    // data
+    @Schema(description = "The data returned by the request.") T data,
+
+    // execution profile
+    @Schema(
+            description =
+                "Profiling information related to the execution of the request. Only set if the endpoint supports profiling and `profile` query parameter is set to `true`.",
+            nullable = true,
+            example =
+                """
+                {
+                   "description":"root",
+                   "queries":[],
+                   "nested":[
+                      {
+                         "description":"FILTER: speed LT 1000",
+                         "queries":[
+                            {
+                               "cql":"SELECT key, leaf, WRITETIME(leaf) FROM cycling.events WHERE p0 = ? AND leaf = ? AND p1 = ? AND dbl_value < ? ALLOW FILTERING",
+                               "executionCount":1,
+                               "rowCount":1
+                            }
+                         ],
+                         "nested":[]
+                      },
+                      {
+                         "description":"LoadProperties",
+                         "queries":[
+                            {
+                               "cql":"SELECT key, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p30, p31, p32, p33, p34, p35, p36, p37, p38, p39, p40, p41, p42, p43, p44, p45, p46, p47, p48, p49, p50, p51, p52, p53, p54, p55, p56, p57, p58, p59, p60, p61, p62, p63, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM cycling.events WHERE key = ?",
+                               "executionCount":1,
+                               "rowCount":21
+                            }
+                         ],
+                         "nested":[]
+                      }
+                   ]
+                }
+                """)
+        ExecutionProfile profile) {}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/model/dto/SimpleResponseWrapper.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/model/dto/SimpleResponseWrapper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.api.v2.model.dto;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * Response wrapper used for those Document API endpoints that do not need information provided by
+ * document response wrapper..
+ *
+ * @param <T> Type of response wrapped
+ */
+public record SimpleResponseWrapper<T>(
+    @Schema(description = "Response data returned by the request.") T data) {}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/model/dto/SimpleResponseWrapper.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/model/dto/SimpleResponseWrapper.java
@@ -17,13 +17,15 @@
 
 package io.stargate.sgv2.docsapi.api.v2.model.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * Response wrapper used for those Document API endpoints that do not need information provided by
- * document response wrapper..
+ * {@link DocumentResponseWrapper}.
  *
  * @param <T> Type of response wrapped
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record SimpleResponseWrapper<T>(
     @Schema(description = "Response data returned by the request.") T data) {}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResource.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.api.v2.namespaces.collections;
+
+import io.smallrye.mutiny.Uni;
+import io.stargate.bridge.proto.Schema;
+import io.stargate.sgv2.docsapi.api.common.exception.model.dto.ApiError;
+import io.stargate.sgv2.docsapi.api.common.properties.datastore.DataStoreProperties;
+import io.stargate.sgv2.docsapi.api.exception.ErrorCode;
+import io.stargate.sgv2.docsapi.api.exception.ErrorCodeRuntimeException;
+import io.stargate.sgv2.docsapi.api.v2.model.dto.SimpleResponseWrapper;
+import io.stargate.sgv2.docsapi.api.v2.namespaces.collections.model.dto.CollectionDto;
+import io.stargate.sgv2.docsapi.api.v2.namespaces.collections.model.dto.CollectionUpgradeType;
+import io.stargate.sgv2.docsapi.api.v2.namespaces.collections.model.dto.CreateCollectionDto;
+import io.stargate.sgv2.docsapi.config.constants.OpenApiConstants;
+import io.stargate.sgv2.docsapi.service.schema.TableManager;
+import io.stargate.sgv2.docsapi.service.schema.qualifier.Authorized;
+import java.net.URI;
+import java.util.List;
+import java.util.Objects;
+import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
+import org.eclipse.microprofile.openapi.annotations.media.SchemaProperty;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameters;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Collections resource. */
+@Path(CollectionsResource.BASE_PATH)
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@SecurityRequirement(name = OpenApiConstants.SecuritySchemes.TOKEN)
+@Tag(ref = OpenApiConstants.Tags.COLLECTIONS)
+public class CollectionsResource {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CollectionsResource.class);
+
+  public static final String BASE_PATH = "/v2/namespaces/{namespace:\\w+}/collections";
+
+  @Inject @Authorized TableManager tableManager;
+
+  @Inject DataStoreProperties dataStoreProperties;
+
+  @Operation(description = "List collections in a namespace.")
+  @Parameters(
+      value = {
+        @Parameter(
+            in = ParameterIn.PATH,
+            name = "namespace",
+            description = "The namespace to fetch collections for.",
+            example = "cycling"),
+        @Parameter(name = "raw", ref = OpenApiConstants.Parameters.RAW),
+      })
+  @APIResponses(
+      value = {
+        @APIResponse(
+            responseCode = "200",
+            description =
+                "Call successful. Note that in case of unwrapping (`raw=true`), the response contains only the contents fof the `data` property.",
+            content = {
+              @Content(
+                  schema =
+                      @org.eclipse.microprofile.openapi.annotations.media.Schema(
+                          implementation = SimpleResponseWrapper.class,
+                          properties =
+                              @SchemaProperty(
+                                  name = "data",
+                                  type = SchemaType.ARRAY,
+                                  implementation = CollectionDto.class,
+                                  uniqueItems = true,
+                                  minItems = 0)))
+            }),
+        @APIResponse(
+            responseCode = "404",
+            description = "Not found.",
+            content =
+                @Content(
+                    examples = {
+                      @ExampleObject(ref = OpenApiConstants.Examples.NAMESPACE_DOES_NOT_EXIST)
+                    },
+                    schema =
+                        @org.eclipse.microprofile.openapi.annotations.media.Schema(
+                            implementation = ApiError.class))),
+        @APIResponse(ref = OpenApiConstants.Responses.GENERAL_400),
+        @APIResponse(ref = OpenApiConstants.Responses.GENERAL_401),
+        @APIResponse(ref = OpenApiConstants.Responses.GENERAL_500),
+        @APIResponse(ref = OpenApiConstants.Responses.GENERAL_503),
+      })
+  @GET
+  public Uni<RestResponse<Object>> getCollections(
+      @PathParam("namespace") String namespace, @QueryParam("raw") boolean raw) {
+
+    // get all valid collection tables
+    return tableManager
+        .getValidCollectionTables(namespace)
+
+        // map to DTO and collect list
+        .map(this::toCollectionDto)
+        .collect()
+        .asList()
+
+        // map to wrapper if needed
+        .map(
+            results -> {
+              if (raw) {
+                return results;
+              } else {
+                return new SimpleResponseWrapper<>(results);
+              }
+            })
+        .map(RestResponse::ok);
+  }
+
+  @Operation(description = "Create a new empty collection in a namespace.")
+  @Parameters(
+      value = {
+        @Parameter(
+            in = ParameterIn.PATH,
+            name = "namespace",
+            description = "The namespace to create the collection in.",
+            example = "cycling"),
+      })
+  @APIResponses(
+      value = {
+        @APIResponse(responseCode = "201", description = "Collection created."),
+        @APIResponse(
+            responseCode = "404",
+            description = "Not found.",
+            content =
+                @Content(
+                    examples = {
+                      @ExampleObject(ref = OpenApiConstants.Examples.NAMESPACE_DOES_NOT_EXIST)
+                    },
+                    schema =
+                        @org.eclipse.microprofile.openapi.annotations.media.Schema(
+                            implementation = ApiError.class))),
+        @APIResponse(
+            responseCode = "409",
+            description = "Conflict.",
+            content =
+                @Content(
+                    schema =
+                        @org.eclipse.microprofile.openapi.annotations.media.Schema(
+                            implementation = ApiError.class,
+                            example =
+                                """
+                                {
+                                    "code": 409,
+                                    "description": "Create failed: collection cycling already exists."
+                                }
+                                """))),
+        @APIResponse(ref = OpenApiConstants.Responses.GENERAL_400),
+        @APIResponse(ref = OpenApiConstants.Responses.GENERAL_401),
+        @APIResponse(ref = OpenApiConstants.Responses.GENERAL_500),
+        @APIResponse(ref = OpenApiConstants.Responses.GENERAL_503),
+      })
+  @POST
+  public Uni<RestResponse<Object>> createCollection(
+      @Context UriInfo uriInfo,
+      @PathParam("namespace") String namespace,
+      @NotNull(message = "payload not provided") @Valid CreateCollectionDto body) {
+
+    String collection = body.name();
+
+    // go get the existing table
+    return tableManager
+        .getValidCollectionTable(namespace, collection)
+
+        // in case there is a table, ensure we report as error
+        .map(
+            table -> {
+              int code = Response.Status.CONFLICT.getStatusCode();
+              ApiError error =
+                  new ApiError(
+                      "Create failed: collection %s already exists.".formatted(collection), code);
+              return RestResponse.ResponseBuilder.create(code).entity(error).build();
+            })
+
+        // otherwise if table does not exist, table manager would fire the error
+        // with DATASTORE_TABLE_DOES_NOT_EXIST
+        .onFailure(
+            t -> {
+              if (t instanceof ErrorCodeRuntimeException ec) {
+                return Objects.equals(ec.getErrorCode(), ErrorCode.DATASTORE_TABLE_DOES_NOT_EXIST);
+              }
+              return false;
+            })
+        .recoverWithUni(
+            () ->
+                tableManager
+                    .createCollectionTable(namespace, collection)
+                    .map(
+                        created -> {
+                          URI location = uriInfo.getBaseUriBuilder().path(collection).build();
+                          return RestResponse.created(location);
+                        }));
+  }
+
+  @Operation(description = "Delete a collection in a namespace.")
+  @Parameters(
+      value = {
+        @Parameter(name = "namespace", ref = OpenApiConstants.Parameters.NAMESPACE),
+        @Parameter(name = "collection", ref = OpenApiConstants.Parameters.COLLECTION)
+      })
+  @APIResponses(
+      value = {
+        @APIResponse(responseCode = "204", description = "Collection deleted."),
+        @APIResponse(
+            responseCode = "404",
+            description = "Not found.",
+            content =
+                @Content(
+                    examples = {
+                      @ExampleObject(ref = OpenApiConstants.Examples.NAMESPACE_DOES_NOT_EXIST),
+                      @ExampleObject(ref = OpenApiConstants.Examples.COLLECTION_DOES_NOT_EXIST)
+                    },
+                    schema =
+                        @org.eclipse.microprofile.openapi.annotations.media.Schema(
+                            implementation = ApiError.class))),
+        @APIResponse(ref = OpenApiConstants.Responses.GENERAL_401),
+        @APIResponse(ref = OpenApiConstants.Responses.GENERAL_500),
+        @APIResponse(ref = OpenApiConstants.Responses.GENERAL_503),
+      })
+  @DELETE
+  @Path("/{collection:\\w+}")
+  public Uni<RestResponse<Object>> deleteCollection(
+      @PathParam("namespace") String namespace, @PathParam("collection") String collection) {
+    // go delete the table
+    return tableManager
+        .dropCollectionTable(namespace, collection)
+        .map(any -> RestResponse.noContent());
+  }
+
+  // simple mapper of CqlTable to the response DTO
+  private CollectionDto toCollectionDto(Schema.CqlTable table) {
+    String name = table.getName();
+
+    // if sai enabled, check if they are all there
+    if (dataStoreProperties.saiEnabled()) {
+      // these are already only secondary indexes
+      // see io.stargate.bridge.service.SchemaHandler#buildSecondaryIndex
+      List<Schema.CqlIndex> indexes = table.getIndexesList();
+      boolean noCustom = indexes.stream().noneMatch(Schema.CqlIndex::getCustom);
+
+      // If all secondary indexes are not SAI or there are no secondary indexes,
+      // then an upgrade is available.
+      if (indexes.size() == 0 || noCustom) {
+        new CollectionDto(name, true, CollectionUpgradeType.SAI_INDEX_UPGRADE);
+      }
+    }
+
+    // no upgrade
+    return new CollectionDto(name, false, null);
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResource.java
@@ -49,7 +49,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import org.eclipse.microprofile.openapi.annotations.Operation;
-import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
@@ -84,10 +83,9 @@ public class CollectionsResource {
   @Parameters(
       value = {
         @Parameter(
-            in = ParameterIn.PATH,
             name = "namespace",
-            description = "The namespace to fetch collections for.",
-            example = "cycling"),
+            ref = OpenApiConstants.Parameters.NAMESPACE,
+            description = "The namespace to fetch collections for."),
         @Parameter(name = "raw", ref = OpenApiConstants.Parameters.RAW),
       })
   @APIResponses(
@@ -154,14 +152,33 @@ public class CollectionsResource {
   @Parameters(
       value = {
         @Parameter(
-            in = ParameterIn.PATH,
             name = "namespace",
-            description = "The namespace to create the collection in.",
-            example = "cycling"),
+            ref = OpenApiConstants.Parameters.NAMESPACE,
+            description = "The namespace to create the collection in."),
       })
   @APIResponses(
       value = {
         @APIResponse(responseCode = "201", description = "Collection created."),
+        @APIResponse(
+            responseCode = "400",
+            description = "Bad request.",
+            content =
+                @Content(
+                    examples = {
+                      @ExampleObject(
+                          name = "Invalid collection name",
+                          value =
+                              """
+                              {
+                                  "code": 400,
+                                  "description": "Could not create collection events-collection, it has invalid characters. Valid characters are alphanumeric and underscores."
+                              }
+                              """),
+                      @ExampleObject(ref = OpenApiConstants.Examples.GENERAL_BAD_REQUEST)
+                    },
+                    schema =
+                        @org.eclipse.microprofile.openapi.annotations.media.Schema(
+                            implementation = ApiError.class))),
         @APIResponse(
             responseCode = "404",
             description = "Not found.",
@@ -188,7 +205,6 @@ public class CollectionsResource {
                                     "description": "Create failed: collection cycling already exists."
                                 }
                                 """))),
-        @APIResponse(ref = OpenApiConstants.Responses.GENERAL_400),
         @APIResponse(ref = OpenApiConstants.Responses.GENERAL_401),
         @APIResponse(ref = OpenApiConstants.Responses.GENERAL_500),
         @APIResponse(ref = OpenApiConstants.Responses.GENERAL_503),

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/CollectionDto.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/CollectionDto.java
@@ -1,0 +1,18 @@
+package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.model.dto;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+public record CollectionDto(
+    @Schema(description = "The name of the collection.", pattern = "\\w+", example = "cycling")
+        String name,
+    @Schema(
+            description =
+                "Whether an upgrade is available. Use the 'upgrade a collection' endpoint with the upgrade type to perform the upgrade.",
+            example = "false")
+        boolean upgradeAvailable,
+    @Schema(
+            description = "The upgrade type, if an upgrade is available.",
+            nullable = true,
+            implementation = CollectionUpgradeType.class,
+            example = "null")
+        CollectionUpgradeType upgradeType) {}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/CollectionDto.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/CollectionDto.java
@@ -2,6 +2,13 @@ package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.model.dto;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+/**
+ * DTO for the get collections response.
+ *
+ * @param name Name of the collection.
+ * @param upgradeAvailable If upgrade is available.
+ * @param upgradeType Type of upgrade, if available.
+ */
 public record CollectionDto(
     @Schema(description = "The name of the collection.", pattern = "\\w+", example = "cycling")
         String name,

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/CollectionDto.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/CollectionDto.java
@@ -1,5 +1,6 @@
 package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.model.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
@@ -9,6 +10,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
  * @param upgradeAvailable If upgrade is available.
  * @param upgradeType Type of upgrade, if available.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record CollectionDto(
     @Schema(description = "The name of the collection.", pattern = "\\w+", example = "cycling")
         String name,

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/CollectionUpgradeType.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/CollectionUpgradeType.java
@@ -19,6 +19,7 @@ package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.model.dto;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+/** DTO for specifying available collection upgrade possibility. */
 public enum CollectionUpgradeType {
   @Schema(description = "Upgrades a collection to use the SAI indexes.")
   SAI_INDEX_UPGRADE;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/CollectionUpgradeType.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/CollectionUpgradeType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.model.dto;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+public enum CollectionUpgradeType {
+  @Schema(description = "Upgrades a collection to use the SAI indexes.")
+  SAI_INDEX_UPGRADE;
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/CreateCollectionDto.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/CreateCollectionDto.java
@@ -4,6 +4,11 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+/**
+ * Request body when creating a new collection.
+ *
+ * @param name Name of the collection.
+ */
 public record CreateCollectionDto(
     @Schema(description = "The name of the collection.", pattern = "\\w+", example = "cycling")
         @NotNull(message = "`name` is required to create a collection")

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/CreateCollectionDto.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/CreateCollectionDto.java
@@ -1,0 +1,11 @@
+package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.model.dto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+public record CreateCollectionDto(
+    @Schema(description = "The name of the collection.", pattern = "\\w+", example = "cycling")
+        @NotNull(message = "`name` is required to create a collection")
+        @NotBlank(message = "`name` is required to create a collection")
+        String name) {}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/config/constants/Constants.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/config/constants/Constants.java
@@ -23,9 +23,6 @@ import io.stargate.bridge.proto.QueryOuterClass.Value;
 /** Static constants. */
 public interface Constants {
 
-  /** Name for the Open API default security scheme. */
-  String OPEN_API_DEFAULT_SECURITY_SCHEME = "Token";
-
   /** Authentication token header name. */
   String AUTHENTICATION_TOKEN_HEADER_NAME = "X-Cassandra-Token";
 

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/config/constants/OpenApiConstants.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/config/constants/OpenApiConstants.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.config.constants;
+
+/** Constants for reusing the OpenAPI objects. */
+public interface OpenApiConstants {
+
+  /** Name for the Open API default security scheme. */
+  interface SecuritySchemes {
+
+    String TOKEN = "Token";
+  }
+
+  interface Tags {
+
+    String NAMESPACES = "Namespaces";
+    String COLLECTIONS = "Collections";
+    String DOCUMENTS = "Documents";
+  }
+
+  /** Parameters reference names. */
+  interface Parameters {
+
+    String NAMESPACE = "namespace";
+    String COLLECTION = "collection";
+    String RAW = "raw";
+  }
+
+  interface Examples {
+
+    // general ones
+    String GENERAL_BAD_REQUEST = "Generic bad request";
+    String GENERAL_MISSING_TOKEN = "Token missing";
+    String GENERAL_UNAUTHORIZED = "Unauthorized";
+    String GENERAL_SERVER_SIDE_ERROR = "Server-side error";
+    String GENERAL_SERVICE_UNAVAILABLE = "Service unavailable";
+
+    // based on the error code
+    String NAMESPACE_DOES_NOT_EXIST = "Namespace does not exist";
+    String COLLECTION_DOES_NOT_EXIST = "Collection does not exist";
+  }
+
+  /** Response reference names. */
+  interface Responses {
+
+    String GENERAL_400 = "GENERAL_400";
+    String GENERAL_401 = "GENERAL_401";
+    String GENERAL_500 = "GENERAL_500";
+    String GENERAL_503 = "GENERAL_503";
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/models/ExecutionProfile.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/models/ExecutionProfile.java
@@ -28,12 +28,12 @@ import org.immutables.value.Value;
 @Value.Immutable(lazyhash = true)
 public interface ExecutionProfile {
 
-  @Schema(description = "Brief information about this execution step")
+  @Schema(description = "Brief information about this execution step.")
   String description();
 
-  @Schema(description = "A set of CQL queries performed under this execution step")
+  @Schema(description = "A set of CQL queries performed under this execution step.")
   List<QueryInfo> queries();
 
-  @Schema(description = "Nested execution steps")
+  @Schema(description = "Nested execution steps.", nullable = true)
   List<ExecutionProfile> nested();
 }

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/AuthorizedTableManager.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/AuthorizedTableManager.java
@@ -1,8 +1,10 @@
 package io.stargate.sgv2.docsapi.service.schema;
 
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.proto.Schema;
 import io.stargate.sgv2.docsapi.service.schema.qualifier.Authorized;
+import java.util.function.Function;
 import javax.enterprise.context.ApplicationScoped;
 
 /**
@@ -15,8 +17,27 @@ import javax.enterprise.context.ApplicationScoped;
 @Authorized
 public class AuthorizedTableManager extends TableManager {
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Uses {@link
+   * io.stargate.sgv2.docsapi.service.schema.common.SchemaManager#getTableAuthorized(String, String,
+   * Function)}
+   */
   @Override
   protected Uni<Schema.CqlTable> getTable(String keyspaceName, String tableName) {
     return schemaManager.getTableAuthorized(keyspaceName, tableName, getMissingKeyspaceFailure());
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Uses {@link
+   * io.stargate.sgv2.docsapi.service.schema.common.SchemaManager#getTablesAuthorized(String,
+   * Function)}
+   */
+  @Override
+  protected Multi<Schema.CqlTable> getAllTables(String keyspaceName) {
+    return schemaManager.getTablesAuthorized(keyspaceName, getMissingKeyspaceFailure());
   }
 }

--- a/sgv2-docsapi/src/main/resources/application.yaml
+++ b/sgv2-docsapi/src/main/resources/application.yaml
@@ -101,7 +101,10 @@ quarkus:
 
         # due to the https://github.com/quarkusio/quarkus/issues/24938
         # we need to define uri templating on our own for now
-        match-patterns: /v2/example/keyspace-exists/[a-z]+=/v2/example/keyspace-exists/{name}
+        match-patterns: |
+          /v2/example/keyspace-exists/[\\w]+=/v2/example/keyspace-exists/{name},
+          /v2/namespaces/[\\w]+/collections=/v2/namespaces/{namespace}/collections,
+          /v2/namespaces/[\\w]+/collections/\w+=/v2/namespaces/{namespace}/collections/{collection}
     # exports at prometheus default path
     export:
       prometheus:

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/exception/JsonParseExceptionMapperTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/exception/JsonParseExceptionMapperTest.java
@@ -18,31 +18,25 @@
 package io.stargate.sgv2.docsapi.api.common.exception;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import io.stargate.sgv2.docsapi.api.common.exception.model.dto.ApiError;
-import java.util.Collections;
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.Test;
 
-public class ConstraintViolationExceptionMapperTest {
+class JsonParseExceptionMapperTest {
+
   @Test
   public void happyPath() {
-    String message = "Email must not be empty";
-    ConstraintViolation<?> violation = mock(ConstraintViolation.class);
-    when(violation.getMessage()).thenReturn(message);
-    ConstraintViolationException error =
-        new ConstraintViolationException(Collections.singleton(violation));
+    String message = "Parsing exception";
+    JsonParseException exception = new JsonParseException(null, message);
 
-    ConstraintViolationExceptionMapper mapper = new ConstraintViolationExceptionMapper();
+    JsonParseExceptionMapper mapper = new JsonParseExceptionMapper();
 
-    try (RestResponse<ApiError> response = mapper.constraintViolationException(error)) {
+    try (RestResponse<ApiError> response = mapper.jsonParseException(exception)) {
       assertThat(response.getStatus()).isEqualTo(400);
       assertThat(response.getEntity().description())
-          .isEqualTo("Request invalid: %s.".formatted(message));
+          .isEqualTo("Unable to process JSON: %s.".formatted(message));
     }
   }
 }

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResourceIntegrationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResourceIntegrationTest.java
@@ -100,6 +100,16 @@ public class CollectionsResourceIntegrationTest {
     }
 
     @Test
+    public void tableExists() {
+      // TODO once we can create keyspace
+    }
+
+    @Test
+    public void tableNotExisting() {
+      // TODO once we can create keyspace
+    }
+
+    @Test
     public void keyspaceNotExisting() {
       String namespace = RandomStringUtils.randomAlphanumeric(16);
       String collection = RandomStringUtils.randomAlphanumeric(16);

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResourceIntegrationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResourceIntegrationTest.java
@@ -22,21 +22,18 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.docsapi.config.constants.Constants;
 import io.stargate.sgv2.docsapi.testprofiles.IntegrationTestProfile;
-import io.stargate.sgv2.docsapi.testresource.StargateTestResource;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@QuarkusTestResource(StargateTestResource.class)
 @TestProfile(IntegrationTestProfile.class)
 public class CollectionsResourceIntegrationTest {
 

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResourceIntegrationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResourceIntegrationTest.java
@@ -20,37 +20,207 @@ package io.stargate.sgv2.docsapi.api.v2.namespaces.collections;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import io.stargate.sgv2.common.cql.builder.Replication;
 import io.stargate.sgv2.docsapi.config.constants.Constants;
+import io.stargate.sgv2.docsapi.service.schema.NamespaceManager;
 import io.stargate.sgv2.docsapi.testprofiles.IntegrationTestProfile;
+import java.time.Duration;
+import javax.enterprise.context.control.ActivateRequestContext;
+import javax.inject.Inject;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestClassOrder;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
 
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
+@ActivateRequestContext
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class CollectionsResourceIntegrationTest {
+
+  // TODO replace with HTTP call and remove @Inject to support end-to-end
+  //  remove @ActivateRequestContext
+  //  remove @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  //  drop keyspace properly, see https://github.com/quarkusio/quarkus/issues/25812
+  //  could be as the junit extension that runs before all tests
 
   // base path for the test
   public static final String BASE_PATH = "/v2/namespaces/{namespace}/collections";
+  public static final String DEFAULT_NAMESPACE = RandomStringUtils.randomAlphanumeric(16);
+  public static final String DEFAULT_COLLECTION = RandomStringUtils.randomAlphanumeric(16);
+
+  @Inject NamespaceManager namespaceManager;
 
   @BeforeAll
-  public static void enableLog() {
+  public void init() {
     RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+
+    namespaceManager
+        .createNamespace(DEFAULT_NAMESPACE, Replication.simpleStrategy(1))
+        .await()
+        .atMost(Duration.ofSeconds(10));
   }
 
   @Nested
+  @Order(1)
+  @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+  class CreateCollection {
+
+    @Test
+    @Order(1)
+    public void happyPath() {
+      String body =
+          """
+              {
+                  "name": "%s"
+              }
+              """
+              .formatted(DEFAULT_COLLECTION);
+
+      given()
+          .contentType(ContentType.JSON)
+          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .body(body)
+          .post(BASE_PATH, DEFAULT_NAMESPACE)
+          .then()
+          .statusCode(201);
+    }
+
+    @Test
+    @Order(2)
+    public void tableExists() {
+      String body =
+          """
+              {
+                  "name": "%s"
+              }
+              """
+              .formatted(DEFAULT_COLLECTION);
+
+      given()
+          .contentType(ContentType.JSON)
+          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .body(body)
+          .post(BASE_PATH, DEFAULT_NAMESPACE)
+          .then()
+          .statusCode(409)
+          .body("code", is(409))
+          .body(
+              "description",
+              is("Create failed: collection %s already exists.".formatted(DEFAULT_COLLECTION)));
+    }
+
+    @Test
+    public void keyspaceNotExisting() {
+      String namespace = RandomStringUtils.randomAlphanumeric(16);
+      String collection = RandomStringUtils.randomAlphanumeric(16);
+      String body =
+          """
+                  {
+                    "name": "%s"
+                  }
+                  """
+              .formatted(collection);
+
+      given()
+          .contentType(ContentType.JSON)
+          .body(body)
+          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .when()
+          .post(BASE_PATH, namespace)
+          .then()
+          .statusCode(404)
+          .body("code", is(404))
+          .body(
+              "description",
+              is("Unknown namespace %s, you must create it first.".formatted(namespace)));
+    }
+
+    @Test
+    public void noPayload() {
+      String namespace = RandomStringUtils.randomAlphanumeric(16);
+
+      given()
+          .contentType(ContentType.JSON)
+          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .when()
+          .post(BASE_PATH, namespace)
+          .then()
+          .statusCode(400)
+          .body("code", is(400))
+          .body("description", is("Request invalid: payload not provided."));
+    }
+
+    @Test
+    public void malformedPayload() {
+      String namespace = RandomStringUtils.randomAlphanumeric(16);
+      String body =
+          """
+                    {
+                      "malformed":
+                    }
+                  """;
+
+      given()
+          .contentType(ContentType.JSON)
+          .body(body)
+          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .when()
+          .post(BASE_PATH, namespace)
+          .then()
+          .statusCode(400)
+          .body("code", is(400))
+          .body("description", startsWith("Unable to process JSON"));
+    }
+
+    @Test
+    public void invalidPayload() {
+      String namespace = RandomStringUtils.randomAlphanumeric(16);
+      String body = "{}";
+
+      given()
+          .contentType(ContentType.JSON)
+          .body(body)
+          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .when()
+          .post(BASE_PATH, namespace)
+          .then()
+          .statusCode(400)
+          .body("code", is(400))
+          .body("description", is("Request invalid: `name` is required to create a collection."));
+    }
+  }
+
+  @Nested
+  @Order(2)
   class GetCollections {
 
     @Test
     public void happyPath() {
-      // TODO once we can create keyspace
+
+      given()
+          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .when()
+          .get(BASE_PATH, DEFAULT_NAMESPACE)
+          .then()
+          .statusCode(200)
+          .body("data[0].name", is(DEFAULT_COLLECTION))
+          .body("data[0].upgradeAvailable", is(false))
+          .body("data[0].upgradeType", is(nullValue()));
     }
 
     @Test
@@ -89,115 +259,31 @@ public class CollectionsResourceIntegrationTest {
   }
 
   @Nested
-  class CreateCollection {
-
-    @Test
-    public void happyPath() {
-      // TODO once we can create keyspace
-    }
-
-    @Test
-    public void tableExists() {
-      // TODO once we can create keyspace
-    }
-
-    @Test
-    public void tableNotExisting() {
-      // TODO once we can create keyspace
-    }
-
-    @Test
-    public void keyspaceNotExisting() {
-      String namespace = RandomStringUtils.randomAlphanumeric(16);
-      String collection = RandomStringUtils.randomAlphanumeric(16);
-      String body =
-          """
-              {
-                "name": "%s"
-              }
-              """
-              .formatted(collection);
-
-      given()
-          .contentType(ContentType.JSON)
-          .body(body)
-          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
-          .when()
-          .post(BASE_PATH, namespace)
-          .then()
-          .statusCode(404)
-          .body("code", is(404))
-          .body(
-              "description",
-              is("Unknown namespace %s, you must create it first.".formatted(namespace)));
-    }
-
-    @Test
-    public void noPayload() {
-      String namespace = RandomStringUtils.randomAlphanumeric(16);
-
-      given()
-          .contentType(ContentType.JSON)
-          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
-          .when()
-          .post(BASE_PATH, namespace)
-          .then()
-          .statusCode(400)
-          .body("code", is(400))
-          .body("description", is("Request invalid: payload not provided."));
-    }
-
-    @Test
-    public void malformedPayload() {
-      String namespace = RandomStringUtils.randomAlphanumeric(16);
-      String body =
-          """
-                {
-                  "malformed":
-                }
-              """;
-
-      given()
-          .contentType(ContentType.JSON)
-          .body(body)
-          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
-          .when()
-          .post(BASE_PATH, namespace)
-          .then()
-          .statusCode(400)
-          .body("code", is(400))
-          .body("description", startsWith("Unable to process JSON"));
-    }
-
-    @Test
-    public void invalidPayload() {
-      String namespace = RandomStringUtils.randomAlphanumeric(16);
-      String body = "{}";
-
-      given()
-          .contentType(ContentType.JSON)
-          .body(body)
-          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
-          .when()
-          .post(BASE_PATH, namespace)
-          .then()
-          .statusCode(400)
-          .body("code", is(400))
-          .body("description", is("Request invalid: `name` is required to create a collection."));
-    }
-  }
-
-  @Nested
+  @Order(3)
   class DeleteCollection {
 
     @Test
     public void happyPath() {
-      // TODO once we can create keyspace
+      given()
+          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .when()
+          .delete(BASE_PATH + "/{collection}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
+          .then()
+          .statusCode(204);
     }
 
     @Test
     public void tableNotExisting() {
-      // TODO once we can create keyspace
+      String collection = RandomStringUtils.randomAlphanumeric(16);
+
+      given()
+          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .when()
+          .delete(BASE_PATH + "/{collection}", DEFAULT_NAMESPACE, collection)
+          .then()
+          .statusCode(404)
+          .body("code", is(404))
+          .body("description", is("Collection '%s' not found.".formatted(collection)));
     }
 
     @Test

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResourceIntegrationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResourceIntegrationTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.api.v2.namespaces.collections;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.stargate.sgv2.docsapi.config.constants.Constants;
+import io.stargate.sgv2.docsapi.testprofiles.IntegrationTestProfile;
+import io.stargate.sgv2.docsapi.testresource.StargateTestResource;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@QuarkusTestResource(StargateTestResource.class)
+@TestProfile(IntegrationTestProfile.class)
+public class CollectionsResourceIntegrationTest {
+
+  // base path for the test
+  public static final String BASE_PATH = "/v2/namespaces/{namespace}/collections";
+
+  @BeforeAll
+  public static void enableLog() {
+    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+  }
+
+  @Nested
+  class GetCollections {
+
+    @Test
+    public void happyPath() {
+      // TODO once we can create keyspace
+    }
+
+    @Test
+    public void happyPathRaw() {
+      // TODO once we can create keyspace
+    }
+
+    @Test
+    public void notCollectionTables() {
+      String namespace = "system";
+
+      given()
+          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .when()
+          .get(BASE_PATH, namespace)
+          .then()
+          .statusCode(200)
+          .body("data", is(empty()));
+    }
+
+    @Test
+    public void keyspaceNotExisting() {
+      String namespace = RandomStringUtils.randomAlphanumeric(16);
+
+      given()
+          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .when()
+          .get(BASE_PATH, namespace)
+          .then()
+          .statusCode(404)
+          .body("code", is(404))
+          .body(
+              "description",
+              is("Unknown namespace %s, you must create it first.".formatted(namespace)));
+    }
+  }
+
+  @Nested
+  class CreateCollection {
+
+    @Test
+    public void happyPath() {
+      // TODO once we can create keyspace
+    }
+
+    @Test
+    public void keyspaceNotExisting() {
+      String namespace = RandomStringUtils.randomAlphanumeric(16);
+      String collection = RandomStringUtils.randomAlphanumeric(16);
+      String body =
+          """
+              {
+                "name": "%s"
+              }
+              """
+              .formatted(collection);
+
+      given()
+          .contentType(ContentType.JSON)
+          .body(body)
+          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .when()
+          .post(BASE_PATH, namespace)
+          .then()
+          .statusCode(404)
+          .body("code", is(404))
+          .body(
+              "description",
+              is("Unknown namespace %s, you must create it first.".formatted(namespace)));
+    }
+
+    @Test
+    public void noPayload() {
+      String namespace = RandomStringUtils.randomAlphanumeric(16);
+
+      given()
+          .contentType(ContentType.JSON)
+          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .when()
+          .post(BASE_PATH, namespace)
+          .then()
+          .statusCode(400)
+          .body("code", is(400))
+          .body("description", is("Request invalid: payload not provided."));
+    }
+
+    @Test
+    public void malformedPayload() {
+      String namespace = RandomStringUtils.randomAlphanumeric(16);
+      String body =
+          """
+                {
+                  "malformed":
+                }
+              """;
+
+      given()
+          .contentType(ContentType.JSON)
+          .body(body)
+          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .when()
+          .post(BASE_PATH, namespace)
+          .then()
+          .statusCode(400)
+          .body("code", is(400))
+          .body("description", startsWith("Unable to process JSON"));
+    }
+
+    @Test
+    public void invalidPayload() {
+      String namespace = RandomStringUtils.randomAlphanumeric(16);
+      String body = "{}";
+
+      given()
+          .contentType(ContentType.JSON)
+          .body(body)
+          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .when()
+          .post(BASE_PATH, namespace)
+          .then()
+          .statusCode(400)
+          .body("code", is(400))
+          .body("description", is("Request invalid: `name` is required to create a collection."));
+    }
+  }
+
+  @Nested
+  class DeleteCollection {
+
+    @Test
+    public void happyPath() {
+      // TODO once we can create keyspace
+    }
+
+    @Test
+    public void tableNotExisting() {
+      // TODO once we can create keyspace
+    }
+
+    @Test
+    public void keyspaceNotExisting() {
+      String namespace = RandomStringUtils.randomAlphanumeric(16);
+      String collection = RandomStringUtils.randomAlphanumeric(16);
+
+      given()
+          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .when()
+          .delete(BASE_PATH + "/{collection}", namespace, collection)
+          .then()
+          .statusCode(404)
+          .body("code", is(404))
+          .body(
+              "description",
+              is("Unknown namespace %s, you must create it first.".formatted(namespace)));
+    }
+
+    @Test
+    public void tableNotAValidCollection() {
+      String namespace = "system";
+      String collection = "local";
+
+      given()
+          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .when()
+          .delete(BASE_PATH + "/{collection}", namespace, collection)
+          .then()
+          .statusCode(400)
+          .body("code", is(400))
+          .body(
+              "description",
+              is(
+                  "The database table system.local is not a Documents collection. Accessing arbitrary tables via the Documents API is not permitted."));
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResourceIntegrationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResourceIntegrationTest.java
@@ -211,7 +211,6 @@ public class CollectionsResourceIntegrationTest {
 
     @Test
     public void happyPath() {
-
       given()
           .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
           .when()
@@ -225,7 +224,16 @@ public class CollectionsResourceIntegrationTest {
 
     @Test
     public void happyPathRaw() {
-      // TODO once we can create keyspace
+      given()
+          .param("raw", true)
+          .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .when()
+          .get(BASE_PATH, DEFAULT_NAMESPACE)
+          .then()
+          .statusCode(200)
+          .body("[0].name", is(DEFAULT_COLLECTION))
+          .body("[0].upgradeAvailable", is(false))
+          .body("[0].upgradeType", is(nullValue()));
     }
 
     @Test

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/AuthorizedTableManagerTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/AuthorizedTableManagerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import io.grpc.stub.StreamObserver;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.bridge.proto.Schema;
@@ -18,6 +19,7 @@ import io.stargate.sgv2.docsapi.api.common.StargateRequestInfo;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.grpc.GrpcClients;
 import io.stargate.sgv2.docsapi.service.schema.qualifier.Authorized;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -54,7 +56,8 @@ class AuthorizedTableManagerTest extends BridgeTest {
         .getStargateBridge();
   }
 
-  Schema.CqlKeyspaceDescribe getValidTableAndKeyspace(String namespace, String collection) {
+  Schema.CqlKeyspaceDescribe.Builder getValidTableAndKeyspaceBuilder(
+      String namespace, String collection) {
     QueryOuterClass.ColumnSpec.Builder partitionColumn =
         QueryOuterClass.ColumnSpec.newBuilder()
             .setName(documentProperties.tableProperties().keyColumnName());
@@ -75,8 +78,11 @@ class AuthorizedTableManagerTest extends BridgeTest {
             .addAllColumns(valueColumns);
     return Schema.CqlKeyspaceDescribe.newBuilder()
         .setCqlKeyspace(Schema.CqlKeyspace.newBuilder().setName(namespace))
-        .addTables(table)
-        .build();
+        .addTables(table);
+  }
+
+  Schema.CqlKeyspaceDescribe getValidTableAndKeyspace(String namespace, String collection) {
+    return getValidTableAndKeyspaceBuilder(namespace, collection).build();
   }
 
   @Nested
@@ -168,6 +174,83 @@ class AuthorizedTableManagerTest extends BridgeTest {
 
       verify(bridgeService).authorizeSchemaReads(schemaReadsCaptor.capture(), any());
       verifyNoMoreInteractions(bridgeService);
+    }
+  }
+
+  @Nested
+  class GetValidCollectionTables {
+
+    @Test
+    public void happyPath() {
+      String namespace = RandomStringUtils.randomAlphanumeric(16);
+      String collection = RandomStringUtils.randomAlphanumeric(16);
+      String collection2 = RandomStringUtils.randomAlphanumeric(16);
+      Schema.AuthorizeSchemaReadsResponse authResponse =
+          Schema.AuthorizeSchemaReadsResponse.newBuilder()
+              .addAllAuthorized(Arrays.asList(true, true))
+              .build();
+      Schema.CqlKeyspaceDescribe keyspace =
+          getValidTableAndKeyspaceBuilder(namespace, collection)
+              .addTables(Schema.CqlTable.newBuilder().setName(collection2).build())
+              .build();
+
+      doAnswer(
+              invocationOnMock -> {
+                StreamObserver<Schema.AuthorizeSchemaReadsResponse> observer =
+                    invocationOnMock.getArgument(1);
+                observer.onNext(authResponse);
+                observer.onCompleted();
+                return null;
+              })
+          .when(bridgeService)
+          .authorizeSchemaReads(any(), any());
+
+      doAnswer(
+              invocationOnMock -> {
+                StreamObserver<Schema.CqlKeyspaceDescribe> observer =
+                    invocationOnMock.getArgument(1);
+                observer.onNext(keyspace);
+                observer.onCompleted();
+                return null;
+              })
+          .when(bridgeService)
+          .describeKeyspace(any(), any());
+
+      tableManager
+          .getValidCollectionTables(namespace)
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(1))
+          .awaitNextItem()
+          .assertItems(keyspace.getTables(0))
+          .awaitCompletion()
+          .assertCompleted();
+
+      verify(bridgeService).authorizeSchemaReads(schemaReadsCaptor.capture(), any());
+      verify(bridgeService).describeKeyspace(any(), any());
+      verifyNoMoreInteractions(bridgeService);
+
+      // asert auth request
+      assertThat(schemaReadsCaptor.getAllValues())
+          .singleElement()
+          .extracting(Schema.AuthorizeSchemaReadsRequest::getSchemaReadsList)
+          .satisfies(
+              reads ->
+                  assertThat(reads)
+                      .hasSize(2)
+                      .anySatisfy(
+                          read -> {
+                            assertThat(read.getKeyspaceName()).isEqualTo(namespace);
+                            assertThat(read.getElementName().getValue()).isEqualTo(collection);
+                            assertThat(read.getElementType())
+                                .isEqualTo(Schema.SchemaRead.ElementType.TABLE);
+                          })
+                      .anySatisfy(
+                          read -> {
+                            assertThat(read.getKeyspaceName()).isEqualTo(namespace);
+                            assertThat(read.getElementName().getValue()).isEqualTo(collection2);
+                            assertThat(read.getElementType())
+                                .isEqualTo(Schema.SchemaRead.ElementType.TABLE);
+                          }));
     }
   }
 }

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/common/SchemaManagerTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/common/SchemaManagerTest.java
@@ -1021,7 +1021,7 @@ class SchemaManagerTest extends BridgeTest {
           .awaitCompletion()
           .assertCompleted();
 
-      verify(bridgeService).describeKeyspace(queryCaptor.capture(), any());
+      verify(bridgeService).describeKeyspace(describeKeyspaceCaptor.capture(), any());
       verifyNoMoreInteractions(bridgeService);
 
       // assert keyspace in cache
@@ -1055,7 +1055,7 @@ class SchemaManagerTest extends BridgeTest {
           .assertHasNotReceivedAnyItem()
           .assertCompleted();
 
-      verify(bridgeService).describeKeyspace(queryCaptor.capture(), any());
+      verify(bridgeService).describeKeyspace(describeKeyspaceCaptor.capture(), any());
       verifyNoMoreInteractions(bridgeService);
 
       // assert keyspace still in cache
@@ -1088,7 +1088,7 @@ class SchemaManagerTest extends BridgeTest {
               .getFailure();
 
       assertThat(failure).isEqualTo(exception);
-      verify(bridgeService).describeKeyspace(queryCaptor.capture(), any());
+      verify(bridgeService).describeKeyspace(describeKeyspaceCaptor.capture(), any());
       verifyNoMoreInteractions(bridgeService);
 
       // assert keyspace not in cache
@@ -1270,7 +1270,7 @@ class SchemaManagerTest extends BridgeTest {
           .assertCompleted();
 
       verify(bridgeService).authorizeSchemaReads(schemaReadsCaptor.capture(), any());
-      verify(bridgeService).describeKeyspace(queryCaptor.capture(), any());
+      verify(bridgeService).describeKeyspace(describeKeyspaceCaptor.capture(), any());
       verifyNoMoreInteractions(bridgeService);
 
       // assert keyspace in cache

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/common/SchemaManagerTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/common/SchemaManagerTest.java
@@ -984,6 +984,120 @@ class SchemaManagerTest extends BridgeTest {
   }
 
   @Nested
+  class GetTables {
+
+    @Test
+    public void happyPath() {
+      String keyspace = RandomStringUtils.randomAlphanumeric(16);
+      String table1 = RandomStringUtils.randomAlphanumeric(16);
+      String table2 = RandomStringUtils.randomAlphanumeric(16);
+      Schema.CqlKeyspace cqlKeyspace = Schema.CqlKeyspace.newBuilder().setName(keyspace).build();
+      Schema.CqlTable cqlTable1 = Schema.CqlTable.newBuilder().setName(table1).build();
+      Schema.CqlTable cqlTable2 = Schema.CqlTable.newBuilder().setName(table2).build();
+      Schema.CqlKeyspaceDescribe response =
+          Schema.CqlKeyspaceDescribe.newBuilder()
+              .setCqlKeyspace(cqlKeyspace)
+              .addTables(cqlTable1)
+              .addTables(cqlTable2)
+              .build();
+
+      doAnswer(
+              invocationOnMock -> {
+                StreamObserver<Schema.CqlKeyspaceDescribe> observer =
+                    invocationOnMock.getArgument(1);
+                observer.onNext(response);
+                observer.onCompleted();
+                return null;
+              })
+          .when(bridgeService)
+          .describeKeyspace(any(), any());
+
+      schemaManager
+          .getTables(keyspace, (k) -> Uni.createFrom().nothing())
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create())
+          .awaitNextItems(2)
+          .assertItems(cqlTable1, cqlTable2)
+          .awaitCompletion()
+          .assertCompleted();
+
+      verify(bridgeService).describeKeyspace(queryCaptor.capture(), any());
+      verifyNoMoreInteractions(bridgeService);
+
+      // assert keyspace in cache
+      assertThat(keyspaceCache.as(CaffeineCache.class).keySet())
+          .contains(new CompositeCacheKey(keyspace, Optional.empty()));
+    }
+
+    @Test
+    public void noTables() {
+      String keyspace = RandomStringUtils.randomAlphanumeric(16);
+      Schema.CqlKeyspace cqlKeyspace = Schema.CqlKeyspace.newBuilder().setName(keyspace).build();
+      Schema.CqlKeyspaceDescribe response =
+          Schema.CqlKeyspaceDescribe.newBuilder().setCqlKeyspace(cqlKeyspace).build();
+
+      doAnswer(
+              invocationOnMock -> {
+                StreamObserver<Schema.CqlKeyspaceDescribe> observer =
+                    invocationOnMock.getArgument(1);
+                observer.onNext(response);
+                observer.onCompleted();
+                return null;
+              })
+          .when(bridgeService)
+          .describeKeyspace(any(), any());
+
+      schemaManager
+          .getTables(keyspace, (k) -> Uni.createFrom().nothing())
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create())
+          .awaitCompletion()
+          .assertHasNotReceivedAnyItem()
+          .assertCompleted();
+
+      verify(bridgeService).describeKeyspace(queryCaptor.capture(), any());
+      verifyNoMoreInteractions(bridgeService);
+
+      // assert keyspace still in cache
+      assertThat(keyspaceCache.as(CaffeineCache.class).keySet())
+          .contains(new CompositeCacheKey(keyspace, Optional.empty()));
+    }
+
+    @Test
+    public void missingKeyspace() {
+      String keyspace = RandomStringUtils.randomAlphanumeric(16);
+
+      doAnswer(
+              invocationOnMock -> {
+                StreamObserver<Schema.CqlKeyspaceDescribe> observer =
+                    invocationOnMock.getArgument(1);
+                Status status = Status.NOT_FOUND;
+                observer.onError(new StatusRuntimeException(status));
+                return null;
+              })
+          .when(bridgeService)
+          .describeKeyspace(any(), any());
+
+      Throwable exception = new RuntimeException("Missing keyspace test exception.");
+      Throwable failure =
+          schemaManager
+              .getTables(keyspace, (k) -> Uni.createFrom().failure(exception))
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create())
+              .awaitFailure()
+              .getFailure();
+
+      assertThat(failure).isEqualTo(exception);
+      verify(bridgeService).describeKeyspace(queryCaptor.capture(), any());
+      verifyNoMoreInteractions(bridgeService);
+
+      // assert keyspace not in cache
+      assertThat(keyspaceCache.as(CaffeineCache.class).keySet())
+          .doesNotContain(new CompositeCacheKey(keyspace, Optional.empty()));
+    }
+  }
+
+  @Nested
   class GetTableAuthorized {
 
     @Test
@@ -1099,6 +1213,92 @@ class SchemaManagerTest extends BridgeTest {
       result.awaitFailure().assertFailedWith(UnauthorizedTableException.class);
       verify(bridgeService).authorizeSchemaReads(schemaReadsCaptor.capture(), any());
       verifyNoMoreInteractions(bridgeService);
+    }
+  }
+
+  @Nested
+  class GetTablesAuthorized {
+
+    @Test
+    public void happyPath() {
+      String keyspace = RandomStringUtils.randomAlphanumeric(16);
+      String table1 = RandomStringUtils.randomAlphanumeric(16);
+      String table2 = RandomStringUtils.randomAlphanumeric(16);
+      Schema.AuthorizeSchemaReadsResponse authResponse =
+          Schema.AuthorizeSchemaReadsResponse.newBuilder()
+              .addAllAuthorized(Arrays.asList(false, true))
+              .build();
+      Schema.CqlKeyspace cqlKeyspace = Schema.CqlKeyspace.newBuilder().setName(keyspace).build();
+      Schema.CqlTable cqlTable1 = Schema.CqlTable.newBuilder().setName(table1).build();
+      Schema.CqlTable cqlTable2 = Schema.CqlTable.newBuilder().setName(table2).build();
+      Schema.CqlKeyspaceDescribe response =
+          Schema.CqlKeyspaceDescribe.newBuilder()
+              .setCqlKeyspace(cqlKeyspace)
+              .addTables(cqlTable1)
+              .addTables(cqlTable2)
+              .build();
+
+      doAnswer(
+              invocationOnMock -> {
+                StreamObserver<Schema.AuthorizeSchemaReadsResponse> observer =
+                    invocationOnMock.getArgument(1);
+                observer.onNext(authResponse);
+                observer.onCompleted();
+                return null;
+              })
+          .when(bridgeService)
+          .authorizeSchemaReads(any(), any());
+
+      doAnswer(
+              invocationOnMock -> {
+                StreamObserver<Schema.CqlKeyspaceDescribe> observer =
+                    invocationOnMock.getArgument(1);
+                observer.onNext(response);
+                observer.onCompleted();
+                return null;
+              })
+          .when(bridgeService)
+          .describeKeyspace(any(), any());
+
+      schemaManager
+          .getTablesAuthorized(keyspace, (k) -> Uni.createFrom().nothing())
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create())
+          .awaitNextItem()
+          .assertItems(cqlTable2)
+          .awaitCompletion()
+          .assertCompleted();
+
+      verify(bridgeService).authorizeSchemaReads(schemaReadsCaptor.capture(), any());
+      verify(bridgeService).describeKeyspace(queryCaptor.capture(), any());
+      verifyNoMoreInteractions(bridgeService);
+
+      // assert keyspace in cache
+      assertThat(keyspaceCache.as(CaffeineCache.class).keySet())
+          .contains(new CompositeCacheKey(keyspace, Optional.empty()));
+
+      // asert auth request
+      assertThat(schemaReadsCaptor.getAllValues())
+          .singleElement()
+          .extracting(Schema.AuthorizeSchemaReadsRequest::getSchemaReadsList)
+          .satisfies(
+              reads ->
+                  assertThat(reads)
+                      .hasSize(2)
+                      .anySatisfy(
+                          read -> {
+                            assertThat(read.getKeyspaceName()).isEqualTo(keyspace);
+                            assertThat(read.getElementName().getValue()).isEqualTo(table1);
+                            assertThat(read.getElementType())
+                                .isEqualTo(Schema.SchemaRead.ElementType.TABLE);
+                          })
+                      .anySatisfy(
+                          read -> {
+                            assertThat(read.getKeyspaceName()).isEqualTo(keyspace);
+                            assertThat(read.getElementName().getValue()).isEqualTo(table2);
+                            assertThat(read.getElementType())
+                                .isEqualTo(Schema.SchemaRead.ElementType.TABLE);
+                          }));
     }
   }
 }


### PR DESCRIPTION
*Depends on #1825.*

**What this PR does**:

Implements V2 `CollectionsResource`:
 * implements all endpoints except the collection upgrade (separate issue #1736)
 * almost all tests expect the happy path due to inability to create a keyspace at the moment
 * proper and extensive API documentation with different examples
 * extension of the `TableManager` and `SchemaManager` to handle needed features

**Which issue(s) this PR fixes**:

Relates to #1722, some tests missing in order to close the ticket.

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [ ] Docs check with @polandll 
- [x] Sync with #1844 depending on what gets in first
