### PR TITLE
Upgrade org.json version to latest (to avoid CVE in deps)

### DIFF
--- a/auth-jwt-service/pom.xml
+++ b/auth-jwt-service/pom.xml
@@ -28,7 +28,6 @@
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20190722</version>
     </dependency>
     <dependency>
       <groupId>com.nimbusds</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -702,6 +702,11 @@
         <version>${javatuples.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.json</groupId>
+        <artifactId>json</artifactId>
+        <version>20220320</version>
+      </dependency>
+      <dependency>
         <groupId>com.bpodgursky</groupId>
         <artifactId>jbool_expressions</artifactId>
         <version>1.23</version>


### PR DESCRIPTION
**What this PR does**:

Change dependency to `org.json:json` into managed; upgrade to latest available version.
This removes one CVE dependency (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250)

**Which issue(s) this PR fixes**:
Fixes #1848

**Checklist**
- [x] Changes manually tested -- rely on existing integration test suite
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
