### PR TITLE
closes #1839: api error response in case of a missing token

### DIFF
--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/security/HeaderBasedAuthenticationMechanism.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/security/HeaderBasedAuthenticationMechanism.java
@@ -35,6 +35,8 @@ import java.util.Optional;
 import java.util.Set;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of the {@link HttpAuthenticationMechanism} that authenticates on a header. If a
@@ -43,6 +45,9 @@ import javax.ws.rs.core.MediaType;
  * @see HeaderIdentityProvider
  */
 public class HeaderBasedAuthenticationMechanism implements HttpAuthenticationMechanism {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(HeaderBasedAuthenticationMechanism.class);
 
   /** The name of the header to be used for the authentication. */
   private final String headerName;
@@ -119,6 +124,7 @@ public class HeaderBasedAuthenticationMechanism implements HttpAuthenticationMec
                     .completionStage(
                         context.response().write(response).map(true).toCompletionStage());
               } catch (JsonProcessingException e) {
+                LOG.error("Unable to serialize API error instance {} to JSON.", apiError, e);
                 return Uni.createFrom().item(true);
               }
             });

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/security/configuration/HeaderBasedSecurityConfiguration.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/security/configuration/HeaderBasedSecurityConfiguration.java
@@ -17,6 +17,7 @@
 
 package io.stargate.sgv2.docsapi.api.common.security.configuration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.arc.lookup.LookupIfProperty;
 import io.quarkus.security.identity.IdentityProvider;
 import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
@@ -33,9 +34,10 @@ public class HeaderBasedSecurityConfiguration {
   @Produces
   @ApplicationScoped
   @LookupIfProperty(name = "stargate.auth.header-based.enabled", stringValue = "true")
-  HttpAuthenticationMechanism httpAuthenticationMechanism(AuthConfig config) {
+  HttpAuthenticationMechanism httpAuthenticationMechanism(
+      AuthConfig config, ObjectMapper objectMapper) {
     String headerName = config.headerBased().headerName();
-    return new HeaderBasedAuthenticationMechanism(headerName);
+    return new HeaderBasedAuthenticationMechanism(headerName, objectMapper);
   }
 
   @Produces

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/example/ExampleResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/example/ExampleResource.java
@@ -46,7 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Example resource showcasing the OpenAPI v3 annotations and the reactive implementation. */
-@Path("/api/v2/example")
+@Path("/v2/example")
 @Produces(MediaType.APPLICATION_JSON)
 @SecurityRequirement(name = Constants.OPEN_API_DEFAULT_SECURITY_SCHEME)
 public class ExampleResource {

--- a/sgv2-docsapi/src/main/resources/application.yaml
+++ b/sgv2-docsapi/src/main/resources/application.yaml
@@ -82,12 +82,13 @@ quarkus:
     port: 8180
     non-application-root-path: stargate
 
-    # every /api/v2 path is authenticated by default
+    # every /v2 path is authenticated by default
     # adapt if changing the authentication mechanism
     auth:
+      proactive: false
       permission:
         default:
-          paths: /api/v2/*
+          paths: /v2/*
           policy: authenticated
 
   # built-in micrometer properties
@@ -100,7 +101,7 @@ quarkus:
 
         # due to the https://github.com/quarkusio/quarkus/issues/24938
         # we need to define uri templating on our own for now
-        match-patterns: /api/v2/example/keyspace-exists/[a-z]+=/api/v2/example/keyspace-exists/{name}
+        match-patterns: /v2/example/keyspace-exists/[a-z]+=/v2/example/keyspace-exists/{name}
     # exports at prometheus default path
     export:
       prometheus:

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/security/HeaderBasedAuthenticationMechanismTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/security/HeaderBasedAuthenticationMechanismTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.api.common.security;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import io.quarkus.test.junit.QuarkusTest;
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class HeaderBasedAuthenticationMechanismTest {
+
+  @ApplicationScoped
+  public static class TestingResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/v2/testing")
+    public String greetAuthorized() {
+      return "hello-authorized";
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/testing")
+    public String greet() {
+      return "hello";
+    }
+  }
+
+  @Test
+  public void missingToken() {
+    given()
+        .when()
+        .get("/v2/testing")
+        .then()
+        .statusCode(401)
+        .body("code", is(401))
+        .body(
+            "description",
+            is(
+                "Role unauthorized for operation: Missing token, expecting one in the X-Cassandra-Token header."));
+  }
+
+  @Test
+  public void notProtectedPaths() {
+    given().when().get("/testing").then().statusCode(200);
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/example/ExampleResourceTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/example/ExampleResourceTest.java
@@ -80,7 +80,7 @@ public class ExampleResourceTest extends BridgeTest {
       given()
           .header(Constants.AUTHENTICATION_TOKEN_HEADER_NAME, token)
           .when()
-          .get("/api/v2/example/keyspace-exists/{name}", keyspaceName)
+          .get("/v2/example/keyspace-exists/{name}", keyspaceName)
           .then()
           .statusCode(200)
           .body("name", is(equalTo(keyspaceName)))
@@ -102,11 +102,7 @@ public class ExampleResourceTest extends BridgeTest {
     public void noToken() {
       String keyspaceName = RandomStringUtils.randomAlphanumeric(16);
 
-      given()
-          .when()
-          .get("/api/v2/example/keyspace-exists/{name}", keyspaceName)
-          .then()
-          .statusCode(401);
+      given().when().get("/v2/example/keyspace-exists/{name}", keyspaceName).then().statusCode(401);
 
       verifyNoInteractions(bridgeInterceptor, bridgeService);
     }


### PR DESCRIPTION
**What this PR does**:

Responds with `ApiError` in case of the missing token. In addition fixes the wrong `/api/v2` to `/v2`..

**Which issue(s) this PR fixes**:
Fixes #1839.

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated

