### PR TITLE
Change REST API module and artifact names to "sgv2-restapi" for Stargate V2

### DIFF
--- a/sgv2-restapi/README.md
+++ b/sgv2-restapi/README.md
@@ -14,11 +14,11 @@ and uses standard DropWizard configuration approach.
 
 Project produces a single runnable uber/fat jar like:
 
-    sgv2-restapi/target/sgv2-rest-service-2.0.0-ALPHA-3-SNAPSHOT.jar
+    sgv2-restapi/target/sgv2-restapi-2.0.0-ALPHA-3-SNAPSHOT.jar
 
 which can be run with something like:
 
-    java -jar sgv2-rest-service-2.0.0-ALPHA-3-SNAPSHOT.jar
+    java -jar sgv2-restapi-2.0.0-ALPHA-3-SNAPSHOT.jar
 
 and assumes existence of an already running Stargate V1 instance (to use its gRPC API).
 Jar contains everything needed for running including DropWizard platform
@@ -38,14 +38,14 @@ While the first two are usually packaged into the uber-jar, system properties ar
 ```
 java -Ddw.server.connector.port=8085 \
    -Ddw.stargate.bridge.host=127.0.0.2 -Ddw.stargate.bridge.port=8091 \
-   -jar sgv2-rest-service-2.0.0-ALPHA-3-SNAPSHOT.jar
+   -jar sgv2-restapi-2.0.0-ALPHA-3-SNAPSHOT.jar
 ```
 
 Also note that file `sgv2-restapi/src/main/resources/config.yaml` contains
 explicit values for many things that have defaults in DropWizard default
 `Configuration` or our `RestServiceServerConfiguration`.
 
-Finally, note that linkage between server type "sgv2-rest-service" and actual
+Finally, note that linkage between server type "sgv2-restapi" and actual
 service implementation class is defined by resource file at:
 
     sgv2-restapi/src/main/resources/META-INF/services/io.dropwizard.server.ServerFactory
@@ -66,7 +66,7 @@ For example:
 
 ```
 java -Ddw.server.connector.port=8082 \
-   -jar sgv2-rest-service-v2.0.0-ALPHA-3.jar
+   -jar sgv2-restapi-v2.0.0-ALPHA-3.jar
 
 ```
 

--- a/sgv2-restapi/pom.xml
+++ b/sgv2-restapi/pom.xml
@@ -8,7 +8,7 @@
     <version>2.0.0-ALPHA-11-SNAPSHOT</version>
   </parent>
   <groupId>io.stargate.web</groupId>
-  <artifactId>sgv2-rest-service</artifactId>
+  <artifactId>sgv2-restapi</artifactId>
   <properties>
     <airline.version>2.8.2</airline.version>
     <swagger-ui.version>3.35.0</swagger-ui.version>

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/impl/RestServiceServer.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/impl/RestServiceServer.java
@@ -64,10 +64,9 @@ import org.glassfish.jersey.server.ServerProperties;
 public class RestServiceServer extends Application<RestServiceServerConfiguration> {
   /**
    * Module name is used for example as the prefix for metrics export.
-   *<p>
-   * Note that Stargate V1 had module name of {@code "restapi"}: for V2 we use different
-   * name to allow separating metrics during upgrade process.
-   *</p>
+   *
+   * <p>Note that Stargate V1 had module name of {@code "restapi"}: for V2 we use different name to
+   * allow separating metrics during upgrade process.
    */
   public static final String REST_SVC_MODULE_NAME = "sgv2-restapi";
 

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/impl/RestServiceServer.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/impl/RestServiceServer.java
@@ -62,7 +62,14 @@ import org.glassfish.jersey.server.ServerProperties;
 
 /** DropWizard {@code Application} that will serve Stargate v2 REST service endpoints. */
 public class RestServiceServer extends Application<RestServiceServerConfiguration> {
-  public static final String REST_SVC_MODULE_NAME = "sgv2-rest-service";
+  /**
+   * Module name is used for example as the prefix for metrics export.
+   *<p>
+   * Note that Stargate V1 had module name of {@code "restapi"}: for V2 we use different
+   * name to allow separating metrics during upgrade process.
+   *</p>
+   */
+  public static final String REST_SVC_MODULE_NAME = "sgv2-restapi";
 
   public static final String[] NON_API_URI_REGEX = new String[] {"^/$", "^/health$", "^/swagger.*"};
 

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/impl/RestServiceServerFactory.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/impl/RestServiceServerFactory.java
@@ -30,7 +30,7 @@ import org.eclipse.jetty.util.thread.ThreadPool;
  * @see "META-INF/services/io.dropwizard.server.ServerFactory"
  * @see "config.yaml"
  */
-@JsonTypeName("sgv2-rest-service")
+@JsonTypeName("sgv2-restapi")
 public class RestServiceServerFactory extends SimpleServerFactory {
 
   @Override

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/impl/RestServiceStarter.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/impl/RestServiceStarter.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-@Command(name = "sgv2-rest-service")
+@Command(name = "sgv2-restapi")
 public class RestServiceStarter {
   @Retention(RetentionPolicy.RUNTIME)
   public @interface Order {

--- a/sgv2-restapi/src/main/resources/config.yaml
+++ b/sgv2-restapi/src/main/resources/config.yaml
@@ -1,5 +1,5 @@
 server:
-  type: sgv2-rest-service
+  type: sgv2-restapi
   applicationContextPath: /
   connector:
     type: http

--- a/starctl-service-rest
+++ b/starctl-service-rest
@@ -64,6 +64,6 @@ echo "Starting REST API Service"
 
 declare -a CMD=(java -server)
 CMD+=("${JAVA_OPTS[@]}")
-CMD+=(-jar $STARGATE_HOME/rest/sgv2-rest-service*.jar)
+CMD+=(-jar $STARGATE_HOME/rest/sgv2-rest*.jar)
 echo "Running" "${CMD[@]}"
 exec "${CMD[@]}"

--- a/testing/src/main/java/io/stargate/it/http/ApiServiceParameters.java
+++ b/testing/src/main/java/io/stargate/it/http/ApiServiceParameters.java
@@ -69,7 +69,7 @@ public interface ApiServiceParameters {
   String serviceLibDirProperty();
 
   @Value.Parameter
-  // example: "sgv2-rest-service"
+  // example: "sgv2-restapi"
   String serviceJarBase();
 
   /** The arguments to pass to the service starter class. */

--- a/testing/src/main/java/io/stargate/it/http/BaseRestApiTest.java
+++ b/testing/src/main/java/io/stargate/it/http/BaseRestApiTest.java
@@ -19,7 +19,7 @@ public class BaseRestApiTest extends BaseIntegrationTest {
     builder.metricsPort(8082);
     builder.serviceStartedMessage("Started RestServiceServer");
     builder.serviceLibDirProperty("stargate.rest.libdir");
-    builder.serviceJarBase("sgv2-rest-service");
+    builder.serviceJarBase("sgv2-restapi");
     builder.bridgeHostPropertyName("dw.stargate.bridge.host");
     builder.bridgePortPropertyName("dw.stargate.bridge.port");
   }

--- a/testing/src/main/java/io/stargate/it/http/RestApiMetricsTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiMetricsTest.java
@@ -217,7 +217,7 @@ public class RestApiMetricsTest extends BaseRestApiTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"sgv2_rest_service"})
+  @ValueSource(strings = {"sgv2_restapi"})
   public void dropwizardMetricsModule(String module) throws IOException {
     String[] expectedMetricGroups =
         new String[] {"TimeBoundHealthCheck", "io_dropwizard_jersey", "org_eclipse_jetty"};

--- a/testing/src/main/java/io/stargate/it/http/RestApiMetricsTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiMetricsTest.java
@@ -107,7 +107,7 @@ public class RestApiMetricsTest extends BaseRestApiTest {
                           assertThat(metric)
                               .contains("method=\"GET\"")
                               // NOTE! Hyphens remain and are NOT converted to underscores
-                              .contains("module=\"sgv2-rest-service\"")
+                              .contains("module=\"sgv2-restapi\"")
                               .contains("uri=\"/v2/schemas/keyspaces\"")
                               .contains(String.format("status=\"%d\"", status))
                               // 13-Jan-2022, tatu: As mentioned above, no tags yet
@@ -119,7 +119,7 @@ public class RestApiMetricsTest extends BaseRestApiTest {
                       metric ->
                           assertThat(metric)
                               .contains("method=\"GET\"")
-                              .contains("module=\"sgv2-rest-service\"")
+                              .contains("module=\"sgv2-restapi\"")
                               .contains("uri=\"/v2/schemas/keyspaces\"")
                               .contains(String.format("status=\"%d\"", status))
                               // 13-Jan-2022, tatu: As mentioned above, no tags yet
@@ -139,7 +139,7 @@ public class RestApiMetricsTest extends BaseRestApiTest {
                       metric ->
                           assertThat(metric)
                               .contains("error=\"false\"")
-                              .contains("module=\"sgv2-rest-service\"")
+                              .contains("module=\"sgv2-restapi\"")
                               .doesNotContain("method=\"GET\"")
                               .doesNotContain("uri=\"/v2/schemas/keyspaces\"")
                               .doesNotContain(String.format("status=\"%d\"", status))
@@ -179,7 +179,7 @@ public class RestApiMetricsTest extends BaseRestApiTest {
                       metric ->
                           assertThat(metric)
                               .contains("method=\"GET\"")
-                              .contains("module=\"sgv2-rest-service-other\"")
+                              .contains("module=\"sgv2-restapi-other\"")
                               .contains("uri=\"root\"")
                               .contains(String.format("status=\"%d\"", status))
                               // 13-Jan-2022, tatu: As mentioned above, no tags yet
@@ -190,7 +190,7 @@ public class RestApiMetricsTest extends BaseRestApiTest {
                       metric ->
                           assertThat(metric)
                               .contains("method=\"GET\"")
-                              .contains("module=\"sgv2-rest-service-other\"")
+                              .contains("module=\"sgv2-restapi-other\"")
                               .contains("uri=\"root\"")
                               .contains(String.format("status=\"%d\"", status))
                               // 13-Jan-2022, tatu: As mentioned above, no tags yet
@@ -209,7 +209,7 @@ public class RestApiMetricsTest extends BaseRestApiTest {
                       metric ->
                           assertThat(metric)
                               .contains("error=\"false\"")
-                              .contains("module=\"sgv2-rest-service-other\"")
+                              .contains("module=\"sgv2-restapi-other\"")
                               .doesNotContain("method=\"GET\"")
                               .doesNotContain("uri=\"root\"")
                               .doesNotContain(String.format("status=\"%d\"", status)));


### PR DESCRIPTION
**What this PR does**:

Changes module name and artifact id (jar base name) used for REST API in Stargate V2: convention here is to add prefix of `sgv2-` to indicate Stargate major version; but since API itself does not change (and no version indicated with Stargate V1), leave that part as-is.
So basically change from

    sgv2-rest-service

to

    sgv2-restapi 

Graphql already uses this approach; Documents API was bundled with REST API in SGv1 do so that is slightly different but will likely follow this convention as well.

This change needs to be done now before we start installing things: earlier ALPHA releases will have old name but that should be ok.

**Which issue(s) this PR fixes**:
No issue filed.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
