### PR TITLE
fixing dependency index for the guava usage

### DIFF
--- a/sgv2-docsapi/src/main/resources/application.yaml
+++ b/sgv2-docsapi/src/main/resources/application.yaml
@@ -91,6 +91,12 @@ quarkus:
           paths: /v2/*
           policy: authenticated
 
+  # Jandex index properties
+  index-dependency:
+    google-guava:
+      group-id: com.google.guava
+      artifact-id: guava
+
   # built-in micrometer properties
   micrometer:
     binder:


### PR DESCRIPTION
**What this PR does**:

Soles the warning:

```
[WARNING] [io.quarkus.deployment.steps.ReflectiveHierarchyStep] Unable to properly register the hierarchy of the following classes for reflection as they are not in the Jandex index:
    - com.google.common.collect.ImmutableList (source: JacksonProcessor > io.stargate.sgv2.docsapi.models.ExecutionProfile)
Consider adding them to the index either by creating a Jandex index for your dependency via the Maven plugin, an empty META-INF/beans.xml or quarkus.index-dependency properties.
```

It's caused because `immutables` use `guava`.

**Which issue(s) this PR fixes**:
No issue.