### PR TITLE
relates to #1737: proper way to skip integration tests

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -54,7 +54,7 @@ echoinfo "Testing Java 17 projects"
 
 cd sgv2-docsapi/
 JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./mvnw -B verify --file ./pom.xml \
--P \!int-tests \
+-DskipIntTests \
 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 cd ../
 

--- a/sgv2-docsapi/README.md
+++ b/sgv2-docsapi/README.md
@@ -127,10 +127,10 @@ Running a test with a different version of the data store or the Stargate coordi
 
 #### Skipping integration tests
 
-You can skip the integration tests during the maven build by disabling the `int-tests` profile:
+You can skip the integration tests during the maven build by disabling the `int-tests` profile using the `-DskipIntTests` property:
 
 ```shell script
-./mvnw verify -P \!int-tests
+./mvnw verify -DskipIntTests
 ```
 
 ### Packaging and running the application

--- a/sgv2-docsapi/pom.xml
+++ b/sgv2-docsapi/pom.xml
@@ -332,7 +332,10 @@
     <profile>
       <id>int-tests</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>skipIntTests</name>
+          <value>!true</value>
+        </property>
       </activation>
       <build>
         <plugins>


### PR DESCRIPTION
**What this PR does**:
Unfortunately, the `int-test` profile was [activated by default](https://maven.apache.org/guides/introduction/introduction-to-profiles.html#details-on-profile-activation), which means it would be deactivated if any other profile was active. This means that if I wanted to run verification with another data store like:

```
./mvnw verify -DskipIntTests
```

It would actually not run the integration tests. 

The fix is simple, just adding a dedicated property

**Which issue(s) this PR fixes**:
Relates to #1737 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
