### PR TITLE
closes #1862: making resume mode on the bridge optional

### DIFF
--- a/bridge-proto/proto/query.proto
+++ b/bridge-proto/proto/query.proto
@@ -50,6 +50,11 @@ message ConsistencyValue {
   Consistency value = 1;
 }
 
+// A wrapper message for ResumeMode, for cases where the mode can be unset.
+message ResumeModeValue {
+  ResumeMode value = 1;
+}
+
 // A CQL value for a collection type.
 // For lists, sets and tuples, this contains the collection elements.
 // For maps, this contains the key and values in order (e.g. key1, value1, key2, value2...)
@@ -237,7 +242,7 @@ message QueryParameters {
   // Configurable resume mode for page state creation; only used when enriched = true.
   // Changes the way that paging state is generated on each row of the result set, during enrichment.
   // If unset, the paging state will not be populated for each row.
-  ResumeMode resumeMode = 12;
+  ResumeModeValue resumeMode = 12;
 }
 
 // A CQL column type.

--- a/bridge/src/main/java/io/stargate/bridge/service/QueryHandler.java
+++ b/bridge/src/main/java/io/stargate/bridge/service/QueryHandler.java
@@ -158,14 +158,18 @@ public class QueryHandler extends MessageHandler<Query, Prepared> {
       Row row,
       QueryOuterClass.ResumeMode resumeMode,
       boolean lastInPage) {
-    if (lastInPage && resultSetPagingState == null) {
-      return EXHAUSTED_PAGE_STATE;
-    }
 
+    // if we don't have resume mode, return null
     if (resumeMode == QueryOuterClass.ResumeMode.UNRECOGNIZED) {
       return null;
     }
 
+    // otherwise, if last and no paging state exhausted
+    if (lastInPage && resultSetPagingState == null) {
+      return EXHAUSTED_PAGE_STATE;
+    }
+
+    // otherwise resolve to internal and make
     PagingPosition.ResumeMode internalResumeMode = PagingPosition.ResumeMode.NEXT_ROW;
     if (resumeMode == QueryOuterClass.ResumeMode.NEXT_PARTITION) {
       internalResumeMode = PagingPosition.ResumeMode.NEXT_PARTITION;

--- a/bridge/src/main/java/io/stargate/bridge/service/QueryHandler.java
+++ b/bridge/src/main/java/io/stargate/bridge/service/QueryHandler.java
@@ -160,7 +160,7 @@ public class QueryHandler extends MessageHandler<Query, Prepared> {
       boolean lastInPage) {
 
     // if we don't have resume mode, return null
-    if (resumeMode == QueryOuterClass.ResumeMode.UNRECOGNIZED) {
+    if (resumeMode == null || resumeMode == QueryOuterClass.ResumeMode.UNRECOGNIZED) {
       return null;
     }
 

--- a/bridge/src/main/java/io/stargate/bridge/service/ValuesHelper.java
+++ b/bridge/src/main/java/io/stargate/bridge/service/ValuesHelper.java
@@ -123,26 +123,12 @@ public class ValuesHelper {
 
   public static ResultSet processResult(Rows rows, QueryParameters parameters)
       throws StatusException {
-    return processResult(
-        rows,
-        parameters.getSkipMetadata(),
-        null,
-        null,
-        null,
-        null,
-        QueryOuterClass.ResumeMode.UNRECOGNIZED);
+    return processResult(rows, parameters.getSkipMetadata(), null, null, null, null, null);
   }
 
   public static ResultSet processResult(Rows rows, BatchParameters parameters)
       throws StatusException {
-    return processResult(
-        rows,
-        parameters.getSkipMetadata(),
-        null,
-        null,
-        null,
-        null,
-        QueryOuterClass.ResumeMode.UNRECOGNIZED);
+    return processResult(rows, parameters.getSkipMetadata(), null, null, null, null, null);
   }
 
   public interface GetComparableBytesFromRow {
@@ -168,9 +154,7 @@ public class ValuesHelper {
       throws StatusException {
 
     QueryOuterClass.ResumeMode resumeMode =
-        parameters.hasResumeMode()
-            ? parameters.getResumeMode().getValue()
-            : QueryOuterClass.ResumeMode.UNRECOGNIZED;
+        parameters.hasResumeMode() ? parameters.getResumeMode().getValue() : null;
     return processResult(
         rows,
         parameters.getSkipMetadata(),

--- a/bridge/src/main/java/io/stargate/bridge/service/ValuesHelper.java
+++ b/bridge/src/main/java/io/stargate/bridge/service/ValuesHelper.java
@@ -166,6 +166,11 @@ public class ValuesHelper {
       BiFunction<List<Column>, List<ByteBuffer>, io.stargate.db.datastore.Row> makeRow,
       RowDecorator rowDecorator)
       throws StatusException {
+
+    QueryOuterClass.ResumeMode resumeMode =
+        parameters.hasResumeMode()
+            ? parameters.getResumeMode().getValue()
+            : QueryOuterClass.ResumeMode.UNRECOGNIZED;
     return processResult(
         rows,
         parameters.getSkipMetadata(),
@@ -173,7 +178,7 @@ public class ValuesHelper {
         getPagingState,
         makeRow,
         rowDecorator,
-        parameters.getResumeMode());
+        resumeMode);
   }
 
   private static ResultSet processResult(

--- a/testing/src/main/java/io/stargate/it/bridge/EnrichedQueryTest.java
+++ b/testing/src/main/java/io/stargate/it/bridge/EnrichedQueryTest.java
@@ -24,87 +24,163 @@ import io.stargate.bridge.proto.StargateBridgeGrpc.StargateBridgeBlockingStub;
 import io.stargate.it.driver.CqlSessionExtension;
 import io.stargate.it.driver.CqlSessionSpec;
 import io.stargate.it.driver.TestKeyspace;
+import java.util.List;
+import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(CqlSessionExtension.class)
 @CqlSessionSpec(
     initQueries = {
-      "CREATE TABLE data(id int PRIMARY KEY, x1 text, x2 text, value int);",
+      "CREATE TABLE data(id int, x1 text, x2 text, value int, PRIMARY KEY ((id), x1));",
       "INSERT INTO data(id, x1, x2, value) values (1, 'a', 'b', 20);",
-      "INSERT INTO data(id, x1, x2, value) values (2, 'a', 'b', 30);",
-      "INSERT INTO data(id, x1, x2, value) values (3, 'a', 'b', 40);",
-      "INSERT INTO data(id, x1, x2, value) values (4, 'a', 'b', 50);",
-      "INSERT INTO data(id, x1, x2, value) values (5, 'a', 'b', 60);",
+      "INSERT INTO data(id, x1, x2, value) values (1, 'b', 'b', 30);",
+      "INSERT INTO data(id, x1, x2, value) values (2, 'a', 'b', 40);",
+      "INSERT INTO data(id, x1, x2, value) values (3, 'a', 'b', 50);",
+      "INSERT INTO data(id, x1, x2, value) values (4, 'a', 'b', 60);",
     })
 public class EnrichedQueryTest extends BridgeIntegrationTest {
 
   @Test
-  public void getEnrichedDataFromRows(@TestKeyspace CqlIdentifier keyspace) {
+  public void enriched(@TestKeyspace CqlIdentifier keyspace) {
     StargateBridgeBlockingStub stub = stubWithCallCredentials();
 
     QueryOuterClass.Response response =
         stub.executeQuery(
             cqlQuery("SELECT * FROM data;", queryParameters(keyspace).setEnriched(true)));
-    assertThat(response).isNotNull();
+
     QueryOuterClass.ResultSet rs = response.getResultSet();
-    assertThat(rs.getRowsCount()).isEqualTo(5);
-    for (int i = 0; i < 5; i++) {
-      QueryOuterClass.Row r = rs.getRows(i);
-      assertThat(r.getComparableBytes()).isNotNull();
-      assertThat(r.getPagingState()).isNotNull();
-      if (i < 4) {
-        assertThat(r.getPagingState().getValue().toByteArray().length).isGreaterThan(0);
-      } else {
-        assertThat(r.getPagingState().getValue().toByteArray().length).isEqualTo(0);
-      }
-      assertThat(r.getValuesCount()).isEqualTo(4);
-    }
+    assertThat(rs.getRowsList())
+        .hasSize(5)
+        .allSatisfy(
+            r -> {
+              assertThat(r.hasComparableBytes()).isTrue();
+              assertThat(r.hasPagingState()).isFalse();
+              assertThat(r.getValuesCount()).isEqualTo(4);
+            });
   }
 
   @Test
-  public void getEnrichedDataUsingPagination(@TestKeyspace CqlIdentifier keyspace) {
+  public void enrichedNextRow(@TestKeyspace CqlIdentifier keyspace) {
     StargateBridgeBlockingStub stub = stubWithCallCredentials();
 
+    QueryOuterClass.ResumeModeValue.Builder resumeMode =
+        QueryOuterClass.ResumeModeValue.newBuilder().setValue(QueryOuterClass.ResumeMode.NEXT_ROW);
     QueryOuterClass.Response response =
-        stub.executeQuery(
-            cqlQuery("SELECT * FROM data;", queryParameters(keyspace).setEnriched(true)));
-    assertThat(response).isNotNull();
-    QueryOuterClass.ResultSet rs = response.getResultSet();
-    assertThat(rs.getRowsCount()).isEqualTo(5);
-    BytesValue thirdRow = rs.getRows(2).getPagingState();
-
-    QueryOuterClass.Response response2 =
         stub.executeQuery(
             cqlQuery(
                 "SELECT * FROM data;",
-                queryParameters(keyspace).setPagingState(thirdRow).setEnriched(true)));
+                queryParameters(keyspace).setEnriched(true).setResumeMode(resumeMode)));
 
+    QueryOuterClass.ResultSet rs = response.getResultSet();
+    assertThat(rs.getRowsList()).hasSize(5);
+    assertThat(rs.getRowsList().subList(0, 4))
+        .allSatisfy(
+            r -> {
+              assertThat(r.hasComparableBytes()).isTrue();
+              assertThat(r.hasPagingState()).isTrue();
+              assertThat(r.getPagingState().toByteString().toByteArray()).isNotEmpty();
+              assertThat(r.getValuesCount()).isEqualTo(4);
+            });
+    assertThat(rs.getRowsList().get(4))
+        .satisfies(
+            r -> {
+              assertThat(r.hasComparableBytes()).isTrue();
+              assertThat(r.hasPagingState()).isTrue();
+              assertThat(r.getPagingState().toByteString().toByteArray()).isEmpty();
+              assertThat(r.getValuesCount()).isEqualTo(4);
+            });
+
+    // let's get first row paging state
+    BytesValue firstRow = rs.getRows(0).getPagingState();
+    QueryOuterClass.Response response2 =
+        stub.executeQuery(
+            cqlQuery("SELECT * FROM data;", queryParameters(keyspace).setPagingState(firstRow)));
+
+    // as it's next row it should have 4 elements
     QueryOuterClass.ResultSet rs2 = response2.getResultSet();
-    assertThat(rs2.getRowsCount()).isEqualTo(2);
-
-    assertThat(rs2.getRows(0).getValues(0)).isEqualTo(rs.getRows(3).getValues(0));
-    assertThat(rs2.getRows(1).getValues(0)).isEqualTo(rs.getRows(4).getValues(0));
-
-    BytesValue lastRow = rs2.getRows(1).getPagingState();
-    assertThat(lastRow.getValue().toByteArray().length).isEqualTo(0);
+    int valueIndex = indexOf(rs.getColumnsList(), "value");
+    assertThat(rs2.getRowsList())
+        .hasSize(4)
+        .extracting(r -> r.getValues(valueIndex).getInt())
+        .contains(30L, 40L, 50L, 60L);
   }
 
   @Test
-  public void getNoEnrichedData(@TestKeyspace CqlIdentifier keyspace) {
+  public void enrichedNextPartition(@TestKeyspace CqlIdentifier keyspace) {
+    StargateBridgeBlockingStub stub = stubWithCallCredentials();
+
+    QueryOuterClass.ResumeModeValue.Builder resumeMode =
+        QueryOuterClass.ResumeModeValue.newBuilder()
+            .setValue(QueryOuterClass.ResumeMode.NEXT_PARTITION);
+    QueryOuterClass.Response response =
+        stub.executeQuery(
+            cqlQuery(
+                "SELECT * FROM data;",
+                queryParameters(keyspace).setEnriched(true).setResumeMode(resumeMode)));
+
+    QueryOuterClass.ResultSet rs = response.getResultSet();
+    assertThat(rs.getRowsList()).hasSize(5);
+    assertThat(rs.getRowsList().subList(0, 4))
+        .allSatisfy(
+            r -> {
+              assertThat(r.hasComparableBytes()).isTrue();
+              assertThat(r.hasPagingState()).isTrue();
+              assertThat(r.getPagingState().toByteString().toByteArray()).isNotEmpty();
+              assertThat(r.getValuesCount()).isEqualTo(4);
+            });
+    assertThat(rs.getRowsList().get(4))
+        .satisfies(
+            r -> {
+              assertThat(r.hasComparableBytes()).isTrue();
+              assertThat(r.hasPagingState()).isTrue();
+              assertThat(r.getPagingState().toByteString().toByteArray()).isEmpty();
+              assertThat(r.getValuesCount()).isEqualTo(4);
+            });
+
+    // let's get first row paging state
+    BytesValue firstRow = rs.getRows(0).getPagingState();
+    QueryOuterClass.Response response2 =
+        stub.executeQuery(
+            cqlQuery("SELECT * FROM data;", queryParameters(keyspace).setPagingState(firstRow)));
+
+    // as it's next partition it should skip one row in same partition
+    QueryOuterClass.ResultSet rs2 = response2.getResultSet();
+    int idIndex = indexOf(rs.getColumnsList(), "id");
+    assertThat(rs2.getRowsList())
+        .hasSize(3)
+        .extracting(r -> r.getValues(idIndex).getInt())
+        .contains(2L, 3L, 4L);
+  }
+
+  @Test
+  public void notEnriched(@TestKeyspace CqlIdentifier keyspace) {
     StargateBridgeBlockingStub stub = stubWithCallCredentials();
 
     QueryOuterClass.Response response =
         stub.executeQuery(
             cqlQuery("SELECT * FROM data;", queryParameters(keyspace).setEnriched(false)));
+
     assertThat(response).isNotNull();
+
     QueryOuterClass.ResultSet rs = response.getResultSet();
-    assertThat(rs.getRowsCount()).isEqualTo(5);
-    for (int i = 0; i < 5; i++) {
-      QueryOuterClass.Row r = rs.getRows(i);
-      assertThat(r.hasComparableBytes()).isFalse();
-      assertThat(r.hasPagingState()).isFalse();
-      assertThat(r.getValuesCount()).isEqualTo(4);
+    assertThat(rs.getRowsList())
+        .hasSize(5)
+        .allSatisfy(
+            r -> {
+              assertThat(r.hasComparableBytes()).isFalse();
+              assertThat(r.hasPagingState()).isFalse();
+              assertThat(r.getValuesCount()).isEqualTo(4);
+            });
+  }
+
+  private int indexOf(List<QueryOuterClass.ColumnSpec> columnsList, String column) {
+    for (int i = 0; i < columnsList.size(); i++) {
+      if (Objects.equals(column, columnsList.get(i).getName())) {
+        return i;
+      }
     }
+    throw new IllegalArgumentException(
+        String.format("Can not find column %s in the column list %s", column, columnsList));
   }
 }


### PR DESCRIPTION
**What this PR does**:
The https://github.com/stargate/stargate/pull/1863 did not make the `ResumeMode` to be optional. In order to support, I wrapped it into a value wrapper.. The same strategy was used for other things as I can see.

I also completely refactored tests to correctly assert on multiply different cases we need to cover..

**Which issue(s) this PR fixes**:
Fixes #1862

cc @EricBorczuk @mpenick 