### PR TITLE
Initial implementation of Host-to-tenant metrics tagger

### DIFF
--- a/metrics-jersey/src/main/java/io/stargate/metrics/jersey/sgv2/MetricsBinderWithTenantId.java
+++ b/metrics-jersey/src/main/java/io/stargate/metrics/jersey/sgv2/MetricsBinderWithTenantId.java
@@ -31,7 +31,7 @@ public class MetricsBinderWithTenantId extends MetricsBinder {
     List<JerseyTagsProvider> providers =
         super.getMeterTagsProviders(
             config, metrics, httpMetricsTagProvider, module, nonApiUriRegexes);
-    //      providers.add(new MyTagsProvider());
+    providers.add(new TenantIdFromHostHeaderTagsProvider());
     return providers;
   }
 
@@ -45,7 +45,7 @@ public class MetricsBinderWithTenantId extends MetricsBinder {
     List<JerseyTagsProvider> providers =
         super.getCounterTagsProviders(
             config, metrics, httpMetricsTagProvider, module, nonApiUriRegexes);
-    //      providers.add(new MyTagsProvider());
+    providers.add(new TenantIdFromHostHeaderTagsProvider());
     return providers;
   }
 }

--- a/metrics-jersey/src/main/java/io/stargate/metrics/jersey/sgv2/MetricsBinderWithTenantId.java
+++ b/metrics-jersey/src/main/java/io/stargate/metrics/jersey/sgv2/MetricsBinderWithTenantId.java
@@ -1,0 +1,51 @@
+package io.stargate.metrics.jersey.sgv2;
+
+import io.micrometer.jersey2.server.JerseyTagsProvider;
+import io.stargate.core.metrics.api.HttpMetricsTagProvider;
+import io.stargate.core.metrics.api.Metrics;
+import io.stargate.metrics.jersey.MetricsBinder;
+import io.stargate.metrics.jersey.config.MetricsListenerConfig;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Extension of {@link MetricsBinder} which adds Tenant Id tag(s) extracted using {@link
+ * TenantIdFromHostHeaderTagsProvider}.
+ */
+public class MetricsBinderWithTenantId extends MetricsBinder {
+  public MetricsBinderWithTenantId(
+      Metrics metrics,
+      HttpMetricsTagProvider httpMetricsTagProvider,
+      String moduleName,
+      Collection<String> nonApiUriRegexes) {
+    super(metrics, httpMetricsTagProvider, moduleName, nonApiUriRegexes);
+  }
+
+  @Override
+  protected List<JerseyTagsProvider> getMeterTagsProviders(
+      MetricsListenerConfig config,
+      Metrics metrics,
+      HttpMetricsTagProvider httpMetricsTagProvider,
+      String module,
+      Collection<String> nonApiUriRegexes) {
+    List<JerseyTagsProvider> providers =
+        super.getMeterTagsProviders(
+            config, metrics, httpMetricsTagProvider, module, nonApiUriRegexes);
+    //      providers.add(new MyTagsProvider());
+    return providers;
+  }
+
+  @Override
+  protected List<JerseyTagsProvider> getCounterTagsProviders(
+      MetricsListenerConfig config,
+      Metrics metrics,
+      HttpMetricsTagProvider httpMetricsTagProvider,
+      String module,
+      Collection<String> nonApiUriRegexes) {
+    List<JerseyTagsProvider> providers =
+        super.getCounterTagsProviders(
+            config, metrics, httpMetricsTagProvider, module, nonApiUriRegexes);
+    //      providers.add(new MyTagsProvider());
+    return providers;
+  }
+}

--- a/metrics-jersey/src/main/java/io/stargate/metrics/jersey/sgv2/TenantIdFromHostHeaderTagsProvider.java
+++ b/metrics-jersey/src/main/java/io/stargate/metrics/jersey/sgv2/TenantIdFromHostHeaderTagsProvider.java
@@ -1,0 +1,77 @@
+package io.stargate.metrics.jersey.sgv2;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.jersey2.server.JerseyTagsProvider;
+import java.util.Collections;
+import javax.ws.rs.core.MultivaluedMap;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.monitoring.RequestEvent;
+
+/** Specialized {@link JerseyTagsProvider} used to extract Tenant Id from "Host" HTTP header. */
+public class TenantIdFromHostHeaderTagsProvider implements JerseyTagsProvider {
+  private static final String DEFAULT_TENANT_TAG_KEY = "tenant";
+
+  private final String tenantTagName;
+
+  /** Tags when tenant is unknown. */
+  private final Tags tagsForUnknown;
+
+  public TenantIdFromHostHeaderTagsProvider() {
+    this(DEFAULT_TENANT_TAG_KEY);
+  }
+
+  /**
+   * @param tenantTagName Tag name to use for Tenant Id, if any; {@code null} or empty String to
+   *     disable extraction
+   */
+  public TenantIdFromHostHeaderTagsProvider(String tenantTagName) {
+    if (tenantTagName == null || tenantTagName.isEmpty()) {
+      this.tenantTagName = null;
+      tagsForUnknown = null;
+    } else {
+      this.tenantTagName = tenantTagName;
+      tagsForUnknown = Tags.of(tenantTagName, "unknown");
+    }
+  }
+
+  @Override
+  public Iterable<Tag> httpRequestTags(RequestEvent event) {
+    return findHostTag(event);
+  }
+
+  @Override
+  public Iterable<Tag> httpLongRequestTags(RequestEvent event) {
+    return findHostTag(event);
+  }
+
+  protected Iterable<Tag> findHostTag(RequestEvent event) {
+    if (tenantTagName == null) {
+      return Collections.emptyList();
+    }
+    ContainerRequest request = event.getContainerRequest();
+    MultivaluedMap<String, String> headers = request.getHeaders();
+
+    // HTTP header names are case-insensitive but MultivaluedMap is case-sensitive
+    // try out commonly used cases
+    String value = headers.getFirst("Host");
+    if (value == null) {
+      value = headers.getFirst("host");
+    }
+    if (value != null) {
+      if (isValidTenantId(value)) {
+        return Tags.of(tenantTagName, trimTenantId(value));
+      }
+    }
+    return tagsForUnknown;
+  }
+
+  protected boolean isValidTenantId(String id) {
+    // Should we enforce minimum 36-character length?
+    return id.length() > 0;
+  }
+
+  protected String trimTenantId(String id) {
+    return (id.length() <= 36) ? id : id.substring(0, 36);
+  }
+}

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/impl/RestServiceServer.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/impl/RestServiceServer.java
@@ -29,6 +29,7 @@ import io.stargate.core.metrics.api.HttpMetricsTagProvider;
 import io.stargate.core.metrics.api.Metrics;
 import io.stargate.core.metrics.api.MetricsScraper;
 import io.stargate.metrics.jersey.MetricsBinder;
+import io.stargate.metrics.jersey.sgv2.MetricsBinderWithTenantId;
 import io.stargate.sgv2.common.grpc.StargateBridgeClient;
 import io.stargate.sgv2.common.grpc.StargateBridgeClientFactory;
 import io.stargate.sgv2.common.http.CreateStargateBridgeClientFilter;
@@ -162,7 +163,7 @@ public class RestServiceServer extends Application<RestServiceServerConfiguratio
     enableCors(environment);
 
     final MetricsBinder metricsBinder =
-        new MetricsBinder(
+        new MetricsBinderWithTenantId(
             metrics,
             httpMetricsTagProvider,
             REST_SVC_MODULE_NAME,

--- a/testing/src/main/java/io/stargate/it/http/RestApiMetricsTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiMetricsTest.java
@@ -36,8 +36,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
- * Leftover test class from Stargate V1 which contains tests against modules that have not yet been
- * extracted out of the Coordinator monolith.
+ * Tests from Stargate V1 that exercise refactored REST API metrics; refactored from earlier
+ * monolithic {@code MetricsTest}.
  */
 @NotThreadSafe
 @StargateSpec()

--- a/testing/src/main/java/io/stargate/it/http/RestApiMetricsTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiMetricsTest.java
@@ -51,13 +51,7 @@ public class RestApiMetricsTest extends BaseRestApiTest {
   @SuppressWarnings("unused") // referenced in @StargateSpec
   public static void buildApiServiceParameters(ApiServiceParameters.Builder builder) {
     BaseRestApiTest.buildApiServiceParameters(builder);
-    // 13-Jan-2022, tatu: In StargateV1 HTTP Tag Provider is registered using OSGi.
-    //    SGv2 does not have equivalent mechanism implemented yet, so tag functionality
-    //    NOT verified currently.
-    /*builder.putSystemProperties(
-    TestingServicesActivator.HTTP_TAG_PROVIDER_PROPERTY,
-    TestingServicesActivator.TAG_ME_HTTP_TAG_PROVIDER); */
-    // This does not seem to do anything (triggered at wrong point)?
+    // These are still needed:
     builder.putSystemProperties("stargate.metrics.http_server_requests_percentiles", "0.95,0.99");
     builder.putSystemProperties(
         "stargate.metrics.http_server_requests_path_param_tags", "keyspaceName");

--- a/testing/src/main/java/io/stargate/it/http/RestApiMetricsTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiMetricsTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import io.stargate.it.storage.StargateSpec;
-import io.stargate.testing.metrics.TagMeHttpMetricsTagProvider;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
@@ -68,6 +67,8 @@ public class RestApiMetricsTest extends BaseRestApiTest {
   //    NOT verified currently.
   @Test
   public void restApiHttpRequestMetrics() throws IOException {
+    final String TEST_UUID = "2f689a6f-82d7-4728-b956-b0dff00eda23";
+
     // call the rest api path with target header
     String path = String.format("%s/v2/schemas/keyspaces", restUrlBase);
     OkHttpClient client = new OkHttpClient().newBuilder().build();
@@ -75,7 +76,8 @@ public class RestApiMetricsTest extends BaseRestApiTest {
         new Request.Builder()
             .url(path)
             .get()
-            .addHeader(TagMeHttpMetricsTagProvider.TAG_ME_HEADER, "test-value")
+            // This should become "tenant" tag
+            .addHeader("Host", TEST_UUID)
             .build();
 
     int status = execute(client, request);
@@ -104,9 +106,7 @@ public class RestApiMetricsTest extends BaseRestApiTest {
                               .contains("module=\"sgv2-restapi\"")
                               .contains("uri=\"/v2/schemas/keyspaces\"")
                               .contains(String.format("status=\"%d\"", status))
-                              // 13-Jan-2022, tatu: As mentioned above, no tags yet
-                              // .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY +
-                              // "=\"test-value\"")
+                              .contains("tenant=\"" + TEST_UUID + "\"")
                               .contains("quantile=\"0.95\"")
                               .doesNotContain("error"))
                   .anySatisfy(
@@ -116,9 +116,7 @@ public class RestApiMetricsTest extends BaseRestApiTest {
                               .contains("module=\"sgv2-restapi\"")
                               .contains("uri=\"/v2/schemas/keyspaces\"")
                               .contains(String.format("status=\"%d\"", status))
-                              // 13-Jan-2022, tatu: As mentioned above, no tags yet
-                              // .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY +
-                              // "=\"test-value\"")
+                              .contains("tenant=\"" + TEST_UUID + "\"")
                               .contains("quantile=\"0.99\"")
                               .doesNotContain("error"));
 
@@ -137,20 +135,25 @@ public class RestApiMetricsTest extends BaseRestApiTest {
                               .doesNotContain("method=\"GET\"")
                               .doesNotContain("uri=\"/v2/schemas/keyspaces\"")
                               .doesNotContain(String.format("status=\"%d\"", status))
-                      // 13-Jan-2022, tatu: As mentioned above, no tags yet
-                      // .doesNotContain(
-                      //    TagMeHttpMetricsTagProvider.TAG_ME_KEY + "=\"test-value\"")
-                      );
+                              .contains("tenant=\"" + TEST_UUID + "\""));
             });
   }
 
   // from [#1660] (PR [#1662]) ("non-api endpoint metrics to be reported with different")
   @Test
   public void restNonApiHttpRequestMetrics() throws IOException {
+    final String TEST_UUID = "4ded57a2-5324-4e82-a881-d9d777672a91";
+
     // call the rest api path with target header
     String path = String.format("%s", metricsUrlBase);
     OkHttpClient client = new OkHttpClient().newBuilder().build();
-    Request request = new Request.Builder().url(path).get().build();
+    Request request =
+        new Request.Builder()
+            .url(path)
+            .get()
+            // This should become "tenant" tag (note: here we pass lower-case)
+            .addHeader("host", TEST_UUID)
+            .build();
 
     int status = execute(client, request);
 
@@ -176,8 +179,7 @@ public class RestApiMetricsTest extends BaseRestApiTest {
                               .contains("module=\"sgv2-restapi-other\"")
                               .contains("uri=\"root\"")
                               .contains(String.format("status=\"%d\"", status))
-                              // 13-Jan-2022, tatu: As mentioned above, no tags yet
-                              // .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY)
+                              .contains("tenant=\"" + TEST_UUID + "\"")
                               .contains("quantile=\"0.95\"")
                               .doesNotContain("error"))
                   .anySatisfy(
@@ -187,8 +189,7 @@ public class RestApiMetricsTest extends BaseRestApiTest {
                               .contains("module=\"sgv2-restapi-other\"")
                               .contains("uri=\"root\"")
                               .contains(String.format("status=\"%d\"", status))
-                              // 13-Jan-2022, tatu: As mentioned above, no tags yet
-                              // .contains(TagMeHttpMetricsTagProvider.TAG_ME_KEY)
+                              .contains("tenant=\"" + TEST_UUID + "\"")
                               .contains("quantile=\"0.99\""))
                   .doesNotContain("error");
 
@@ -206,7 +207,8 @@ public class RestApiMetricsTest extends BaseRestApiTest {
                               .contains("module=\"sgv2-restapi-other\"")
                               .doesNotContain("method=\"GET\"")
                               .doesNotContain("uri=\"root\"")
-                              .doesNotContain(String.format("status=\"%d\"", status)));
+                              .doesNotContain(String.format("status=\"%d\"", status))
+                              .contains("tenant=\"" + TEST_UUID + "\""));
             });
   }
 


### PR DESCRIPTION
**What this PR does**:

Adds equivalent Host/tenant Metrics tag for SGv2/REST API as what SGv1/REST does (although in slightly simpler way)

**Which issue(s) this PR fixes**:
Fixes #1565

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
