### PR TITLE
 relates to #1738: queries for the document reads adapted for V2

### DIFF
--- a/sgv2-docsapi/pom.xml
+++ b/sgv2-docsapi/pom.xml
@@ -109,6 +109,10 @@
       <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
       <version>2.9.0</version>

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/condition/BaseCondition.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/condition/BaseCondition.java
@@ -16,6 +16,7 @@
 
 package io.stargate.sgv2.docsapi.service.query.condition;
 
+import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.common.cql.builder.BuiltCondition;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.service.common.model.RowWrapper;
@@ -24,6 +25,7 @@ import io.stargate.sgv2.docsapi.service.util.DocsApiUtils;
 import java.util.Optional;
 import java.util.function.Predicate;
 import javax.validation.constraints.NotNull;
+import org.apache.commons.lang3.tuple.Pair;
 
 /** Interface for the base filtering condition. */
 public interface BaseCondition extends Predicate<RowWrapper> {
@@ -40,8 +42,11 @@ public interface BaseCondition extends Predicate<RowWrapper> {
     return getBuiltCondition().isPresent();
   }
 
-  /** @return Returns persistence built condition, if this condition supports database querying. */
-  Optional<BuiltCondition> getBuiltCondition();
+  /**
+   * @return Returns persistence built condition together with bind value, if this condition
+   *     supports database querying.
+   */
+  Optional<Pair<BuiltCondition, QueryOuterClass.Value>> getBuiltCondition();
 
   /** @return Returns filter operation code used by this condition. */
   FilterOperationCode getFilterOperationCode();

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/condition/impl/BooleanCondition.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/condition/impl/BooleanCondition.java
@@ -19,6 +19,7 @@ package io.stargate.sgv2.docsapi.service.query.condition.impl;
 import io.stargate.bridge.grpc.Values;
 import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.common.cql.builder.BuiltCondition;
+import io.stargate.sgv2.common.cql.builder.Term;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.config.constants.Constants;
 import io.stargate.sgv2.docsapi.service.common.model.RowWrapper;
@@ -26,6 +27,7 @@ import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
 import io.stargate.sgv2.docsapi.service.query.filter.operation.FilterOperationCode;
 import io.stargate.sgv2.docsapi.service.query.filter.operation.ValueFilterOperation;
 import java.util.Optional;
+import org.apache.commons.lang3.tuple.Pair;
 import org.immutables.value.Value;
 
 /** Condition that accepts boolean filter values and compare against boolean database row value. */
@@ -61,7 +63,7 @@ public abstract class BooleanCondition implements BaseCondition {
 
   /** {@inheritDoc} */
   @Override
-  public Optional<BuiltCondition> getBuiltCondition() {
+  public Optional<Pair<BuiltCondition, QueryOuterClass.Value>> getBuiltCondition() {
     String column = documentProperties().tableProperties().booleanValueColumnName();
     return getFilterOperation()
         .getQueryPredicate()
@@ -74,7 +76,8 @@ public abstract class BooleanCondition implements BaseCondition {
                           ? Constants.NUMERIC_BOOLEAN_TRUE
                           : Constants.NUMERIC_BOOLEAN_FALSE)
                       : Values.of(getQueryValue());
-              return BuiltCondition.of(column, predicate, value);
+              BuiltCondition condition = BuiltCondition.of(column, predicate, Term.marker());
+              return Pair.of(condition, value);
             });
   }
 

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/condition/impl/ExistsCondition.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/condition/impl/ExistsCondition.java
@@ -16,12 +16,14 @@
 
 package io.stargate.sgv2.docsapi.service.query.condition.impl;
 
+import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.common.cql.builder.BuiltCondition;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.service.common.model.RowWrapper;
 import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
 import io.stargate.sgv2.docsapi.service.query.filter.operation.FilterOperationCode;
 import java.util.Optional;
+import org.apache.commons.lang3.tuple.Pair;
 import org.immutables.value.Value;
 
 /**
@@ -48,7 +50,7 @@ public abstract class ExistsCondition implements BaseCondition {
 
   /** {@inheritDoc} */
   @Override
-  public Optional<BuiltCondition> getBuiltCondition() {
+  public Optional<Pair<BuiltCondition, QueryOuterClass.Value>> getBuiltCondition() {
     return Optional.empty();
   }
 

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/condition/impl/GenericCondition.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/condition/impl/GenericCondition.java
@@ -16,6 +16,7 @@
 
 package io.stargate.sgv2.docsapi.service.query.condition.impl;
 
+import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.common.cql.builder.BuiltCondition;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.service.common.model.RowWrapper;
@@ -23,6 +24,7 @@ import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
 import io.stargate.sgv2.docsapi.service.query.filter.operation.FilterOperationCode;
 import io.stargate.sgv2.docsapi.service.query.filter.operation.GenericFilterOperation;
 import java.util.Optional;
+import org.apache.commons.lang3.tuple.Pair;
 import org.immutables.value.Value;
 
 /**
@@ -63,7 +65,7 @@ public abstract class GenericCondition<V> implements BaseCondition {
    * <p>This implementation always returns empty. Sub-class to override.
    */
   @Override
-  public Optional<BuiltCondition> getBuiltCondition() {
+  public Optional<Pair<BuiltCondition, QueryOuterClass.Value>> getBuiltCondition() {
     return Optional.empty();
   }
 

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/condition/impl/NumberCondition.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/condition/impl/NumberCondition.java
@@ -17,13 +17,16 @@
 package io.stargate.sgv2.docsapi.service.query.condition.impl;
 
 import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.common.cql.builder.BuiltCondition;
+import io.stargate.sgv2.common.cql.builder.Term;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.service.common.model.RowWrapper;
 import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
 import io.stargate.sgv2.docsapi.service.query.filter.operation.FilterOperationCode;
 import io.stargate.sgv2.docsapi.service.query.filter.operation.ValueFilterOperation;
 import java.util.Optional;
+import org.apache.commons.lang3.tuple.Pair;
 import org.immutables.value.Value;
 
 /** Condition that accepts number filter values and compare against double database row value. */
@@ -55,13 +58,16 @@ public abstract class NumberCondition implements BaseCondition {
 
   /** {@inheritDoc} */
   @Override
-  public Optional<BuiltCondition> getBuiltCondition() {
+  public Optional<Pair<BuiltCondition, QueryOuterClass.Value>> getBuiltCondition() {
     String column = documentProperties().tableProperties().doubleValueColumnName();
     return getFilterOperation()
         .getQueryPredicate()
         .map(
-            predicate ->
-                BuiltCondition.of(column, predicate, Values.of(getQueryValue().doubleValue())));
+            predicate -> {
+              QueryOuterClass.Value value = Values.of(getQueryValue().doubleValue());
+              BuiltCondition condition = BuiltCondition.of(column, predicate, Term.marker());
+              return Pair.of(condition, value);
+            });
   }
 
   /** {@inheritDoc} */

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/condition/impl/StringCondition.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/condition/impl/StringCondition.java
@@ -17,13 +17,16 @@
 package io.stargate.sgv2.docsapi.service.query.condition.impl;
 
 import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.common.cql.builder.BuiltCondition;
+import io.stargate.sgv2.common.cql.builder.Term;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.service.common.model.RowWrapper;
 import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
 import io.stargate.sgv2.docsapi.service.query.filter.operation.FilterOperationCode;
 import io.stargate.sgv2.docsapi.service.query.filter.operation.ValueFilterOperation;
 import java.util.Optional;
+import org.apache.commons.lang3.tuple.Pair;
 import org.immutables.value.Value;
 
 /** Condition that accepts string filter values and compare against string database row value. */
@@ -55,11 +58,16 @@ public abstract class StringCondition implements BaseCondition {
 
   /** {@inheritDoc} */
   @Override
-  public Optional<BuiltCondition> getBuiltCondition() {
+  public Optional<Pair<BuiltCondition, QueryOuterClass.Value>> getBuiltCondition() {
     String column = documentProperties().tableProperties().stringValueColumnName();
     return getFilterOperation()
         .getQueryPredicate()
-        .map(predicate -> BuiltCondition.of(column, predicate, Values.of(getQueryValue())));
+        .map(
+            predicate -> {
+              QueryOuterClass.Value value = Values.of(getQueryValue());
+              BuiltCondition condition = BuiltCondition.of(column, predicate, Term.marker());
+              return Pair.of(condition, value);
+            });
   }
 
   /** {@inheritDoc} */

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/AbstractSearchQueryBuilder.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/AbstractSearchQueryBuilder.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.db;
+
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.common.cql.builder.BuiltCondition;
+import io.stargate.sgv2.common.cql.builder.QueryBuilder;
+import io.stargate.sgv2.common.cql.builder.QueryBuilderImpl;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/** Abstract class that can create a query for a document search. */
+public abstract class AbstractSearchQueryBuilder {
+
+  /** Document properties that should be used to resolve column names. */
+  protected final DocumentProperties documentProperties;
+
+  public AbstractSearchQueryBuilder(DocumentProperties documentProperties) {
+    this.documentProperties = documentProperties;
+  }
+
+  /** @return All fixed predicates. */
+  protected abstract Collection<BuiltCondition> getPredicates();
+
+  /** @return Predicates that depends on the binding value. */
+  protected abstract Collection<BuiltCondition> getBindPredicates();
+
+  /** @return Should <code>ALLOW FILTERING</code> be used. */
+  protected abstract boolean allowFiltering();
+
+  /**
+   * Builds the query without limit (no functions).
+   *
+   * @param keyspace keyspace
+   * @param table table
+   * @param columns columns to query, must not be empty
+   * @return Completable future that returns prepared query
+   */
+  public QueryOuterClass.Query buildQuery(String keyspace, String table, String... columns) {
+    return buildQuery(keyspace, table, null, Collections.emptyList(), columns);
+  }
+
+  /**
+   * Builds the query with limit (no functions).
+   *
+   * @param keyspace keyspace
+   * @param table table
+   * @param columns columns to query, must not be empty
+   * @return Completable future that returns prepared query
+   */
+  public QueryOuterClass.Query buildQuery(
+      String keyspace, String table, Integer limit, String... columns) {
+    return buildQuery(keyspace, table, limit, Collections.emptyList(), columns);
+  }
+
+  public QueryOuterClass.Query buildQuery(
+      String keyspace, String table, List<QueryBuilderImpl.FunctionCall> functions) {
+    return buildQuery(keyspace, table, null, functions);
+  }
+
+  public QueryOuterClass.Query buildQuery(
+      String keyspace,
+      String table,
+      Integer limit,
+      List<QueryBuilderImpl.FunctionCall> functions,
+      String... columns) {
+    QueryBuilder.QueryBuilder__47 builder =
+        new QueryBuilder()
+            .select()
+            .column(columns)
+            .function(functions)
+            .writeTimeColumn(documentProperties.tableProperties().leafColumnName())
+            .from(keyspace, table)
+            .where(getPredicates())
+            .where(getBindPredicates())
+            .limit(limit);
+
+    // resolve allow limit
+    if (allowFiltering()) {
+      return builder.allowFiltering().build();
+    } else {
+      return builder.build();
+    }
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/DocumentSearchQueryBuilder.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/DocumentSearchQueryBuilder.java
@@ -26,6 +26,7 @@ import io.stargate.sgv2.docsapi.service.query.FilterExpression;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * The query builder that extends the {@link FilterExpressionSearchQueryBuilder} and adds predicate
@@ -44,10 +45,10 @@ public class DocumentSearchQueryBuilder extends FilterExpressionSearchQueryBuild
   }
 
   @Override
-  protected Collection<BuiltCondition> getBindPredicates() {
+  protected List<BuiltCondition> getBindPredicates() {
     DocumentTableProperties tableProps = documentProperties.tableProperties();
 
-    Collection<BuiltCondition> bindPredicates = new ArrayList<>(super.getBindPredicates());
+    List<BuiltCondition> bindPredicates = new ArrayList<>(super.getBindPredicates());
     BuiltCondition condition =
         BuiltCondition.of(tableProps.keyColumnName(), Predicate.EQ, Term.marker());
     bindPredicates.add(condition);

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/DocumentSearchQueryBuilder.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/DocumentSearchQueryBuilder.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.db.impl;
+
+import io.stargate.sgv2.common.cql.builder.BuiltCondition;
+import io.stargate.sgv2.common.cql.builder.Predicate;
+import io.stargate.sgv2.common.cql.builder.Term;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentTableProperties;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * The query builder that extends the {@link FilterExpressionSearchQueryBuilder} and adds predicate
+ * to match the document id. Binding of the document id is needed for the query provided.
+ */
+public class DocumentSearchQueryBuilder extends FilterExpressionSearchQueryBuilder {
+
+  public DocumentSearchQueryBuilder(
+      DocumentProperties documentProperties, FilterExpression expression) {
+    this(documentProperties, Collections.singleton(expression));
+  }
+
+  public DocumentSearchQueryBuilder(
+      DocumentProperties documentProperties, Collection<FilterExpression> expressions) {
+    super(documentProperties, expressions);
+  }
+
+  @Override
+  protected Collection<BuiltCondition> getBindPredicates() {
+    DocumentTableProperties tableProps = documentProperties.tableProperties();
+
+    Collection<BuiltCondition> bindPredicates = new ArrayList<>(super.getBindPredicates());
+    BuiltCondition condition =
+        BuiltCondition.of(tableProps.keyColumnName(), Predicate.EQ, Term.marker());
+    bindPredicates.add(condition);
+    return bindPredicates;
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/DocumentTtlQueryBuilder.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/DocumentTtlQueryBuilder.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.db.impl;
+
+import com.google.common.collect.ImmutableList;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.common.cql.builder.BuiltCondition;
+import io.stargate.sgv2.common.cql.builder.Predicate;
+import io.stargate.sgv2.common.cql.builder.QueryBuilderImpl;
+import io.stargate.sgv2.common.cql.builder.Term;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentTableProperties;
+import io.stargate.sgv2.docsapi.service.query.search.db.AbstractSearchQueryBuilder;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/** Simple query builder to get the TTL of a document. */
+public class DocumentTtlQueryBuilder extends AbstractSearchQueryBuilder {
+
+  public DocumentTtlQueryBuilder(DocumentProperties documentProperties) {
+    super(documentProperties);
+  }
+
+  @Override
+  protected boolean allowFiltering() {
+    return false;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public QueryOuterClass.Query buildQuery(String keyspace, String table, String... columns) {
+    DocumentTableProperties tableProps = documentProperties.tableProperties();
+    List<QueryBuilderImpl.FunctionCall> ttlFunction =
+        ImmutableList.of(QueryBuilderImpl.FunctionCall.ttl(tableProps.leafColumnName()));
+    return buildQuery(keyspace, table, null, ttlFunction, tableProps.keyColumnName());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Collection<BuiltCondition> getPredicates() {
+    return Collections.emptyList();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected Collection<BuiltCondition> getBindPredicates() {
+    DocumentTableProperties tableProps = documentProperties.tableProperties();
+
+    BuiltCondition condition =
+        BuiltCondition.of(tableProps.keyColumnName(), Predicate.EQ, Term.marker());
+    return Collections.singletonList(condition);
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/DocumentTtlQueryBuilder.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/DocumentTtlQueryBuilder.java
@@ -26,7 +26,6 @@ import io.stargate.sgv2.common.cql.builder.Term;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentTableProperties;
 import io.stargate.sgv2.docsapi.service.query.search.db.AbstractSearchQueryBuilder;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -53,13 +52,18 @@ public class DocumentTtlQueryBuilder extends AbstractSearchQueryBuilder {
 
   /** {@inheritDoc} */
   @Override
-  public Collection<BuiltCondition> getPredicates() {
+  public List<BuiltCondition> getPredicates() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  protected List<QueryOuterClass.Value> getValues() {
     return Collections.emptyList();
   }
 
   /** {@inheritDoc} */
   @Override
-  protected Collection<BuiltCondition> getBindPredicates() {
+  protected List<BuiltCondition> getBindPredicates() {
     DocumentTableProperties tableProps = documentProperties.tableProperties();
 
     BuiltCondition condition =

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FilterExpressionSearchQueryBuilder.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FilterExpressionSearchQueryBuilder.java
@@ -17,6 +17,7 @@
 
 package io.stargate.sgv2.docsapi.service.query.search.db.impl;
 
+import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.common.cql.builder.BuiltCondition;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.service.query.FilterExpression;
@@ -24,6 +25,7 @@ import io.stargate.sgv2.docsapi.service.query.FilterPath;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * The builder that extends the {@link FilterPathSearchQueryBuilder} and adds predicates based on
@@ -50,7 +52,6 @@ public class FilterExpressionSearchQueryBuilder extends FilterPathSearchQueryBui
       DocumentProperties documentProperties, FilterPath filterPath) {
     super(documentProperties, filterPath, true);
     this.expressions = Collections.emptyList();
-    System.out.println("here3");
   }
 
   /**
@@ -59,12 +60,22 @@ public class FilterExpressionSearchQueryBuilder extends FilterPathSearchQueryBui
    * <p>Adds predicates for each expression.
    */
   @Override
-  public Collection<BuiltCondition> getPredicates() {
-    Collection<BuiltCondition> predicates = super.getPredicates();
+  protected Pair<List<BuiltCondition>, List<QueryOuterClass.Value>> resolve() {
+    Pair<List<BuiltCondition>, List<QueryOuterClass.Value>> resolve = super.resolve();
+    List<BuiltCondition> predicates = resolve.getLeft();
+    List<QueryOuterClass.Value> values = resolve.getRight();
 
-    expressions.forEach(e -> e.getCondition().getBuiltCondition().ifPresent(predicates::add));
+    expressions.forEach(
+        e ->
+            e.getCondition()
+                .getBuiltCondition()
+                .ifPresent(
+                    builtCondition -> {
+                      predicates.add(builtCondition.getLeft());
+                      values.add(builtCondition.getRight());
+                    }));
 
-    return predicates;
+    return Pair.of(predicates, values);
   }
 
   // confirms we have single filter path and extracts it

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FilterExpressionSearchQueryBuilder.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FilterExpressionSearchQueryBuilder.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.db.impl;
+
+import io.stargate.sgv2.common.cql.builder.BuiltCondition;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.FilterPath;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The builder that extends the {@link FilterPathSearchQueryBuilder} and adds predicates based on
+ * the collection of {@link FilterExpression}. Note that all expressions given must be related to
+ * the same {@link FilterPath}.
+ */
+public class FilterExpressionSearchQueryBuilder extends FilterPathSearchQueryBuilder {
+
+  private final Collection<FilterExpression> expressions;
+
+  public FilterExpressionSearchQueryBuilder(
+      DocumentProperties documentProperties, FilterExpression expression) {
+    this(documentProperties, Collections.singleton(expression));
+  }
+
+  public FilterExpressionSearchQueryBuilder(
+      DocumentProperties documentProperties, Collection<FilterExpression> expressions) {
+    super(documentProperties, getFilterPath(expressions), true);
+    this.expressions = expressions;
+  }
+
+  // pipe constructor to super class, no expressions defined
+  protected FilterExpressionSearchQueryBuilder(
+      DocumentProperties documentProperties, FilterPath filterPath) {
+    super(documentProperties, filterPath, true);
+    this.expressions = Collections.emptyList();
+    System.out.println("here3");
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Adds predicates for each expression.
+   */
+  @Override
+  public Collection<BuiltCondition> getPredicates() {
+    Collection<BuiltCondition> predicates = super.getPredicates();
+
+    expressions.forEach(e -> e.getCondition().getBuiltCondition().ifPresent(predicates::add));
+
+    return predicates;
+  }
+
+  // confirms we have single filter path and extracts it
+  private static FilterPath getFilterPath(Collection<FilterExpression> expressions) {
+    List<FilterPath> filterPaths =
+        expressions.stream().map(FilterExpression::getFilterPath).distinct().toList();
+
+    if (filterPaths.size() != 1) {
+      throw new IllegalArgumentException(
+          "FilterExpressionSearchQueryBuilder accepts only expressions with same path.");
+    }
+
+    return filterPaths.get(0);
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FilterPathSearchQueryBuilder.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FilterPathSearchQueryBuilder.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.db.impl;
+
+import io.stargate.bridge.grpc.Values;
+import io.stargate.sgv2.common.cql.builder.BuiltCondition;
+import io.stargate.sgv2.common.cql.builder.Predicate;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentTableProperties;
+import io.stargate.sgv2.docsapi.api.exception.ErrorCode;
+import io.stargate.sgv2.docsapi.api.exception.ErrorCodeRuntimeException;
+import io.stargate.sgv2.docsapi.service.query.FilterPath;
+import io.stargate.sgv2.docsapi.service.util.DocsApiUtils;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/** The search query builder that creates all needed predicates for a {@link FilterPath}. */
+public class FilterPathSearchQueryBuilder extends PathSearchQueryBuilder {
+
+  private final FilterPath filterPath;
+
+  private final boolean matchField;
+
+  /**
+   * @param filterPath Filter path
+   * @param matchField If field name should be matches as well, adds extra predicates
+   */
+  public FilterPathSearchQueryBuilder(
+      DocumentProperties documentProperties, FilterPath filterPath, boolean matchField) {
+    super(documentProperties, filterPath.getParentPath());
+    this.filterPath = filterPath;
+    this.matchField = matchField;
+  }
+
+  @Override
+  protected boolean allowFiltering() {
+    return true;
+  }
+
+  @Override
+  protected Collection<BuiltCondition> getBindPredicates() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Collection<BuiltCondition> getPredicates() {
+    Collection<BuiltCondition> predicates = super.getPredicates();
+
+    int maxDepth = documentProperties.maxDepth();
+    predicates.addAll(getFieldPredicates(maxDepth));
+    predicates.addAll(getRemainingPathPredicates(maxDepth));
+    return predicates;
+  }
+
+  public FilterPath getFilterPath() {
+    return filterPath;
+  }
+
+  private List<BuiltCondition> getFieldPredicates(int maxDepth) {
+    int parentSize = filterPath.getParentPath().size();
+    if (parentSize >= maxDepth) {
+      throw new ErrorCodeRuntimeException(ErrorCode.DOCS_API_GENERAL_DEPTH_EXCEEDED);
+    } else {
+      DocumentTableProperties tableProps = documentProperties.tableProperties();
+      String field = DocsApiUtils.convertEscapedCharacters(filterPath.getField());
+      if (matchField) {
+        // apply to p and leaf, as index is on leaf, and we want it kicking in
+        return Arrays.asList(
+            BuiltCondition.of(
+                tableProps.pathColumnName(parentSize), Predicate.EQ, Values.of(field)),
+            BuiltCondition.of(tableProps.leafColumnName(), Predicate.EQ, Values.of(field)));
+      } else {
+        // TODO confirm this is really needed
+        //  confirm this could be needed only on non-empty path
+        return Collections.singletonList(
+            BuiltCondition.of(tableProps.pathColumnName(parentSize), Predicate.GT, Values.of("")));
+      }
+    }
+  }
+
+  private List<BuiltCondition> getRemainingPathPredicates(int maxDepth) {
+    int fullSize = filterPath.getPath().size();
+    if (fullSize >= maxDepth) {
+      return Collections.emptyList();
+    } else {
+      DocumentTableProperties tableProps = documentProperties.tableProperties();
+      return Collections.singletonList(
+          BuiltCondition.of(tableProps.pathColumnName(fullSize), Predicate.EQ, Values.of("")));
+    }
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FullSearchQueryBuilder.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FullSearchQueryBuilder.java
@@ -17,11 +17,12 @@
 
 package io.stargate.sgv2.docsapi.service.query.search.db.impl;
 
+import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.common.cql.builder.BuiltCondition;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.service.query.search.db.AbstractSearchQueryBuilder;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /** Simple query builder for document population. */
 public class FullSearchQueryBuilder extends AbstractSearchQueryBuilder {
@@ -36,12 +37,17 @@ public class FullSearchQueryBuilder extends AbstractSearchQueryBuilder {
   }
 
   @Override
-  protected Collection<BuiltCondition> getPredicates() {
+  protected List<BuiltCondition> getPredicates() {
     return Collections.emptyList();
   }
 
   @Override
-  protected Collection<BuiltCondition> getBindPredicates() {
+  protected List<QueryOuterClass.Value> getValues() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  protected List<BuiltCondition> getBindPredicates() {
     return Collections.emptyList();
   }
 }

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FullSearchQueryBuilder.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FullSearchQueryBuilder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.db.impl;
+
+import io.stargate.sgv2.common.cql.builder.BuiltCondition;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.service.query.search.db.AbstractSearchQueryBuilder;
+import java.util.Collection;
+import java.util.Collections;
+
+/** Simple query builder for document population. */
+public class FullSearchQueryBuilder extends AbstractSearchQueryBuilder {
+
+  public FullSearchQueryBuilder(DocumentProperties documentProperties) {
+    super(documentProperties);
+  }
+
+  @Override
+  protected boolean allowFiltering() {
+    return false;
+  }
+
+  @Override
+  protected Collection<BuiltCondition> getPredicates() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  protected Collection<BuiltCondition> getBindPredicates() {
+    return Collections.emptyList();
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/PathSearchQueryBuilder.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/PathSearchQueryBuilder.java
@@ -24,15 +24,16 @@ import io.stargate.bridge.grpc.Values;
 import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.common.cql.builder.BuiltCondition;
 import io.stargate.sgv2.common.cql.builder.Predicate;
+import io.stargate.sgv2.common.cql.builder.Term;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentTableProperties;
 import io.stargate.sgv2.docsapi.service.query.search.db.AbstractSearchQueryBuilder;
 import io.stargate.sgv2.docsapi.service.util.DocsApiUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * The search query builder that creates all needed predicates for a path represented as a list of
@@ -41,11 +42,57 @@ import java.util.List;
 public class PathSearchQueryBuilder extends AbstractSearchQueryBuilder {
 
   private final List<String> path;
+  private Pair<List<BuiltCondition>, List<QueryOuterClass.Value>> conditionsAndValues;
 
   /** @param path Path to match. */
   public PathSearchQueryBuilder(DocumentProperties documentProperties, List<String> path) {
     super(documentProperties);
     this.path = path;
+  }
+
+  /**
+   * Resolves the pair that contains the predicates and values that are known at the creation time.
+   * The conditions must be created with the marker.
+   *
+   * <p>Subclasses can override, but always must include the result of the super call.
+   *
+   * @return Pair of conditions to value list. Lists must be same size.
+   */
+  protected Pair<List<BuiltCondition>, List<QueryOuterClass.Value>> resolve() {
+    DocumentTableProperties tableProps = documentProperties.tableProperties();
+
+    List<BuiltCondition> predicates = new ArrayList<>();
+    List<QueryOuterClass.Value> values = new ArrayList<>();
+
+    // copied from the DocumentService
+    for (int i = 0; i < path.size(); i++) {
+      String next = path.get(i);
+      String[] pathSegmentSplit = next.split(DocsApiUtils.COMMA_PATTERN.pattern());
+      if (pathSegmentSplit.length == 1) {
+        String pathSegment = pathSegmentSplit[0];
+        if (pathSegment.equals(GLOB_VALUE) || pathSegment.equals(GLOB_ARRAY_VALUE)) {
+          predicates.add(
+              BuiltCondition.of(tableProps.pathColumnName(i), Predicate.GT, Term.marker()));
+          values.add(Values.of(""));
+        } else {
+          predicates.add(
+              BuiltCondition.of(tableProps.pathColumnName(i), Predicate.EQ, Term.marker()));
+          values.add(Values.of(DocsApiUtils.convertEscapedCharacters(pathSegment)));
+        }
+      } else {
+        List<QueryOuterClass.Value> segmentValues =
+            Arrays.stream(pathSegmentSplit)
+                .map(DocsApiUtils::convertEscapedCharacters)
+                .map(Values::of)
+                .toList();
+
+        predicates.add(
+            BuiltCondition.of(tableProps.pathColumnName(i), Predicate.IN, Term.marker()));
+        values.add(Values.of(segmentValues));
+      }
+    }
+
+    return Pair.of(predicates, values);
   }
 
   @Override
@@ -55,48 +102,36 @@ public class PathSearchQueryBuilder extends AbstractSearchQueryBuilder {
 
   /** {@inheritDoc} */
   @Override
-  protected Collection<BuiltCondition> getBindPredicates() {
+  protected List<BuiltCondition> getBindPredicates() {
     return Collections.emptyList();
   }
 
   /** {@inheritDoc} */
   @Override
-  public Collection<BuiltCondition> getPredicates() {
-    return getPathPredicates();
+  protected final List<BuiltCondition> getPredicates() {
+    ensureResolved();
+    return conditionsAndValues.getLeft();
   }
 
-  private List<BuiltCondition> getPathPredicates() {
-    DocumentTableProperties tableProps = documentProperties.tableProperties();
+  /** {@inheritDoc} */
+  @Override
+  protected final List<QueryOuterClass.Value> getValues() {
+    ensureResolved();
+    return conditionsAndValues.getRight();
+  }
 
-    List<BuiltCondition> predicates = new ArrayList<>();
-    // copied from the DocumentService
-    for (int i = 0; i < path.size(); i++) {
-      String next = path.get(i);
-      String[] pathSegmentSplit = next.split(DocsApiUtils.COMMA_PATTERN.pattern());
-      if (pathSegmentSplit.length == 1) {
-        String pathSegment = pathSegmentSplit[0];
-        if (pathSegment.equals(GLOB_VALUE) || pathSegment.equals(GLOB_ARRAY_VALUE)) {
-          predicates.add(
-              BuiltCondition.of(tableProps.pathColumnName(i), Predicate.GT, Values.of("")));
-        } else {
-          predicates.add(
-              BuiltCondition.of(
-                  tableProps.pathColumnName(i),
-                  Predicate.EQ,
-                  Values.of(DocsApiUtils.convertEscapedCharacters(pathSegment))));
-        }
-      } else {
-        List<QueryOuterClass.Value> values =
-            Arrays.stream(pathSegmentSplit)
-                .map(DocsApiUtils::convertEscapedCharacters)
-                .map(Values::of)
-                .toList();
+  private void ensureResolved() {
+    if (null == conditionsAndValues) {
+      conditionsAndValues = resolve();
 
-        predicates.add(
-            BuiltCondition.of(tableProps.pathColumnName(i), Predicate.IN, Values.of(values)));
+      // ensure size
+      int conditions = conditionsAndValues.getLeft().size();
+      int values = conditionsAndValues.getRight().size();
+      if (conditions != values) {
+        throw new IllegalStateException(
+            "Size of the conditions (%d) does not match the size of the bind values (%d)."
+                .formatted(conditions, values));
       }
     }
-
-    return predicates;
   }
 }

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/PathSearchQueryBuilder.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/PathSearchQueryBuilder.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.db.impl;
+
+import static io.stargate.sgv2.docsapi.config.constants.Constants.GLOB_ARRAY_VALUE;
+import static io.stargate.sgv2.docsapi.config.constants.Constants.GLOB_VALUE;
+
+import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.common.cql.builder.BuiltCondition;
+import io.stargate.sgv2.common.cql.builder.Predicate;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentTableProperties;
+import io.stargate.sgv2.docsapi.service.query.search.db.AbstractSearchQueryBuilder;
+import io.stargate.sgv2.docsapi.service.util.DocsApiUtils;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The search query builder that creates all needed predicates for a path represented as a list of
+ * string.
+ */
+public class PathSearchQueryBuilder extends AbstractSearchQueryBuilder {
+
+  private final List<String> path;
+
+  /** @param path Path to match. */
+  public PathSearchQueryBuilder(DocumentProperties documentProperties, List<String> path) {
+    super(documentProperties);
+    this.path = path;
+  }
+
+  @Override
+  protected boolean allowFiltering() {
+    return !path.isEmpty();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected Collection<BuiltCondition> getBindPredicates() {
+    return Collections.emptyList();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Collection<BuiltCondition> getPredicates() {
+    return getPathPredicates();
+  }
+
+  private List<BuiltCondition> getPathPredicates() {
+    DocumentTableProperties tableProps = documentProperties.tableProperties();
+
+    List<BuiltCondition> predicates = new ArrayList<>();
+    // copied from the DocumentService
+    for (int i = 0; i < path.size(); i++) {
+      String next = path.get(i);
+      String[] pathSegmentSplit = next.split(DocsApiUtils.COMMA_PATTERN.pattern());
+      if (pathSegmentSplit.length == 1) {
+        String pathSegment = pathSegmentSplit[0];
+        if (pathSegment.equals(GLOB_VALUE) || pathSegment.equals(GLOB_ARRAY_VALUE)) {
+          predicates.add(
+              BuiltCondition.of(tableProps.pathColumnName(i), Predicate.GT, Values.of("")));
+        } else {
+          predicates.add(
+              BuiltCondition.of(
+                  tableProps.pathColumnName(i),
+                  Predicate.EQ,
+                  Values.of(DocsApiUtils.convertEscapedCharacters(pathSegment))));
+        }
+      } else {
+        List<QueryOuterClass.Value> values =
+            Arrays.stream(pathSegmentSplit)
+                .map(DocsApiUtils::convertEscapedCharacters)
+                .map(Values::of)
+                .toList();
+
+        predicates.add(
+            BuiltCondition.of(tableProps.pathColumnName(i), Predicate.IN, Values.of(values)));
+      }
+    }
+
+    return predicates;
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/PopulateSearchQueryBuilder.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/PopulateSearchQueryBuilder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.db.impl;
+
+import io.stargate.sgv2.common.cql.builder.BuiltCondition;
+import io.stargate.sgv2.common.cql.builder.Predicate;
+import io.stargate.sgv2.common.cql.builder.Term;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentTableProperties;
+import io.stargate.sgv2.docsapi.service.query.search.db.AbstractSearchQueryBuilder;
+import java.util.Collection;
+import java.util.Collections;
+
+/** Simple query builder for document population. */
+public class PopulateSearchQueryBuilder extends AbstractSearchQueryBuilder {
+
+  public PopulateSearchQueryBuilder(DocumentProperties documentProperties) {
+    super(documentProperties);
+  }
+
+  @Override
+  protected boolean allowFiltering() {
+    return false;
+  }
+
+  @Override
+  protected Collection<BuiltCondition> getPredicates() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  protected Collection<BuiltCondition> getBindPredicates() {
+    DocumentTableProperties tableProps = documentProperties.tableProperties();
+
+    BuiltCondition condition =
+        BuiltCondition.of(tableProps.keyColumnName(), Predicate.EQ, Term.marker());
+    return Collections.singletonList(condition);
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/PopulateSearchQueryBuilder.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/PopulateSearchQueryBuilder.java
@@ -17,17 +17,18 @@
 
 package io.stargate.sgv2.docsapi.service.query.search.db.impl;
 
+import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.common.cql.builder.BuiltCondition;
 import io.stargate.sgv2.common.cql.builder.Predicate;
 import io.stargate.sgv2.common.cql.builder.Term;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentTableProperties;
 import io.stargate.sgv2.docsapi.service.query.search.db.AbstractSearchQueryBuilder;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /** Simple query builder for document population. */
-public class PopulateSearchQueryBuilder extends AbstractSearchQueryBuilder {
+public final class PopulateSearchQueryBuilder extends AbstractSearchQueryBuilder {
 
   public PopulateSearchQueryBuilder(DocumentProperties documentProperties) {
     super(documentProperties);
@@ -39,12 +40,17 @@ public class PopulateSearchQueryBuilder extends AbstractSearchQueryBuilder {
   }
 
   @Override
-  protected Collection<BuiltCondition> getPredicates() {
+  protected List<BuiltCondition> getPredicates() {
     return Collections.emptyList();
   }
 
   @Override
-  protected Collection<BuiltCondition> getBindPredicates() {
+  protected List<QueryOuterClass.Value> getValues() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  protected List<BuiltCondition> getBindPredicates() {
     DocumentTableProperties tableProps = documentProperties.tableProperties();
 
     BuiltCondition condition =

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/SubDocumentSearchQueryBuilder.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/SubDocumentSearchQueryBuilder.java
@@ -18,12 +18,14 @@
 package io.stargate.sgv2.docsapi.service.query.search.db.impl;
 
 import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.common.cql.builder.BuiltCondition;
 import io.stargate.sgv2.common.cql.builder.Predicate;
+import io.stargate.sgv2.common.cql.builder.Term;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentTableProperties;
-import java.util.Collection;
 import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * Search query builder that matches all rows on the given #subDocumentsPath for a single document.
@@ -39,14 +41,17 @@ public class SubDocumentSearchQueryBuilder extends PathSearchQueryBuilder {
     this.documentId = documentId;
   }
 
-  /** {@inheritDoc} */
   @Override
-  public Collection<BuiltCondition> getPredicates() {
-    DocumentTableProperties tableProps = documentProperties.tableProperties();
+  protected Pair<List<BuiltCondition>, List<QueryOuterClass.Value>> resolve() {
+    Pair<List<BuiltCondition>, List<QueryOuterClass.Value>> resolve = super.resolve();
 
-    Collection<BuiltCondition> predicates = super.getPredicates();
-    predicates.add(
-        BuiltCondition.of(tableProps.keyColumnName(), Predicate.EQ, Values.of(documentId)));
-    return predicates;
+    List<BuiltCondition> predicates = resolve.getLeft();
+    List<QueryOuterClass.Value> values = resolve.getRight();
+
+    DocumentTableProperties tableProps = documentProperties.tableProperties();
+    predicates.add(BuiltCondition.of(tableProps.keyColumnName(), Predicate.EQ, Term.marker()));
+    values.add(Values.of(documentId));
+
+    return Pair.of(predicates, values);
   }
 }

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/SubDocumentSearchQueryBuilder.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/SubDocumentSearchQueryBuilder.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.db.impl;
+
+import io.stargate.bridge.grpc.Values;
+import io.stargate.sgv2.common.cql.builder.BuiltCondition;
+import io.stargate.sgv2.common.cql.builder.Predicate;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentTableProperties;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Search query builder that matches all rows on the given #subDocumentsPath for a single document.
+ */
+public class SubDocumentSearchQueryBuilder extends PathSearchQueryBuilder {
+
+  /** Doc id to target. */
+  private final String documentId;
+
+  public SubDocumentSearchQueryBuilder(
+      DocumentProperties documentProperties, String documentId, List<String> subDocumentsPath) {
+    super(documentProperties, subDocumentsPath);
+    this.documentId = documentId;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Collection<BuiltCondition> getPredicates() {
+    DocumentTableProperties tableProps = documentProperties.tableProperties();
+
+    Collection<BuiltCondition> predicates = super.getPredicates();
+    predicates.add(
+        BuiltCondition.of(tableProps.keyColumnName(), Predicate.EQ, Values.of(documentId)));
+    return predicates;
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/ExpressionParserTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/ExpressionParserTest.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
 import io.stargate.bridge.grpc.Values;
-import io.stargate.sgv2.common.cql.builder.Literal;
 import io.stargate.sgv2.common.cql.builder.Predicate;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCode;
@@ -92,8 +91,9 @@ class ExpressionParserTest {
                           assertThat(sc.getBuiltCondition())
                               .hasValueSatisfying(
                                   builtCondition -> {
-                                    assertThat(builtCondition.predicate()).isEqualTo(Predicate.EQ);
-                                    assertThat(((Literal) builtCondition.value()).get())
+                                    assertThat(builtCondition.getLeft().predicate())
+                                        .isEqualTo(Predicate.EQ);
+                                    assertThat(builtCondition.getRight())
                                         .isEqualTo(Values.of("some-value"));
                                   });
                           assertThat(sc.getFilterOperation()).isEqualTo(EqFilterOperation.of());
@@ -360,8 +360,9 @@ class ExpressionParserTest {
                           assertThat(sc.getBuiltCondition())
                               .hasValueSatisfying(
                                   builtCondition -> {
-                                    assertThat(builtCondition.predicate()).isEqualTo(Predicate.LT);
-                                    assertThat(((Literal) builtCondition.value()).get())
+                                    assertThat(builtCondition.getLeft().predicate())
+                                        .isEqualTo(Predicate.LT);
+                                    assertThat(builtCondition.getRight())
                                         .isEqualTo(Values.of("some-value"));
                                   });
                           assertThat(sc.getFilterOperation()).isEqualTo(LtFilterOperation.of());
@@ -392,8 +393,9 @@ class ExpressionParserTest {
                           assertThat(sc.getBuiltCondition())
                               .hasValueSatisfying(
                                   builtCondition -> {
-                                    assertThat(builtCondition.predicate()).isEqualTo(Predicate.GTE);
-                                    assertThat(((Literal) builtCondition.value()).get())
+                                    assertThat(builtCondition.getLeft().predicate())
+                                        .isEqualTo(Predicate.GTE);
+                                    assertThat(builtCondition.getRight())
                                         .isEqualTo(Values.of(Boolean.TRUE));
                                   });
                           assertThat(sc.getFilterOperation()).isEqualTo(GteFilterOperation.of());
@@ -424,9 +426,9 @@ class ExpressionParserTest {
                           assertThat(sc.getBuiltCondition())
                               .hasValueSatisfying(
                                   builtCondition -> {
-                                    assertThat(builtCondition.predicate()).isEqualTo(Predicate.LTE);
-                                    assertThat(((Literal) builtCondition.value()).get())
-                                        .isEqualTo(Values.of(22d));
+                                    assertThat(builtCondition.getLeft().predicate())
+                                        .isEqualTo(Predicate.LTE);
+                                    assertThat(builtCondition.getRight()).isEqualTo(Values.of(22d));
                                   });
                           assertThat(sc.getFilterOperation()).isEqualTo(LteFilterOperation.of());
                           assertThat(sc.getQueryValue()).isEqualTo(22);
@@ -456,8 +458,9 @@ class ExpressionParserTest {
                           assertThat(sc.getBuiltCondition())
                               .hasValueSatisfying(
                                   builtCondition -> {
-                                    assertThat(builtCondition.predicate()).isEqualTo(Predicate.EQ);
-                                    assertThat(((Literal) builtCondition.value()).get())
+                                    assertThat(builtCondition.getLeft().predicate())
+                                        .isEqualTo(Predicate.EQ);
+                                    assertThat(builtCondition.getRight())
                                         .isEqualTo(Values.of("some-value"));
                                   });
                           assertThat(sc.getFilterOperation()).isEqualTo(EqFilterOperation.of());
@@ -490,8 +493,9 @@ class ExpressionParserTest {
                           assertThat(sc.getBuiltCondition())
                               .hasValueSatisfying(
                                   builtCondition -> {
-                                    assertThat(builtCondition.predicate()).isEqualTo(Predicate.EQ);
-                                    assertThat(((Literal) builtCondition.value()).get())
+                                    assertThat(builtCondition.getLeft().predicate())
+                                        .isEqualTo(Predicate.EQ);
+                                    assertThat(builtCondition.getRight())
                                         .isEqualTo(Values.of("some-value"));
                                   });
                           assertThat(sc.getFilterOperation()).isEqualTo(EqFilterOperation.of());
@@ -524,8 +528,9 @@ class ExpressionParserTest {
                           assertThat(sc.getBuiltCondition())
                               .hasValueSatisfying(
                                   builtCondition -> {
-                                    assertThat(builtCondition.predicate()).isEqualTo(Predicate.EQ);
-                                    assertThat(((Literal) builtCondition.value()).get())
+                                    assertThat(builtCondition.getLeft().predicate())
+                                        .isEqualTo(Predicate.EQ);
+                                    assertThat(builtCondition.getRight())
                                         .isEqualTo(Values.of("some-value"));
                                   });
                           assertThat(sc.getFilterOperation()).isEqualTo(EqFilterOperation.of());
@@ -557,8 +562,9 @@ class ExpressionParserTest {
                           assertThat(sc.getBuiltCondition())
                               .hasValueSatisfying(
                                   builtCondition -> {
-                                    assertThat(builtCondition.predicate()).isEqualTo(Predicate.EQ);
-                                    assertThat(((Literal) builtCondition.value()).get())
+                                    assertThat(builtCondition.getLeft().predicate())
+                                        .isEqualTo(Predicate.EQ);
+                                    assertThat(builtCondition.getRight())
                                         .isEqualTo(Values.of("some-value"));
                                   });
                           assertThat(sc.getFilterOperation()).isEqualTo(EqFilterOperation.of());
@@ -596,9 +602,9 @@ class ExpressionParserTest {
                                       assertThat(sc.getBuiltCondition())
                                           .hasValueSatisfying(
                                               builtCondition -> {
-                                                assertThat(builtCondition.predicate())
+                                                assertThat(builtCondition.getLeft().predicate())
                                                     .isEqualTo(Predicate.EQ);
-                                                assertThat(((Literal) builtCondition.value()).get())
+                                                assertThat(builtCondition.getRight())
                                                     .isEqualTo(Values.of("some-value"));
                                               });
                                       assertThat(sc.getFilterOperation())
@@ -664,9 +670,9 @@ class ExpressionParserTest {
                                       assertThat(sc.getBuiltCondition())
                                           .hasValueSatisfying(
                                               builtCondition -> {
-                                                assertThat(builtCondition.predicate())
+                                                assertThat(builtCondition.getLeft().predicate())
                                                     .isEqualTo(Predicate.EQ);
-                                                assertThat(((Literal) builtCondition.value()).get())
+                                                assertThat(builtCondition.getRight())
                                                     .isEqualTo(Values.of("some-value"));
                                               });
                                       assertThat(sc.getFilterOperation())
@@ -734,13 +740,12 @@ class ExpressionParserTest {
                                                                     builtCondition -> {
                                                                       assertThat(
                                                                               builtCondition
+                                                                                  .getLeft()
                                                                                   .predicate())
                                                                           .isEqualTo(Predicate.EQ);
                                                                       assertThat(
-                                                                              ((Literal)
-                                                                                      builtCondition
-                                                                                          .value())
-                                                                                  .get())
+                                                                              builtCondition
+                                                                                  .getRight())
                                                                           .isEqualTo(
                                                                               Values.of(
                                                                                   "some-value"));
@@ -829,13 +834,12 @@ class ExpressionParserTest {
                                                                     builtCondition -> {
                                                                       assertThat(
                                                                               builtCondition
+                                                                                  .getLeft()
                                                                                   .predicate())
                                                                           .isEqualTo(Predicate.EQ);
                                                                       assertThat(
-                                                                              ((Literal)
-                                                                                      builtCondition
-                                                                                          .value())
-                                                                                  .get())
+                                                                              builtCondition
+                                                                                  .getRight())
                                                                           .isEqualTo(
                                                                               Values.of(
                                                                                   "some-value"));

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/condition/impl/BooleanConditionTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/condition/impl/BooleanConditionTest.java
@@ -23,14 +23,16 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.common.cql.builder.BuiltCondition;
-import io.stargate.sgv2.common.cql.builder.Literal;
+import io.stargate.sgv2.common.cql.builder.Marker;
 import io.stargate.sgv2.common.cql.builder.Predicate;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.service.common.model.RowWrapper;
 import io.stargate.sgv2.docsapi.service.query.filter.operation.ValueFilterOperation;
 import java.util.Optional;
 import org.apache.commons.lang3.RandomUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -83,14 +85,16 @@ class BooleanConditionTest {
 
       ImmutableBooleanCondition condition =
           ImmutableBooleanCondition.of(filterOperation, value, documentProperties, false);
-      Optional<BuiltCondition> result = condition.getBuiltCondition();
+      Optional<Pair<BuiltCondition, QueryOuterClass.Value>> result = condition.getBuiltCondition();
 
       assertThat(result)
           .hasValueSatisfying(
               builtCondition -> {
-                assertThat(builtCondition.predicate()).isEqualTo(eq);
-                assertThat(((Literal) builtCondition.value()).get()).isEqualTo(Values.of(value));
-                assertThat(builtCondition.lhs()).isEqualTo(BuiltCondition.LHS.column("bool_value"));
+                assertThat(builtCondition.getLeft().predicate()).isEqualTo(eq);
+                assertThat(builtCondition.getLeft().value()).isInstanceOf(Marker.class);
+                assertThat(builtCondition.getLeft().lhs())
+                    .isEqualTo(BuiltCondition.LHS.column("bool_value"));
+                assertThat(builtCondition.getRight()).isEqualTo(Values.of(value));
               });
     }
 
@@ -101,14 +105,16 @@ class BooleanConditionTest {
 
       ImmutableBooleanCondition condition =
           ImmutableBooleanCondition.of(filterOperation, true, documentProperties, true);
-      Optional<BuiltCondition> result = condition.getBuiltCondition();
+      Optional<Pair<BuiltCondition, QueryOuterClass.Value>> result = condition.getBuiltCondition();
 
       assertThat(result)
           .hasValueSatisfying(
               builtCondition -> {
-                assertThat(builtCondition.predicate()).isEqualTo(eq);
-                assertThat(((Literal) builtCondition.value()).get()).isEqualTo(Values.of(1));
-                assertThat(builtCondition.lhs()).isEqualTo(BuiltCondition.LHS.column("bool_value"));
+                assertThat(builtCondition.getLeft().predicate()).isEqualTo(eq);
+                assertThat(builtCondition.getLeft().value()).isInstanceOf(Marker.class);
+                assertThat(builtCondition.getLeft().lhs())
+                    .isEqualTo(BuiltCondition.LHS.column("bool_value"));
+                assertThat(builtCondition.getRight()).isEqualTo(Values.of(1));
               });
     }
 
@@ -119,14 +125,16 @@ class BooleanConditionTest {
 
       ImmutableBooleanCondition condition =
           ImmutableBooleanCondition.of(filterOperation, false, documentProperties, true);
-      Optional<BuiltCondition> result = condition.getBuiltCondition();
+      Optional<Pair<BuiltCondition, QueryOuterClass.Value>> result = condition.getBuiltCondition();
 
       assertThat(result)
           .hasValueSatisfying(
               builtCondition -> {
-                assertThat(builtCondition.predicate()).isEqualTo(eq);
-                assertThat(((Literal) builtCondition.value()).get()).isEqualTo(Values.of(0));
-                assertThat(builtCondition.lhs()).isEqualTo(BuiltCondition.LHS.column("bool_value"));
+                assertThat(builtCondition.getLeft().predicate()).isEqualTo(eq);
+                assertThat(builtCondition.getLeft().value()).isInstanceOf(Marker.class);
+                assertThat(builtCondition.getLeft().lhs())
+                    .isEqualTo(BuiltCondition.LHS.column("bool_value"));
+                assertThat(builtCondition.getRight()).isEqualTo(Values.of(0));
               });
     }
 
@@ -137,7 +145,7 @@ class BooleanConditionTest {
 
       ImmutableBooleanCondition condition =
           ImmutableBooleanCondition.of(filterOperation, value, documentProperties, true);
-      Optional<BuiltCondition> result = condition.getBuiltCondition();
+      Optional<Pair<BuiltCondition, QueryOuterClass.Value>> result = condition.getBuiltCondition();
 
       assertThat(result).isEmpty();
     }

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/condition/impl/GenericConditionTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/condition/impl/GenericConditionTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.common.cql.builder.BuiltCondition;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.service.common.model.RowWrapper;
@@ -31,6 +32,7 @@ import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.NotInFilterO
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -86,7 +88,7 @@ class GenericConditionTest {
 
       GenericCondition<Object> condition =
           ImmutableGenericCondition.of(filterOperation, new Object(), documentProperties, true);
-      Optional<BuiltCondition> result = condition.getBuiltCondition();
+      Optional<Pair<BuiltCondition, QueryOuterClass.Value>> result = condition.getBuiltCondition();
 
       assertThat(result).isEmpty();
     }

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/condition/impl/NumberConditionTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/condition/impl/NumberConditionTest.java
@@ -23,14 +23,16 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.common.cql.builder.BuiltCondition;
-import io.stargate.sgv2.common.cql.builder.Literal;
+import io.stargate.sgv2.common.cql.builder.Marker;
 import io.stargate.sgv2.common.cql.builder.Predicate;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.service.common.model.RowWrapper;
 import io.stargate.sgv2.docsapi.service.query.filter.operation.ValueFilterOperation;
 import java.util.Optional;
 import org.apache.commons.lang3.RandomUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -82,15 +84,16 @@ class NumberConditionTest {
 
       ImmutableNumberCondition condition =
           ImmutableNumberCondition.of(filterOperation, value, documentProperties);
-      Optional<BuiltCondition> result = condition.getBuiltCondition();
+      Optional<Pair<BuiltCondition, QueryOuterClass.Value>> result = condition.getBuiltCondition();
 
       assertThat(result)
           .hasValueSatisfying(
               builtCondition -> {
-                assertThat(builtCondition.predicate()).isEqualTo(eq);
-                assertThat(((Literal) builtCondition.value()).get())
-                    .isEqualTo(Values.of(value.doubleValue()));
-                assertThat(builtCondition.lhs()).isEqualTo(BuiltCondition.LHS.column("dbl_value"));
+                assertThat(builtCondition.getLeft().predicate()).isEqualTo(eq);
+                assertThat(builtCondition.getLeft().value()).isInstanceOf(Marker.class);
+                assertThat(builtCondition.getLeft().lhs())
+                    .isEqualTo(BuiltCondition.LHS.column("dbl_value"));
+                assertThat((builtCondition.getRight())).isEqualTo(Values.of(value.doubleValue()));
               });
     }
 
@@ -101,7 +104,7 @@ class NumberConditionTest {
 
       ImmutableNumberCondition condition =
           ImmutableNumberCondition.of(filterOperation, value, documentProperties);
-      Optional<BuiltCondition> result = condition.getBuiltCondition();
+      Optional<Pair<BuiltCondition, QueryOuterClass.Value>> result = condition.getBuiltCondition();
 
       assertThat(result).isEmpty();
     }

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/condition/impl/StringConditionTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/condition/impl/StringConditionTest.java
@@ -23,14 +23,16 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.common.cql.builder.BuiltCondition;
-import io.stargate.sgv2.common.cql.builder.Literal;
+import io.stargate.sgv2.common.cql.builder.Marker;
 import io.stargate.sgv2.common.cql.builder.Predicate;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.service.common.model.RowWrapper;
 import io.stargate.sgv2.docsapi.service.query.filter.operation.ValueFilterOperation;
 import java.util.Optional;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -82,14 +84,16 @@ class StringConditionTest {
 
       ImmutableStringCondition condition =
           ImmutableStringCondition.of(filterOperation, value, documentProperties);
-      Optional<BuiltCondition> result = condition.getBuiltCondition();
+      Optional<Pair<BuiltCondition, QueryOuterClass.Value>> result = condition.getBuiltCondition();
 
       assertThat(result)
           .hasValueSatisfying(
               builtCondition -> {
-                assertThat(builtCondition.predicate()).isEqualTo(eq);
-                assertThat(((Literal) builtCondition.value()).get()).isEqualTo(Values.of(value));
-                assertThat(builtCondition.lhs()).isEqualTo(BuiltCondition.LHS.column("text_value"));
+                assertThat(builtCondition.getLeft().predicate()).isEqualTo(eq);
+                assertThat(builtCondition.getLeft().value()).isInstanceOf(Marker.class);
+                assertThat(builtCondition.getLeft().lhs())
+                    .isEqualTo(BuiltCondition.LHS.column("text_value"));
+                assertThat(builtCondition.getRight()).isEqualTo(Values.of(value));
               });
     }
 
@@ -100,7 +104,7 @@ class StringConditionTest {
 
       ImmutableStringCondition condition =
           ImmutableStringCondition.of(filterOperation, value, documentProperties);
-      Optional<BuiltCondition> result = condition.getBuiltCondition();
+      Optional<Pair<BuiltCondition, QueryOuterClass.Value>> result = condition.getBuiltCondition();
 
       assertThat(result).isEmpty();
     }

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/DocumentTtlQueryBuilderTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/DocumentTtlQueryBuilderTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.db.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import javax.inject.Inject;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class DocumentTtlQueryBuilderTest {
+
+  private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
+  private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
+
+  @Inject DocumentProperties documentProperties;
+
+  @Nested
+  class BuildQuery {
+
+    @Test
+    public void happyPath() {
+      DocumentTtlQueryBuilder queryBuilder = new DocumentTtlQueryBuilder(documentProperties);
+      QueryOuterClass.Query query = queryBuilder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+
+      String expected =
+          "SELECT key, TTL(leaf), WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE key = ?"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+    }
+
+    @Test
+    public void happyPathAddedColumnsIgnored() {
+
+      DocumentTtlQueryBuilder queryBuilder = new DocumentTtlQueryBuilder(documentProperties);
+      QueryOuterClass.Query query =
+          queryBuilder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME, "column1", "column2");
+
+      String expected =
+          "SELECT key, TTL(leaf), WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE key = ?"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/DocumentsSearchQueryBuilderTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/DocumentsSearchQueryBuilderTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.db.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.when;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.FilterPath;
+import io.stargate.sgv2.docsapi.service.query.ImmutableFilterPath;
+import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
+import io.stargate.sgv2.docsapi.testprofiles.MaxDepth4TestProfile;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import javax.inject.Inject;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@QuarkusTest
+@TestProfile(MaxDepth4TestProfile.class)
+class DocumentsSearchQueryBuilderTest {
+
+  private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
+  private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
+
+  @Inject DocumentProperties documentProperties;
+
+  @Mock FilterExpression filterExpression;
+
+  @BeforeEach
+  public void init() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Nested
+  class Constructor {
+
+    @Test
+    public void differentPathsNotAllowed() {
+      FilterPath filterPath1 = ImmutableFilterPath.of(Collections.singletonList("field"));
+      FilterPath filterPath2 = ImmutableFilterPath.of(Collections.singletonList("another"));
+      when(filterExpression.getFilterPath()).thenReturn(filterPath1).thenReturn(filterPath2);
+
+      Throwable t =
+          catchThrowable(
+              () ->
+                  new DocumentSearchQueryBuilder(
+                      documentProperties, Arrays.asList(filterExpression, filterExpression)));
+
+      assertThat(t).isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  class BuildQuery {
+
+    @Mock BaseCondition condition;
+
+    @BeforeEach
+    public void init() {
+      MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void happyPath() {
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.getCondition()).thenReturn(condition);
+      when(condition.getBuiltCondition()).thenReturn(Optional.empty());
+
+      FilterExpressionSearchQueryBuilder builder =
+          new DocumentSearchQueryBuilder(documentProperties, filterExpression);
+      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+
+      String expected =
+          String.format(
+              "SELECT WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND key = ? ALLOW FILTERING",
+              KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+      assertThat(query.getValues().getValuesList())
+          .containsExactly(Values.of("field"), Values.of("field"), Values.of(""));
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/DocumentsSearchQueryBuilderTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/DocumentsSearchQueryBuilderTest.java
@@ -89,6 +89,8 @@ class DocumentsSearchQueryBuilderTest {
 
     @Test
     public void happyPath() {
+      String documentId = RandomStringUtils.randomAlphanumeric(16);
+      QueryOuterClass.Value documentIdValue = Values.of(documentId);
       FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
       when(filterExpression.getFilterPath()).thenReturn(filterPath);
       when(filterExpression.getCondition()).thenReturn(condition);
@@ -96,7 +98,9 @@ class DocumentsSearchQueryBuilderTest {
 
       FilterExpressionSearchQueryBuilder builder =
           new DocumentSearchQueryBuilder(documentProperties, filterExpression);
-      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      QueryOuterClass.Query query =
+          builder.bindWithValues(
+              builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME), documentIdValue);
 
       String expected =
           String.format(
@@ -104,7 +108,7 @@ class DocumentsSearchQueryBuilderTest {
               KEYSPACE_NAME, COLLECTION_NAME);
       assertThat(query.getCql()).isEqualTo(expected);
       assertThat(query.getValues().getValuesList())
-          .containsExactly(Values.of("field"), Values.of("field"), Values.of(""));
+          .containsExactly(Values.of("field"), Values.of("field"), Values.of(""), documentIdValue);
     }
   }
 }

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FilterExpressionSearchQueryBuilderTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FilterExpressionSearchQueryBuilderTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.db.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.when;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.common.cql.builder.BuiltCondition;
+import io.stargate.sgv2.common.cql.builder.Predicate;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.FilterPath;
+import io.stargate.sgv2.docsapi.service.query.ImmutableFilterPath;
+import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
+import io.stargate.sgv2.docsapi.testprofiles.MaxDepth4TestProfile;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import javax.inject.Inject;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@QuarkusTest
+@TestProfile(MaxDepth4TestProfile.class)
+class FilterExpressionSearchQueryBuilderTest {
+
+  private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
+  private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
+
+  @Inject DocumentProperties documentProperties;
+
+  @Mock FilterExpression filterExpression;
+
+  @BeforeEach
+  public void init() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Nested
+  class Constructor {
+
+    @Test
+    public void differentPathsNotAllowed() {
+      FilterPath filterPath1 = ImmutableFilterPath.of(Collections.singletonList("field"));
+      FilterPath filterPath2 = ImmutableFilterPath.of(Collections.singletonList("another"));
+      when(filterExpression.getFilterPath()).thenReturn(filterPath1).thenReturn(filterPath2);
+
+      Throwable t =
+          catchThrowable(
+              () ->
+                  new FilterExpressionSearchQueryBuilder(
+                      documentProperties, Arrays.asList(filterExpression, filterExpression)));
+
+      assertThat(t).isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  class BuildQuery {
+
+    @Mock BaseCondition condition;
+
+    FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+
+    @BeforeEach
+    public void initMocks() {
+      MockitoAnnotations.openMocks(this);
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.getCondition()).thenReturn(condition);
+    }
+
+    @Test
+    public void happyPath() {
+      QueryOuterClass.Value textValue = Values.of("value");
+      BuiltCondition builtCondition = BuiltCondition.of("text_value", Predicate.EQ, textValue);
+      when(condition.getBuiltCondition()).thenReturn(Optional.of(builtCondition));
+
+      FilterExpressionSearchQueryBuilder builder =
+          new FilterExpressionSearchQueryBuilder(documentProperties, filterExpression);
+      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+
+      String expected =
+          String.format(
+              "SELECT WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND text_value = ? ALLOW FILTERING",
+              KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+      assertThat(query.getValues().getValuesList())
+          .containsExactly(Values.of("field"), Values.of("field"), Values.of(""), textValue);
+    }
+
+    @Test
+    public void noCondition() {
+      when(condition.getBuiltCondition()).thenReturn(Optional.empty());
+
+      FilterExpressionSearchQueryBuilder builder =
+          new FilterExpressionSearchQueryBuilder(documentProperties, filterExpression);
+      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+
+      String expected =
+          String.format(
+              "SELECT WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? ALLOW FILTERING",
+              KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+      assertThat(query.getValues().getValuesList())
+          .containsExactly(Values.of("field"), Values.of("field"), Values.of(""));
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FilterExpressionSearchQueryBuilderTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FilterExpressionSearchQueryBuilderTest.java
@@ -27,6 +27,7 @@ import io.stargate.bridge.grpc.Values;
 import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.common.cql.builder.BuiltCondition;
 import io.stargate.sgv2.common.cql.builder.Predicate;
+import io.stargate.sgv2.common.cql.builder.Term;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.service.query.FilterExpression;
 import io.stargate.sgv2.docsapi.service.query.FilterPath;
@@ -38,6 +39,7 @@ import java.util.Collections;
 import java.util.Optional;
 import javax.inject.Inject;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -96,12 +98,14 @@ class FilterExpressionSearchQueryBuilderTest {
     @Test
     public void happyPath() {
       QueryOuterClass.Value textValue = Values.of("value");
-      BuiltCondition builtCondition = BuiltCondition.of("text_value", Predicate.EQ, textValue);
-      when(condition.getBuiltCondition()).thenReturn(Optional.of(builtCondition));
+      BuiltCondition builtCondition = BuiltCondition.of("text_value", Predicate.EQ, Term.marker());
+      when(condition.getBuiltCondition())
+          .thenReturn(Optional.of(Pair.of(builtCondition, textValue)));
 
       FilterExpressionSearchQueryBuilder builder =
           new FilterExpressionSearchQueryBuilder(documentProperties, filterExpression);
-      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      QueryOuterClass.Query query =
+          builder.bind(builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME));
 
       String expected =
           String.format(
@@ -118,7 +122,8 @@ class FilterExpressionSearchQueryBuilderTest {
 
       FilterExpressionSearchQueryBuilder builder =
           new FilterExpressionSearchQueryBuilder(documentProperties, filterExpression);
-      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      QueryOuterClass.Query query =
+          builder.bind(builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME));
 
       String expected =
           String.format(

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FilterPathSearchQueryBuilderTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FilterPathSearchQueryBuilderTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.db.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.api.exception.ErrorCode;
+import io.stargate.sgv2.docsapi.api.exception.ErrorCodeRuntimeException;
+import io.stargate.sgv2.docsapi.service.query.FilterPath;
+import io.stargate.sgv2.docsapi.service.query.ImmutableFilterPath;
+import io.stargate.sgv2.docsapi.testprofiles.MaxDepth4TestProfile;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.inject.Inject;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(MaxDepth4TestProfile.class)
+class FilterPathSearchQueryBuilderTest {
+
+  private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
+  private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
+
+  @Inject DocumentProperties documentProperties;
+
+  @Nested
+  class BuildQuery {
+
+    @Test
+    public void fieldOnly() {
+      List<String> path = Collections.singletonList("field");
+      FilterPath filterPath = ImmutableFilterPath.of(path);
+
+      FilterPathSearchQueryBuilder builder =
+          new FilterPathSearchQueryBuilder(documentProperties, filterPath, true);
+      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+
+      String expected =
+          String.format(
+              "SELECT WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? ALLOW FILTERING",
+              KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+      assertThat(query.getValues().getValuesList())
+          .containsExactly(Values.of("field"), Values.of("field"), Values.of(""));
+    }
+
+    @Test
+    public void fieldWithColumns() {
+      List<String> path = Collections.singletonList("field");
+      FilterPath filterPath = ImmutableFilterPath.of(path);
+
+      FilterPathSearchQueryBuilder builder =
+          new FilterPathSearchQueryBuilder(documentProperties, filterPath, true);
+      QueryOuterClass.Query query =
+          builder.buildQuery(
+              KEYSPACE_NAME,
+              COLLECTION_NAME,
+              documentProperties.tableProperties().pathColumnName(0));
+
+      String expected =
+          String.format(
+              "SELECT p0, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? ALLOW FILTERING",
+              KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+      assertThat(query.getValues().getValuesList())
+          .containsExactly(Values.of("field"), Values.of("field"), Values.of(""));
+    }
+
+    @Test
+    public void fieldWithLimit() {
+      List<String> path = Collections.singletonList("field");
+      FilterPath filterPath = ImmutableFilterPath.of(path);
+
+      FilterPathSearchQueryBuilder builder =
+          new FilterPathSearchQueryBuilder(documentProperties, filterPath, true);
+      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME, 5);
+
+      String expected =
+          String.format(
+              "SELECT WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? LIMIT 5 ALLOW FILTERING",
+              KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+      assertThat(query.getValues().getValuesList())
+          .containsExactly(Values.of("field"), Values.of("field"), Values.of(""));
+    }
+
+    @Test
+    public void fieldAndParentPath() {
+      List<String> path = Arrays.asList("path", "to", "field");
+      FilterPath filterPath = ImmutableFilterPath.of(path);
+
+      FilterPathSearchQueryBuilder builder =
+          new FilterPathSearchQueryBuilder(documentProperties, filterPath, true);
+      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+
+      String expected =
+          String.format(
+              "SELECT WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 = ? AND p2 = ? AND leaf = ? AND p3 = ? ALLOW FILTERING",
+              KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+      assertThat(query.getValues().getValuesList())
+          .containsExactly(
+              Values.of("path"),
+              Values.of("to"),
+              Values.of("field"),
+              Values.of("field"),
+              Values.of(""));
+    }
+
+    @Test
+    public void fieldAndParentGlob() {
+      List<String> path = Arrays.asList("path", "*", "field");
+      FilterPath filterPath = ImmutableFilterPath.of(path);
+
+      FilterPathSearchQueryBuilder builder =
+          new FilterPathSearchQueryBuilder(documentProperties, filterPath, true);
+      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+
+      String expected =
+          String.format(
+              "SELECT WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 > ? AND p2 = ? AND leaf = ? AND p3 = ? ALLOW FILTERING",
+              KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+      assertThat(query.getValues().getValuesList())
+          .containsExactly(
+              Values.of("path"),
+              Values.of(""),
+              Values.of("field"),
+              Values.of("field"),
+              Values.of(""));
+    }
+
+    @Test
+    public void fieldAndParentArrayGlob() {
+      List<String> path = Arrays.asList("path", "[*]", "field");
+      FilterPath filterPath = ImmutableFilterPath.of(path);
+
+      FilterPathSearchQueryBuilder builder =
+          new FilterPathSearchQueryBuilder(documentProperties, filterPath, true);
+      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+
+      String expected =
+          String.format(
+              "SELECT WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 > ? AND p2 = ? AND leaf = ? AND p3 = ? ALLOW FILTERING",
+              KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+      assertThat(query.getValues().getValuesList())
+          .containsExactly(
+              Values.of("path"),
+              Values.of(""),
+              Values.of("field"),
+              Values.of("field"),
+              Values.of(""));
+    }
+
+    @Test
+    public void fieldAndParentPathSplit() {
+      List<String> path = Arrays.asList("path", "one,two,three", "field");
+      FilterPath filterPath = ImmutableFilterPath.of(path);
+
+      FilterPathSearchQueryBuilder builder =
+          new FilterPathSearchQueryBuilder(documentProperties, filterPath, true);
+      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+
+      String expected =
+          String.format(
+              "SELECT WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 IN ? AND p2 = ? AND leaf = ? AND p3 = ? ALLOW FILTERING",
+              KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+      assertThat(query.getValues().getValuesList())
+          .containsExactly(
+              Values.of("path"),
+              Values.of(Values.of("one"), Values.of("two"), Values.of("three")),
+              Values.of("field"),
+              Values.of("field"),
+              Values.of(""));
+    }
+
+    @Test
+    public void fieldAndParentArrayPathSplit() {
+      List<String> path = Arrays.asList("path", "[000000],[000001],[000002]", "field");
+      FilterPath filterPath = ImmutableFilterPath.of(path);
+
+      FilterPathSearchQueryBuilder builder =
+          new FilterPathSearchQueryBuilder(documentProperties, filterPath, true);
+      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+
+      String expected =
+          String.format(
+              "SELECT WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 IN ? AND p2 = ? AND leaf = ? AND p3 = ? ALLOW FILTERING",
+              KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+      assertThat(query.getValues().getValuesList())
+          .containsExactly(
+              Values.of("path"),
+              Values.of(Values.of("[000000]"), Values.of("[000001]"), Values.of("[000002]")),
+              Values.of("field"),
+              Values.of("field"),
+              Values.of(""));
+    }
+
+    @Test
+    public void maxDepthExceeded() {
+      List<String> path =
+          IntStream.range(0, documentProperties.maxDepth() + 1)
+              .mapToObj(Integer::toString)
+              .collect(Collectors.toList());
+      FilterPath filterPath = ImmutableFilterPath.of(path);
+
+      FilterPathSearchQueryBuilder builder =
+          new FilterPathSearchQueryBuilder(documentProperties, filterPath, true);
+      Throwable t = catchThrowable(() -> builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME));
+
+      assertThat(t)
+          .isInstanceOf(ErrorCodeRuntimeException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DOCS_API_GENERAL_DEPTH_EXCEEDED);
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FilterPathSearchQueryBuilderTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FilterPathSearchQueryBuilderTest.java
@@ -59,7 +59,8 @@ class FilterPathSearchQueryBuilderTest {
 
       FilterPathSearchQueryBuilder builder =
           new FilterPathSearchQueryBuilder(documentProperties, filterPath, true);
-      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      QueryOuterClass.Query query =
+          builder.bind(builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME));
 
       String expected =
           String.format(
@@ -78,10 +79,11 @@ class FilterPathSearchQueryBuilderTest {
       FilterPathSearchQueryBuilder builder =
           new FilterPathSearchQueryBuilder(documentProperties, filterPath, true);
       QueryOuterClass.Query query =
-          builder.buildQuery(
-              KEYSPACE_NAME,
-              COLLECTION_NAME,
-              documentProperties.tableProperties().pathColumnName(0));
+          builder.bind(
+              builder.buildQuery(
+                  KEYSPACE_NAME,
+                  COLLECTION_NAME,
+                  documentProperties.tableProperties().pathColumnName(0)));
 
       String expected =
           String.format(
@@ -99,7 +101,8 @@ class FilterPathSearchQueryBuilderTest {
 
       FilterPathSearchQueryBuilder builder =
           new FilterPathSearchQueryBuilder(documentProperties, filterPath, true);
-      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME, 5);
+      QueryOuterClass.Query query =
+          builder.bind(builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME, 5));
 
       String expected =
           String.format(
@@ -117,7 +120,8 @@ class FilterPathSearchQueryBuilderTest {
 
       FilterPathSearchQueryBuilder builder =
           new FilterPathSearchQueryBuilder(documentProperties, filterPath, true);
-      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      QueryOuterClass.Query query =
+          builder.bind(builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME));
 
       String expected =
           String.format(
@@ -140,7 +144,8 @@ class FilterPathSearchQueryBuilderTest {
 
       FilterPathSearchQueryBuilder builder =
           new FilterPathSearchQueryBuilder(documentProperties, filterPath, true);
-      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      QueryOuterClass.Query query =
+          builder.bind(builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME));
 
       String expected =
           String.format(
@@ -163,7 +168,8 @@ class FilterPathSearchQueryBuilderTest {
 
       FilterPathSearchQueryBuilder builder =
           new FilterPathSearchQueryBuilder(documentProperties, filterPath, true);
-      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      QueryOuterClass.Query query =
+          builder.bind(builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME));
 
       String expected =
           String.format(
@@ -186,7 +192,8 @@ class FilterPathSearchQueryBuilderTest {
 
       FilterPathSearchQueryBuilder builder =
           new FilterPathSearchQueryBuilder(documentProperties, filterPath, true);
-      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      QueryOuterClass.Query query =
+          builder.bind(builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME));
 
       String expected =
           String.format(
@@ -209,7 +216,8 @@ class FilterPathSearchQueryBuilderTest {
 
       FilterPathSearchQueryBuilder builder =
           new FilterPathSearchQueryBuilder(documentProperties, filterPath, true);
-      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      QueryOuterClass.Query query =
+          builder.bind(builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME));
 
       String expected =
           String.format(

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FullSearchQueryBuilderTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FullSearchQueryBuilderTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.db.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import javax.inject.Inject;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class FullSearchQueryBuilderTest {
+
+  private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
+  private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
+
+  @Inject DocumentProperties documentProperties;
+
+  @Nested
+  class BuildQuery {
+
+    @Test
+    public void happyPath() {
+      FullSearchQueryBuilder queryBuilder = new FullSearchQueryBuilder(documentProperties);
+      QueryOuterClass.Query query = queryBuilder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+
+      String expected =
+          "SELECT WRITETIME(leaf) FROM \"%s\".\"%s\"".formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/PathSearchQueryBuilderTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/PathSearchQueryBuilderTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.db.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.testprofiles.MaxDepth4TestProfile;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.inject.Inject;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(MaxDepth4TestProfile.class)
+class PathSearchQueryBuilderTest {
+
+  private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
+  private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
+
+  @Inject DocumentProperties documentProperties;
+
+  @Nested
+  class BuildQuery {
+
+    @Test
+    public void simplePath() {
+      List<String> path = Arrays.asList("path", "to", "something");
+
+      PathSearchQueryBuilder builder = new PathSearchQueryBuilder(documentProperties, path);
+      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+
+      String expected =
+          String.format(
+              "SELECT WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 = ? AND p2 = ? ALLOW FILTERING",
+              KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+      assertThat(query.getValues().getValuesList())
+          .containsExactly(Values.of("path"), Values.of("to"), Values.of("something"));
+    }
+
+    @Test
+    public void glob() {
+      List<String> path = Arrays.asList("path", "*", "something");
+
+      PathSearchQueryBuilder builder = new PathSearchQueryBuilder(documentProperties, path);
+      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+
+      String expected =
+          String.format(
+              "SELECT WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 > ? AND p2 = ? ALLOW FILTERING",
+              KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+      assertThat(query.getValues().getValuesList())
+          .containsExactly(Values.of("path"), Values.of(""), Values.of("something"));
+    }
+
+    @Test
+    public void arrayGlob() {
+      List<String> path = Arrays.asList("path", "[*]", "something");
+
+      PathSearchQueryBuilder builder = new PathSearchQueryBuilder(documentProperties, path);
+      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+
+      String expected =
+          String.format(
+              "SELECT WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 > ? AND p2 = ? ALLOW FILTERING",
+              KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+      assertThat(query.getValues().getValuesList())
+          .containsExactly(Values.of("path"), Values.of(""), Values.of("something"));
+    }
+
+    @Test
+    public void pathSplit() {
+      List<String> path = Arrays.asList("path", "one,two,three", "something");
+
+      PathSearchQueryBuilder builder = new PathSearchQueryBuilder(documentProperties, path);
+      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+
+      String expected =
+          String.format(
+              "SELECT WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 IN ? AND p2 = ? ALLOW FILTERING",
+              KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+      assertThat(query.getValues().getValuesList())
+          .containsExactly(
+              Values.of("path"),
+              Values.of(Values.of("one"), Values.of("two"), Values.of("three")),
+              Values.of("something"));
+    }
+
+    @Test
+    public void arrayPathSplit() {
+      List<String> path = Arrays.asList("path", "[000000],[000001],[000002]", "something");
+
+      PathSearchQueryBuilder builder = new PathSearchQueryBuilder(documentProperties, path);
+      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+
+      String expected =
+          String.format(
+              "SELECT WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 IN ? AND p2 = ? ALLOW FILTERING",
+              KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+      assertThat(query.getValues().getValuesList())
+          .containsExactly(
+              Values.of("path"),
+              Values.of(Values.of("[000000]"), Values.of("[000001]"), Values.of("[000002]")),
+              Values.of("something"));
+    }
+
+    @Test
+    public void emptyPath() {
+      List<String> path = Collections.emptyList();
+
+      PathSearchQueryBuilder builder = new PathSearchQueryBuilder(documentProperties, path);
+      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+
+      String expected =
+          String.format(
+              "SELECT WRITETIME(leaf) FROM \"%s\".\"%s\"", KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/PathSearchQueryBuilderTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/PathSearchQueryBuilderTest.java
@@ -50,7 +50,8 @@ class PathSearchQueryBuilderTest {
       List<String> path = Arrays.asList("path", "to", "something");
 
       PathSearchQueryBuilder builder = new PathSearchQueryBuilder(documentProperties, path);
-      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      QueryOuterClass.Query query =
+          builder.bind(builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME));
 
       String expected =
           String.format(
@@ -66,7 +67,8 @@ class PathSearchQueryBuilderTest {
       List<String> path = Arrays.asList("path", "*", "something");
 
       PathSearchQueryBuilder builder = new PathSearchQueryBuilder(documentProperties, path);
-      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      QueryOuterClass.Query query =
+          builder.bind(builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME));
 
       String expected =
           String.format(
@@ -82,7 +84,8 @@ class PathSearchQueryBuilderTest {
       List<String> path = Arrays.asList("path", "[*]", "something");
 
       PathSearchQueryBuilder builder = new PathSearchQueryBuilder(documentProperties, path);
-      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      QueryOuterClass.Query query =
+          builder.bind(builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME));
 
       String expected =
           String.format(
@@ -98,7 +101,8 @@ class PathSearchQueryBuilderTest {
       List<String> path = Arrays.asList("path", "one,two,three", "something");
 
       PathSearchQueryBuilder builder = new PathSearchQueryBuilder(documentProperties, path);
-      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      QueryOuterClass.Query query =
+          builder.bind(builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME));
 
       String expected =
           String.format(
@@ -117,7 +121,8 @@ class PathSearchQueryBuilderTest {
       List<String> path = Arrays.asList("path", "[000000],[000001],[000002]", "something");
 
       PathSearchQueryBuilder builder = new PathSearchQueryBuilder(documentProperties, path);
-      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      QueryOuterClass.Query query =
+          builder.bind(builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME));
 
       String expected =
           String.format(
@@ -136,12 +141,14 @@ class PathSearchQueryBuilderTest {
       List<String> path = Collections.emptyList();
 
       PathSearchQueryBuilder builder = new PathSearchQueryBuilder(documentProperties, path);
-      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      QueryOuterClass.Query query =
+          builder.bind(builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME));
 
       String expected =
           String.format(
               "SELECT WRITETIME(leaf) FROM \"%s\".\"%s\"", KEYSPACE_NAME, COLLECTION_NAME);
       assertThat(query.getCql()).isEqualTo(expected);
+      assertThat(query.getValues().getValuesList()).isEmpty();
     }
   }
 }

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/PopulateSearchQueryBuilderTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/PopulateSearchQueryBuilderTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.db.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import javax.inject.Inject;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class PopulateSearchQueryBuilderTest {
+
+  private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
+  private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
+
+  @Inject DocumentProperties documentProperties;
+
+  @Nested
+  class BuildQuery {
+
+    @Test
+    public void happyPath() {
+      PopulateSearchQueryBuilder queryBuilder = new PopulateSearchQueryBuilder(documentProperties);
+      QueryOuterClass.Query query = queryBuilder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+
+      String expected =
+          "SELECT WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE key = ?"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/SubDocumentSearchQueryBuilderTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/SubDocumentSearchQueryBuilderTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.db.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.testprofiles.MaxDepth4TestProfile;
+import java.util.Arrays;
+import java.util.List;
+import javax.inject.Inject;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(MaxDepth4TestProfile.class)
+class SubDocumentSearchQueryBuilderTest {
+
+  private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
+  private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
+
+  @Inject DocumentProperties documentProperties;
+
+  @Nested
+  class BuildQuery {
+
+    @Test
+    public void happyPath() {
+      List<String> path = Arrays.asList("path", "to", "something");
+      String docId = "d1234";
+
+      SubDocumentSearchQueryBuilder builder =
+          new SubDocumentSearchQueryBuilder(documentProperties, docId, path);
+      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+
+      String expected =
+          String.format(
+              "SELECT WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 = ? AND p2 = ? AND key = ? ALLOW FILTERING",
+              KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(query.getCql()).isEqualTo(expected);
+      assertThat(query.getValues().getValuesList())
+          .containsExactly(
+              Values.of("path"), Values.of("to"), Values.of("something"), Values.of("d1234"));
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/SubDocumentSearchQueryBuilderTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/SubDocumentSearchQueryBuilderTest.java
@@ -51,7 +51,8 @@ class SubDocumentSearchQueryBuilderTest {
 
       SubDocumentSearchQueryBuilder builder =
           new SubDocumentSearchQueryBuilder(documentProperties, docId, path);
-      QueryOuterClass.Query query = builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      QueryOuterClass.Query query =
+          builder.bind(builder.buildQuery(KEYSPACE_NAME, COLLECTION_NAME));
 
       String expected =
           String.format(

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/QueryBuilderImpl.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/cql/builder/QueryBuilderImpl.java
@@ -1523,6 +1523,14 @@ public class QueryBuilderImpl {
       return function(columnName, alias, "SUM");
     }
 
+    public static FunctionCall ttl(String columnName) {
+      return ttl(columnName, null);
+    }
+
+    public static FunctionCall ttl(String columnName, String alias) {
+      return function(columnName, alias, "TTL");
+    }
+
     public static FunctionCall writeTime(String columnName) {
       return writeTime(columnName, null);
     }


### PR DESCRIPTION
**What this PR does**:
First part of the #1738, where I only converted all the search query builders to the V2. Note that there was a slight change in the design from the V1, as V2 is not supporting the mixed mode markers & literals in the conditions.. Thus, everything is refactored to use a marker. 

`TTL` function was not in the `QueryBuilderImpl` in V2, I added the code, but was confused that there was no DSL chnage in V1 to reference this in `"select star? column* function* ((count|min|max|avg|sum|writeTimeColumn) as?)* "`. We should resolve this.

**Which issue(s) this PR fixes**:
Relates to #1738<issue number>

**Checklist**
- [x] Automated Tests added/updated
- [x] TTL function
