### PR TITLE
relates to #1738: ported search weight and expression rules

### DIFF
--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/rules/ExpressionUtils.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/rules/ExpressionUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.rules;
+
+import com.bpodgursky.jbool_expressions.Expression;
+import com.bpodgursky.jbool_expressions.rules.RuleSet;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+
+public class ExpressionUtils {
+
+  /**
+   * Converts the given expression to CNF and eliminates boolean NOT operators but inverting the
+   * negated {@link FilterExpression}s.
+   *
+   * <p>Note: If selectivity hints are not defined on all filters, the simplification process may
+   * lose user-provided hints. This can be avoided by the user by providing hints on all filters or
+   * by simplifying the expression up front.
+   */
+  public static Expression<FilterExpression> toSimplifiedCnf(
+      Expression<FilterExpression> expression) {
+    // Note: this will push NOTs down to the leaf (FilterExpression) level
+    Expression<FilterExpression> cnf = RuleSet.toCNF(expression);
+
+    // Resolve NOTs by inverting negated FilterExpressions
+    Expression<FilterExpression> negationResolved = NegateFilters.resolve(cnf);
+
+    // Re-simplify the expression after eliminating NOTs
+    return RuleSet.simplify(negationResolved);
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/rules/NegateFilters.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/rules/NegateFilters.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.rules;
+
+import com.bpodgursky.jbool_expressions.Expression;
+import com.bpodgursky.jbool_expressions.Not;
+import com.bpodgursky.jbool_expressions.options.ExprOptions;
+import com.bpodgursky.jbool_expressions.rules.Rule;
+import com.bpodgursky.jbool_expressions.rules.RuleList;
+import com.bpodgursky.jbool_expressions.rules.RulesHelper;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import java.util.Collections;
+import java.util.List;
+
+public class NegateFilters extends Rule<Expression<FilterExpression>, FilterExpression> {
+
+  private static final RuleList<FilterExpression> rules =
+      new RuleList<>(Collections.singletonList(new NegateFilters()));
+
+  @Override
+  public Expression<FilterExpression> applyInternal(
+      Expression<FilterExpression> input, ExprOptions<FilterExpression> options) {
+    Not<FilterExpression> negated = (Not<FilterExpression>) input;
+    FilterExpression child = (FilterExpression) negated.getChildren().get(0);
+
+    return child.negate();
+  }
+
+  @Override
+  protected boolean isApply(Expression<FilterExpression> input) {
+    if (!(input instanceof Not)) {
+      return false;
+    }
+
+    Not<FilterExpression> negated = (Not<FilterExpression>) input;
+
+    List<Expression<FilterExpression>> children = negated.getChildren();
+    if (children.size() != 1) {
+      return false;
+    }
+
+    Expression<FilterExpression> child = children.get(0);
+    return child instanceof FilterExpression;
+  }
+
+  public static Expression<FilterExpression> resolve(Expression<FilterExpression> expression) {
+    return RulesHelper.applyAll(expression, rules, ExprOptions.noCaching());
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/rules/TrueFilterExpressions.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/rules/TrueFilterExpressions.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.rules;
+
+import com.bpodgursky.jbool_expressions.Expression;
+import com.bpodgursky.jbool_expressions.Literal;
+import com.bpodgursky.jbool_expressions.options.ExprOptions;
+import com.bpodgursky.jbool_expressions.rules.Rule;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import java.util.function.Predicate;
+
+/**
+ * A {@link Rule} that coverts any {@link Expression<FilterExpression>} matching the given predicate
+ * to {@link Literal#getTrue()}.
+ */
+public class TrueFilterExpressions extends Rule<Expression<FilterExpression>, FilterExpression> {
+
+  private final Predicate<Expression<FilterExpression>> truePredicate;
+
+  public TrueFilterExpressions(Predicate<Expression<FilterExpression>> truePredicate) {
+    this.truePredicate = truePredicate;
+  }
+
+  @Override
+  public Expression<FilterExpression> applyInternal(
+      Expression<FilterExpression> input, ExprOptions<FilterExpression> options) {
+    boolean test = truePredicate.test(input);
+    if (test) {
+      return Literal.getTrue();
+    } else {
+      return input;
+    }
+  }
+
+  // only instance of FilterExpression
+  @Override
+  protected boolean isApply(Expression<FilterExpression> input) {
+    return true;
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/weight/ExpressionWeightResolver.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/weight/ExpressionWeightResolver.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.weight;
+
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.function.BiFunction;
+
+/**
+ * Interface that can resolve what {@link FilterExpression} should be executed first.
+ *
+ * @param <T>
+ */
+public interface ExpressionWeightResolver<T extends FilterExpression> {
+
+  Comparator<BaseCondition> CONDITION_COMPARATOR =
+      Comparator.comparing(BaseCondition::isPersistenceCondition)
+          .thenComparing(c -> !c.isEvaluateOnMissingFields())
+          .reversed();
+
+  /**
+   * Compares two expressions and resolves which one should be executed first.
+   *
+   * @param o1 first
+   * @param o2 second
+   * @return result by the comparator contract
+   */
+  default int compare(T o1, T o2) {
+    return CONDITION_COMPARATOR.compare(o1.getCondition(), o2.getCondition());
+  }
+
+  /**
+   * Compares two expression collections and resolves which one should be executed first.
+   *
+   * @param c1 first
+   * @param c2 second
+   * @return result by the comparator contract
+   */
+  default int compare(Collection<T> c1, Collection<T> c2) {
+    int result = 0;
+    for (T e1 : c1) {
+      for (T e2 : c2) {
+        result += compare(e1, e2);
+      }
+    }
+    return result;
+  }
+
+  /** @return Returns expression that should be executed first from two. */
+  default BiFunction<T, T, T> single() {
+    return (e1, e2) -> {
+      int compare = compare(e1, e2);
+      return compare > 0 ? e2 : e1;
+    };
+  }
+
+  /** @return Returns collection of expression that should be executed first from two. */
+  default BiFunction<Collection<T>, Collection<T>, Collection<T>> collection() {
+    return (c1, c2) -> {
+      int compare = compare(c1, c2);
+      return compare > 0 ? c2 : c1;
+    };
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/weight/impl/UserOrderWeightResolver.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/weight/impl/UserOrderWeightResolver.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.weight.impl;
+
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.search.weight.ExpressionWeightResolver;
+import java.util.Collection;
+
+/** The {@link ExpressionWeightResolver} that respects the user oder of the expressions. */
+public class UserOrderWeightResolver implements ExpressionWeightResolver<FilterExpression> {
+
+  private static final UserOrderWeightResolver INSTANCE = new UserOrderWeightResolver();
+
+  public static UserOrderWeightResolver of() {
+    return INSTANCE;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int compare(FilterExpression o1, FilterExpression o2) {
+    int result = ExpressionWeightResolver.super.compare(o1, o2);
+    if (result != 0) {
+      return result;
+    }
+
+    result = Double.compare(o1.getSelectivity(), o2.getSelectivity());
+    if (result != 0) {
+      return result;
+    }
+
+    return Integer.compare(o1.getOrderIndex(), o2.getOrderIndex());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int compare(Collection<FilterExpression> c1, Collection<FilterExpression> c2) {
+    int result = ExpressionWeightResolver.super.compare(c1, c2);
+    if (result != 0) {
+      return result;
+    }
+
+    result = Double.compare(lowestSelectivity(c1), lowestSelectivity(c2));
+    if (result != 0) {
+      return result;
+    }
+
+    return Integer.compare(lowestIndex(c1), lowestIndex(c2));
+  }
+
+  private int lowestIndex(Collection<FilterExpression> collection) {
+    return collection.stream()
+        .mapToInt(FilterExpression::getOrderIndex)
+        .min()
+        .orElse(Integer.MAX_VALUE);
+  }
+
+  private double lowestSelectivity(Collection<FilterExpression> collection) {
+    return collection.stream()
+        .mapToDouble(FilterExpression::getSelectivity)
+        .min()
+        .orElse(Double.MAX_VALUE);
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/rules/ExpressionUtilsTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/rules/ExpressionUtilsTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.rules;
+
+import static io.stargate.sgv2.docsapi.service.query.filter.operation.FilterOperationCode.GT;
+import static io.stargate.sgv2.docsapi.service.query.filter.operation.FilterOperationCode.LTE;
+import static io.stargate.sgv2.docsapi.service.query.rules.ExpressionUtils.toSimplifiedCnf;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bpodgursky.jbool_expressions.And;
+import com.bpodgursky.jbool_expressions.Expression;
+import com.bpodgursky.jbool_expressions.Not;
+import com.bpodgursky.jbool_expressions.Or;
+import io.quarkus.test.junit.QuarkusTest;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.FilterPath;
+import io.stargate.sgv2.docsapi.service.query.ImmutableFilterExpression;
+import io.stargate.sgv2.docsapi.service.query.ImmutableFilterPath;
+import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
+import io.stargate.sgv2.docsapi.service.query.condition.impl.ImmutableNumberCondition;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.FilterOperationCode;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.ValueFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.GtFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.LteFilterOperation;
+import java.util.Collections;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class ExpressionUtilsTest {
+
+  @Inject DocumentProperties documentProperties;
+
+  private FilterExpression e(FilterOperationCode op, int value) {
+    FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+
+    ValueFilterOperation operation;
+    switch (op) {
+      case GT:
+        operation = GtFilterOperation.of();
+        break;
+      case LTE:
+        operation = LteFilterOperation.of();
+        break;
+      default:
+        throw new UnsupportedOperationException("Unsupported op code: " + op);
+    }
+
+    BaseCondition condition = ImmutableNumberCondition.of(operation, value, documentProperties);
+    return ImmutableFilterExpression.of(filterPath, condition, 0);
+  }
+
+  @Nested
+  class CNF {
+
+    @Test
+    void oneCondition() {
+      Expression<FilterExpression> cnf = toSimplifiedCnf(e(GT, 1));
+      assertThat(cnf.toLexicographicString()).isEqualTo("field GT 1");
+    }
+
+    @Test
+    void simpleAnd() {
+      Expression<FilterExpression> cnf = toSimplifiedCnf(And.of(e(GT, 1), e(LTE, 2)));
+      assertThat(cnf.toLexicographicString()).isEqualTo("(field GT 1 & field LTE 2)");
+    }
+
+    @Test
+    void simpleOr() {
+      Expression<FilterExpression> cnf = toSimplifiedCnf(Or.of(e(GT, 1), e(LTE, 2)));
+      assertThat(cnf.toLexicographicString()).isEqualTo("(field GT 1 | field LTE 2)");
+    }
+
+    @Test
+    void orOfAnd() {
+      Expression<FilterExpression> cnf =
+          toSimplifiedCnf(Or.of(e(LTE, 1), And.of(e(GT, 2), e(LTE, 3))));
+      assertThat(cnf.toLexicographicString())
+          .isEqualTo("((field GT 2 | field LTE 1) & (field LTE 1 | field LTE 3))");
+    }
+
+    @Test
+    void andOfOr() {
+      Expression<FilterExpression> cnf =
+          toSimplifiedCnf(And.of(e(LTE, 1), Or.of(e(GT, 2), e(LTE, 3))));
+      assertThat(cnf.toLexicographicString())
+          .isEqualTo("((field GT 2 | field LTE 3) & field LTE 1)");
+    }
+
+    @Test
+    void wrappingOr() {
+      Expression<FilterExpression> cnf =
+          toSimplifiedCnf(Or.of(And.of(e(LTE, 1), Or.of(e(GT, 2), e(LTE, 3)))));
+      assertThat(cnf.toLexicographicString())
+          .isEqualTo("((field GT 2 | field LTE 3) & field LTE 1)");
+    }
+
+    @Test
+    void orOfAndWithNegation() {
+      Expression<FilterExpression> cnf =
+          toSimplifiedCnf(Or.of(Not.of(e(LTE, 1)), e(GT, 2), And.of(e(GT, 3), e(LTE, 4))));
+      // Note: the first predicate got inverted
+      // Note: predicate-specific simplification is not supported (yet?), as in:
+      // field GT 2 | field GT 3 => field GT 2
+      assertThat(cnf.toLexicographicString())
+          .isEqualTo(
+              "((field GT 1 | field GT 2 | field GT 3) & (field GT 1 | field GT 2 | field LTE 4))");
+    }
+  }
+
+  @Nested
+  class Negation {
+    @Test
+    void negatedAnd() {
+      Expression<FilterExpression> cnf = toSimplifiedCnf(Not.of(And.of(e(GT, 1), e(LTE, 2))));
+      // Note: predicates got inverted
+      assertThat(cnf.toLexicographicString()).isEqualTo("(field GT 2 | field LTE 1)");
+    }
+
+    @Test
+    void negatedOr() {
+      Expression<FilterExpression> cnf = toSimplifiedCnf(Not.of(Or.of(e(GT, 1), e(LTE, 2))));
+      // Note: predicates got inverted
+      assertThat(cnf.toLexicographicString()).isEqualTo("(field GT 2 & field LTE 1)");
+    }
+  }
+
+  @Nested
+  class Simplification {
+    @Test
+    void andWithSame() {
+      Expression<FilterExpression> cnf = toSimplifiedCnf(And.of(e(GT, 1), e(GT, 1)));
+      // Note: duplicate condition got removed
+      assertThat(cnf.toLexicographicString()).isEqualTo("field GT 1");
+    }
+
+    @Test
+    void andWithSameNegated() {
+      Expression<FilterExpression> cnf = toSimplifiedCnf(And.of(e(GT, 1), Not.of(e(GT, 1))));
+      assertThat(cnf.toLexicographicString()).isEqualTo("false");
+    }
+
+    @Test
+    void orWithSameNegated() {
+      Expression<FilterExpression> cnf = toSimplifiedCnf(Or.of(e(GT, 1), Not.of(e(GT, 1))));
+      assertThat(cnf.toLexicographicString()).isEqualTo("true");
+    }
+
+    @Test
+    void impliedAndSubExpression() {
+      // Note: the first OR condition implies the AND sub-expression
+      Expression<FilterExpression> cnf =
+          toSimplifiedCnf(Or.of(e(GT, 2), And.of(e(GT, 2), e(LTE, 3))));
+      assertThat(cnf.toLexicographicString()).isEqualTo("field GT 2");
+    }
+
+    @Test
+    void impliedNegatedAndSubExpression() {
+      // Note: the first OR condition implies the AND sub-expression
+      Expression<FilterExpression> cnf =
+          toSimplifiedCnf(Or.of(e(LTE, 2), And.of(Not.of(e(GT, 2)), e(LTE, 3))));
+      assertThat(cnf.toLexicographicString()).isEqualTo("field LTE 2");
+    }
+
+    @Test
+    void negatedImpliesAndSubExpression() {
+      // Note: the first OR condition implies the AND sub-expression
+      Expression<FilterExpression> cnf =
+          toSimplifiedCnf(Or.of(Not.of(e(LTE, 2)), And.of(e(GT, 2), e(LTE, 3))));
+      assertThat(cnf.toLexicographicString()).isEqualTo("field GT 2");
+    }
+
+    @Test
+    void andWithEquivalentInvertedNegatedPredicate() {
+      Expression<FilterExpression> cnf = toSimplifiedCnf(And.of(e(GT, 1), Not.of(e(LTE, 1))));
+      assertThat(cnf.toLexicographicString()).isEqualTo("field GT 1");
+    }
+
+    @Test
+    void impliedAndSubExpressionWithNegatedOrOfSame() {
+      // Note: the second OR condition implies the AND sub-expression
+      // Note: the first OR condition is equivalent to the second OR condition
+      Expression<FilterExpression> cnf =
+          toSimplifiedCnf(Or.of(Not.of(e(LTE, 2)), e(GT, 2), And.of(e(GT, 2), e(LTE, 3))));
+      assertThat(cnf.toLexicographicString()).isEqualTo("field GT 2");
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/weight/ExpressionWeightResolverTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/weight/ExpressionWeightResolverTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.weight;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class ExpressionWeightResolverTest {
+
+  ExpressionWeightResolver<FilterExpression> weightResolver = new ExpressionWeightResolver<>() {};
+
+  @Mock FilterExpression expression1;
+
+  @Mock FilterExpression expression2;
+
+  @Mock BaseCondition baseCondition1;
+
+  @Mock BaseCondition baseCondition2;
+
+  @BeforeEach
+  public void setup() {
+    MockitoAnnotations.openMocks(this);
+    when(expression1.getCondition()).thenReturn(baseCondition1);
+    when(expression2.getCondition()).thenReturn(baseCondition2);
+  }
+
+  @Nested
+  class Single {
+
+    @Test
+    public void persistenceWins() {
+      when(baseCondition1.isPersistenceCondition()).thenReturn(true);
+      when(baseCondition2.isPersistenceCondition()).thenReturn(false);
+
+      FilterExpression result = weightResolver.single().apply(expression1, expression2);
+      FilterExpression resultReverse = weightResolver.single().apply(expression2, expression1);
+
+      assertThat(result).isEqualTo(expression1);
+      assertThat(resultReverse).isEqualTo(expression1);
+    }
+
+    @Test
+    public void nonEvalOnMissingWins() {
+      when(baseCondition1.isPersistenceCondition()).thenReturn(false);
+      when(baseCondition1.isEvaluateOnMissingFields()).thenReturn(false);
+      when(baseCondition2.isPersistenceCondition()).thenReturn(false);
+      when(baseCondition2.isEvaluateOnMissingFields()).thenReturn(true);
+
+      FilterExpression result = weightResolver.single().apply(expression1, expression2);
+      FilterExpression resultReverse = weightResolver.single().apply(expression2, expression1);
+
+      assertThat(result).isEqualTo(expression1);
+      assertThat(resultReverse).isEqualTo(expression1);
+    }
+  }
+
+  @Nested
+  class CollectionCompare {
+
+    @BeforeEach
+    public void setup() {
+      when(expression1.getCondition()).thenReturn(baseCondition1);
+      when(expression2.getCondition()).thenReturn(baseCondition2);
+    }
+
+    @Test
+    public void singlePersistenceWinOverMixed() {
+      when(baseCondition1.isPersistenceCondition()).thenReturn(true);
+      when(baseCondition2.isPersistenceCondition()).thenReturn(false);
+      List<FilterExpression> first = Arrays.asList(expression1, expression1, expression2);
+      List<FilterExpression> second = Collections.singletonList(expression1);
+
+      Collection<FilterExpression> result = weightResolver.collection().apply(first, second);
+      Collection<FilterExpression> resultReversed =
+          weightResolver.collection().apply(second, first);
+
+      assertThat(result).isEqualTo(second);
+      assertThat(resultReversed).isEqualTo(second);
+    }
+
+    @Test
+    public void multiPersistenceWinOverMixed() {
+      when(baseCondition1.isPersistenceCondition()).thenReturn(true);
+      when(baseCondition2.isPersistenceCondition()).thenReturn(false);
+      List<FilterExpression> first = Arrays.asList(expression1, expression1, expression2);
+      List<FilterExpression> second = Arrays.asList(expression1, expression1);
+
+      Collection<FilterExpression> result = weightResolver.collection().apply(first, second);
+      Collection<FilterExpression> resultReversed =
+          weightResolver.collection().apply(second, first);
+
+      assertThat(result).isEqualTo(second);
+      assertThat(resultReversed).isEqualTo(second);
+    }
+
+    @Test
+    public void inMemoryWinsOverEval() {
+      when(baseCondition1.isPersistenceCondition()).thenReturn(false);
+      when(baseCondition2.isPersistenceCondition()).thenReturn(false);
+      when(baseCondition2.isEvaluateOnMissingFields()).thenReturn(true);
+      List<FilterExpression> first = Arrays.asList(expression1, expression2);
+      List<FilterExpression> second = Arrays.asList(expression1, expression1);
+
+      Collection<FilterExpression> result = weightResolver.collection().apply(first, second);
+      Collection<FilterExpression> resultReversed =
+          weightResolver.collection().apply(second, first);
+
+      assertThat(result).isEqualTo(second);
+      assertThat(resultReversed).isEqualTo(second);
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/weight/impl/UserOrderWeightResolverTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/weight/impl/UserOrderWeightResolverTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.weight.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserOrderWeightResolverTest {
+
+  UserOrderWeightResolver resolver = UserOrderWeightResolver.of();
+
+  @Nested
+  class Compare {
+
+    @Mock FilterExpression e1;
+
+    @Mock FilterExpression e2;
+
+    @Mock FilterExpression e3;
+
+    @Mock BaseCondition condition1;
+
+    @Mock BaseCondition condition2;
+
+    @Mock BaseCondition condition3;
+
+    @BeforeEach
+    public void init() {
+      MockitoAnnotations.openMocks(this);
+      lenient().when(e1.getCondition()).thenReturn(condition1);
+      lenient().when(e2.getCondition()).thenReturn(condition2);
+      lenient().when(e3.getCondition()).thenReturn(condition3);
+    }
+
+    @Test
+    public void singleHappyPath() {
+      when(e1.getOrderIndex()).thenReturn(0);
+      when(e2.getOrderIndex()).thenReturn(1);
+
+      FilterExpression result = resolver.single().apply(e1, e2);
+      FilterExpression resultReversed = resolver.single().apply(e2, e1);
+
+      assertThat(result).isEqualTo(e1);
+      assertThat(resultReversed).isEqualTo(e1);
+    }
+
+    @Test
+    public void singleSuperRespected() {
+      when(condition2.isPersistenceCondition()).thenReturn(true);
+
+      FilterExpression result = resolver.single().apply(e1, e2);
+      FilterExpression resultReversed = resolver.single().apply(e2, e1);
+
+      assertThat(result).isEqualTo(e2);
+      assertThat(resultReversed).isEqualTo(e2);
+    }
+
+    @Test
+    public void collectionHappyPath() {
+      when(e1.getOrderIndex()).thenReturn(0);
+      when(e2.getOrderIndex()).thenReturn(1);
+      when(e3.getOrderIndex()).thenReturn(2);
+
+      List<FilterExpression> c1 = Arrays.asList(e1, e2);
+      List<FilterExpression> c2 = Arrays.asList(e2, e3);
+
+      Collection<FilterExpression> result = resolver.collection().apply(c1, c2);
+      Collection<FilterExpression> resultReversed = resolver.collection().apply(c2, c1);
+
+      assertThat(result).isEqualTo(c1);
+      assertThat(resultReversed).isEqualTo(c1);
+    }
+
+    @Test
+    public void collectionSuperRespected() {
+      when(condition3.isPersistenceCondition()).thenReturn(true);
+
+      List<FilterExpression> c1 = Arrays.asList(e1, e2);
+      List<FilterExpression> c2 = Arrays.asList(e2, e3);
+
+      Collection<FilterExpression> result = resolver.collection().apply(c1, c2);
+      Collection<FilterExpression> resultReversed = resolver.collection().apply(c2, c1);
+
+      assertThat(result).isEqualTo(c2);
+      assertThat(resultReversed).isEqualTo(c2);
+    }
+  }
+
+  @Nested
+  class CompareWithSelectivity {
+
+    @Mock FilterExpression e1;
+
+    @Mock FilterExpression e2;
+
+    @Mock FilterExpression e3;
+
+    @Mock FilterExpression e4;
+
+    @Mock BaseCondition condition;
+
+    @BeforeEach
+    public void init() {
+      lenient().when(e1.getCondition()).thenReturn(condition);
+      lenient().when(e2.getCondition()).thenReturn(condition);
+      lenient().when(e3.getCondition()).thenReturn(condition);
+      lenient().when(e4.getCondition()).thenReturn(condition);
+    }
+
+    @Test
+    public void singleExplicitSelectivity() {
+      when(e1.getSelectivity()).thenReturn(1.0);
+      when(e2.getSelectivity()).thenReturn(0.9);
+
+      // Note: e2 has smaller (better) selectivity
+      assertThat(resolver.single().apply(e1, e2)).isEqualTo(e2);
+      assertThat(resolver.single().apply(e2, e1)).isEqualTo(e2);
+    }
+
+    @Test
+    public void collectionExplicitSelectivityUnambiguous() {
+      when(e1.getSelectivity()).thenReturn(1.0); // worst selectivity
+      when(e2.getSelectivity()).thenReturn(0.5);
+      when(e3.getSelectivity()).thenReturn(0.1); // best selectivity
+
+      List<FilterExpression> c1 = Arrays.asList(e1, e2);
+      List<FilterExpression> c2 = Arrays.asList(e2, e3);
+
+      // Note: each c1 element is not better that each c2 element
+      assertThat(resolver.collection().apply(c1, c2)).isEqualTo(c2);
+      assertThat(resolver.collection().apply(c2, c1)).isEqualTo(c2);
+
+      List<FilterExpression> c3 = Arrays.asList(e1, e3);
+
+      // Note: c1 elements are worse than c2 elements "in total"
+      assertThat(resolver.collection().apply(c1, c3)).isEqualTo(c3);
+      assertThat(resolver.collection().apply(c3, c1)).isEqualTo(c3);
+
+      // Note: c3 elements are worse than c2 elements "in total"
+      assertThat(resolver.collection().apply(c2, c3)).isEqualTo(c2);
+      assertThat(resolver.collection().apply(c3, c2)).isEqualTo(c2);
+    }
+
+    @Test
+    public void collectionExplicitSelectivityComplex() {
+      when(e1.getSelectivity()).thenReturn(1.0); // worst selectivity
+      when(e2.getSelectivity()).thenReturn(0.5);
+      when(e3.getSelectivity()).thenReturn(0.2);
+      when(e4.getSelectivity()).thenReturn(0.1); // best selectivity
+
+      // Note: c1 elements are equal to c2 elements "in total"
+      List<FilterExpression> c1 = Arrays.asList(e1, e4);
+      List<FilterExpression> c2 = Arrays.asList(e2, e3);
+
+      // c1 contains the best selectivity filter, so it wins
+      assertThat(resolver.collection().apply(c1, c2)).isEqualTo(c1);
+      assertThat(resolver.collection().apply(c2, c1)).isEqualTo(c1);
+    }
+  }
+}


### PR DESCRIPTION
**What this PR does**:
Peace of #1738 that is only copy & paste. No functional changes, except imports and adapting one test to be a `@QuarkusTest`. Should not be reviewed in details.

**Which issue(s) this PR fixes**:
Relates to #1738 

**Checklist**
- [x] Automated Tests added/updated
