### PR TITLE
Add optimistic handling of schema metadata (fixes #1873)

### DIFF
--- a/bridge-proto/proto/bridge.proto
+++ b/bridge-proto/proto/bridge.proto
@@ -28,6 +28,10 @@ service StargateBridge {
   // Executes a single CQL query.
   rpc ExecuteQuery(Query) returns (Response) {}
 
+  // Executes a single CQL query, assuming that the client has the latest metadata of a particular
+  // keyspace.
+  rpc ExecuteQueryWithSchema(QueryWithSchema) returns (QueryWithSchemaResponse) {}
+
   // Executes a batch of CQL queries.
   rpc ExecuteBatch(Batch) returns (Response) {}
 

--- a/bridge-proto/proto/bridge.proto
+++ b/bridge-proto/proto/bridge.proto
@@ -28,8 +28,12 @@ service StargateBridge {
   // Executes a single CQL query.
   rpc ExecuteQuery(Query) returns (Response) {}
 
-  // Executes a single CQL query, assuming that the client has the latest metadata of a particular
-  // keyspace.
+  // Executes a single CQL query, assuming that a keyspace with the given version hash exists on the
+  // bridge side.
+  // This is an optimization when the client builds a query based on a keyspace's contents: with
+  // this operation, it can use its local version of the keyspace (therefore avoiding an extra
+  // network hop to fetch it), and execute the query optimistically. If the keyspace has changed,
+  // the bridge will reply with the new version, allowing the client to retry.
   rpc ExecuteQueryWithSchema(QueryWithSchema) returns (QueryWithSchemaResponse) {}
 
   // Executes a batch of CQL queries.

--- a/bridge-proto/proto/schema.proto
+++ b/bridge-proto/proto/schema.proto
@@ -162,11 +162,21 @@ message SupportedFeaturesResponse {
 
 message QueryWithSchema {
   Query query = 1;
+  // The keyspace that the query operates on.
   string keyspace_name = 2;
+  // The version hash of the keyspace that the client used to build the query.
   sint32 keyspace_hash = 3;
 }
 
 message QueryWithSchemaResponse {
-  Response response = 1;
-  CqlKeyspaceDescribe new_keyspace = 2;
+  message NoKeyspace {}
+
+  oneof inner {
+    // The keyspace hadn't changed on the bridge side, the query succeeded
+    Response response = 1;
+    // The keyspace changed on the bridge side, this is the new metadata.
+    CqlKeyspaceDescribe new_keyspace = 2;
+    // The keyspace was deleted on the bridge side.
+    NoKeyspace no_keyspace = 3;
+  }
 }

--- a/bridge-proto/proto/schema.proto
+++ b/bridge-proto/proto/schema.proto
@@ -158,3 +158,15 @@ message SupportedFeaturesResponse {
   // Whether the persistence backend supports logged CQL batches.
   bool logged_batches = 3;
 }
+
+
+message QueryWithSchema {
+  Query query = 1;
+  string keyspace_name = 2;
+  sint32 keyspace_hash = 3;
+}
+
+message QueryWithSchemaResponse {
+  Response response = 1;
+  CqlKeyspaceDescribe new_keyspace = 2;
+}

--- a/bridge/src/main/java/io/stargate/bridge/service/BridgeService.java
+++ b/bridge/src/main/java/io/stargate/bridge/service/BridgeService.java
@@ -98,7 +98,10 @@ public class BridgeService extends StargateBridgeGrpc.StargateBridgeImplBase {
     Keyspace keyspace = persistence.schema().keyspace(decoratedName);
 
     if (keyspace == null) {
-      responseObserver.onNext(Schema.QueryWithSchemaResponse.newBuilder().build());
+      responseObserver.onNext(
+          Schema.QueryWithSchemaResponse.newBuilder()
+              .setNoKeyspace(Schema.QueryWithSchemaResponse.NoKeyspace.getDefaultInstance())
+              .build());
       responseObserver.onCompleted();
     } else if (keyspace.hashCode() != keyspaceHash) {
       try {

--- a/bridge/src/main/java/io/stargate/bridge/service/BridgeService.java
+++ b/bridge/src/main/java/io/stargate/bridge/service/BridgeService.java
@@ -16,6 +16,7 @@
 package io.stargate.bridge.service;
 
 import io.grpc.Context;
+import io.grpc.StatusException;
 import io.grpc.stub.StreamObserver;
 import io.stargate.auth.AuthorizationService;
 import io.stargate.bridge.proto.QueryOuterClass.Batch;
@@ -25,6 +26,7 @@ import io.stargate.bridge.proto.Schema;
 import io.stargate.bridge.proto.StargateBridgeGrpc;
 import io.stargate.db.Persistence;
 import io.stargate.db.Result;
+import io.stargate.db.schema.Keyspace;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
@@ -83,6 +85,53 @@ public class BridgeService extends StargateBridgeGrpc.StargateBridgeImplBase {
             schemaAgreementRetries,
             synchronizedStreamObserver)
         .handle();
+  }
+
+  @Override
+  public void executeQueryWithSchema(
+      Schema.QueryWithSchema request,
+      StreamObserver<Schema.QueryWithSchemaResponse> responseObserver) {
+    String keyspaceName = request.getKeyspaceName();
+    int keyspaceHash = request.getKeyspaceHash();
+    String decoratedName =
+        persistence.decorateKeyspaceName(keyspaceName, BridgeService.HEADERS_KEY.get());
+    Keyspace keyspace = persistence.schema().keyspace(decoratedName);
+
+    if (keyspace == null) {
+      responseObserver.onNext(Schema.QueryWithSchemaResponse.newBuilder().build());
+      responseObserver.onCompleted();
+    } else if (keyspace.hashCode() != keyspaceHash) {
+      try {
+        responseObserver.onNext(
+            Schema.QueryWithSchemaResponse.newBuilder()
+                .setNewKeyspace(
+                    SchemaHandler.buildKeyspaceDescription(keyspace, keyspaceName, decoratedName))
+                .build());
+        responseObserver.onCompleted();
+      } catch (StatusException e) {
+        responseObserver.onError(e);
+      }
+    } else {
+      executeQuery(
+          request.getQuery(),
+          new StreamObserver<Response>() {
+            @Override
+            public void onNext(Response response) {
+              responseObserver.onNext(
+                  Schema.QueryWithSchemaResponse.newBuilder().setResponse(response).build());
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+              responseObserver.onError(throwable);
+            }
+
+            @Override
+            public void onCompleted() {
+              responseObserver.onCompleted();
+            }
+          });
+    }
   }
 
   @Override

--- a/bridge/src/test/java/io/stargate/bridge/service/BaseBridgeServiceTest.java
+++ b/bridge/src/test/java/io/stargate/bridge/service/BaseBridgeServiceTest.java
@@ -40,6 +40,7 @@ import io.stargate.bridge.proto.QueryOuterClass.Query;
 import io.stargate.bridge.proto.QueryOuterClass.QueryParameters;
 import io.stargate.bridge.proto.QueryOuterClass.Value;
 import io.stargate.bridge.proto.QueryOuterClass.Values;
+import io.stargate.bridge.proto.Schema;
 import io.stargate.bridge.proto.StargateBridgeGrpc;
 import io.stargate.bridge.proto.StargateBridgeGrpc.StargateBridgeBlockingStub;
 import io.stargate.db.BoundStatement;
@@ -112,6 +113,20 @@ public class BaseBridgeServiceTest {
   protected QueryOuterClass.Response executeQuery(
       StargateBridgeBlockingStub stub, String cql, Value... values) {
     return stub.executeQuery(Query.newBuilder().setCql(cql).setValues(valuesOf(values)).build());
+  }
+
+  protected Schema.QueryWithSchemaResponse executeQueryWithSchema(
+      StargateBridgeBlockingStub stub,
+      String keyspaceName,
+      int keyspaceHash,
+      String cql,
+      Value... values) {
+    return stub.executeQueryWithSchema(
+        Schema.QueryWithSchema.newBuilder()
+            .setKeyspaceName(keyspaceName)
+            .setKeyspaceHash(keyspaceHash)
+            .setQuery(Query.newBuilder().setCql(cql).setValues(valuesOf(values)))
+            .build());
   }
 
   protected static Values.Builder valuesOf(Value... values) {

--- a/bridge/src/test/java/io/stargate/bridge/service/ExecuteQueryWithSchemaTest.java
+++ b/bridge/src/test/java/io/stargate/bridge/service/ExecuteQueryWithSchemaTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.bridge.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.ProtocolVersion;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
+import io.stargate.bridge.Utils;
+import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.Schema.QueryWithSchemaResponse;
+import io.stargate.db.BoundStatement;
+import io.stargate.db.Parameters;
+import io.stargate.db.Result;
+import io.stargate.db.Statement;
+import io.stargate.db.schema.Column;
+import io.stargate.db.schema.ImmutableKeyspace;
+import io.stargate.db.schema.Keyspace;
+import io.stargate.db.schema.Schema;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+public class ExecuteQueryWithSchemaTest extends BaseBridgeServiceTest {
+
+  private static final Keyspace KEYSPACE = ImmutableKeyspace.builder().name("ks").build();
+
+  @Mock Schema schema;
+
+  @BeforeEach
+  public void mockKeyspace() {
+    when(persistence.decorateKeyspaceName(any(), any()))
+        .thenAnswer(
+            i -> {
+              String keyspaceName = i.getArgument(0);
+              return mockDecorate(keyspaceName);
+            });
+    lenient().when(schema.keyspace(mockDecorate(KEYSPACE.name()))).thenReturn(KEYSPACE);
+    when(persistence.schema()).thenReturn(schema);
+  }
+
+  @Test
+  public void shouldReturnResponseWhenSchemaUpToDate() {
+    QueryWithSchemaResponse withSchemaResponse =
+        queryWithSchema(KEYSPACE.name(), KEYSPACE.hashCode());
+
+    assertThat(withSchemaResponse.hasResponse()).isTrue();
+    assertThat(withSchemaResponse.getResponse())
+        .satisfies(
+            response -> {
+              assertThat(response.getResultSet().getRowsCount()).isEqualTo(1);
+              assertThat(response.getResultSet().getRows(0).getValues(0).getString())
+                  .isEqualTo("vValue");
+            });
+  }
+
+  @Test
+  public void shouldReturnNewSchemaWhenOutOfDate() {
+    int wrongKeyspaceHash = KEYSPACE.hashCode() + 1;
+    QueryWithSchemaResponse withSchemaResponse =
+        queryWithSchema(KEYSPACE.name(), wrongKeyspaceHash);
+
+    assertThat(withSchemaResponse.hasNewKeyspace()).isTrue();
+    assertThat(withSchemaResponse.getNewKeyspace().getHash().getValue())
+        .isEqualTo(KEYSPACE.hashCode());
+  }
+
+  @Test
+  public void shouldReturnEmptyResponseWhenKeyspaceDeleted() {
+    QueryWithSchemaResponse withSchemaResponse = queryWithSchema("nonExistingKs", 1);
+
+    assertThat(withSchemaResponse.hasNoKeyspace()).isTrue();
+  }
+
+  private QueryWithSchemaResponse queryWithSchema(String keyspaceName, int keyspaceHash) {
+    final String query = "SELECT v FROM ks.tbl WHERE k = ?";
+
+    Result.ResultMetadata resultMetadata =
+        Utils.makeResultMetadata(Column.create("v", Column.Type.Text));
+    Result.Prepared prepared =
+        new Result.Prepared(
+            Utils.STATEMENT_ID,
+            Utils.RESULT_METADATA_ID,
+            resultMetadata,
+            Utils.makePreparedMetadata(Column.create("k", Column.Type.Text)),
+            false,
+            false);
+    when(connection.prepare(eq(query), any(Parameters.class)))
+        .thenReturn(CompletableFuture.completedFuture(prepared));
+
+    when(connection.execute(any(Statement.class), any(Parameters.class), anyLong()))
+        .then(
+            invocation -> {
+              BoundStatement statement =
+                  (BoundStatement) invocation.getArgument(0, Statement.class);
+              assertStatement(prepared, statement, Values.of("kValue"));
+              return CompletableFuture.completedFuture(
+                  new Result.Rows(
+                      Collections.singletonList(
+                          Collections.singletonList(
+                              TypeCodecs.TEXT.encode("vValue", ProtocolVersion.DEFAULT))),
+                      resultMetadata));
+            });
+
+    when(persistence.newConnection()).thenReturn(connection);
+
+    startServer(persistence);
+
+    return executeQueryWithSchema(
+        makeBlockingStub(), keyspaceName, keyspaceHash, query, Values.of("kValue"));
+  }
+
+  private static String mockDecorate(String keyspaceName) {
+    return "tenant_" + keyspaceName;
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/bridge/ValidatingStargateBridge.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/bridge/ValidatingStargateBridge.java
@@ -50,6 +50,12 @@ public class ValidatingStargateBridge implements StargateBridge {
   }
 
   @Override
+  public Uni<Schema.QueryWithSchemaResponse> executeQueryWithSchema(
+      Schema.QueryWithSchema request) {
+    throw new UnsupportedOperationException("Not implemented yet");
+  }
+
+  @Override
   public Uni<QueryOuterClass.Response> executeBatch(QueryOuterClass.Batch batch) {
     return batch.getQueriesList().stream()
         .map(

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/bridge/ValidatingStargateBridge.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/bridge/ValidatingStargateBridge.java
@@ -52,7 +52,9 @@ public class ValidatingStargateBridge implements StargateBridge {
   @Override
   public Uni<Schema.QueryWithSchemaResponse> executeQueryWithSchema(
       Schema.QueryWithSchema request) {
-    throw new UnsupportedOperationException("Not implemented yet");
+    // Simulate a successful execution (keyspace was up to date)
+    return executeQuery(request.getQuery())
+        .map(response -> Schema.QueryWithSchemaResponse.newBuilder().setResponse(response).build());
   }
 
   @Override

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2IndexesResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2IndexesResourceImpl.java
@@ -89,13 +89,12 @@ public class Sgv2IndexesResourceImpl extends ResourceBase implements Sgv2Indexes
       throw new WebApplicationException("columnName must be provided", Status.BAD_REQUEST);
     }
 
-    bridge.executeQuery(
+    queryWithTable(
+        bridge,
         keyspaceName,
         tableName,
-        maybeTable -> {
-          maybeTable
-              .orElseThrow(() -> new WebApplicationException("Table not found", Status.NOT_FOUND))
-              .getColumnsList().stream()
+        table -> {
+          table.getColumnsList().stream()
               .filter(c -> columnName.equals(c.getName()))
               .findAny()
               .orElseThrow(

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2TablesResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2TablesResourceImpl.java
@@ -146,11 +146,10 @@ public class Sgv2TablesResourceImpl extends ResourceBase implements Sgv2TablesRe
       final Sgv2TableAddRequest tableUpdate,
       final HttpServletRequest request) {
     requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
-    return callWithTable(
+    queryWithTable(
         bridge,
         keyspaceName,
         tableName,
-        false,
         (tableDef) -> {
           Sgv2Table.TableOptions options = tableUpdate.getTableOptions();
           List<?> clusteringExpressions = options.getClusteringExpression();
@@ -165,18 +164,14 @@ public class Sgv2TablesResourceImpl extends ResourceBase implements Sgv2TablesRe
             throw new WebApplicationException(
                 "No update provided for defaultTTL", Status.BAD_REQUEST);
           }
-          QueryOuterClass.Query query =
-              new QueryBuilder()
-                  .alter()
-                  .table(keyspaceName, tableName)
-                  .withDefaultTTL(options.getDefaultTimeToLive())
-                  .parameters(PARAMETERS_FOR_LOCAL_QUORUM)
-                  .build();
-          bridge.executeQuery(query);
-          return Response.status(Status.OK)
-              .entity(Collections.singletonMap("name", tableName))
+          return new QueryBuilder()
+              .alter()
+              .table(keyspaceName, tableName)
+              .withDefaultTTL(options.getDefaultTimeToLive())
+              .parameters(PARAMETERS_FOR_LOCAL_QUORUM)
               .build();
         });
+    return Response.status(Status.OK).entity(Collections.singletonMap("name", tableName)).build();
   }
 
   @Override

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/DefaultStargateBridgeClient.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/DefaultStargateBridgeClient.java
@@ -125,7 +125,7 @@ class DefaultStargateBridgeClient implements StargateBridgeClient {
       Query query;
       try {
         query = produceQuery(queryProducer, Optional.of(keyspace), tableName);
-      } catch (Throwable t) {
+      } catch (Exception ignored) {
         // Always retry with the latest version, in case the error is caused by stale metadata
         // (e.g. using a table that has not yet replicated to our local cache)
         return forceFetchAndExecute(keyspaceName, decoratedKeyspaceName, tableName, queryProducer);

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/StargateBridgeClient.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/StargateBridgeClient.java
@@ -48,11 +48,9 @@ public interface StargateBridgeClient {
     return Futures.getUninterruptibly(executeQueryAsync(query));
   }
 
-  default Response executeQuery(
-      String keyspaceName, Function<Optional<CqlKeyspaceDescribe>, Query> queryProducer) {
-    // TODO replace naive implementation with optimistic retry
-    return executeQuery(queryProducer.apply(getKeyspace(keyspaceName, false)));
-  }
+  // TODO create async variant?
+  Response executeQuery(
+      String keyspaceName, Function<Optional<CqlKeyspaceDescribe>, Query> queryProducer);
 
   default Response executeQuery(
       String keyspaceName, String tableName, Function<Optional<CqlTable>, Query> queryProducer) {

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/StargateBridgeClient.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/StargateBridgeClient.java
@@ -59,6 +59,7 @@ public interface StargateBridgeClient {
     return Futures.getUninterruptibly(executeQueryAsync(query));
   }
 
+  /** @see #executeQueryAsync(String, String, Function) */
   default Response executeQuery(
       String keyspaceName, String tableName, Function<Optional<CqlTable>, Query> queryProducer) {
     return Futures.getUninterruptibly(executeQueryAsync(keyspaceName, tableName, queryProducer));

--- a/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/StargateBridgeClient.java
+++ b/sgv2-service-common/src/main/java/io/stargate/sgv2/common/grpc/StargateBridgeClient.java
@@ -43,28 +43,25 @@ public interface StargateBridgeClient {
    */
   CompletionStage<Response> executeQueryAsync(Query query);
 
+  /**
+   * Builds a CQL query based on the definition of a table, and executes it.
+   *
+   * @param queryProducer the function that builds the query. It will receive <code>Optional.empty()
+   *     </code> if the table does not exist. Note that it may be invoked more than once (the
+   *     implementation uses an optimistic approach to avoid systematically pre-fetching the table
+   *     definition, so it may have to retry).
+   */
+  CompletionStage<Response> executeQueryAsync(
+      String keyspaceName, String tableName, Function<Optional<CqlTable>, Query> queryProducer);
+
   /** @see #executeQueryAsync(Query) */
   default Response executeQuery(Query query) {
     return Futures.getUninterruptibly(executeQueryAsync(query));
   }
 
-  // TODO create async variant?
-  Response executeQuery(
-      String keyspaceName, Function<Optional<CqlKeyspaceDescribe>, Query> queryProducer);
-
   default Response executeQuery(
       String keyspaceName, String tableName, Function<Optional<CqlTable>, Query> queryProducer) {
-    return executeQuery(
-        keyspaceName,
-        maybeKeyspace -> {
-          Optional<CqlTable> maybeTable =
-              maybeKeyspace.flatMap(
-                  keyspace ->
-                      keyspace.getTablesList().stream()
-                          .filter(t -> t.getName().equals(tableName))
-                          .findFirst());
-          return queryProducer.apply(maybeTable);
-        });
+    return Futures.getUninterruptibly(executeQueryAsync(keyspaceName, tableName, queryProducer));
   }
 
   /**

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2SchemaTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2SchemaTest.java
@@ -1114,9 +1114,9 @@ public class RestApiv2SchemaTest extends BaseRestApiTest {
                 "%s/v2/schemas/keyspaces/%s/tables/invalid_table/indexes",
                 restUrlBase, keyspaceName),
             objectMapper.writeValueAsString(indexAdd),
-            HttpStatus.SC_NOT_FOUND);
+            HttpStatus.SC_BAD_REQUEST);
     ApiError response = objectMapper.readValue(body, ApiError.class);
-    assertThat(response.getCode()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+    assertThat(response.getCode()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
     assertThat(response.getDescription()).containsPattern("Table.*not found");
 
     // invalid column


### PR DESCRIPTION
**What this PR does**:
Add a way to execute queries optimistically, to avoid pre-fetching the schema (even if it's just a hash check) before each query.

**Which issue(s) this PR fixes**:
Fixes #1873

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
