### PR TITLE
Fix #1817 for SGv2/REST by supporting multi-dc setting for createKeyspace

### DIFF
--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/SchemaBuilderHelper.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/SchemaBuilderHelper.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class SchemaBuilderHelper {
   private static final int DEFAULT_REPLICAS_FOR_SIMPLE = 1;
@@ -50,16 +52,13 @@ public class SchemaBuilderHelper {
                 payload));
       }
       // must have "name"s; will default replica counts as well
-      for (Map.Entry<String, Integer> entry : kdef.datacenters.entrySet()) {
-        String name = entry.getKey();
+      for (DatacenterDefinition dc : kdef.datacenters) {
+        String name = dc.getName();
         if (name == null || name.isEmpty()) {
           throw new IllegalArgumentException(
               String.format(
                   "malformatted JSON payload (%s) for Keyspace creation: one of 'datacenters' entries missing 'name'",
                   payload));
-        }
-        if (entry.getValue() == null) {
-          entry.setValue(DEFAULT_REPLICAS_FOR_NETWORKED);
         }
       }
     }
@@ -74,6 +73,26 @@ public class SchemaBuilderHelper {
   static class KeyspaceCreateDefinition {
     public String name;
     public int replicas = DEFAULT_REPLICAS_FOR_SIMPLE;
-    public Map<String, Integer> datacenters;
+    public List<DatacenterDefinition> datacenters;
+
+    public Map<String, Integer> datacentersAsMap() {
+      return datacenters.stream()
+          .collect(
+              Collectors.toMap(DatacenterDefinition::getName, DatacenterDefinition::getReplicas));
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class DatacenterDefinition {
+    protected String name;
+    protected int replicas = DEFAULT_REPLICAS_FOR_NETWORKED;
+
+    public String getName() {
+      return name;
+    }
+
+    public int getReplicas() {
+      return replicas;
+    }
   }
 }

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2KeyspacesResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2KeyspacesResourceImpl.java
@@ -15,7 +15,9 @@
  */
 package io.stargate.sgv2.restsvc.resources.schemas;
 
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.stargate.bridge.proto.QueryOuterClass.Query;
 import io.stargate.bridge.proto.Schema;
@@ -27,7 +29,9 @@ import io.stargate.sgv2.common.http.CreateStargateBridgeClient;
 import io.stargate.sgv2.restsvc.models.Sgv2Keyspace;
 import io.stargate.sgv2.restsvc.models.Sgv2RESTResponse;
 import io.stargate.sgv2.restsvc.resources.ResourceBase;
+import java.io.IOException;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -39,13 +43,19 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Path("/v2/schemas/keyspaces")
 @Produces(MediaType.APPLICATION_JSON)
 @Singleton
 @CreateStargateBridgeClient
 public class Sgv2KeyspacesResourceImpl extends ResourceBase implements Sgv2KeyspacesResourceApi {
+  private static final Logger LOGGER = LoggerFactory.getLogger(Sgv2KeyspacesResourceImpl.class);
+
   private static final JsonMapper JSON_MAPPER = new JsonMapper();
+  private static final ObjectReader REPLICA_SETTINGS_READER =
+      JSON_MAPPER.readerFor(JsonNode.class).with(JsonReadFeature.ALLOW_SINGLE_QUOTES);
 
   private static final SchemaBuilderHelper schemaBuilder = new SchemaBuilderHelper(JSON_MAPPER);
 
@@ -98,12 +108,13 @@ public class Sgv2KeyspacesResourceImpl extends ResourceBase implements Sgv2Keysp
               .withReplication(Replication.simpleStrategy(ksCreateDef.replicas))
               .build();
     } else {
+      Map<String, Integer> dcMap = ksCreateDef.datacentersAsMap();
       query =
           new QueryBuilder()
               .create()
               .keyspace(keyspaceName)
               .ifNotExists()
-              .withReplication(Replication.networkTopologyStrategy(ksCreateDef.datacenters))
+              .withReplication(Replication.networkTopologyStrategy(dcMap))
               .build();
     }
 
@@ -134,7 +145,34 @@ public class Sgv2KeyspacesResourceImpl extends ResourceBase implements Sgv2Keysp
   private static Sgv2Keyspace keyspaceFrom(CqlKeyspaceDescribe describe) {
     Schema.CqlKeyspace keyspace = describe.getCqlKeyspace();
     Sgv2Keyspace ks = new Sgv2Keyspace(keyspace.getName());
-    // TODO parse and convert "replication" option
+
+    Map<String, String> options = keyspace.getOptionsMap();
+    String replication = options.get("replication");
+    if (replication != null && !replication.isEmpty()) {
+      try {
+        JsonNode replicaSettings = REPLICA_SETTINGS_READER.readValue(replication);
+        // Ugh, this gets ugly; "options" has "class" for strategy, then DC:replica-count
+        // as entries. Also, cannot remove from Map.
+        JsonNode strategyNode = replicaSettings.path("class");
+        if ("NetworkTopologyStrategy".equals(strategyNode.asText())) {
+          Iterator<Map.Entry<String, JsonNode>> it = replicaSettings.fields();
+          while (it.hasNext()) {
+            Map.Entry<String, JsonNode> entry = it.next();
+            JsonNode value = entry.getValue();
+            if (value.isIntegralNumber()) {
+              ks.addDatacenter(entry.getKey(), value.asInt());
+            }
+          }
+        }
+      } catch (IOException e) {
+        LOGGER.warn(
+            "Malformed 'replication' settings for keyspace {} (problem: {}), input: {}",
+            keyspace.getName(),
+            e.getMessage(),
+            replication);
+      }
+    }
+
     return ks;
   }
 }

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2SchemaTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2SchemaTest.java
@@ -227,8 +227,9 @@ public class RestApiv2SchemaTest extends BaseRestApiTest {
 
     Map<String, Keyspace.Datacenter> expectedDCs = new HashMap<>();
     expectedDCs.put("dc1", new Keyspace.Datacenter("dc1", 1));
+    Optional<List<Keyspace.Datacenter>> dcs = Optional.ofNullable(keyspace.getDatacenters());
     Map<String, Keyspace.Datacenter> actualDCs =
-        keyspace.getDatacenters().stream()
+        dcs.orElse(Collections.emptyList()).stream()
             .collect(Collectors.toMap(Keyspace.Datacenter::getName, Function.identity()));
 
     assertThat(actualDCs).usingRecursiveComparison().isEqualTo(expectedDCs);


### PR DESCRIPTION
**What this PR does**:

Fixes #1817 by making multi-DC argument work; also fix "getKeyspace(s)" so it exposes same information.

**Which issue(s) this PR fixes**:
Fixes #1817

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated (in previous commit for the same issue)
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
