### PR TITLE
closes #1738: read bridge service for docs V2

### DIFF
--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/properties/document/DocumentTableColumns.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/properties/document/DocumentTableColumns.java
@@ -4,12 +4,16 @@ import io.stargate.sgv2.common.cql.builder.Column;
 import io.stargate.sgv2.common.cql.builder.ImmutableColumn;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /** Helper for understanding the available document table columns. */
 public interface DocumentTableColumns {
 
   /** @return All columns as the {@link ImmutableColumn} representation. */
   List<Column> allColumns();
+
+  /** @return All names of columns in an array, ordered in same way as {@link #allColumns()} */
+  String[] allColumnNamesArray();
 
   /** @return Value columns, including the leaf, as {@link Set}. */
   Set<String> valueColumnNames();
@@ -20,13 +24,17 @@ public interface DocumentTableColumns {
   /** @return All the JSON path columns based on the max depth as ordered {@link List}. */
   List<String> pathColumnNamesList();
 
-  // TODO document, optimize
-  default List<String> allColumnNamesWithPathDepth(int depth) {
+  /**
+   * Provides a stream of all columns names, but with the path columns being limited to given depth.
+   *
+   * @param depth max depth of the path columns
+   * @return Stream
+   */
+  default Stream<String> allColumnNamesWithPathDepth(int depth) {
     List<String> path = pathColumnNamesList().subList(0, depth);
 
     return allColumns().stream()
         .map(Column::name)
-        .filter(c -> path.contains(c) || !pathColumnNamesList().contains(c))
-        .toList();
+        .filter(c -> path.contains(c) || !pathColumnNamesList().contains(c));
   }
 }

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/properties/document/DocumentTableColumns.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/properties/document/DocumentTableColumns.java
@@ -19,4 +19,14 @@ public interface DocumentTableColumns {
 
   /** @return All the JSON path columns based on the max depth as ordered {@link List}. */
   List<String> pathColumnNamesList();
+
+  // TODO document, optimize
+  default List<String> allColumnNamesWithPathDepth(int depth) {
+    List<String> path = pathColumnNamesList().subList(0, depth);
+
+    return allColumns().stream()
+        .map(Column::name)
+        .filter(c -> path.contains(c) || !pathColumnNamesList().contains(c))
+        .toList();
+  }
 }

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/properties/document/impl/DocumentPropertiesImpl.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/properties/document/impl/DocumentPropertiesImpl.java
@@ -26,6 +26,6 @@ public record DocumentPropertiesImpl(
         documentConfig.maxPageSize(),
         documentConfig.maxSearchPageSize(),
         new DocumentTablePropertiesImpl(documentConfig),
-        new DocumentTableColumnsImpl(documentConfig, numericBooleans));
+        DocumentTableColumnsImpl.of(documentConfig, numericBooleans));
   }
 }

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/properties/document/impl/DocumentPropertiesImpl.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/properties/document/impl/DocumentPropertiesImpl.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package io.stargate.sgv2.docsapi.api.common.properties.document.impl;
 
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/properties/document/impl/DocumentTableColumnsImpl.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/properties/document/impl/DocumentTableColumnsImpl.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package io.stargate.sgv2.docsapi.api.common.properties.document.impl;
 
 import com.google.common.collect.ImmutableSet;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/properties/document/impl/DocumentTablePropertiesImpl.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/properties/document/impl/DocumentTablePropertiesImpl.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package io.stargate.sgv2.docsapi.api.common.properties.document.impl;
 
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentTableProperties;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/common/model/Paginator.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/common/model/Paginator.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.docsapi.service.common.model;
+
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+import io.stargate.sgv2.docsapi.service.util.ByteBufferUtils;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+/**
+ * This class is in charge of keeping the data of the Docs API pagination process. It's not only a
+ * stateful component, but a state machine with a initial state. It's created on the REST layer and
+ * passed through to the DocumentService that is in charge of its changes. After being populated its
+ * `documentPageState` can be passed by the REST layer to the client as a JSON string.
+ *
+ * @author Dmitri Bourlatchkov
+ */
+public class Paginator {
+
+  public final int docPageSize;
+  private ByteBuffer currentPageState; // keeps track of the DB page state while querying the DB
+
+  public Paginator(String pageState, int pageSize) {
+    if (pageSize <= 0) {
+      throw new IllegalArgumentException("Invalid page size: " + pageSize);
+    }
+
+    docPageSize = pageSize;
+
+    if (pageState != null) {
+      this.currentPageState = ByteBufferUtils.fromBase64UrlParam(pageState);
+    }
+  }
+
+  /**
+   * Utility to make the external paging state from docs, without side effects in {@link Paginator}.
+   *
+   * @param paginator Paginator
+   * @param docs document
+   * @return String to serve to external
+   */
+  public static String makeExternalPagingState(Paginator paginator, List<RawDocument> docs) {
+    // If we have less docs than the page requires, this means there's no point requesting the
+    // next page. Note that in this case the last doc in the list _may_ have an internal paging
+    // state. This may happen if some docs are filtered in memory after fetching from persistence.
+    if (docs.size() >= paginator.docPageSize) {
+      RawDocument lastDoc = docs.get(docs.size() - 1);
+      ByteBuffer byteBuffer = lastDoc.makePagingState();
+      if (null != byteBuffer) {
+        return ByteBufferUtils.toBase64ForUrl(byteBuffer);
+      }
+    }
+    return null;
+  }
+
+  public String makeExternalPagingState() {
+    if (currentPageState == null) {
+      return null;
+    }
+
+    return ByteBufferUtils.toBase64ForUrl(currentPageState);
+  }
+
+  public void clearDocumentPageState() {
+    this.currentPageState = null;
+  }
+
+  public void setDocumentPageState(RawDocument document) {
+    this.currentPageState = document.makePagingState();
+  }
+
+  public void setDocumentPageState(List<RawDocument> docs) {
+    if (docs.size() < docPageSize) {
+      // If we have less docs than the page requires, this means there's no point requesting the
+      // next page. Note that in this case the last doc in the list _may_ have an internal paging
+      // state. This may happen if some docs are filtered in memory after fetching from persistence.
+      clearDocumentPageState();
+    } else {
+      RawDocument lastDoc = docs.get(docs.size() - 1);
+      setDocumentPageState(lastDoc);
+    }
+  }
+
+  public ByteBuffer getCurrentDbPageState() {
+    return currentPageState;
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/ReadBridgeService.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/ReadBridgeService.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query;
+
+import com.bpodgursky.jbool_expressions.Expression;
+import com.bpodgursky.jbool_expressions.Literal;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.common.model.Paginator;
+import io.stargate.sgv2.docsapi.service.query.executor.QueryExecutor;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+import io.stargate.sgv2.docsapi.service.query.search.db.impl.DocumentTtlQueryBuilder;
+import io.stargate.sgv2.docsapi.service.query.search.db.impl.FullSearchQueryBuilder;
+import io.stargate.sgv2.docsapi.service.query.search.db.impl.PopulateSearchQueryBuilder;
+import io.stargate.sgv2.docsapi.service.query.search.db.impl.SubDocumentSearchQueryBuilder;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.BaseResolver;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.DocumentsResolver;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.impl.SubDocumentsResolver;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import org.apache.commons.lang3.tuple.Pair;
+
+public class ReadBridgeService {
+
+  @Inject QueryExecutor queryExecutor;
+
+  @Inject DocumentProperties documentProperties;
+
+  /**
+   * Searches a complete collection in order to find the documents that match the given expression.
+   * Starts the search for the given {@link Paginator} state.
+   *
+   * @param queryExecutor Query executor for running queries.
+   * @param keyspace Keyspace to search in.
+   * @param collection Collection to search in.
+   * @param expression Expression tree
+   * @param paginator {@link Paginator}
+   * @param context Context for recording profiling information
+   * @return Flowable of {@link RawDocument}s.
+   */
+  public Multi<RawDocument> searchDocuments(
+      QueryExecutor queryExecutor,
+      String keyspace,
+      String collection,
+      Expression<FilterExpression> expression,
+      Paginator paginator,
+      ExecutionContext context) {
+
+    // if we have true immediately, means we can only do full search
+    if (Literal.EXPR_TYPE.equals(expression.getExprType())) {
+
+      // for the sake of correctness make sure we don't have a false
+      if (Literal.getFalse().equals(expression)) {
+        return Multi.createFrom().empty();
+      }
+
+      // fetch docs, no need to populate as all rows are taken
+      return fullSearch(keyspace, collection, paginator, nestedFullSearch(context))
+
+          // load only for the page size
+          .select()
+          .first(paginator.docPageSize);
+    } else {
+      // otherwise resolve the expression
+      DocumentsResolver documentsResolver =
+          BaseResolver.resolve(expression, context, documentProperties);
+
+      // load the candidates
+      Multi<RawDocument> candidates =
+          documentsResolver
+              .getDocuments(queryExecutor, keyspace, collection, paginator)
+
+              // limit to requested page size only to stop fetching extra docs
+              .select()
+              .first(paginator.docPageSize);
+
+      // then populate
+      return populateCandidates(candidates, keyspace, collection, nestedPopulate(context));
+    }
+  }
+
+  /**
+   * Searches a single document in order to find the sub-documents that match the given expression.
+   * Sub-documents are defined by the #subDocumentPath, everything outside this path is ignored.
+   * Starts the search for the given {@link Paginator} state.
+   *
+   * @param queryExecutor Query executor for running queries.
+   * @param keyspace Keyspace to search in.
+   * @param collection Collection to search in.
+   * @param documentId Document ID to search in
+   * @param subDocumentPath Path where to find sub-documents
+   * @param expression Expression tree to fulfill (note that #subDocumentPath must be already
+   *     included in the {@link FilterExpression}s)
+   * @param paginator {@link Paginator}
+   * @param context Context for recording profiling information
+   * @return Flowable of {@link RawDocument}s representing sub-documents in the given
+   *     #subDocumentPath.
+   */
+  public Multi<RawDocument> searchSubDocuments(
+      QueryExecutor queryExecutor,
+      String keyspace,
+      String collection,
+      String documentId,
+      List<String> subDocumentPath,
+      Expression<FilterExpression> expression,
+      Paginator paginator,
+      ExecutionContext context) {
+
+    // for the sake of correctness make sure we don't have false
+    if (Literal.getFalse().equals(expression)) {
+      return Multi.createFrom().empty();
+    }
+
+    // create the resolver and return results
+    SubDocumentsResolver subDocumentsResolver =
+        new SubDocumentsResolver(
+            expression, documentId, subDocumentPath, context, documentProperties);
+    return subDocumentsResolver
+        .getDocuments(queryExecutor, keyspace, collection, paginator)
+
+        // limit to requested page size only to stop fetching extra docs
+        .select()
+        .first(paginator.docPageSize);
+  }
+
+  /**
+   * Gets a single document optionally limit to the the #subDocumentPath.
+   *
+   * @param queryExecutor Query executor for running queries.
+   * @param keyspace Keyspace to search in.
+   * @param collection Collection to search in.
+   * @param documentId Document ID to search in
+   * @param subDocumentPath Path where to find the document
+   * @param context Context for recording profiling information
+   * @return Flowable of {@link RawDocument}s representing a document or sub-document in the given
+   *     #subDocumentPath.
+   */
+  public Multi<RawDocument> getDocument(
+      QueryExecutor queryExecutor,
+      String keyspace,
+      String collection,
+      String documentId,
+      List<String> subDocumentPath,
+      ExecutionContext context) {
+
+    return fullDocument(
+            keyspace, collection, documentId, subDocumentPath, nestedFullDocument(context))
+
+        // take one, as there can be only one document
+        .select()
+        .first();
+  }
+
+  /**
+   * Gets a single document's rows with its TTL data in each row.
+   *
+   * @param queryExecutor Query executor for running queries.
+   * @param keyspace Keyspace to search in.
+   * @param collection Collection to search in.
+   * @param documentId Document ID to search in
+   * @param context Context for recording profiling information
+   * @return Flowable of {@link RawDocument}s representing a document's rows with TTL as a column
+   */
+  public Multi<RawDocument> getDocumentTtlInfo(
+      QueryExecutor queryExecutor,
+      String keyspace,
+      String collection,
+      String documentId,
+      ExecutionContext context) {
+    return documentTtl(keyspace, collection, documentId, context).select().first();
+  }
+
+  private Multi<RawDocument> fullSearch(
+      String keyspace, String collection, Paginator paginator, ExecutionContext context) {
+    FullSearchQueryBuilder queryBuilder = new FullSearchQueryBuilder(documentProperties);
+
+    // prepare first (this could be cached for the max depth)
+    return Uni.createFrom()
+        .item(
+            () -> {
+              int maxDepth = documentProperties.maxDepth();
+              String[] columns =
+                  documentProperties
+                      .tableColumns()
+                      .allColumnNamesWithPathDepth(maxDepth)
+                      .toArray(String[]::new);
+              return queryBuilder.buildQuery(keyspace, collection, columns);
+            })
+        .memoize()
+        .indefinitely()
+        .onItem()
+        .transformToMulti(
+            built -> {
+              QueryOuterClass.Query query = queryBuilder.bind(built);
+              return queryExecutor.queryDocs(
+                  query,
+                  documentProperties.getApproximateStoragePageSize(paginator.docPageSize),
+                  true,
+                  paginator.getCurrentDbPageState(),
+                  true,
+                  context);
+            });
+  }
+
+  private Multi<RawDocument> documentTtl(
+      String keyspace, String collection, String documentId, ExecutionContext context) {
+
+    DocumentTtlQueryBuilder queryBuilder = new DocumentTtlQueryBuilder(documentProperties);
+
+    // prepare first
+    return Uni.createFrom()
+        .item(() -> queryBuilder.buildQuery(keyspace, collection))
+        .memoize()
+        .indefinitely()
+        .onItem()
+        .transformToMulti(
+            built -> {
+              QueryOuterClass.Value idValue = Values.of(documentId);
+              QueryOuterClass.Query query = queryBuilder.bindWithValues(built, idValue);
+              return queryExecutor.queryDocs(
+                  query, documentProperties.maxSearchPageSize(), false, null, false, context);
+            });
+  }
+
+  private Multi<RawDocument> fullDocument(
+      String keyspace,
+      String collection,
+      String documentId,
+      List<String> subDocumentPath,
+      ExecutionContext context) {
+
+    SubDocumentSearchQueryBuilder queryBuilder =
+        new SubDocumentSearchQueryBuilder(documentProperties, documentId, subDocumentPath);
+
+    // prepare first
+    return Uni.createFrom()
+        .item(
+            () -> {
+              int maxDepth = documentProperties.maxDepth();
+              String[] columns =
+                  documentProperties
+                      .tableColumns()
+                      .allColumnNamesWithPathDepth(maxDepth)
+                      .toArray(String[]::new);
+
+              return queryBuilder.buildQuery(keyspace, collection, columns);
+            })
+        .memoize()
+        .indefinitely()
+        .onItem()
+        .transformToMulti(
+            prepared -> {
+              // since we have the doc id, use the max storage page size to grab all the rows for
+              // that doc
+              QueryOuterClass.Query query = queryBuilder.bind(prepared);
+
+              // TODO correct row state fetch
+              return queryExecutor.queryDocs(
+                  query, documentProperties.maxSearchPageSize(), false, null, true, context);
+            });
+  }
+
+  // populates the given documents by using a prepared query
+  private Multi<RawDocument> populateCandidates(
+      Multi<RawDocument> candidates, String keyspace, String collection, ExecutionContext context) {
+
+    PopulateSearchQueryBuilder queryBuilder = new PopulateSearchQueryBuilder(documentProperties);
+
+    // prepare query
+    Uni<QueryOuterClass.Query> preparedSingle =
+        Uni.createFrom()
+            .item(
+                () -> {
+                  // columns from depth
+                  int maxDepth = documentProperties.maxDepth();
+                  String[] columns =
+                      documentProperties
+                          .tableColumns()
+                          .allColumnNamesWithPathDepth(maxDepth)
+                          .toArray(String[]::new);
+
+                  // build
+                  return queryBuilder.buildQuery(keyspace, collection, columns);
+                })
+            // then cache so we can reuse for each document
+            .memoize()
+            .indefinitely();
+
+    // combine
+    return candidates
+
+        // keep the order of incoming docs
+        .onItem()
+        .transformToUniAndConcatenate(doc -> preparedSingle.map(prepared -> Pair.of(doc, prepared)))
+
+        // buffer some amount of elements, so we can do the document population in parallel
+        // since max page size is 20, this means max of 4 buffering
+        .group()
+        .intoLists()
+        .of(5)
+
+        // then concat map to respect order
+        .concatMap(
+            all -> {
+              // map to list of single item multi of RawDocument
+              List<Multi<RawDocument>> multiList =
+                  all.stream()
+                      .map(
+                          p -> {
+                            // bind for this doc id
+                            RawDocument document = p.getLeft();
+                            QueryOuterClass.Value idValue = Values.of(document.id());
+                            QueryOuterClass.Query query =
+                                queryBuilder.bindWithValues(p.getRight(), idValue);
+
+                            // fetch, take one and then populate into the original doc
+                            // since we have the doc id, use the max storage page size to grab all
+                            // the rows
+                            // for
+                            // that doc
+                            return queryExecutor
+                                .queryDocs(
+                                    query,
+                                    documentProperties.maxSearchPageSize(),
+                                    false,
+                                    null,
+                                    false,
+                                    context)
+                                .select()
+                                .first()
+                                .map(document::populateFrom);
+                          })
+                      .collect(Collectors.toList());
+
+              // this is the trick to execute the all 5 in parallel
+              // once they are all done, just map back to flowable
+              // note that this respects the order, so we always return in correct order
+              return Multi.createBy().concatenating().streams(multiList);
+            });
+  }
+
+  private ExecutionContext nestedPopulate(ExecutionContext context) {
+    return context.nested("LoadProperties");
+  }
+
+  private ExecutionContext nestedFullSearch(ExecutionContext context) {
+    return context.nested("LoadAllDocuments");
+  }
+
+  private ExecutionContext nestedFullDocument(ExecutionContext context) {
+    return context.nested("GetFullDocument");
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/ReadBridgeService.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/ReadBridgeService.java
@@ -52,7 +52,6 @@ public class ReadBridgeService {
    * Searches a complete collection in order to find the documents that match the given expression.
    * Starts the search for the given {@link Paginator} state.
    *
-   * @param queryExecutor Query executor for running queries.
    * @param keyspace Keyspace to search in.
    * @param collection Collection to search in.
    * @param expression Expression tree
@@ -61,7 +60,6 @@ public class ReadBridgeService {
    * @return Flowable of {@link RawDocument}s.
    */
   public Multi<RawDocument> searchDocuments(
-      QueryExecutor queryExecutor,
       String keyspace,
       String collection,
       Expression<FilterExpression> expression,
@@ -106,7 +104,6 @@ public class ReadBridgeService {
    * Sub-documents are defined by the #subDocumentPath, everything outside this path is ignored.
    * Starts the search for the given {@link Paginator} state.
    *
-   * @param queryExecutor Query executor for running queries.
    * @param keyspace Keyspace to search in.
    * @param collection Collection to search in.
    * @param documentId Document ID to search in
@@ -119,7 +116,6 @@ public class ReadBridgeService {
    *     #subDocumentPath.
    */
   public Multi<RawDocument> searchSubDocuments(
-      QueryExecutor queryExecutor,
       String keyspace,
       String collection,
       String documentId,
@@ -148,7 +144,6 @@ public class ReadBridgeService {
   /**
    * Gets a single document optionally limit to the the #subDocumentPath.
    *
-   * @param queryExecutor Query executor for running queries.
    * @param keyspace Keyspace to search in.
    * @param collection Collection to search in.
    * @param documentId Document ID to search in
@@ -158,7 +153,6 @@ public class ReadBridgeService {
    *     #subDocumentPath.
    */
   public Multi<RawDocument> getDocument(
-      QueryExecutor queryExecutor,
       String keyspace,
       String collection,
       String documentId,
@@ -176,7 +170,6 @@ public class ReadBridgeService {
   /**
    * Gets a single document's rows with its TTL data in each row.
    *
-   * @param queryExecutor Query executor for running queries.
    * @param keyspace Keyspace to search in.
    * @param collection Collection to search in.
    * @param documentId Document ID to search in
@@ -184,11 +177,7 @@ public class ReadBridgeService {
    * @return Flowable of {@link RawDocument}s representing a document's rows with TTL as a column
    */
   public Multi<RawDocument> getDocumentTtlInfo(
-      QueryExecutor queryExecutor,
-      String keyspace,
-      String collection,
-      String documentId,
-      ExecutionContext context) {
+      String keyspace, String collection, String documentId, ExecutionContext context) {
     return documentTtl(keyspace, collection, documentId, context).select().first();
   }
 

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/ReadBridgeService.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/ReadBridgeService.java
@@ -37,9 +37,11 @@ import io.stargate.sgv2.docsapi.service.query.search.resolver.DocumentsResolver;
 import io.stargate.sgv2.docsapi.service.query.search.resolver.impl.SubDocumentsResolver;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import org.apache.commons.lang3.tuple.Pair;
 
+@ApplicationScoped
 public class ReadBridgeService {
 
   @Inject QueryExecutor queryExecutor;
@@ -274,9 +276,19 @@ public class ReadBridgeService {
               // that doc
               QueryOuterClass.Query query = queryBuilder.bind(prepared);
 
-              // TODO correct row state fetch
+              // note that we fetch row paging, only if key depth is more than 1
+              // if it's one, then we are getting a whole document, thus no paging
+              int keyDepth = subDocumentPath.size() + 1;
+              boolean fetchRowPaging = keyDepth > 1;
+
               return queryExecutor.queryDocs(
-                  query, documentProperties.maxSearchPageSize(), false, null, true, context);
+                  keyDepth,
+                  query,
+                  documentProperties.maxSearchPageSize(),
+                  false,
+                  null,
+                  fetchRowPaging,
+                  context);
             });
   }
 

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/ReadBridgeService.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/ReadBridgeService.java
@@ -188,12 +188,7 @@ public class ReadBridgeService {
     return Uni.createFrom()
         .item(
             () -> {
-              int maxDepth = documentProperties.maxDepth();
-              String[] columns =
-                  documentProperties
-                      .tableColumns()
-                      .allColumnNamesWithPathDepth(maxDepth)
-                      .toArray(String[]::new);
+              String[] columns = documentProperties.tableColumns().allColumnNamesArray();
 
               FullSearchQueryBuilder queryBuilder = new FullSearchQueryBuilder(documentProperties);
               QueryOuterClass.Query query = queryBuilder.buildQuery(keyspace, collection, columns);
@@ -244,12 +239,7 @@ public class ReadBridgeService {
     return Uni.createFrom()
         .item(
             () -> {
-              int maxDepth = documentProperties.maxDepth();
-              String[] columns =
-                  documentProperties
-                      .tableColumns()
-                      .allColumnNamesWithPathDepth(maxDepth)
-                      .toArray(String[]::new);
+              String[] columns = documentProperties.tableColumns().allColumnNamesArray();
 
               SubDocumentSearchQueryBuilder queryBuilder =
                   new SubDocumentSearchQueryBuilder(
@@ -291,13 +281,7 @@ public class ReadBridgeService {
         Uni.createFrom()
             .item(
                 () -> {
-                  // columns from depth
-                  int maxDepth = documentProperties.maxDepth();
-                  String[] columns =
-                      documentProperties
-                          .tableColumns()
-                          .allColumnNamesWithPathDepth(maxDepth)
-                          .toArray(String[]::new);
+                  String[] columns = documentProperties.tableColumns().allColumnNamesArray();
 
                   // build
                   return queryBuilder.buildQuery(keyspace, collection, columns);

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/eval/RawDocumentEvalRule.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/eval/RawDocumentEvalRule.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.eval;
+
+import com.bpodgursky.jbool_expressions.Expression;
+import com.bpodgursky.jbool_expressions.eval.EvalRule;
+import io.stargate.sgv2.docsapi.service.common.model.RowWrapper;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Evaluates a single FilterExpression against set of rows. Note that this {@link EvalRule} expects
+ * all rows of a document to be provided.
+ */
+public class RawDocumentEvalRule extends EvalRule<FilterExpression> {
+
+  private final List<RowWrapper> rows;
+
+  public RawDocumentEvalRule(RawDocument document) {
+    this(document.rows());
+  }
+
+  public RawDocumentEvalRule(List<RowWrapper> rows) {
+    this.rows = rows;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean evaluate(
+      Expression<FilterExpression> expression, Map<String, EvalRule<FilterExpression>> rules) {
+    FilterExpression filterExpression = (FilterExpression) expression;
+
+    // check if any row matches the filter path and if we should evaluate on missing
+    boolean anyOnPath = rows.stream().anyMatch(filterExpression::matchesFilterPath);
+    boolean evaluateOnMissingFields = filterExpression.getCondition().isEvaluateOnMissingFields();
+
+    // if so do a test, otherwise return false, that means that no row matches the filter path and
+    // condition is not eval on missing
+    if (anyOnPath || evaluateOnMissingFields) {
+      return filterExpression.test(rows);
+    } else {
+      return false;
+    }
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/BaseResolver.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/BaseResolver.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.resolver;
+
+import com.bpodgursky.jbool_expressions.And;
+import com.bpodgursky.jbool_expressions.Expression;
+import com.bpodgursky.jbool_expressions.Literal;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.rules.ExpressionUtils;
+
+/**
+ * Base resolver knows what {@link DocumentsResolver} should be created for the given {@link
+ * Expression}.
+ */
+public final class BaseResolver {
+
+  private BaseResolver() {}
+
+  /**
+   * Resolves the document resolver without any parent.
+   *
+   * @param expression {@link Expression}
+   * @param documentProperties {@link DocumentProperties}
+   * @return DocumentsResolver
+   */
+  public static DocumentsResolver resolve(
+      Expression<FilterExpression> expression,
+      ExecutionContext context,
+      DocumentProperties documentProperties) {
+    return resolve(expression, context, null, documentProperties);
+  }
+
+  /**
+   * Resolves the document resolver with optional parent.
+   *
+   * @param expression {@link Expression}
+   * @param parent parent or <code>null</code>
+   * @param documentProperties {@link DocumentProperties}
+   * @return DocumentsResolver
+   */
+  public static DocumentsResolver resolve(
+      Expression<FilterExpression> expression,
+      ExecutionContext context,
+      DocumentsResolver parent,
+      DocumentProperties documentProperties) {
+    // if we are hitting the literal TRUE, then return parent
+    if (Literal.EXPR_TYPE.equals(expression.getExprType())) {
+      return parent;
+    }
+
+    // execute cnf optimization
+    Expression<FilterExpression> cnf = ExpressionUtils.toSimplifiedCnf(expression);
+
+    // since this will simplify as well, check if we have And
+    // if we have And proceed to the CNF resolver
+    if (And.EXPR_TYPE.equals(cnf.getExprType())) {
+      return CnfResolver.resolve(cnf, context, parent, documentProperties);
+    } else {
+      // otherwise wrap to AND, and forward to the CNF
+      return CnfResolver.resolve(And.of(cnf), context, parent, documentProperties);
+    }
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/CnfResolver.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/CnfResolver.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.resolver;
+
+import com.bpodgursky.jbool_expressions.And;
+import com.bpodgursky.jbool_expressions.Expression;
+import com.bpodgursky.jbool_expressions.Literal;
+import com.bpodgursky.jbool_expressions.Or;
+import com.bpodgursky.jbool_expressions.options.ExprOptions;
+import com.bpodgursky.jbool_expressions.rules.Rule;
+import com.bpodgursky.jbool_expressions.rules.RuleList;
+import com.bpodgursky.jbool_expressions.rules.RulesHelper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.api.exception.ErrorCode;
+import io.stargate.sgv2.docsapi.api.exception.ErrorCodeRuntimeException;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.FilterPath;
+import io.stargate.sgv2.docsapi.service.query.rules.TrueFilterExpressions;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.filter.CandidatesFilter;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.filter.impl.InMemoryCandidatesFilter;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.filter.impl.PersistenceCandidatesFilter;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.impl.AllFiltersResolver;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.impl.AnyFiltersResolver;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.impl.InMemoryDocumentsResolver;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.impl.OrExpressionDocumentsResolver;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.impl.PersistenceDocumentsResolver;
+import io.stargate.sgv2.docsapi.service.query.search.weight.ExpressionWeightResolver;
+import io.stargate.sgv2.docsapi.service.query.search.weight.impl.UserOrderWeightResolver;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/** Static resolver that accepts the {@link And} expression in the CNF form. */
+public final class CnfResolver {
+
+  private CnfResolver() {}
+
+  /**
+   * Returns a document resolver for a single {@link And} expression in CNF form without a parent.
+   *
+   * @param expression {@link FilterExpression}
+   * @param context {@link ExecutionContext}
+   * @param documentProperties {@link DocumentProperties}
+   * @return DocumentsResolver
+   */
+  public static DocumentsResolver resolve(
+      Expression<FilterExpression> expression,
+      ExecutionContext context,
+      DocumentProperties documentProperties) {
+    return resolve(expression, context, null, documentProperties);
+  }
+
+  /**
+   * Returns a document resolver for a single {@link And} expression in CNF form.
+   *
+   * @param expression {@link FilterExpression}
+   * @param context {@link ExecutionContext}
+   * @param parent parent resolver or <code>null</code>
+   * @param documentProperties {@link DocumentProperties}
+   * @return DocumentsResolver
+   */
+  public static DocumentsResolver resolve(
+      Expression<FilterExpression> expression,
+      ExecutionContext context,
+      DocumentsResolver parent,
+      DocumentProperties documentProperties) {
+    // from the children inside and
+    And<FilterExpression> andExpression = (And<FilterExpression>) expression;
+    List<Expression<FilterExpression>> children = andExpression.getChildren();
+
+    UserOrderWeightResolver weightResolver = UserOrderWeightResolver.of();
+
+    // try to get the next persistence resolver
+    return nextPersistenceResolver(
+            expression, children, weightResolver, context, parent, documentProperties)
+        // if not persistent ones exists, go for the ORs
+        .orElseGet(
+            () ->
+                nextOrResolver(
+                        expression, children, weightResolver, context, parent, documentProperties)
+                    // if this is not working, go for the memory
+                    .orElseGet(
+                        () ->
+                            nextInMemoryResolver(
+                                    expression,
+                                    children,
+                                    weightResolver,
+                                    context,
+                                    parent,
+                                    documentProperties)
+                                .orElseThrow(
+                                    () ->
+                                        // this should never happen
+                                        new ErrorCodeRuntimeException(
+                                            ErrorCode.DOCS_API_SEARCH_EXPRESSION_NOT_RESOLVED))));
+  }
+
+  private static Optional<DocumentsResolver> nextPersistenceResolver(
+      Expression<FilterExpression> root,
+      List<Expression<FilterExpression>> children,
+      ExpressionWeightResolver<FilterExpression> weightResolver,
+      ExecutionContext context,
+      DocumentsResolver parent,
+      DocumentProperties documentProperties) {
+
+    // find available and next most important set of persistence expressions
+    // these would be the ones on the same filter path
+    return allPersistenceExpressions(children)
+        .map(
+            nextExpressions -> {
+              // if we don't have a parent, then we can not filter with candidates
+              // take best one
+              if (null == parent) {
+                Collection<FilterExpression> selected =
+                    indexByFilterPath(nextExpressions).asMap().values().stream()
+                        .reduce((ec1, ec2) -> weightResolver.collection().apply(ec1, ec2))
+                        .orElseThrow(
+                            () -> new IllegalArgumentException("No persistence expressions."));
+
+                // construct current
+                DocumentsResolver current =
+                    new PersistenceDocumentsResolver(selected, context, documentProperties);
+                // then simplify root
+                Expression<FilterExpression> simplified =
+                    simplifyCnfExpression(root, ImmutableList.copyOf(selected));
+                // and resolve further
+                return BaseResolver.resolve(simplified, context, current, documentProperties);
+              } else {
+                // if we have candidates, then do all memory filters at once
+                List<Function<ExecutionContext, CandidatesFilter>> all =
+                    indexByFilterPath(nextExpressions).asMap().values().stream()
+                        .map(
+                            value ->
+                                PersistenceCandidatesFilter.forExpressions(
+                                    value, documentProperties))
+                        .collect(Collectors.toList());
+                DocumentsResolver current = new AllFiltersResolver(all, context, parent);
+
+                // then simplify root
+                Expression<FilterExpression> simplified =
+                    simplifyCnfExpression(root, ImmutableList.copyOf(nextExpressions));
+
+                // and resolve further
+                return BaseResolver.resolve(simplified, context, current, documentProperties);
+              }
+            });
+  }
+
+  private static Optional<DocumentsResolver> nextInMemoryResolver(
+      Expression<FilterExpression> root,
+      List<Expression<FilterExpression>> children,
+      ExpressionWeightResolver<FilterExpression> weightResolver,
+      ExecutionContext context,
+      DocumentsResolver parent,
+      DocumentProperties documentProperties) {
+
+    // find all available in memory expressions
+    return allInMemoryExpressionExpressions(children)
+        .map(
+            inMemoryExpressions -> {
+              // if we don't have a parent, then we can not filter with candidates
+              // take best one
+              if (null == parent) {
+                Collection<FilterExpression> selected =
+                    indexByFilterPath(inMemoryExpressions).asMap().values().stream()
+                        .reduce((ec1, ec2) -> weightResolver.collection().apply(ec1, ec2))
+                        .orElseThrow(() -> new IllegalArgumentException("No memory expressions."));
+
+                // construct current
+                DocumentsResolver current =
+                    new InMemoryDocumentsResolver(selected, context, documentProperties);
+                // then simplify root
+                Expression<FilterExpression> simplified =
+                    simplifyCnfExpression(root, ImmutableList.copyOf(selected));
+                // and resolve further
+                return BaseResolver.resolve(simplified, context, current, documentProperties);
+              } else {
+                // if we have candidates, then do all memory filters at once
+                List<Function<ExecutionContext, CandidatesFilter>> all =
+                    indexByFilterPath(inMemoryExpressions).asMap().values().stream()
+                        .map(
+                            value ->
+                                InMemoryCandidatesFilter.forExpressions(value, documentProperties))
+                        .collect(Collectors.toList());
+                DocumentsResolver current = new AllFiltersResolver(all, context, parent);
+
+                // then simplify root
+                Expression<FilterExpression> simplified =
+                    simplifyCnfExpression(root, ImmutableList.copyOf(inMemoryExpressions));
+                // and resolve further
+                return BaseResolver.resolve(simplified, context, current, documentProperties);
+              }
+            });
+  }
+
+  private static Optional<DocumentsResolver> nextOrResolver(
+      Expression<FilterExpression> root,
+      List<Expression<FilterExpression>> children,
+      ExpressionWeightResolver<FilterExpression> weightResolver,
+      ExecutionContext context,
+      DocumentsResolver parent,
+      DocumentProperties documentProperties) {
+
+    // find next OR expression
+    return nextOrExpression(children, weightResolver)
+        .map(
+            or -> {
+              // simplify root
+              Expression<FilterExpression> simplified =
+                  simplifyCnfExpression(root, Collections.singletonList(or));
+
+              // if we don't have a parent, then we can not filter with candidates
+              // take best one
+              if (null == parent) {
+                // construct current
+                DocumentsResolver current =
+                    new OrExpressionDocumentsResolver(or, context, documentProperties);
+
+                // and resolve further
+                return BaseResolver.resolve(simplified, context, current, documentProperties);
+              } else {
+                // collect all children
+                Set<FilterExpression> expressions = new HashSet<>();
+                or.collectK(expressions, Integer.MAX_VALUE);
+
+                // map to the correct filters
+                List<Function<ExecutionContext, CandidatesFilter>> input =
+                    expressions.stream()
+                        .map(
+                            exp -> {
+                              if (exp.getCondition().isPersistenceCondition()) {
+                                return PersistenceCandidatesFilter.forExpression(
+                                    exp, documentProperties);
+                              } else {
+                                return InMemoryCandidatesFilter.forExpression(
+                                    exp, documentProperties);
+                              }
+                            })
+                        .collect(Collectors.toList());
+
+                // create the resolver
+                AnyFiltersResolver current = new AnyFiltersResolver(input, context, parent);
+
+                // and resolve further
+                return BaseResolver.resolve(simplified, context, current, documentProperties);
+              }
+            });
+  }
+
+  /** Simplifies by having all resolved ones replaced by {@link Literal#getTrue()} */
+  private static Expression<FilterExpression> simplifyCnfExpression(
+      Expression<FilterExpression> root, Collection<Expression<FilterExpression>> resolved) {
+    List<Rule<?, FilterExpression>> rules = new ArrayList<>();
+    rules.add(new TrueFilterExpressions(resolved::contains));
+    rules.addAll(RulesHelper.<FilterExpression>simplifyRules().getRules());
+
+    RuleList<FilterExpression> ruleList = new RuleList<>(rules);
+    return RulesHelper.applyAll(root, ruleList, ExprOptions.noCaching());
+  }
+
+  /** Finds all expression with persistence conditions. */
+  private static Optional<Collection<FilterExpression>> allPersistenceExpressions(
+      List<Expression<FilterExpression>> children) {
+
+    // collect
+    List<FilterExpression> persistenceExpressions =
+        getFilterExpressions(children, e -> e.getCondition().isPersistenceCondition());
+
+    // if not available return empty
+    if (persistenceExpressions.isEmpty()) {
+      return Optional.empty();
+    } else {
+      return Optional.of(persistenceExpressions);
+    }
+  }
+
+  /** Finds all expression with in-memory conditions. */
+  private static Optional<Collection<FilterExpression>> allInMemoryExpressionExpressions(
+      List<Expression<FilterExpression>> children) {
+    List<FilterExpression> inMemoryExpressions =
+        getFilterExpressions(children, e -> !e.getCondition().isPersistenceCondition());
+
+    if (inMemoryExpressions.isEmpty()) {
+      return Optional.empty();
+    } else {
+      return Optional.of(inMemoryExpressions);
+    }
+  }
+
+  /**
+   * Finds next OR expression that should be executed. Favors the ones that have the best filters
+   * based on the #weightResolver.
+   */
+  private static Optional<Or<FilterExpression>> nextOrExpression(
+      List<Expression<FilterExpression>> children,
+      ExpressionWeightResolver<FilterExpression> weightResolver) {
+    List<Or<FilterExpression>> ors = getOrExpressions(children);
+
+    if (ors.isEmpty()) {
+      return Optional.empty();
+    } else {
+      return ors.stream()
+          .min(
+              (or1, or2) -> {
+                List<FilterExpression> first =
+                    getFilterExpressions(or1.getChildren(), filterExpression -> true);
+                List<FilterExpression> second =
+                    getFilterExpressions(or2.getChildren(), filterExpression -> true);
+                return weightResolver.compare(first, second);
+              });
+    }
+  }
+
+  /** index the expressions by filter path */
+  private static Multimap<FilterPath, FilterExpression> indexByFilterPath(
+      Iterable<FilterExpression> persistenceExpressions) {
+    return Multimaps.index(persistenceExpressions, FilterExpression::getFilterPath);
+  }
+
+  /** Extracts only {@link FilterExpression} from collection of {@link Expression}s. */
+  private static List<FilterExpression> getFilterExpressions(
+      List<Expression<FilterExpression>> children, Predicate<FilterExpression> predicate) {
+    return children.stream()
+        .filter(FilterExpression.class::isInstance)
+        .map(FilterExpression.class::cast)
+        .filter(predicate)
+        .collect(Collectors.toList());
+  }
+
+  /** Extracts only {@link Or<FilterExpression>} from collection of {@link Expression}s. */
+  private static List<Or<FilterExpression>> getOrExpressions(
+      List<Expression<FilterExpression>> children) {
+    List<?> result =
+        children.stream()
+            .filter(Or.class::isInstance)
+            .map(Or.class::cast)
+            .collect(Collectors.toList());
+
+    return (List<Or<FilterExpression>>) result;
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/DocumentsResolver.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/DocumentsResolver.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.resolver;
+
+import io.smallrye.mutiny.Multi;
+import io.stargate.sgv2.docsapi.service.common.model.Paginator;
+import io.stargate.sgv2.docsapi.service.query.executor.QueryExecutor;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+
+/** Base interface for all the document resolvers. */
+public interface DocumentsResolver {
+
+  /**
+   * Returns documents resolved by this resolver.
+   *
+   * @param queryExecutor {@link QueryExecutor}
+   * @param keyspace keyspace to search in
+   * @param collection collection to search in
+   * @param paginator {@link Paginator}
+   * @return Flowable of documents.
+   */
+  Multi<RawDocument> getDocuments(
+      QueryExecutor queryExecutor, String keyspace, String collection, Paginator paginator);
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/CandidatesFilter.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/CandidatesFilter.java
@@ -17,7 +17,6 @@
 
 package io.stargate.sgv2.docsapi.service.query.search.resolver.filter;
 
-import io.reactivex.rxjava3.annotations.NonNull;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.docsapi.service.query.executor.QueryExecutor;
@@ -27,14 +26,13 @@ import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
 public interface CandidatesFilter {
 
   /**
-   * Returns single that emmit query that this filter needs.
+   * Returns uni that emmit built, but not bound, query that this filter needs.
    *
    * @param keyspace Keyspace
    * @param collection Collection
    * @return Prepared query in a single
    */
-  @NonNull
-  Uni<QueryOuterClass.Query> prepareQuery(String keyspace, String collection); // TODO rename
+  Uni<QueryOuterClass.Query> prepareQuery(String keyspace, String collection);
 
   /**
    * Executes a filter for given {@link RawDocument} operating with the query that was supplied in

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/CandidatesFilter.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/CandidatesFilter.java
@@ -34,7 +34,7 @@ public interface CandidatesFilter {
    * @return Prepared query in a single
    */
   @NonNull
-  Uni<QueryOuterClass.Query> prepareQuery(String keyspace, String collection);
+  Uni<QueryOuterClass.Query> prepareQuery(String keyspace, String collection); // TODO rename
 
   /**
    * Executes a filter for given {@link RawDocument} operating with the query that was supplied in

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/CandidatesFilter.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/CandidatesFilter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.resolver.filter;
+
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.smallrye.mutiny.Uni;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.service.query.executor.QueryExecutor;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+
+/** Interface for candidates filtering. */
+public interface CandidatesFilter {
+
+  /**
+   * Returns single that emmit query that this filter needs.
+   *
+   * @param keyspace Keyspace
+   * @param collection Collection
+   * @return Prepared query in a single
+   */
+  @NonNull
+  Uni<QueryOuterClass.Query> prepareQuery(String keyspace, String collection);
+
+  /**
+   * Executes a filter for given {@link RawDocument} operating with the query that was supplied in
+   * the {@link #prepareQuery(String, String)}.
+   *
+   * <p>Returns the Uni that must never emit <code>null</code>. If this uni emits true, we consider
+   * this filter to be successful. If the uni emits false, we consider that filter is not passed.
+   *
+   * @param preparedQuery Query provided as part of the {@link #prepareQuery(String, String)}
+   * @param document Document to filter
+   * @return Uni, if emits true, then filter is considered as passed
+   */
+  Uni<Boolean> bindAndFilter(
+      QueryExecutor queryExecutor, QueryOuterClass.Query preparedQuery, RawDocument document);
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/impl/InMemoryCandidatesFilter.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/impl/InMemoryCandidatesFilter.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.resolver.filter.impl;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.common.model.RowWrapper;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.FilterPath;
+import io.stargate.sgv2.docsapi.service.query.executor.QueryExecutor;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+import io.stargate.sgv2.docsapi.service.query.search.db.impl.DocumentSearchQueryBuilder;
+import io.stargate.sgv2.docsapi.service.query.search.db.impl.FilterPathSearchQueryBuilder;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.filter.CandidatesFilter;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * {{@link CandidatesFilter} that works with set of {@link FilterExpression}s that contain only
+ * in-memory conditions.
+ */
+public class InMemoryCandidatesFilter implements CandidatesFilter {
+
+  private final Collection<FilterExpression> expressions;
+
+  private final FilterPathSearchQueryBuilder queryBuilder;
+
+  private final ExecutionContext context;
+
+  private final DocumentProperties documentProperties;
+
+  private InMemoryCandidatesFilter(
+      Collection<FilterExpression> expressions,
+      ExecutionContext context,
+      DocumentProperties documentProperties) {
+    boolean hasPersistence =
+        expressions.stream().anyMatch(e -> e.getCondition().isPersistenceCondition());
+
+    if (hasPersistence) {
+      throw new IllegalArgumentException(
+          "InMemoryCandidatesDocumentsResolver works only with the non persistence conditions.");
+    }
+
+    this.expressions = expressions;
+    this.queryBuilder = new DocumentSearchQueryBuilder(documentProperties, expressions);
+    this.context = createContext(context, expressions);
+    this.documentProperties = documentProperties;
+  }
+
+  public static Function<ExecutionContext, CandidatesFilter> forExpression(
+      FilterExpression expression, DocumentProperties documentProperties) {
+    return forExpressions(Collections.singletonList(expression), documentProperties);
+  }
+
+  public static Function<ExecutionContext, CandidatesFilter> forExpressions(
+      Collection<FilterExpression> expressions, DocumentProperties documentProperties) {
+    return context -> new InMemoryCandidatesFilter(expressions, context, documentProperties);
+  }
+
+  @Override
+  public Uni<QueryOuterClass.Query> prepareQuery(String keyspace, String collection) {
+    FilterPath filterPath = queryBuilder.getFilterPath();
+    // resolve depth we need
+    // TODO optimize
+    String[] neededColumns =
+        documentProperties
+            .tableColumns()
+            .allColumnNamesWithPathDepth(filterPath.getPath().size() + 1)
+            .toArray(String[]::new);
+
+    // we can only fetch one row if path is fixed
+    Integer limit = filterPath.isFixed() ? 1 : null;
+    return Uni.createFrom()
+        .item(() -> queryBuilder.buildQuery(keyspace, collection, limit, neededColumns))
+        .memoize()
+        .indefinitely();
+  }
+
+  @Override
+  public Uni<Boolean> bindAndFilter(
+      QueryExecutor queryExecutor, QueryOuterClass.Query preparedQuery, RawDocument document) {
+    QueryOuterClass.Value idValue = Values.of(document.id());
+    QueryOuterClass.Query query = queryBuilder.bindWithValues(preparedQuery, idValue);
+
+    // query, take one, test against expression
+    FilterPath filterPath = queryBuilder.getFilterPath();
+
+    // page size 2 with limit 1 to ensure no extra page fetching (only on fixed path)
+    // use max storage page size otherwise as we have the doc id
+    int pageSize = filterPath.isFixed() ? 2 : documentProperties.maxSearchPageSize();
+    return queryExecutor
+        .queryDocs(query, pageSize, false, null, false, context)
+
+        // get first
+        .select()
+        .first()
+
+        // map to rows
+        .map(d -> matchAll(expressions).test(d.rows()))
+
+        // handle case with no results
+        .onCompletion()
+        .ifEmpty()
+        .switchTo(
+            Multi.createFrom()
+                .deferred(
+                    () -> {
+                      // check if we might have only evaluate on missing
+                      boolean allEvalOnMissing =
+                          expressions.stream()
+                              .allMatch(e -> e.getCondition().isEvaluateOnMissingFields());
+
+                      // if so, pass empty row list here, so we test against this
+                      // otherwise keep empty
+                      if (allEvalOnMissing) {
+                        boolean test = matchAll(expressions).test(Collections.emptyList());
+                        return Multi.createFrom().items(test);
+                      } else {
+                        return Multi.createFrom().items(false);
+                      }
+                    }))
+
+        // and then convert to uni that will always emit
+        .toUni();
+  }
+
+  private Predicate<? super List<RowWrapper>> matchAll(Collection<FilterExpression> expressions) {
+    return documentRows -> {
+      for (FilterExpression expression : expressions) {
+        if (!expression.test(documentRows)) {
+          return false;
+        }
+      }
+      return true;
+    };
+  }
+
+  private ExecutionContext createContext(
+      ExecutionContext context, Collection<FilterExpression> expressions) {
+    String expressionDesc =
+        expressions.stream()
+            .map(FilterExpression::getDescription)
+            .collect(Collectors.joining(" AND "));
+
+    return context.nested("FILTER IN MEMORY: " + expressionDesc);
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/impl/InMemoryCandidatesFilter.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/impl/InMemoryCandidatesFilter.java
@@ -39,7 +39,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
- * {{@link CandidatesFilter} that works with set of {@link FilterExpression}s that contain only
+ * {@link CandidatesFilter} that works with set of {@link FilterExpression}s that contain only
  * in-memory conditions.
  */
 public class InMemoryCandidatesFilter implements CandidatesFilter {

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/impl/PersistenceCandidatesFilter.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/impl/PersistenceCandidatesFilter.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.resolver.filter.impl;
+
+import io.smallrye.mutiny.Uni;
+import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentTableProperties;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.FilterPath;
+import io.stargate.sgv2.docsapi.service.query.executor.QueryExecutor;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+import io.stargate.sgv2.docsapi.service.query.search.db.impl.DocumentSearchQueryBuilder;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.filter.CandidatesFilter;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * {@link CandidatesFilter} that works with set of {@link FilterExpression}s that are on the same
+ * path containing only persistence conditions.
+ */
+public class PersistenceCandidatesFilter implements CandidatesFilter {
+
+  private final DocumentSearchQueryBuilder queryBuilder;
+
+  private final ExecutionContext context;
+
+  private final DocumentProperties documentProperties;
+
+  private PersistenceCandidatesFilter(
+      Collection<FilterExpression> expressions,
+      ExecutionContext context,
+      DocumentProperties documentProperties) {
+    boolean hasInMemory =
+        expressions.stream().anyMatch(e -> !e.getCondition().isPersistenceCondition());
+
+    if (hasInMemory) {
+      throw new IllegalArgumentException(
+          "PersistenceCandidatesDocumentsResolver works only with the persistence conditions.");
+    }
+
+    this.queryBuilder = new DocumentSearchQueryBuilder(documentProperties, expressions);
+    this.context = createContext(context, expressions);
+    this.documentProperties = documentProperties;
+  }
+
+  public static Function<ExecutionContext, CandidatesFilter> forExpression(
+      FilterExpression expression, DocumentProperties documentProperties) {
+    return forExpressions(Collections.singletonList(expression), documentProperties);
+  }
+
+  public static Function<ExecutionContext, CandidatesFilter> forExpressions(
+      Collection<FilterExpression> expressions, DocumentProperties documentProperties) {
+    return context -> new PersistenceCandidatesFilter(expressions, context, documentProperties);
+  }
+
+  @Override
+  public Uni<QueryOuterClass.Query> prepareQuery(String keyspace, String collection) {
+    DocumentTableProperties tableProps = documentProperties.tableProperties();
+
+    return Uni.createFrom()
+        .item(
+            () -> {
+              FilterPath filterPath = queryBuilder.getFilterPath();
+              Integer limit = filterPath.isFixed() ? 1 : null;
+              return queryBuilder.buildQuery(
+                  keyspace,
+                  collection,
+                  limit,
+                  tableProps.keyColumnName(),
+                  tableProps.leafColumnName());
+            })
+        .memoize()
+        .indefinitely();
+  }
+
+  @Override
+  public Uni<Boolean> bindAndFilter(
+      QueryExecutor queryExecutor, QueryOuterClass.Query preparedQuery, RawDocument document) {
+    QueryOuterClass.Value idValue = Values.of(document.id());
+    QueryOuterClass.Query query = queryBuilder.bindWithValues(preparedQuery, idValue);
+
+    // execute query
+    // page size 2 with limit 1 to ensure no additional pages fetched (only on fixed path)
+    // use max storage page size otherwise as we have the doc id
+    FilterPath filterPath = queryBuilder.getFilterPath();
+    int pageSize = filterPath.isFixed() ? 2 : documentProperties.maxSearchPageSize();
+    return queryExecutor
+        .queryDocs(query, pageSize, false, null, false, context)
+
+        // select only first one
+        .select()
+        .first()
+
+        // if we have an item report true, otherwise on empty false
+        .onItem()
+        .transform(any -> true)
+        .onCompletion()
+        .ifEmpty()
+        .continueWith(false)
+
+        // and then convert to uni that will always emit
+        .toUni();
+  }
+
+  private ExecutionContext createContext(
+      ExecutionContext context, Collection<FilterExpression> expressions) {
+    String expressionDesc =
+        expressions.stream()
+            .map(FilterExpression::getDescription)
+            .collect(Collectors.joining(" AND "));
+
+    return context.nested("FILTER: " + expressionDesc);
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/AbstractFiltersResolver.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/AbstractFiltersResolver.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in comHpliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.resolver.impl;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.service.common.model.Paginator;
+import io.stargate.sgv2.docsapi.service.query.executor.QueryExecutor;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.DocumentsResolver;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.filter.CandidatesFilter;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
+
+public abstract class AbstractFiltersResolver implements DocumentsResolver {
+
+  protected abstract DocumentsResolver getCandidatesResolver();
+
+  protected abstract Collection<CandidatesFilter> getCandidatesFilters();
+
+  protected abstract Multi<RawDocument> resolveSources(
+      RawDocument rawDocument, List<Uni<Boolean>> sources);
+
+  protected DocumentProperties documentProperties;
+
+  @Override
+  public Multi<RawDocument> getDocuments(
+      QueryExecutor queryExecutor, String keyspace, String collection, Paginator paginator) {
+    Multi<RawDocument> candidates =
+        getCandidatesResolver().getDocuments(queryExecutor, keyspace, collection, paginator);
+
+    Uni<List<Pair<QueryOuterClass.Query, CandidatesFilter>>> queriesToCandidates =
+        Multi.createFrom()
+            .iterable(getCandidatesFilters())
+            .onItem()
+            .transformToUniAndMerge(
+                filter ->
+                    filter.prepareQuery(keyspace, collection).map(built -> Pair.of(built, filter)))
+
+            // collect as list
+            .collect()
+            .asList()
+
+            // cache
+            .memoize()
+            .indefinitely();
+
+    return candidates
+
+        // keep the order of incoming docs
+        .onItem()
+        .transformToUniAndConcatenate(
+            doc -> queriesToCandidates.map(prepared -> Pair.of(doc, prepared)))
+
+        // keep the order of the resolved docs
+        .onItem()
+        .transformToMultiAndConcatenate(
+            pair -> {
+              RawDocument doc = pair.getLeft();
+              List<Uni<Boolean>> sources =
+                  pair.getRight().stream()
+                      .map(
+                          queryToFilter -> {
+                            CandidatesFilter filter = queryToFilter.getRight();
+                            QueryOuterClass.Query query = queryToFilter.getLeft();
+                            return filter.bindAndFilter(queryExecutor, query, doc);
+                          })
+                      .collect(Collectors.toList());
+
+              // only if all filters emit the item, return the doc
+              // this means all filters are passed
+              return resolveSources(doc, sources);
+            });
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/AllFiltersResolver.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/AllFiltersResolver.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in comHpliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.resolver.impl;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.DocumentsResolver;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.filter.CandidatesFilter;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class AllFiltersResolver extends AbstractFiltersResolver {
+
+  private final Collection<CandidatesFilter> candidatesFilters;
+
+  private final DocumentsResolver candidatesResolver;
+
+  public AllFiltersResolver(
+      Function<ExecutionContext, CandidatesFilter> candidatesFilterSupplier,
+      ExecutionContext context,
+      DocumentsResolver candidatesResolver) {
+    this(Collections.singleton(candidatesFilterSupplier), context, candidatesResolver);
+  }
+
+  public AllFiltersResolver(
+      Collection<Function<ExecutionContext, CandidatesFilter>> candidatesFilterSuppliers,
+      ExecutionContext context,
+      DocumentsResolver candidatesResolver) {
+    ExecutionContext nested = context.nested("PARALLEL [ALL OF]");
+    this.candidatesFilters =
+        candidatesFilterSuppliers.stream().map(s -> s.apply(nested)).collect(Collectors.toList());
+    this.candidatesResolver = candidatesResolver;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected Collection<CandidatesFilter> getCandidatesFilters() {
+    return candidatesFilters;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected DocumentsResolver getCandidatesResolver() {
+    return candidatesResolver;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected Multi<RawDocument> resolveSources(RawDocument rawDocument, List<Uni<Boolean>> sources) {
+    // only if all filters emit true, return the doc
+    // this means all filters are passed
+
+    return Uni.join()
+        .all(sources)
+        .andFailFast()
+        .onItem()
+        .transformToMulti(
+            results -> {
+              if (results.contains(Boolean.FALSE)) {
+                return Multi.createFrom().empty();
+              } else {
+                return Multi.createFrom().items(rawDocument);
+              }
+            });
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/AllFiltersResolver.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/AllFiltersResolver.java
@@ -17,10 +17,8 @@
 
 package io.stargate.sgv2.docsapi.service.query.search.resolver.impl;
 
-import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.docsapi.service.ExecutionContext;
-import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
 import io.stargate.sgv2.docsapi.service.query.search.resolver.DocumentsResolver;
 import io.stargate.sgv2.docsapi.service.query.search.resolver.filter.CandidatesFilter;
 import java.util.Collection;
@@ -66,21 +64,10 @@ public class AllFiltersResolver extends AbstractFiltersResolver {
 
   /** {@inheritDoc} */
   @Override
-  protected Multi<RawDocument> resolveSources(RawDocument rawDocument, List<Uni<Boolean>> sources) {
+  protected Uni<Boolean> resolveSources(List<Uni<Boolean>> sources) {
     // only if all filters emit true, return the doc
     // this means all filters are passed
 
-    return Uni.join()
-        .all(sources)
-        .andFailFast()
-        .onItem()
-        .transformToMulti(
-            results -> {
-              if (results.contains(Boolean.FALSE)) {
-                return Multi.createFrom().empty();
-              } else {
-                return Multi.createFrom().items(rawDocument);
-              }
-            });
+    return Uni.join().all(sources).andFailFast().map(results -> !results.contains(Boolean.FALSE));
   }
 }

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/AnyFiltersResolver.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/AnyFiltersResolver.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.resolver.impl;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.DocumentsResolver;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.filter.CandidatesFilter;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class AnyFiltersResolver extends AbstractFiltersResolver {
+
+  private final Collection<CandidatesFilter> candidatesFilters;
+
+  private final DocumentsResolver candidatesResolver;
+
+  public AnyFiltersResolver(
+      Function<ExecutionContext, CandidatesFilter> candidatesFilterSupplier,
+      ExecutionContext context,
+      DocumentsResolver candidatesResolver) {
+    this(Collections.singleton(candidatesFilterSupplier), context, candidatesResolver);
+  }
+
+  public AnyFiltersResolver(
+      Collection<Function<ExecutionContext, CandidatesFilter>> candidatesFilterSuppliers,
+      ExecutionContext context,
+      DocumentsResolver candidatesResolver) {
+    ExecutionContext nested = context.nested("PARALLEL [ANY OF]");
+    this.candidatesFilters =
+        candidatesFilterSuppliers.stream().map(s -> s.apply(nested)).collect(Collectors.toList());
+    this.candidatesResolver = candidatesResolver;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected DocumentsResolver getCandidatesResolver() {
+    return candidatesResolver;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected Collection<CandidatesFilter> getCandidatesFilters() {
+    return candidatesFilters;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected Multi<RawDocument> resolveSources(RawDocument rawDocument, List<Uni<Boolean>> sources) {
+    // only one signal is needed here, we can dispose the rest immediately
+    // when one emits, map to the document because we need to return the document that passes
+    // it's important to keep with the concatMap approach in the abstract class
+
+    // transform uni to a multi, but only if true
+    List<Multi<Boolean>> trueFilters =
+        sources.stream().map(uni -> uni.toMulti().filter(b -> b)).toList();
+
+    // then merge, take only one! and map to raw document
+    return Multi.createBy()
+        .merging()
+        .withRequests(1)
+        .streams(trueFilters)
+        .select()
+        .first()
+        .map(any -> rawDocument);
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/InMemoryDocumentsResolver.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/InMemoryDocumentsResolver.java
@@ -91,20 +91,19 @@ public class InMemoryDocumentsResolver implements DocumentsResolver {
       QueryExecutor queryExecutor, String keyspace, String collection, Paginator paginator) {
 
     // if we have a filter path query then need all the columns on the filter, plus one additional
-    // to match
-    // otherwise we need all columns
-    Integer neededDepth =
+    // to match, otherwise we need all columns
+    String[] neededColumns =
         Optional.of(queryBuilder)
             .filter(FilterPathSearchQueryBuilder.class::isInstance)
             .map(FilterPathSearchQueryBuilder.class::cast)
             .map(qb -> qb.getFilterPath().getPath().size() + 1)
-            .orElse(documentProperties.maxDepth());
-
-    String[] neededColumns =
-        documentProperties
-            .tableColumns()
-            .allColumnNamesWithPathDepth(neededDepth)
-            .toArray(String[]::new);
+            .map(
+                depth ->
+                    documentProperties
+                        .tableColumns()
+                        .allColumnNamesWithPathDepth(depth)
+                        .toArray(String[]::new))
+            .orElse(documentProperties.tableColumns().allColumnNamesArray());
 
     // bind and build the query
     return Uni.createFrom()

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/InMemoryDocumentsResolver.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/InMemoryDocumentsResolver.java
@@ -100,7 +100,6 @@ public class InMemoryDocumentsResolver implements DocumentsResolver {
             .map(qb -> qb.getFilterPath().getPath().size() + 1)
             .orElse(documentProperties.maxDepth());
 
-    // TODO optimize list to string necessary
     String[] neededColumns =
         documentProperties
             .tableColumns()

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/InMemoryDocumentsResolver.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/InMemoryDocumentsResolver.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.resolver.impl;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.common.model.Paginator;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.executor.QueryExecutor;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+import io.stargate.sgv2.docsapi.service.query.search.db.AbstractSearchQueryBuilder;
+import io.stargate.sgv2.docsapi.service.query.search.db.impl.FilterExpressionSearchQueryBuilder;
+import io.stargate.sgv2.docsapi.service.query.search.db.impl.FilterPathSearchQueryBuilder;
+import io.stargate.sgv2.docsapi.service.query.search.db.impl.FullSearchQueryBuilder;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.DocumentsResolver;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * * {@link DocumentsResolver} that works with set of {@link FilterExpression}s that are on the same
+ * * path containing only in-memory conditions.
+ */
+public class InMemoryDocumentsResolver implements DocumentsResolver {
+
+  private final Collection<FilterExpression> expressions;
+
+  private final AbstractSearchQueryBuilder queryBuilder;
+
+  private final ExecutionContext context;
+
+  private final boolean evaluateOnMissing;
+
+  private final DocumentProperties documentProperties;
+
+  public InMemoryDocumentsResolver(
+      FilterExpression expression,
+      ExecutionContext context,
+      DocumentProperties documentProperties) {
+    this(Collections.singletonList(expression), context, documentProperties);
+  }
+
+  public InMemoryDocumentsResolver(
+      Collection<FilterExpression> expressions,
+      ExecutionContext context,
+      DocumentProperties documentProperties) {
+    boolean hasPersistence =
+        expressions.stream().anyMatch(e -> e.getCondition().isPersistenceCondition());
+
+    if (hasPersistence) {
+      throw new IllegalArgumentException(
+          "InMemoryCandidatesDocumentsResolver works only with the non persistence conditions.");
+    }
+
+    // if we have a single one that evaluate son the
+    evaluateOnMissing =
+        expressions.stream().anyMatch(e -> e.getCondition().isEvaluateOnMissingFields());
+
+    this.expressions = expressions;
+    this.queryBuilder =
+        evaluateOnMissing
+            ? new FullSearchQueryBuilder(documentProperties)
+            : new FilterExpressionSearchQueryBuilder(documentProperties, expressions);
+    this.context = createContext(context, expressions);
+    this.documentProperties = documentProperties;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Multi<RawDocument> getDocuments(
+      QueryExecutor queryExecutor, String keyspace, String collection, Paginator paginator) {
+
+    // if we have a filter path query then need all the columns on the filter, plus one additional
+    // to match
+    // otherwise we need all columns
+    Integer neededDepth =
+        Optional.of(queryBuilder)
+            .filter(FilterPathSearchQueryBuilder.class::isInstance)
+            .map(FilterPathSearchQueryBuilder.class::cast)
+            .map(qb -> qb.getFilterPath().getPath().size() + 1)
+            .orElse(documentProperties.maxDepth());
+
+    // TODO optimize list to string necessary
+    String[] neededColumns =
+        documentProperties
+            .tableColumns()
+            .allColumnNamesWithPathDepth(neededDepth)
+            .toArray(String[]::new);
+
+    // prepare the query
+    return Uni.createFrom()
+        .item(() -> queryBuilder.buildQuery(keyspace, collection, neededColumns))
+
+        // cache it
+        .memoize()
+        .indefinitely()
+
+        // then bind and execute
+        .onItem()
+        .transformToMulti(
+            built -> {
+              // once ready bind (no values) and fire
+              QueryOuterClass.Query query = queryBuilder.bind(built);
+
+              // in case we have a full search then base the page size on the app. doc size
+              // otherwise start with the requested page size, plus one more than needed to stop
+              // pre-fetching
+              int pageSize =
+                  evaluateOnMissing
+                      ? documentProperties.getApproximateStoragePageSize(paginator.docPageSize)
+                      : paginator.docPageSize + 1;
+              // fetch paging as this can be the first resolver in chain
+              boolean fetchRowPaging = true;
+              return queryExecutor.queryDocs(
+                  query,
+                  pageSize,
+                  true,
+                  paginator.getCurrentDbPageState(),
+                  fetchRowPaging,
+                  context);
+            })
+
+        // then filter to match the expression (in-memory filters have no predicates on the values)
+        .select()
+        .where(matchAll(expressions));
+  }
+
+  private Predicate<? super RawDocument> matchAll(Collection<FilterExpression> expressions) {
+    return rawDocument -> {
+      for (FilterExpression expression : expressions) {
+        if (!expression.test(rawDocument)) {
+          return false;
+        }
+      }
+      return true;
+    };
+  }
+
+  private ExecutionContext createContext(
+      ExecutionContext context, Collection<FilterExpression> expressions) {
+    String expressionDesc =
+        expressions.stream()
+            .map(FilterExpression::getDescription)
+            .collect(Collectors.joining(" AND "));
+
+    return context.nested("FILTER IN MEMORY: " + expressionDesc);
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolver.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolver.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.resolver.impl;
+
+import com.bpodgursky.jbool_expressions.Or;
+import com.bpodgursky.jbool_expressions.eval.EvalEngine;
+import com.bpodgursky.jbool_expressions.eval.EvalRule;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentTableProperties;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.common.model.Paginator;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.eval.RawDocumentEvalRule;
+import io.stargate.sgv2.docsapi.service.query.executor.QueryExecutor;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+import io.stargate.sgv2.docsapi.service.query.search.db.AbstractSearchQueryBuilder;
+import io.stargate.sgv2.docsapi.service.query.search.db.impl.FilterExpressionSearchQueryBuilder;
+import io.stargate.sgv2.docsapi.service.query.search.db.impl.FilterPathSearchQueryBuilder;
+import io.stargate.sgv2.docsapi.service.query.search.db.impl.FullSearchQueryBuilder;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.DocumentsResolver;
+import io.stargate.sgv2.docsapi.service.query.search.weight.impl.UserOrderWeightResolver;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class OrExpressionDocumentsResolver implements DocumentsResolver {
+
+  private final Or<FilterExpression> expression;
+
+  private final List<AbstractSearchQueryBuilder> queryBuilders;
+
+  private final ExecutionContext context;
+
+  private final boolean evaluateOnMissing;
+
+  private final DocumentProperties documentProperties;
+
+  public OrExpressionDocumentsResolver(
+      Or<FilterExpression> expression,
+      ExecutionContext context,
+      DocumentProperties documentProperties) {
+    List<FilterExpression> children = getChildren(expression);
+
+    this.expression = expression;
+    this.evaluateOnMissing =
+        children.stream().anyMatch(e -> e.getCondition().isEvaluateOnMissingFields());
+    this.documentProperties = documentProperties;
+    this.queryBuilders = buildQueries(evaluateOnMissing, children);
+    this.context = createContext(context, expression);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Multi<RawDocument> getDocuments(
+      QueryExecutor queryExecutor, String keyspace, String collection, Paginator paginator) {
+    // find the max size of columns in all queries and use that for now
+    String[] columns =
+        queryBuilders.stream()
+            .map(qb -> columnsForQuery(qb, documentProperties.maxDepth()))
+            .max(Comparator.comparingInt(o -> o.length))
+            .orElseGet(
+                () ->
+                    documentProperties
+                        .tableColumns()
+                        .allColumnNamesWithPathDepth(documentProperties.maxDepth())
+                        .toArray(String[]::new));
+
+    // resolve if no path are there, used in the filtering
+    boolean noPaths =
+        Arrays.stream(columns)
+            .noneMatch(
+                c -> Objects.equals(c, documentProperties.tableProperties().pathColumnName(0)));
+
+    return Multi.createFrom()
+        .iterable(queryBuilders)
+        .concatMap(
+            queryBuilder ->
+                Uni.createFrom()
+                    .item(
+                        () -> {
+                          QueryOuterClass.Query query =
+                              queryBuilder.buildQuery(keyspace, collection, columns);
+                          return queryBuilder.bind(query);
+                        })
+                    .toMulti())
+        .collect()
+        .asList()
+        .memoize()
+        .indefinitely()
+        .onItem()
+        .transformToMulti(
+            boundQueries -> {
+
+              // execute them all by respecting the paging state
+              // if we have evaluate on missing then we have single query, so go for the
+              // getStoragePageSize
+              // otherwise the page size for each query should be requested page size + 1
+              // since we are doing in order merge of the results to preserve sorting
+              // we can not fetch fewer document
+              int pageSize =
+                  evaluateOnMissing
+                      ? documentProperties.getApproximateStoragePageSize(paginator.docPageSize)
+                      : paginator.docPageSize + 1;
+              return queryExecutor.queryDocs(
+                  boundQueries, pageSize, true, paginator.getCurrentDbPageState(), true, context);
+            })
+        .filter(
+            doc -> {
+              // now we can get doc as a result of the persistence or in memory query
+              // if we only run persistence queries we can return true immediately
+              // running only persistence queries means we had no path columns
+              if (noPaths) {
+                return true;
+              }
+
+              // otherwise evaluate using the EvalEngine
+              // this is gonna test the persistence expressions as well, but this is fine
+              Map<String, EvalRule<FilterExpression>> rules = EvalEngine.booleanRules();
+              rules.put(FilterExpression.EXPR_TYPE, new RawDocumentEvalRule(doc));
+              return EvalEngine.evaluate(expression, rules);
+            });
+  }
+
+  private String[] columnsForQuery(AbstractSearchQueryBuilder queryBuilder, int maxDepth) {
+    DocumentTableProperties tableProps = documentProperties.tableProperties();
+    String[] columns;
+    if (queryBuilder instanceof FilterExpressionSearchQueryBuilder) {
+      columns = new String[] {tableProps.keyColumnName(), tableProps.leafColumnName()};
+    } else if (queryBuilder instanceof FilterPathSearchQueryBuilder) {
+      FilterPathSearchQueryBuilder fpqb = (FilterPathSearchQueryBuilder) queryBuilder;
+      columns =
+          documentProperties
+              .tableColumns()
+              .allColumnNamesWithPathDepth(fpqb.getFilterPath().getPath().size() + 1)
+              .toArray(String[]::new);
+    } else {
+      columns =
+          documentProperties
+              .tableColumns()
+              .allColumnNamesWithPathDepth(maxDepth)
+              .toArray(String[]::new);
+    }
+    return columns;
+  }
+
+  private List<AbstractSearchQueryBuilder> buildQueries(
+      boolean evaluateOnMissing, List<FilterExpression> children) {
+    // if any condition is evaluated on missing, then we can do a full search only
+    if (evaluateOnMissing) {
+      return Collections.singletonList(new FullSearchQueryBuilder(documentProperties));
+    }
+
+    // otherwise, for each persistence condition an own builder
+    List<AbstractSearchQueryBuilder> persistenceQueries =
+        children.stream()
+            .filter(e -> e.getCondition().isPersistenceCondition())
+            .map(
+                isPersistenceCondition ->
+                    new FilterExpressionSearchQueryBuilder(
+                        documentProperties, isPersistenceCondition))
+            .collect(Collectors.toList());
+
+    // for the memory ones, we can collect only distinct filter paths
+    List<AbstractSearchQueryBuilder> inMemoryQueries =
+        children.stream()
+            .filter(e -> !e.getCondition().isPersistenceCondition())
+            .map(FilterExpression::getFilterPath)
+            .distinct()
+            .map(fp -> new FilterPathSearchQueryBuilder(documentProperties, fp, true))
+            .collect(Collectors.toList());
+
+    // merge and return
+    persistenceQueries.addAll(inMemoryQueries);
+    return persistenceQueries;
+  }
+
+  private List<FilterExpression> getChildren(Or<FilterExpression> expression) {
+    // collect first
+    Set<FilterExpression> set = new HashSet<>();
+    expression.collectK(set, Integer.MAX_VALUE);
+
+    // then always maintain a same order by sorting
+    UserOrderWeightResolver resolver = UserOrderWeightResolver.of();
+    List<FilterExpression> result = new ArrayList<>(set);
+    result.sort(resolver::compare);
+    return result;
+  }
+
+  private ExecutionContext createContext(
+      ExecutionContext context, Or<FilterExpression> expression) {
+    // Note: use toLexicographicString to ensure a stable order of sub-expressions.
+    return context.nested("MERGING OR: expression '" + expression.toLexicographicString() + "'");
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolver.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolver.java
@@ -81,14 +81,9 @@ public class OrExpressionDocumentsResolver implements DocumentsResolver {
     // find the max size of columns in all queries and use that for now
     String[] columns =
         queryBuilders.stream()
-            .map(qb -> columnsForQuery(qb, documentProperties.maxDepth()))
+            .map(qb -> columnsForQuery(qb))
             .max(Comparator.comparingInt(o -> o.length))
-            .orElseGet(
-                () ->
-                    documentProperties
-                        .tableColumns()
-                        .allColumnNamesWithPathDepth(documentProperties.maxDepth())
-                        .toArray(String[]::new));
+            .orElseGet(() -> documentProperties.tableColumns().allColumnNamesArray());
 
     // resolve if no path are there, used in the filtering
     boolean noPaths =
@@ -146,7 +141,7 @@ public class OrExpressionDocumentsResolver implements DocumentsResolver {
             });
   }
 
-  private String[] columnsForQuery(AbstractSearchQueryBuilder queryBuilder, int maxDepth) {
+  private String[] columnsForQuery(AbstractSearchQueryBuilder queryBuilder) {
     DocumentTableProperties tableProps = documentProperties.tableProperties();
     String[] columns;
     if (queryBuilder instanceof FilterExpressionSearchQueryBuilder) {
@@ -159,11 +154,7 @@ public class OrExpressionDocumentsResolver implements DocumentsResolver {
               .allColumnNamesWithPathDepth(fpqb.getFilterPath().getPath().size() + 1)
               .toArray(String[]::new);
     } else {
-      columns =
-          documentProperties
-              .tableColumns()
-              .allColumnNamesWithPathDepth(maxDepth)
-              .toArray(String[]::new);
+      columns = documentProperties.tableColumns().allColumnNamesArray();
     }
     return columns;
   }

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/PersistenceDocumentsResolver.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/PersistenceDocumentsResolver.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.resolver.impl;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentTableProperties;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.common.model.Paginator;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.executor.QueryExecutor;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+import io.stargate.sgv2.docsapi.service.query.search.db.AbstractSearchQueryBuilder;
+import io.stargate.sgv2.docsapi.service.query.search.db.impl.FilterExpressionSearchQueryBuilder;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.DocumentsResolver;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+/**
+ * {@link DocumentsResolver} that works with set of {@link FilterExpression}s that are on the same
+ * path containing only persistence conditions.
+ */
+public class PersistenceDocumentsResolver implements DocumentsResolver {
+
+  private final AbstractSearchQueryBuilder queryBuilder;
+
+  private final ExecutionContext context;
+
+  private final DocumentProperties documentProperties;
+
+  public PersistenceDocumentsResolver(
+      FilterExpression expression,
+      ExecutionContext context,
+      DocumentProperties documentProperties) {
+    this(Collections.singletonList(expression), context, documentProperties);
+  }
+
+  public PersistenceDocumentsResolver(
+      Collection<FilterExpression> expressions,
+      ExecutionContext context,
+      DocumentProperties documentProperties) {
+    boolean hasInMemory =
+        expressions.stream().anyMatch(e -> !e.getCondition().isPersistenceCondition());
+
+    if (hasInMemory) {
+      throw new IllegalArgumentException(
+          "PersistenceDocumentsResolver works only with the persistence conditions.");
+    }
+
+    this.queryBuilder = new FilterExpressionSearchQueryBuilder(documentProperties, expressions);
+    this.context = createContext(context, expressions);
+    this.documentProperties = documentProperties;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Multi<RawDocument> getDocuments(
+      QueryExecutor queryExecutor, String keyspace, String collection, Paginator paginator) {
+
+    DocumentTableProperties tableProperties = documentProperties.tableProperties();
+
+    // prepare the query
+    return Uni.createFrom()
+        .item(
+            () ->
+                queryBuilder.buildQuery(
+                    keyspace,
+                    collection,
+                    tableProperties.keyColumnName(),
+                    tableProperties.leafColumnName()))
+
+        // cache the prepared
+        .memoize()
+        .indefinitely()
+
+        // then bind and execute
+        .onItem()
+        .transformToMulti(
+            built -> {
+              // bind (no values needed)
+              QueryOuterClass.Query query = queryBuilder.bind(built);
+
+              // execute by respecting the paging state
+              // take always one more than needed to stop pre-fetching
+              // use exponential page size to increase when more is needed
+              int pageSize = paginator.docPageSize + 1;
+              // fetch paging as this can be the first resolver in chain
+              boolean fetchRowPaging = true;
+              return queryExecutor.queryDocs(
+                  query,
+                  pageSize,
+                  true,
+                  paginator.getCurrentDbPageState(),
+                  fetchRowPaging,
+                  context);
+            });
+  }
+
+  private ExecutionContext createContext(
+      ExecutionContext context, Collection<FilterExpression> expressions) {
+    String expressionDesc =
+        expressions.stream()
+            .map(FilterExpression::getDescription)
+            .collect(Collectors.joining(" AND "));
+
+    return context.nested("FILTER: " + expressionDesc);
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/SubDocumentsResolver.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/SubDocumentsResolver.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.resolver.impl;
+
+import com.bpodgursky.jbool_expressions.Expression;
+import com.bpodgursky.jbool_expressions.eval.EvalEngine;
+import com.bpodgursky.jbool_expressions.eval.EvalRule;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.common.cql.builder.Column;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.common.model.Paginator;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.eval.RawDocumentEvalRule;
+import io.stargate.sgv2.docsapi.service.query.executor.QueryExecutor;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+import io.stargate.sgv2.docsapi.service.query.search.db.AbstractSearchQueryBuilder;
+import io.stargate.sgv2.docsapi.service.query.search.db.impl.SubDocumentSearchQueryBuilder;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.DocumentsResolver;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A document resolver that loads full (sub-)documents on the given sub-path that match an
+ * Expression.
+ *
+ * <p>Note that this resolver has two modes, controlled by the #splitOnSubPathKeys constructor
+ * parameters:
+ *
+ * <ol>
+ *   <li>1. <code>false</code> - there is no split by the keys on the sub-path, effectively the
+ *       whole document on the sub-path is returned
+ *   <li>2. <code>true</code> - there is extra split by the key values in the doc on the sub-path,
+ *       effectively returns document per key
+ * </ol>
+ */
+public class SubDocumentsResolver implements DocumentsResolver {
+
+  private final Expression<FilterExpression> expression;
+
+  private final AbstractSearchQueryBuilder queryBuilder;
+
+  private final ExecutionContext context;
+
+  private final int keyDepth;
+
+  private final DocumentProperties documentProperties;
+
+  public SubDocumentsResolver(
+      Expression<FilterExpression> expression,
+      String documentId,
+      List<String> subDocumentPath,
+      ExecutionContext context,
+      DocumentProperties documentProperties) {
+    this.expression = expression;
+    this.context = createContext(context, subDocumentPath);
+    this.queryBuilder =
+        new SubDocumentSearchQueryBuilder(documentProperties, documentId, subDocumentPath);
+    // key depth explained:
+    //  - one extra for the document id
+    this.keyDepth = subDocumentPath.size() + 1;
+    this.documentProperties = documentProperties;
+  }
+
+  @Override
+  public Multi<RawDocument> getDocuments(
+      QueryExecutor queryExecutor, String keyspace, String collection, Paginator paginator) {
+
+    // todo optimize
+    String[] columns =
+        documentProperties.tableColumns().allColumns().stream()
+            .map(Column::name)
+            .toArray(String[]::new);
+
+    // prepare the query
+    return Uni.createFrom()
+        .item(() -> queryBuilder.buildQuery(keyspace, collection, columns))
+
+        // cache the prepared
+        .memoize()
+        .indefinitely()
+
+        // then bind and execute
+        .onItem()
+        .transformToMulti(
+            built -> {
+              // bind (no values needed)
+              QueryOuterClass.Query query = queryBuilder.bind(built);
+
+              // execute by respecting the paging state
+              // go for max storage page size as we have the document
+              return queryExecutor.queryDocs(
+                  keyDepth,
+                  query,
+                  documentProperties.getApproximateStoragePageSize(paginator.docPageSize),
+                  true,
+                  paginator.getCurrentDbPageState(),
+                  true,
+                  context);
+            })
+        .filter(
+            document -> {
+              Map<String, EvalRule<FilterExpression>> rules = EvalEngine.booleanRules();
+              rules.put(FilterExpression.EXPR_TYPE, new RawDocumentEvalRule(document));
+              return EvalEngine.evaluate(expression, rules);
+            });
+  }
+
+  private ExecutionContext createContext(ExecutionContext context, List<String> prependPath) {
+    return context.nested(
+        "SearchSubDocuments: sub-path '"
+            + String.join(".", prependPath)
+            + "', expression: '"
+            + expression.toString()
+            + "'");
+  }
+}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/SubDocumentsResolver.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/SubDocumentsResolver.java
@@ -23,7 +23,6 @@ import com.bpodgursky.jbool_expressions.eval.EvalRule;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.proto.QueryOuterClass;
-import io.stargate.sgv2.common.cql.builder.Column;
 import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.service.ExecutionContext;
 import io.stargate.sgv2.docsapi.service.common.model.Paginator;
@@ -83,11 +82,7 @@ public class SubDocumentsResolver implements DocumentsResolver {
   public Multi<RawDocument> getDocuments(
       QueryExecutor queryExecutor, String keyspace, String collection, Paginator paginator) {
 
-    // todo optimize
-    String[] columns =
-        documentProperties.tableColumns().allColumns().stream()
-            .map(Column::name)
-            .toArray(String[]::new);
+    String[] columns = documentProperties.tableColumns().allColumnNamesArray();
 
     // prepare the query
     return Uni.createFrom()

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/SubDocumentsResolver.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/SubDocumentsResolver.java
@@ -91,7 +91,11 @@ public class SubDocumentsResolver implements DocumentsResolver {
 
     // prepare the query
     return Uni.createFrom()
-        .item(() -> queryBuilder.buildQuery(keyspace, collection, columns))
+        .item(
+            () -> {
+              QueryOuterClass.Query query = queryBuilder.buildQuery(keyspace, collection, columns);
+              return queryBuilder.bind(query);
+            })
 
         // cache the prepared
         .memoize()
@@ -100,10 +104,7 @@ public class SubDocumentsResolver implements DocumentsResolver {
         // then bind and execute
         .onItem()
         .transformToMulti(
-            built -> {
-              // bind (no values needed)
-              QueryOuterClass.Query query = queryBuilder.bind(built);
-
+            query -> {
               // note that we fetch row paging, only if key depth is more than 1
               // if it's one, then we are getting a whole document, thus no paging
               boolean fetchRowPaging = keyDepth > 1;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/SubDocumentsResolver.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/SubDocumentsResolver.java
@@ -104,6 +104,10 @@ public class SubDocumentsResolver implements DocumentsResolver {
               // bind (no values needed)
               QueryOuterClass.Query query = queryBuilder.bind(built);
 
+              // note that we fetch row paging, only if key depth is more than 1
+              // if it's one, then we are getting a whole document, thus no paging
+              boolean fetchRowPaging = keyDepth > 1;
+
               // execute by respecting the paging state
               // go for max storage page size as we have the document
               return queryExecutor.queryDocs(
@@ -112,7 +116,7 @@ public class SubDocumentsResolver implements DocumentsResolver {
                   documentProperties.getApproximateStoragePageSize(paginator.docPageSize),
                   true,
                   paginator.getCurrentDbPageState(),
-                  true,
+                  fetchRowPaging,
                   context);
             })
         .filter(

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/util/ByteBufferUtils.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/util/ByteBufferUtils.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.docsapi.service.util;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Base64;
+
+/** @author Dmitri Bourlatchkov */
+public class ByteBufferUtils {
+
+  private ByteBufferUtils() {}
+
+  public static String toBase64(ByteBuffer buffer) {
+    return toBase64(getArray(buffer));
+  }
+
+  public static String toBase64(byte[] bytes) {
+    return Base64.getEncoder().encodeToString(bytes);
+  }
+
+  public static ByteBuffer fromBase64(String base64) {
+    return ByteBuffer.wrap(Base64.getDecoder().decode(base64));
+  }
+
+  public static String toBase64ForUrl(ByteBuffer buffer) {
+    return toBase64ForUrl(getArray(buffer));
+  }
+
+  public static String toBase64ForUrl(byte[] bytes) {
+    return Base64.getUrlEncoder().encodeToString(bytes);
+  }
+
+  public static ByteBuffer fromBase64UrlParam(String base64) {
+    // As per PR #1405 (and earlier issue #1041), special handling no longer needed
+    /*    if (base64.chars().anyMatch(c -> c == '/' || c == '+' || c == ' ')) {
+    Fix legacy strings that got broken by decoding `+` at HTTP level
+         base64 = base64.replace(' ', '+');
+         // Use the decoder compatible with the encoder previously used for URL params
+         return ByteBuffer.wrap(Base64.getDecoder().decode(base64));
+       }
+    */
+    return ByteBuffer.wrap(Base64.getUrlDecoder().decode(base64));
+  }
+
+  /**
+   * Extract the content of the provided {@code ByteBuffer} as a byte array.
+   *
+   * <p>This method work with any type of {@code ByteBuffer} (direct and non-direct ones), but when
+   * the {@code ByteBuffer} is backed by an array, this method will try to avoid copy when possible.
+   * As a consequence, changes to the returned byte array may or may not reflect into the initial
+   * {@code ByteBuffer}.
+   *
+   * @param bytes the buffer whose content to extract.
+   * @return a byte array with the content of {@code bytes}. That array may be the array backing
+   *     {@code bytes} if this can avoid a copy.
+   */
+  public static byte[] getArray(ByteBuffer bytes) {
+    int length = bytes.remaining();
+
+    if (bytes.hasArray()) {
+      int boff = bytes.arrayOffset() + bytes.position();
+      if (boff == 0 && length == bytes.array().length) return bytes.array();
+      else return Arrays.copyOfRange(bytes.array(), boff, boff + length);
+    }
+    // else, DirectByteBuffer.get() is the fastest route
+    byte[] array = new byte[length];
+    bytes.duplicate().get(array);
+    return array;
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/DocsApiTestSchemaProvider.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/DocsApiTestSchemaProvider.java
@@ -41,13 +41,14 @@ public class DocsApiTestSchemaProvider {
 
   private final CqlTable table;
   private final CqlKeyspace keyspace;
+  private final int maxDepth;
 
   @Inject
   public DocsApiTestSchemaProvider(DocumentProperties documentProperties) {
     String keyspaceName = RandomStringUtils.randomAlphabetic(16).toLowerCase();
     String collectionName = RandomStringUtils.randomAlphabetic(16).toLowerCase();
 
-    int maxDepth = documentProperties.maxDepth();
+    maxDepth = documentProperties.maxDepth();
     DocumentTableProperties tableProperties = documentProperties.tableProperties();
 
     keyspace = CqlKeyspace.newBuilder().setName(keyspaceName).build();
@@ -108,10 +109,14 @@ public class DocsApiTestSchemaProvider {
   }
 
   public Stream<ColumnSpec> allColumnSpecStream() {
+    return allColumnSpecWithPathDepthStream(maxDepth);
+  }
+
+  public Stream<ColumnSpec> allColumnSpecWithPathDepthStream(int depth) {
     Stream<ColumnSpec> allColumns =
         Streams.concat(
             table.getPartitionKeyColumnsList().stream(),
-            table.getClusteringKeyColumnsList().stream(),
+            table.getClusteringKeyColumnsList().stream().limit(depth),
             table.getColumnsList().stream(),
             table.getStaticColumnsList().stream());
     return allColumns;
@@ -119,5 +124,9 @@ public class DocsApiTestSchemaProvider {
 
   public List<ColumnSpec> allColumnSpec() {
     return allColumnSpecStream().toList();
+  }
+
+  public List<ColumnSpec> allColumnSpecForPathDepth(int depth) {
+    return allColumnSpecWithPathDepthStream(depth).toList();
   }
 }

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/OpenMocksTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/OpenMocksTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.MockitoAnnotations;
+
+/** Simple interface for tests needing to open mocks before eah test. */
+public interface OpenMocksTest {
+
+  @BeforeEach
+  default void openMocks() {
+    MockitoAnnotations.openMocks(this);
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/bridge/AbstractValidatingStargateBridgeTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/bridge/AbstractValidatingStargateBridgeTest.java
@@ -51,6 +51,11 @@ public abstract class AbstractValidatingStargateBridgeTest {
     return bridge.withQuery(cql, values);
   }
 
+  protected ValidatingStargateBridge.QueryExpectation withAnySelectFrom(
+      String keyspace, String table) {
+    return bridge.withAnySelectFrom(keyspace, table);
+  }
+
   protected void resetExpectations() {
     bridge.reset();
   }

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/ReadBridgeServiceTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/ReadBridgeServiceTest.java
@@ -36,7 +36,6 @@ import io.stargate.sgv2.docsapi.service.ExecutionContext;
 import io.stargate.sgv2.docsapi.service.common.model.Paginator;
 import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
 import io.stargate.sgv2.docsapi.service.query.condition.impl.ImmutableStringCondition;
-import io.stargate.sgv2.docsapi.service.query.executor.QueryExecutor;
 import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.EqFilterOperation;
 import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
 import io.stargate.sgv2.docsapi.testprofiles.MaxDepth4TestProfile;
@@ -58,8 +57,6 @@ class ReadBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
   @Inject ReadBridgeService service;
 
   @Inject DocumentProperties documentProperties;
-
-  @Inject QueryExecutor queryExecutor;
 
   @Inject DocsApiTestSchemaProvider schemaProvider;
 
@@ -153,8 +150,7 @@ class ReadBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
 
       List<RawDocument> result =
           service
-              .searchDocuments(
-                  queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, expression, paginator, context)
+              .searchDocuments(KEYSPACE_NAME, COLLECTION_NAME, expression, paginator, context)
               .subscribe()
               .withSubscriber(AssertSubscriber.create(100))
               .awaitItems(2)
@@ -306,8 +302,7 @@ class ReadBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
 
       List<RawDocument> result =
           service
-              .searchDocuments(
-                  queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, expression, paginator, context)
+              .searchDocuments(KEYSPACE_NAME, COLLECTION_NAME, expression, paginator, context)
               .subscribe()
               .withSubscriber(AssertSubscriber.create(100))
               .awaitItems(1)
@@ -406,8 +401,7 @@ class ReadBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
               .returningNothing();
 
       service
-          .searchDocuments(
-              queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, expression, paginator, context)
+          .searchDocuments(KEYSPACE_NAME, COLLECTION_NAME, expression, paginator, context)
           .subscribe()
           .withSubscriber(AssertSubscriber.create(100))
           .awaitCompletion()
@@ -503,12 +497,7 @@ class ReadBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
       List<RawDocument> result =
           service
               .searchDocuments(
-                  queryExecutor,
-                  KEYSPACE_NAME,
-                  COLLECTION_NAME,
-                  Literal.getTrue(),
-                  paginator,
-                  context)
+                  KEYSPACE_NAME, COLLECTION_NAME, Literal.getTrue(), paginator, context)
               .subscribe()
               .withSubscriber(AssertSubscriber.create(100))
               .awaitItems(2)
@@ -631,7 +620,6 @@ class ReadBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
       List<RawDocument> result =
           service
               .searchSubDocuments(
-                  queryExecutor,
                   KEYSPACE_NAME,
                   COLLECTION_NAME,
                   documentId,
@@ -729,7 +717,6 @@ class ReadBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
       List<RawDocument> result =
           service
               .searchSubDocuments(
-                  queryExecutor,
                   KEYSPACE_NAME,
                   COLLECTION_NAME,
                   documentId,
@@ -837,7 +824,6 @@ class ReadBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
       List<RawDocument> result =
           service
               .searchSubDocuments(
-                  queryExecutor,
                   KEYSPACE_NAME,
                   COLLECTION_NAME,
                   documentId,
@@ -956,8 +942,7 @@ class ReadBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
 
       List<RawDocument> result =
           service
-              .getDocument(
-                  queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, documentId, subPath, context)
+              .getDocument(KEYSPACE_NAME, COLLECTION_NAME, documentId, subPath, context)
               .subscribe()
               .withSubscriber(AssertSubscriber.create(100))
               .awaitItems(1)
@@ -1020,8 +1005,7 @@ class ReadBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
 
       List<RawDocument> result =
           service
-              .getDocumentTtlInfo(
-                  queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, documentId, context)
+              .getDocumentTtlInfo(KEYSPACE_NAME, COLLECTION_NAME, documentId, context)
               .subscribe()
               .withSubscriber(AssertSubscriber.create(100))
               .awaitItems(1)
@@ -1136,8 +1120,7 @@ class ReadBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
                       Values.NULL)));
 
       service
-          .searchDocuments(
-              queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, expression, paginator, context)
+          .searchDocuments(KEYSPACE_NAME, COLLECTION_NAME, expression, paginator, context)
           .subscribe()
           .withSubscriber(AssertSubscriber.create(100))
           .awaitItems(1)

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/ReadBridgeServiceTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/ReadBridgeServiceTest.java
@@ -1,0 +1,1215 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bpodgursky.jbool_expressions.And;
+import com.bpodgursky.jbool_expressions.Expression;
+import com.bpodgursky.jbool_expressions.Literal;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.DocsApiTestSchemaProvider;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.bridge.AbstractValidatingStargateBridgeTest;
+import io.stargate.sgv2.docsapi.bridge.ValidatingStargateBridge;
+import io.stargate.sgv2.docsapi.models.ExecutionProfile;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.common.model.Paginator;
+import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
+import io.stargate.sgv2.docsapi.service.query.condition.impl.ImmutableStringCondition;
+import io.stargate.sgv2.docsapi.service.query.executor.QueryExecutor;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.EqFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+import io.stargate.sgv2.docsapi.testprofiles.MaxDepth4TestProfile;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.inject.Inject;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(MaxDepth4TestProfile.class)
+class ReadBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
+
+  private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
+  private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
+
+  @Inject ReadBridgeService service;
+
+  @Inject DocumentProperties documentProperties;
+
+  @Inject QueryExecutor queryExecutor;
+
+  @Inject DocsApiTestSchemaProvider schemaProvider;
+
+  @Nested
+  class SearchDocuments {
+
+    @Test
+    public void happyPath() throws Exception {
+      Paginator paginator = new Paginator(null, 20);
+      ExecutionContext context = ExecutionContext.create(true);
+      FilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("some", "field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(EqFilterOperation.of(), "find-me", documentProperties);
+      FilterExpression expression = ImmutableFilterExpression.of(filterPath, condition, 0);
+
+      String candidatesCql =
+          "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 = ? AND leaf = ? AND p2 = ? AND text_value = ? ALLOW FILTERING"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert candidatesAssert =
+          withQuery(
+                  candidatesCql,
+                  Values.of("some"),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of("find-me"))
+              .withPageSize(paginator.docPageSize + 1)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(List.of(List.of(Values.of("1")), List.of(Values.of("2"))));
+
+      String populateCql =
+          "SELECT key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE key = ?"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert populateFirstAssert =
+          withQuery(populateCql, Values.of("1"))
+              .withPageSize(documentProperties.maxSearchPageSize())
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(
+                  Arrays.asList(
+                      List.of(
+                          Values.of("1"),
+                          Values.of("some"),
+                          Values.of("field"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("field"),
+                          Values.of("find-me"),
+                          Values.NULL,
+                          Values.NULL),
+                      List.of(
+                          Values.of("1"),
+                          Values.of("another"),
+                          Values.of("field"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("field"),
+                          Values.of("other"),
+                          Values.NULL,
+                          Values.NULL)));
+
+      ValidatingStargateBridge.QueryAssert populateSecondAssert =
+          withQuery(populateCql, Values.of("2"))
+              .withPageSize(documentProperties.maxSearchPageSize())
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(
+                  Arrays.asList(
+                      List.of(
+                          Values.of("2"),
+                          Values.of("some"),
+                          Values.of("field"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("field"),
+                          Values.of("find-me"),
+                          Values.NULL,
+                          Values.NULL),
+                      List.of(
+                          Values.of("2"),
+                          Values.of("another2"),
+                          Values.of("field"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("field"),
+                          Values.of("other2"),
+                          Values.NULL,
+                          Values.NULL)));
+
+      List<RawDocument> result =
+          service
+              .searchDocuments(
+                  queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, expression, paginator, context)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(100))
+              .awaitItems(2)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      // assert results
+      assertThat(result).hasSize(2);
+      assertThat(result.get(0))
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows())
+                    .hasSize(2)
+                    .anySatisfy(
+                        r -> {
+                          assertThat(r.getString("key")).isEqualTo("1");
+                          assertThat(r.getString("text_value")).isEqualTo("find-me");
+                          assertThat(r.getString("p0")).isEqualTo("some");
+                          assertThat(r.getString("p1")).isEqualTo("field");
+                        })
+                    .anySatisfy(
+                        r -> {
+                          assertThat(r.getString("key")).isEqualTo("1");
+                          assertThat(r.getString("text_value")).isEqualTo("other");
+                          assertThat(r.getString("p0")).isEqualTo("another");
+                          assertThat(r.getString("p1")).isEqualTo("field");
+                        });
+              });
+      assertThat(result.get(1))
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("2");
+                assertThat(doc.rows())
+                    .hasSize(2)
+                    .anySatisfy(
+                        r -> {
+                          assertThat(r.getString("key")).isEqualTo("2");
+                          assertThat(r.getString("text_value")).isEqualTo("find-me");
+                          assertThat(r.getString("p0")).isEqualTo("some");
+                          assertThat(r.getString("p1")).isEqualTo("field");
+                        })
+                    .anySatisfy(
+                        r -> {
+                          assertThat(r.getString("key")).isEqualTo("2");
+                          assertThat(r.getString("text_value")).isEqualTo("other2");
+                          assertThat(r.getString("p0")).isEqualTo("another2");
+                        });
+              });
+
+      // assert queries execution
+      candidatesAssert.assertExecuteCount().isEqualTo(1);
+      populateFirstAssert.assertExecuteCount().isEqualTo(1);
+      populateSecondAssert.assertExecuteCount().isEqualTo(1);
+
+      // assert execution context
+      ExecutionProfile executionProfile = context.toProfile();
+      assertThat(executionProfile.nested())
+          .hasSize(2)
+          .anySatisfy(
+              c -> {
+                assertThat(c.description()).isEqualTo("FILTER: some.field EQ find-me");
+                assertThat(c.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(2);
+                          assertThat(queryInfo.preparedCQL())
+                              .isEqualTo(
+                                  String.format(
+                                      candidatesCql, KEYSPACE_NAME + "." + COLLECTION_NAME));
+                        });
+              })
+          .anySatisfy(
+              c -> {
+                assertThat(c.description()).isEqualTo("LoadProperties");
+                assertThat(c.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(2);
+                          assertThat(queryInfo.rowCount()).isEqualTo(4);
+                          assertThat(queryInfo.preparedCQL())
+                              .isEqualTo(
+                                  String.format(
+                                      populateCql, KEYSPACE_NAME + "." + COLLECTION_NAME));
+                        });
+              });
+    }
+
+    @Test
+    public void limitedResults() {
+      Paginator paginator = new Paginator(null, 1);
+      ExecutionContext context = ExecutionContext.create(true);
+      FilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("some", "field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(EqFilterOperation.of(), "find-me", documentProperties);
+      FilterExpression expression = ImmutableFilterExpression.of(filterPath, condition, 0);
+
+      String candidatesCql =
+          "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 = ? AND leaf = ? AND p2 = ? AND text_value = ? ALLOW FILTERING"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert candidatesAssert =
+          withQuery(
+                  candidatesCql,
+                  Values.of("some"),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of("find-me"))
+              .withPageSize(paginator.docPageSize + 1)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(List.of(List.of(Values.of("1")), List.of(Values.of("2"))));
+
+      String populateCql =
+          "SELECT key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE key = ?"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert populateFirstAssert =
+          withQuery(populateCql, Values.of("1"))
+              .withPageSize(documentProperties.maxSearchPageSize())
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(
+                  Arrays.asList(
+                      List.of(
+                          Values.of("1"),
+                          Values.of("some"),
+                          Values.of("field"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("field"),
+                          Values.of("find-me"),
+                          Values.NULL,
+                          Values.NULL),
+                      List.of(
+                          Values.of("1"),
+                          Values.of("another"),
+                          Values.of("field"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("field"),
+                          Values.of("other"),
+                          Values.NULL,
+                          Values.NULL)));
+
+      List<RawDocument> result =
+          service
+              .searchDocuments(
+                  queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, expression, paginator, context)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(100))
+              .awaitItems(1)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      // assert results
+      assertThat(result)
+          .singleElement()
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows())
+                    .hasSize(2)
+                    .anySatisfy(
+                        r -> {
+                          assertThat(r.getString("key")).isEqualTo("1");
+                          assertThat(r.getString("text_value")).isEqualTo("find-me");
+                          assertThat(r.getString("p0")).isEqualTo("some");
+                          assertThat(r.getString("p1")).isEqualTo("field");
+                        })
+                    .anySatisfy(
+                        r -> {
+                          assertThat(r.getString("key")).isEqualTo("1");
+                          assertThat(r.getString("text_value")).isEqualTo("other");
+                          assertThat(r.getString("p0")).isEqualTo("another");
+                          assertThat(r.getString("p1")).isEqualTo("field");
+                        });
+              });
+
+      // assert queries execution
+      candidatesAssert.assertExecuteCount().isEqualTo(1);
+      populateFirstAssert.assertExecuteCount().isEqualTo(1);
+
+      // assert execution context
+      ExecutionProfile executionProfile = context.toProfile();
+      assertThat(executionProfile.nested())
+          .hasSize(2)
+          .anySatisfy(
+              c -> {
+                assertThat(c.description()).isEqualTo("FILTER: some.field EQ find-me");
+                assertThat(c.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(2);
+                          assertThat(queryInfo.preparedCQL())
+                              .isEqualTo(
+                                  String.format(
+                                      candidatesCql, KEYSPACE_NAME + "." + COLLECTION_NAME));
+                        });
+              })
+          .anySatisfy(
+              c -> {
+                assertThat(c.description()).isEqualTo("LoadProperties");
+                assertThat(c.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(2);
+                          assertThat(queryInfo.preparedCQL())
+                              .isEqualTo(
+                                  String.format(
+                                      populateCql, KEYSPACE_NAME + "." + COLLECTION_NAME));
+                        });
+              });
+    }
+
+    @Test
+    public void nothingToPopulate() {
+      Paginator paginator = new Paginator(null, 1);
+      ExecutionContext context = ExecutionContext.create(true);
+      FilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("some", "field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(EqFilterOperation.of(), "find-me", documentProperties);
+      FilterExpression expression = ImmutableFilterExpression.of(filterPath, condition, 0);
+
+      String candidatesCql =
+          "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 = ? AND leaf = ? AND p2 = ? AND text_value = ? ALLOW FILTERING"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert candidatesAssert =
+          withQuery(
+                  candidatesCql,
+                  Values.of("some"),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of("find-me"))
+              .withPageSize(paginator.docPageSize + 1)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returningNothing();
+
+      service
+          .searchDocuments(
+              queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, expression, paginator, context)
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(100))
+          .awaitCompletion()
+          .assertCompleted()
+          .assertHasNotReceivedAnyItem();
+
+      // assert queries execution
+      candidatesAssert.assertExecuteCount().isEqualTo(1);
+
+      // assert execution context
+      ExecutionProfile executionProfile = context.toProfile();
+      assertThat(executionProfile.nested())
+          .hasSize(2)
+          .anySatisfy(
+              c -> {
+                assertThat(c.description()).isEqualTo("FILTER: some.field EQ find-me");
+                assertThat(c.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(0);
+                          assertThat(queryInfo.preparedCQL())
+                              .isEqualTo(
+                                  String.format(
+                                      candidatesCql, KEYSPACE_NAME + "." + COLLECTION_NAME));
+                        });
+              })
+          .anySatisfy(
+              c -> {
+                assertThat(c.description()).isEqualTo("LoadProperties");
+                assertThat(c.queries()).isEmpty();
+              });
+    }
+
+    @Test
+    public void fullSearch() {
+      Paginator paginator = new Paginator(null, 20);
+      ExecutionContext context = ExecutionContext.create(true);
+
+      String searchCql =
+          "SELECT key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\""
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert searchAssert =
+          withQuery(searchCql)
+              .withPageSize(documentProperties.getApproximateStoragePageSize(paginator.docPageSize))
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(
+                  Arrays.asList(
+                      List.of(
+                          Values.of("1"),
+                          Values.of("some"),
+                          Values.of("field"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("field"),
+                          Values.of("find-me"),
+                          Values.NULL,
+                          Values.NULL),
+                      List.of(
+                          Values.of("1"),
+                          Values.of("another"),
+                          Values.of("field"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("field"),
+                          Values.of("other"),
+                          Values.NULL,
+                          Values.NULL),
+                      List.of(
+                          Values.of("2"),
+                          Values.of("some"),
+                          Values.of("field"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("field"),
+                          Values.of("find-me"),
+                          Values.NULL,
+                          Values.NULL),
+                      List.of(
+                          Values.of("2"),
+                          Values.of("another2"),
+                          Values.of("field"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("field"),
+                          Values.of("other2"),
+                          Values.NULL,
+                          Values.NULL)));
+
+      List<RawDocument> result =
+          service
+              .searchDocuments(
+                  queryExecutor,
+                  KEYSPACE_NAME,
+                  COLLECTION_NAME,
+                  Literal.getTrue(),
+                  paginator,
+                  context)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(100))
+              .awaitItems(2)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      // assert results
+      assertThat(result).hasSize(2);
+      assertThat(result.get(0))
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows())
+                    .hasSize(2)
+                    .anySatisfy(
+                        r -> {
+                          assertThat(r.getString("key")).isEqualTo("1");
+                          assertThat(r.getString("text_value")).isEqualTo("find-me");
+                          assertThat(r.getString("p0")).isEqualTo("some");
+                          assertThat(r.getString("p1")).isEqualTo("field");
+                        })
+                    .anySatisfy(
+                        r -> {
+                          assertThat(r.getString("key")).isEqualTo("1");
+                          assertThat(r.getString("text_value")).isEqualTo("other");
+                          assertThat(r.getString("p0")).isEqualTo("another");
+                          assertThat(r.getString("p1")).isEqualTo("field");
+                        });
+              });
+      assertThat(result.get(1))
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("2");
+                assertThat(doc.rows())
+                    .hasSize(2)
+                    .anySatisfy(
+                        r -> {
+                          assertThat(r.getString("key")).isEqualTo("2");
+                          assertThat(r.getString("text_value")).isEqualTo("find-me");
+                          assertThat(r.getString("p0")).isEqualTo("some");
+                          assertThat(r.getString("p1")).isEqualTo("field");
+                        })
+                    .anySatisfy(
+                        r -> {
+                          assertThat(r.getString("key")).isEqualTo("2");
+                          assertThat(r.getString("text_value")).isEqualTo("other2");
+                          assertThat(r.getString("p0")).isEqualTo("another2");
+                        });
+              });
+
+      // assert queries execution
+      searchAssert.assertExecuteCount().isEqualTo(1);
+
+      // assert execution context
+      ExecutionProfile executionProfile = context.toProfile();
+      assertThat(executionProfile.nested())
+          .hasSize(1)
+          .anySatisfy(
+              c -> {
+                assertThat(c.description()).isEqualTo("LoadAllDocuments");
+                assertThat(c.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(4);
+                          assertThat(queryInfo.preparedCQL())
+                              .isEqualTo(
+                                  String.format(searchCql, KEYSPACE_NAME + "." + COLLECTION_NAME));
+                        });
+              });
+    }
+  }
+
+  @Nested
+  class SearchSubDocuments {
+
+    @Test
+    public void searchFullDoc() {
+      String documentId = RandomStringUtils.randomAlphanumeric(16);
+      Paginator paginator = new Paginator(null, 20);
+      ExecutionContext context = ExecutionContext.create(true);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(EqFilterOperation.of(), "find-me", documentProperties);
+      FilterExpression expression = ImmutableFilterExpression.of(filterPath, condition, 0);
+
+      String cql =
+          "SELECT key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE key = ?"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert cqlAssert =
+          withQuery(cql, Values.of(documentId))
+              .withPageSize(documentProperties.getApproximateStoragePageSize(paginator.docPageSize))
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(
+                  Arrays.asList(
+                      List.of(
+                          Values.of(documentId),
+                          Values.of("field"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("field"),
+                          Values.of("find-me"),
+                          Values.NULL,
+                          Values.NULL),
+                      List.of(
+                          Values.of(documentId),
+                          Values.of("another"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("another"),
+                          Values.of("other"),
+                          Values.NULL,
+                          Values.NULL)));
+
+      List<RawDocument> result =
+          service
+              .searchSubDocuments(
+                  queryExecutor,
+                  KEYSPACE_NAME,
+                  COLLECTION_NAME,
+                  documentId,
+                  Collections.emptyList(),
+                  expression,
+                  paginator,
+                  context)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(100))
+              .awaitItems(1)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      // assert results
+      assertThat(result)
+          .singleElement()
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo(documentId);
+                assertThat(doc.rows())
+                    .hasSize(2)
+                    .anySatisfy(
+                        r -> {
+                          assertThat(r.getString("key")).isEqualTo(documentId);
+                          assertThat(r.getString("text_value")).isEqualTo("find-me");
+                          assertThat(r.getString("p0")).isEqualTo("field");
+                          assertThat(r.getString("p1")).isEqualTo("");
+                        })
+                    .anySatisfy(
+                        r -> {
+                          assertThat(r.getString("key")).isEqualTo(documentId);
+                          assertThat(r.getString("text_value")).isEqualTo("other");
+                          assertThat(r.getString("p0")).isEqualTo("another");
+                          assertThat(r.getString("p1")).isEqualTo("");
+                        });
+              });
+
+      // assert queries execution
+      cqlAssert.assertExecuteCount().isEqualTo(1);
+
+      // assert execution context
+      ExecutionProfile executionProfile = context.toProfile();
+      assertThat(executionProfile.nested())
+          .hasSize(1)
+          .anySatisfy(
+              c -> {
+                assertThat(c.description())
+                    .isEqualTo("SearchSubDocuments: sub-path '', expression: 'field EQ find-me'");
+                assertThat(c.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(2);
+                          assertThat(queryInfo.preparedCQL())
+                              .isEqualTo(String.format(cql, KEYSPACE_NAME + "." + COLLECTION_NAME));
+                        });
+              });
+    }
+
+    @Test
+    public void searchSubDoc() {
+      String documentId = RandomStringUtils.randomAlphanumeric(16);
+      Paginator paginator = new Paginator(null, 10);
+      ExecutionContext context = ExecutionContext.create(true);
+      List<String> subPath = Collections.singletonList("field");
+      FilterPath filterPath = ImmutableFilterPath.of(subPath);
+      BaseCondition condition =
+          ImmutableStringCondition.of(EqFilterOperation.of(), "find-me", documentProperties);
+      FilterExpression expression = ImmutableFilterExpression.of(filterPath, condition, 0);
+
+      String cql =
+          "SELECT key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND key = ? ALLOW FILTERING"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert cqlAssert =
+          withQuery(cql, Values.of("field"), Values.of(documentId))
+              .withPageSize(documentProperties.getApproximateStoragePageSize(paginator.docPageSize))
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_ROW)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(
+                  List.of(
+                      List.of(
+                          Values.of(documentId),
+                          Values.of("field"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("field"),
+                          Values.of("find-me"),
+                          Values.NULL,
+                          Values.NULL)));
+
+      List<RawDocument> result =
+          service
+              .searchSubDocuments(
+                  queryExecutor,
+                  KEYSPACE_NAME,
+                  COLLECTION_NAME,
+                  documentId,
+                  subPath,
+                  expression,
+                  paginator,
+                  context)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(100))
+              .awaitItems(1)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      // assert results
+      assertThat(result)
+          .singleElement()
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo(documentId);
+                assertThat(doc.rows())
+                    .hasSize(1)
+                    .anySatisfy(
+                        r -> {
+                          assertThat(r.getString("key")).isEqualTo(documentId);
+                          assertThat(r.getString("text_value")).isEqualTo("find-me");
+                          assertThat(r.getString("p0")).isEqualTo("field");
+                          assertThat(r.getString("p1")).isEqualTo("");
+                        });
+              });
+
+      // assert queries execution
+      cqlAssert.assertExecuteCount().isEqualTo(1);
+
+      // assert execution context
+      ExecutionProfile executionProfile = context.toProfile();
+      assertThat(executionProfile.nested())
+          .hasSize(1)
+          .anySatisfy(
+              c -> {
+                assertThat(c.description())
+                    .isEqualTo(
+                        "SearchSubDocuments: sub-path 'field', expression: 'field EQ find-me'");
+                assertThat(c.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                          assertThat(queryInfo.preparedCQL())
+                              .isEqualTo(String.format(cql, KEYSPACE_NAME + "." + COLLECTION_NAME));
+                        });
+              });
+    }
+
+    @Test
+    public void searchSubDocPaginated() throws Exception {
+      String documentId = RandomStringUtils.randomAlphanumeric(16);
+      Paginator paginator = new Paginator(null, 2);
+      ExecutionContext context = ExecutionContext.create(true);
+      List<String> subPath = Collections.singletonList("*");
+
+      String cql =
+          "SELECT key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 > ? AND key = ? ALLOW FILTERING"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert cqlAssert =
+          withQuery(cql, Values.of(""), Values.of(documentId))
+              .withPageSize(documentProperties.getApproximateStoragePageSize(paginator.docPageSize))
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_ROW)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(
+                  List.of(
+                      List.of(
+                          Values.of(documentId),
+                          Values.of("field1"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("field1"),
+                          Values.of("v1"),
+                          Values.NULL,
+                          Values.NULL),
+                      List.of(
+                          Values.of(documentId),
+                          Values.of("field2"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("field2"),
+                          Values.of("v2"),
+                          Values.NULL,
+                          Values.NULL),
+                      List.of(
+                          Values.of(documentId),
+                          Values.of("field3"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("field3"),
+                          Values.of("v3"),
+                          Values.NULL,
+                          Values.NULL)));
+
+      List<RawDocument> result =
+          service
+              .searchSubDocuments(
+                  queryExecutor,
+                  KEYSPACE_NAME,
+                  COLLECTION_NAME,
+                  documentId,
+                  subPath,
+                  Literal.getTrue(),
+                  paginator,
+                  context)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(100))
+              .awaitItems(2)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      // assert results
+      assertThat(result).hasSize(2);
+      assertThat(result.get(0))
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo(documentId);
+                assertThat(doc.rows())
+                    .singleElement()
+                    .satisfies(
+                        r -> {
+                          assertThat(r.getString("key")).isEqualTo(documentId);
+                          assertThat(r.getString("p0")).isEqualTo("field1");
+                        });
+              });
+      assertThat(result.get(1))
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo(documentId);
+                assertThat(doc.rows())
+                    .singleElement()
+                    .satisfies(
+                        r -> {
+                          assertThat(r.getString("key")).isEqualTo(documentId);
+                          assertThat(r.getString("p0")).isEqualTo("field2");
+                        });
+              });
+
+      // assert queries execution
+      cqlAssert.assertExecuteCount().isEqualTo(1);
+
+      // assert execution context
+      ExecutionProfile executionProfile = context.toProfile();
+      assertThat(executionProfile.nested())
+          .hasSize(1)
+          .anySatisfy(
+              c -> {
+                assertThat(c.description())
+                    .isEqualTo("SearchSubDocuments: sub-path '*', expression: 'true'");
+                assertThat(c.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(3);
+                          assertThat(queryInfo.preparedCQL())
+                              .isEqualTo(String.format(cql, KEYSPACE_NAME + "." + COLLECTION_NAME));
+                        });
+              });
+    }
+  }
+
+  @Nested
+  class GetDocument {
+
+    @Test
+    public void getSubDoc() throws Exception {
+      String documentId = RandomStringUtils.randomAlphanumeric(16);
+      ExecutionContext context = ExecutionContext.create(true);
+      List<String> subPath = Collections.singletonList("field");
+
+      String cql =
+          "SELECT key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND key = ? ALLOW FILTERING"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert cqlAssert =
+          withQuery(cql, Values.of("field"), Values.of(documentId))
+              .withPageSize(documentProperties.maxSearchPageSize())
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_ROW)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(
+                  List.of(
+                      List.of(
+                          Values.of(documentId),
+                          Values.of("field"),
+                          Values.of("k1"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("k1"),
+                          Values.of("v1"),
+                          Values.NULL,
+                          Values.NULL),
+                      List.of(
+                          Values.of(documentId),
+                          Values.of("field"),
+                          Values.of("k2"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("k2"),
+                          Values.of("v2"),
+                          Values.NULL,
+                          Values.NULL),
+                      List.of(
+                          Values.of(documentId),
+                          Values.of("field"),
+                          Values.of("k3"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("k3"),
+                          Values.of("v3"),
+                          Values.NULL,
+                          Values.NULL)));
+
+      List<RawDocument> result =
+          service
+              .getDocument(
+                  queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, documentId, subPath, context)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(100))
+              .awaitItems(1)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      // assert results
+      assertThat(result)
+          .singleElement()
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo(documentId);
+                assertThat(doc.rows()).hasSize(3);
+              });
+
+      // assert queries execution
+      cqlAssert.assertExecuteCount().isEqualTo(1);
+
+      // assert execution context
+      ExecutionProfile executionProfile = context.toProfile();
+      assertThat(executionProfile.nested())
+          .hasSize(1)
+          .anySatisfy(
+              c -> {
+                assertThat(c.description()).isEqualTo("GetFullDocument");
+                assertThat(c.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(3);
+                          assertThat(queryInfo.preparedCQL())
+                              .isEqualTo(String.format(cql, KEYSPACE_NAME + "." + COLLECTION_NAME));
+                        });
+              });
+    }
+  }
+
+  @Nested
+  class GetDocumentTtlInfo {
+
+    @Test
+    public void happyPath() throws Exception {
+      String documentId = RandomStringUtils.randomAlphanumeric(16);
+      ExecutionContext context = ExecutionContext.create(true);
+
+      String cql =
+          "SELECT key, TTL(leaf), WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE key = ?"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert cqlAssert =
+          withQuery(cql, Values.of(documentId))
+              .withPageSize(documentProperties.maxSearchPageSize())
+              .enriched()
+              .withColumnSpec(
+                  List.of(
+                      QueryOuterClass.ColumnSpec.newBuilder().setName("key").build(),
+                      QueryOuterClass.ColumnSpec.newBuilder().setName("ttl(leaf)").build()))
+              .returning(Arrays.asList(List.of(Values.of(documentId), Values.of(100))));
+
+      List<RawDocument> result =
+          service
+              .getDocumentTtlInfo(
+                  queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, documentId, context)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(100))
+              .awaitItems(1)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      // assert results
+      assertThat(result)
+          .singleElement()
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo(documentId);
+                assertThat(doc.rows()).hasSize(1);
+              });
+
+      // assert queries execution
+      cqlAssert.assertExecuteCount().isEqualTo(1);
+
+      // assert execution context
+      ExecutionProfile executionProfile = context.toProfile();
+      assertThat(executionProfile.queries())
+          .singleElement()
+          .satisfies(
+              queryInfo -> {
+                assertThat(queryInfo.execCount()).isEqualTo(1);
+                assertThat(queryInfo.rowCount()).isEqualTo(1);
+                assertThat(queryInfo.preparedCQL())
+                    .isEqualTo(String.format(cql, KEYSPACE_NAME + "." + COLLECTION_NAME));
+              });
+    }
+  }
+
+  @Nested
+  class SelectivityHints {
+
+    @Test
+    public void predicateOrderWithExplicitSelectivity() {
+      Paginator paginator = new Paginator(null, 20);
+      ExecutionContext context = ExecutionContext.create(true);
+      FilterPath filterPath1 = ImmutableFilterPath.of(Arrays.asList("some", "field1"));
+      FilterPath filterPath2 = ImmutableFilterPath.of(Arrays.asList("some", "field2"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(EqFilterOperation.of(), "find-me", documentProperties);
+      Expression<FilterExpression> expression =
+          And.of(
+              // the filter on field2 is listed first but with worse selectivity
+              FilterExpression.of(filterPath2, condition, 0, 0.9),
+              // the filter on field1 is listed second but with better selectivity
+              FilterExpression.of(filterPath1, condition, 1, 0.5));
+
+      String candidatesCql =
+          "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 = ? AND leaf = ? AND p2 = ? AND text_value = ? ALLOW FILTERING"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      withQuery(
+              candidatesCql,
+              Values.of("some"),
+              Values.of("field1"),
+              Values.of("field1"),
+              Values.of(""),
+              Values.of("find-me"))
+          .withPageSize(paginator.docPageSize + 1)
+          .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+          .enriched()
+          .withColumnSpec(schemaProvider.allColumnSpec())
+          .returning(Collections.singletonList(List.of(Values.of("1"))));
+
+      String filterCql =
+          "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 = ? AND leaf = ? AND p2 = ? AND text_value = ? AND key = ? LIMIT 1 ALLOW FILTERING"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      withQuery(
+              filterCql,
+              Values.of("some"),
+              Values.of("field2"),
+              Values.of("field2"),
+              Values.of(""),
+              Values.of("find-me"),
+              Values.of("1"))
+          .enriched()
+          .withColumnSpec(schemaProvider.allColumnSpec())
+          .returning(Collections.singletonList(List.of(Values.of("1"))));
+
+      String populateCql =
+          "SELECT key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE key = ?"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+
+      withQuery(populateCql, Values.of("1"))
+          .withPageSize(documentProperties.maxSearchPageSize())
+          .enriched()
+          .withColumnSpec(schemaProvider.allColumnSpec())
+          .returning(
+              Arrays.asList(
+                  List.of(
+                      Values.of("1"),
+                      Values.of("some"),
+                      Values.of("field"),
+                      Values.of(""),
+                      Values.of(""),
+                      Values.of("field"),
+                      Values.of("find-me"),
+                      Values.NULL,
+                      Values.NULL),
+                  List.of(
+                      Values.of("1"),
+                      Values.of("another"),
+                      Values.of("field"),
+                      Values.of(""),
+                      Values.of(""),
+                      Values.of("field"),
+                      Values.of("other"),
+                      Values.NULL,
+                      Values.NULL)));
+
+      service
+          .searchDocuments(
+              queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, expression, paginator, context)
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(100))
+          .awaitItems(1)
+          .awaitCompletion()
+          .assertCompleted();
+
+      // Rely on profiling output to validate the order of filter execution
+      ExecutionProfile executionProfile = context.toProfile();
+      assertThat(executionProfile.nested()).hasSize(3);
+
+      assertThat(executionProfile.nested())
+          .element(0)
+          .satisfies(
+              c -> {
+                // Note: the filter on field1 becomes the top filter due to its lower selectivity
+                assertThat(c.description()).isEqualTo("FILTER: some.field1 EQ find-me");
+                assertThat(c.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                          assertThat(queryInfo.preparedCQL())
+                              .isEqualTo(
+                                  String.format(
+                                      candidatesCql, KEYSPACE_NAME + "." + COLLECTION_NAME));
+                        });
+              });
+
+      assertThat(executionProfile.nested())
+          .element(1)
+          .satisfies(
+              c -> {
+                assertThat(c.description()).isEqualTo("PARALLEL [ALL OF]");
+                assertThat(c.nested())
+                    .singleElement()
+                    .satisfies(
+                        c1 -> {
+                          // Note: the filter on field2 becomes the nested filter due to its worse
+                          // selectivity
+                          assertThat(c1.description()).isEqualTo("FILTER: some.field2 EQ find-me");
+                          assertThat(c1.queries())
+                              .singleElement()
+                              .satisfies(
+                                  queryInfo -> {
+                                    assertThat(queryInfo.execCount()).isEqualTo(1);
+                                    assertThat(queryInfo.rowCount()).isEqualTo(1);
+                                    assertThat(queryInfo.preparedCQL())
+                                        .isEqualTo(
+                                            String.format(
+                                                filterCql, KEYSPACE_NAME + "." + COLLECTION_NAME));
+                                  });
+                        });
+              });
+
+      assertThat(executionProfile.nested())
+          .element(2)
+          .satisfies(
+              c -> {
+                assertThat(c.description()).isEqualTo("LoadProperties");
+                assertThat(c.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(2);
+                          assertThat(queryInfo.preparedCQL())
+                              .isEqualTo(
+                                  String.format(
+                                      populateCql, KEYSPACE_NAME + "." + COLLECTION_NAME));
+                        });
+              });
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/eval/RawDocumentEvalRuleTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/eval/RawDocumentEvalRuleTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.eval;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.bpodgursky.jbool_expressions.eval.EvalEngine;
+import io.stargate.sgv2.docsapi.service.common.model.RowWrapper;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RawDocumentEvalRuleTest {
+
+  @Mock FilterExpression expression;
+
+  @Mock BaseCondition baseCondition;
+
+  @Mock RowWrapper row;
+
+  @Nested
+  class Evaluate {
+
+    @BeforeEach
+    public void init() {
+      when(expression.getCondition()).thenReturn(baseCondition);
+    }
+
+    @Test
+    public void evalTrue() {
+      List<RowWrapper> rows = Collections.singletonList(row);
+      when(expression.test(rows)).thenReturn(true);
+      when(expression.matchesFilterPath(any())).thenReturn(true);
+      when(expression.getExprType()).thenReturn(FilterExpression.EXPR_TYPE);
+
+      RawDocumentEvalRule eval = new RawDocumentEvalRule(rows);
+      boolean result =
+          EvalEngine.evaluate(
+              expression, Collections.singletonMap(FilterExpression.EXPR_TYPE, eval));
+
+      assertThat(result).isTrue();
+      verify(expression).test(rows);
+      verify(expression).getExprType();
+      verifyNoMoreInteractions(expression);
+    }
+
+    @Test
+    public void evalFalse() {
+      List<RowWrapper> rows = Collections.singletonList(row);
+      when(expression.test(rows)).thenReturn(false);
+      when(expression.matchesFilterPath(any())).thenReturn(true);
+      when(expression.getExprType()).thenReturn(FilterExpression.EXPR_TYPE);
+
+      RawDocumentEvalRule eval = new RawDocumentEvalRule(rows);
+      boolean result =
+          EvalEngine.evaluate(
+              expression, Collections.singletonMap(FilterExpression.EXPR_TYPE, eval));
+
+      assertThat(result).isFalse();
+      verify(expression).test(rows);
+      verify(expression).getExprType();
+      verifyNoMoreInteractions(expression);
+    }
+
+    @Test
+    public void evalNotOnPathButEvaluateOnMissingFields() {
+      List<RowWrapper> rows = Collections.singletonList(row);
+      when(expression.test(rows)).thenReturn(true);
+      when(expression.matchesFilterPath(any())).thenReturn(false);
+      when(expression.getExprType()).thenReturn(FilterExpression.EXPR_TYPE);
+      when(baseCondition.isEvaluateOnMissingFields()).thenReturn(true);
+
+      RawDocumentEvalRule eval = new RawDocumentEvalRule(rows);
+      boolean result =
+          EvalEngine.evaluate(
+              expression, Collections.singletonMap(FilterExpression.EXPR_TYPE, eval));
+
+      assertThat(result).isTrue();
+      verify(expression).test(rows);
+      verify(expression).getExprType();
+      verifyNoMoreInteractions(expression);
+    }
+
+    @Test
+    public void notOnPathNotEvaluateOnMissingFields() {
+      List<RowWrapper> rows = Collections.singletonList(row);
+      when(expression.matchesFilterPath(any())).thenReturn(false);
+      when(expression.getExprType()).thenReturn(FilterExpression.EXPR_TYPE);
+
+      RawDocumentEvalRule eval = new RawDocumentEvalRule(rows);
+      boolean result =
+          EvalEngine.evaluate(
+              expression, Collections.singletonMap(FilterExpression.EXPR_TYPE, eval));
+
+      assertThat(result).isFalse();
+      verify(expression).getExprType();
+      verifyNoMoreInteractions(expression);
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/model/paging/CombinedPagingStateTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/model/paging/CombinedPagingStateTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
+import io.stargate.sgv2.docsapi.service.util.ByteBufferUtils;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
@@ -130,9 +131,9 @@ class CombinedPagingStateTest {
       ByteBuffer s2 = ByteBuffer.wrap(new byte[] {-1, -3});
       List<ByteBuffer> combined = deserialize(3, serialize(ImmutableList.of(s0, s1, s2)));
       assertThat(combined).hasSize(3);
-      assertThat(getArray(combined.get(0))).isEqualTo(s0.array());
-      assertThat(getArray(combined.get(1))).isEqualTo(s1.array());
-      assertThat(getArray(combined.get(2))).isEqualTo(s2.array());
+      assertThat(ByteBufferUtils.getArray(combined.get(0))).isEqualTo(s0.array());
+      assertThat(ByteBufferUtils.getArray(combined.get(1))).isEqualTo(s1.array());
+      assertThat(ByteBufferUtils.getArray(combined.get(2))).isEqualTo(s2.array());
     }
 
     @Test
@@ -142,14 +143,14 @@ class CombinedPagingStateTest {
 
       List<ByteBuffer> combined = deserialize(3, serialize(Arrays.asList(s0, null, s1)));
       assertThat(combined).hasSize(3);
-      assertThat(getArray(combined.get(0))).isEqualTo(s0.array());
+      assertThat(ByteBufferUtils.getArray(combined.get(0))).isEqualTo(s0.array());
       assertThat(combined.get(1)).isNull();
-      assertThat(getArray(combined.get(2))).isEqualTo(s1.array());
+      assertThat(ByteBufferUtils.getArray(combined.get(2))).isEqualTo(s1.array());
 
       combined = deserialize(3, serialize(Arrays.asList(null, s0, null)));
       assertThat(combined).hasSize(3);
       assertThat(combined.get(0)).isNull();
-      assertThat(getArray(combined.get(1))).isEqualTo(s0.array());
+      assertThat(ByteBufferUtils.getArray(combined.get(1))).isEqualTo(s0.array());
       assertThat(combined.get(2)).isNull();
     }
 
@@ -181,32 +182,6 @@ class CombinedPagingStateTest {
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("2") // actual number of sub-states
           .hasMessageContaining("1345"); // expected number of sub-states
-    }
-
-    /**
-     * Extract the content of the provided {@code ByteBuffer} as a byte array.
-     *
-     * <p>This method work with any type of {@code ByteBuffer} (direct and non-direct ones), but
-     * when the {@code ByteBuffer} is backed by an array, this method will try to avoid copy when
-     * possible. As a consequence, changes to the returned byte array may or may not reflect into
-     * the initial {@code ByteBuffer}.
-     *
-     * @param bytes the buffer whose content to extract.
-     * @return a byte array with the content of {@code bytes}. That array may be the array backing
-     *     {@code bytes} if this can avoid a copy.
-     */
-    public static byte[] getArray(ByteBuffer bytes) {
-      int length = bytes.remaining();
-
-      if (bytes.hasArray()) {
-        int boff = bytes.arrayOffset() + bytes.position();
-        if (boff == 0 && length == bytes.array().length) return bytes.array();
-        else return Arrays.copyOfRange(bytes.array(), boff, boff + length);
-      }
-      // else, DirectByteBuffer.get() is the fastest route
-      byte[] array = new byte[length];
-      bytes.duplicate().get(array);
-      return array;
     }
   }
 }

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/BaseResolverTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/BaseResolverTest.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.resolver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bpodgursky.jbool_expressions.And;
+import com.bpodgursky.jbool_expressions.Literal;
+import com.bpodgursky.jbool_expressions.Not;
+import com.bpodgursky.jbool_expressions.Or;
+import io.quarkus.test.junit.QuarkusTest;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.FilterPath;
+import io.stargate.sgv2.docsapi.service.query.ImmutableFilterExpression;
+import io.stargate.sgv2.docsapi.service.query.ImmutableFilterPath;
+import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
+import io.stargate.sgv2.docsapi.service.query.condition.impl.ImmutableStringCondition;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.FilterOperationCode;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.EqFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.GtFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.LtFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.NeFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.search.db.impl.FilterExpressionSearchQueryBuilder;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.filter.impl.InMemoryCandidatesFilter;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.filter.impl.PersistenceCandidatesFilter;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.impl.AllFiltersResolver;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.impl.InMemoryDocumentsResolver;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.impl.OrExpressionDocumentsResolver;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.impl.PersistenceDocumentsResolver;
+import java.util.Collection;
+import java.util.Collections;
+import javax.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@QuarkusTest
+class BaseResolverTest {
+
+  @Mock DocumentsResolver candidatesResolver;
+
+  @Inject DocumentProperties documentProperties;
+
+  @BeforeEach
+  public void init() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Nested
+  class Resolve {
+
+    @Test
+    public void literalTrue() {
+      ExecutionContext context = ExecutionContext.create(true);
+
+      DocumentsResolver result =
+          BaseResolver.resolve(Literal.getTrue(), context, documentProperties);
+
+      assertThat(result).isNull();
+    }
+
+    @Test
+    public void singleExpressionPersistenceNoCandidates() {
+      ExecutionContext context = ExecutionContext.create(true);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(EqFilterOperation.of(), "find-me", documentProperties);
+      FilterExpression expression = ImmutableFilterExpression.of(filterPath, condition, 0);
+
+      DocumentsResolver result = BaseResolver.resolve(expression, context, documentProperties);
+
+      assertThat(result).isInstanceOf(PersistenceDocumentsResolver.class);
+    }
+
+    @Test
+    public void singleExpressionPersistenceCandidates() {
+      ExecutionContext context = ExecutionContext.create(true);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(EqFilterOperation.of(), "find-me", documentProperties);
+      FilterExpression expression = ImmutableFilterExpression.of(filterPath, condition, 0);
+
+      DocumentsResolver result =
+          BaseResolver.resolve(expression, context, candidatesResolver, documentProperties);
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              AllFiltersResolver.class,
+              allOf -> {
+                assertThat(allOf)
+                    .hasFieldOrPropertyWithValue("candidatesResolver", candidatesResolver);
+                assertThat(allOf)
+                    .extracting("candidatesFilters")
+                    .asList()
+                    .singleElement()
+                    .isInstanceOf(PersistenceCandidatesFilter.class);
+              });
+    }
+
+    @Test
+    public void singleExpressionInMemoryNoCandidates() {
+      ExecutionContext context = ExecutionContext.create(true);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(NeFilterOperation.of(), "find-me", documentProperties);
+      FilterExpression expression = ImmutableFilterExpression.of(filterPath, condition, 0);
+
+      DocumentsResolver result = BaseResolver.resolve(expression, context, documentProperties);
+
+      assertThat(result).isInstanceOf(InMemoryDocumentsResolver.class);
+    }
+
+    @Test
+    public void singleExpressionInMemoryCandidates() {
+      ExecutionContext context = ExecutionContext.create(true);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(NeFilterOperation.of(), "find-me", documentProperties);
+      FilterExpression expression = ImmutableFilterExpression.of(filterPath, condition, 0);
+
+      DocumentsResolver result =
+          BaseResolver.resolve(expression, context, candidatesResolver, documentProperties);
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              AllFiltersResolver.class,
+              allOf -> {
+                assertThat(allOf)
+                    .hasFieldOrPropertyWithValue("candidatesResolver", candidatesResolver);
+                assertThat(allOf)
+                    .extracting("candidatesFilters")
+                    .asList()
+                    .singleElement()
+                    .isInstanceOf(InMemoryCandidatesFilter.class);
+              });
+    }
+
+    @Test
+    public void andOnSamePath() {
+      ExecutionContext context = ExecutionContext.create(true);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition1 =
+          ImmutableStringCondition.of(GtFilterOperation.of(), "find-me", documentProperties);
+      BaseCondition condition2 =
+          ImmutableStringCondition.of(LtFilterOperation.of(), "find-me", documentProperties);
+      FilterExpression expression1 = ImmutableFilterExpression.of(filterPath, condition1, 0);
+      FilterExpression expression2 = ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      DocumentsResolver result =
+          BaseResolver.resolve(And.of(expression1, expression2), context, documentProperties);
+
+      assertThat(result).isInstanceOf(PersistenceDocumentsResolver.class);
+    }
+
+    @Test
+    public void andWithSingleExpressionDoesNotFail() {
+      ExecutionContext context = ExecutionContext.create(true);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition1 =
+          ImmutableStringCondition.of(GtFilterOperation.of(), "find-me", documentProperties);
+      FilterExpression expression1 = ImmutableFilterExpression.of(filterPath, condition1, 0);
+
+      DocumentsResolver result =
+          BaseResolver.resolve(And.of(expression1), context, documentProperties);
+
+      assertThat(result).isInstanceOf(PersistenceDocumentsResolver.class);
+    }
+
+    @Test
+    public void andWithNegation() {
+      ExecutionContext context = ExecutionContext.create(true);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition1 =
+          ImmutableStringCondition.of(GtFilterOperation.of(), "find-me", documentProperties);
+      FilterExpression expression1 = ImmutableFilterExpression.of(filterPath, condition1, 0);
+
+      DocumentsResolver result =
+          BaseResolver.resolve(Not.of(And.of(expression1)), context, documentProperties);
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              PersistenceDocumentsResolver.class,
+              resolver -> {
+                assertThat(resolver)
+                    .extracting("queryBuilder")
+                    .isInstanceOfSatisfying(
+                        FilterExpressionSearchQueryBuilder.class,
+                        qb ->
+                            assertThat(qb)
+                                .extracting("expressions")
+                                .isInstanceOfSatisfying(
+                                    Collection.class,
+                                    expressions -> {
+                                      assertThat(expressions).hasSize(1);
+                                      assertThat(expressions.iterator().next())
+                                          .isInstanceOfSatisfying(
+                                              FilterExpression.class,
+                                              filter -> {
+                                                assertThat(
+                                                        filter
+                                                            .getCondition()
+                                                            .getFilterOperationCode())
+                                                    .isEqualTo(
+                                                        FilterOperationCode.LTE); // inverse of "GT"
+                                              });
+                                    }));
+              });
+    }
+
+    @Test
+    public void orOnSamePath() {
+      ExecutionContext context = ExecutionContext.create(true);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition1 =
+          ImmutableStringCondition.of(GtFilterOperation.of(), "find-me", documentProperties);
+      BaseCondition condition2 =
+          ImmutableStringCondition.of(LtFilterOperation.of(), "find-me", documentProperties);
+      FilterExpression expression1 = ImmutableFilterExpression.of(filterPath, condition1, 0);
+      FilterExpression expression2 = ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      DocumentsResolver result =
+          BaseResolver.resolve(Or.of(expression1, expression2), context, documentProperties);
+
+      assertThat(result).isInstanceOf(OrExpressionDocumentsResolver.class);
+    }
+
+    @Test
+    public void orWithSingleExpressionDoesNotFail() {
+      ExecutionContext context = ExecutionContext.create(true);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition1 =
+          ImmutableStringCondition.of(GtFilterOperation.of(), "find-me", documentProperties);
+      FilterExpression expression1 = ImmutableFilterExpression.of(filterPath, condition1, 0);
+
+      DocumentsResolver result =
+          BaseResolver.resolve(Or.of(expression1), context, documentProperties);
+
+      assertThat(result).isInstanceOf(PersistenceDocumentsResolver.class);
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/CnfResolverTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/CnfResolverTest.java
@@ -1,0 +1,338 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.resolver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bpodgursky.jbool_expressions.And;
+import com.bpodgursky.jbool_expressions.Or;
+import io.quarkus.test.junit.QuarkusTest;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.FilterPath;
+import io.stargate.sgv2.docsapi.service.query.ImmutableFilterExpression;
+import io.stargate.sgv2.docsapi.service.query.ImmutableFilterPath;
+import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
+import io.stargate.sgv2.docsapi.service.query.condition.impl.ImmutableGenericCondition;
+import io.stargate.sgv2.docsapi.service.query.condition.impl.ImmutableStringCondition;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.GtFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.InFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.LtFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.filter.impl.InMemoryCandidatesFilter;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.filter.impl.PersistenceCandidatesFilter;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.impl.AllFiltersResolver;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.impl.AnyFiltersResolver;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.impl.InMemoryDocumentsResolver;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.impl.OrExpressionDocumentsResolver;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.impl.PersistenceDocumentsResolver;
+import java.util.Collections;
+import javax.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+
+@QuarkusTest
+class CnfResolverTest {
+
+  @Inject DocumentProperties documentProperties;
+
+  @BeforeEach
+  public void init() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Nested
+  class Resolve {
+
+    @Test
+    public void twoExpressionSamePath() {
+      ExecutionContext context = ExecutionContext.create(true);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition1 =
+          ImmutableStringCondition.of(GtFilterOperation.of(), "find-me", documentProperties);
+      BaseCondition condition2 =
+          ImmutableStringCondition.of(LtFilterOperation.of(), "find-me", documentProperties);
+      FilterExpression expression1 = ImmutableFilterExpression.of(filterPath, condition1, 0);
+      FilterExpression expression2 = ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      DocumentsResolver result =
+          CnfResolver.resolve(And.of(expression1, expression2), context, documentProperties);
+
+      assertThat(result).isInstanceOf(PersistenceDocumentsResolver.class);
+    }
+
+    @Test
+    public void twoPersistenceExpressionDifferentPath() {
+      ExecutionContext context = ExecutionContext.create(true);
+      FilterPath filterPath1 = ImmutableFilterPath.of(Collections.singletonList("b"));
+      FilterPath filterPath2 = ImmutableFilterPath.of(Collections.singletonList("a"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(GtFilterOperation.of(), "find-me", documentProperties);
+      FilterExpression expression1 = ImmutableFilterExpression.of(filterPath1, condition, 0);
+      FilterExpression expression2 = ImmutableFilterExpression.of(filterPath2, condition, 1);
+
+      And<FilterExpression> and = And.of(expression1, expression2);
+      DocumentsResolver result = CnfResolver.resolve(and, context, documentProperties);
+
+      // ensure not reordering
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              AllFiltersResolver.class,
+              allOf -> {
+                assertThat(allOf)
+                    .extracting("candidatesResolver")
+                    .isInstanceOfSatisfying(
+                        PersistenceDocumentsResolver.class,
+                        r -> {
+                          assertThat(r)
+                              .extracting("queryBuilder")
+                              .extracting("filterPath")
+                              .isEqualTo(filterPath1);
+                        });
+                assertThat(allOf)
+                    .extracting("candidatesFilters")
+                    .asList()
+                    .singleElement()
+                    .isInstanceOfSatisfying(
+                        PersistenceCandidatesFilter.class,
+                        f -> {
+                          assertThat(f)
+                              .extracting("queryBuilder")
+                              .extracting("filterPath")
+                              .isEqualTo(filterPath2);
+                        });
+              });
+    }
+
+    @Test
+    public void twoMemoryExpressionDifferentPath() {
+      ExecutionContext context = ExecutionContext.create(true);
+      FilterPath filterPath1 = ImmutableFilterPath.of(Collections.singletonList("b"));
+      FilterPath filterPath2 = ImmutableFilterPath.of(Collections.singletonList("a"));
+      BaseCondition condition =
+          ImmutableGenericCondition.of(
+              InFilterOperation.of(),
+              Collections.singletonList("find-me"),
+              documentProperties,
+              false);
+      FilterExpression expression1 = ImmutableFilterExpression.of(filterPath1, condition, 0);
+      FilterExpression expression2 = ImmutableFilterExpression.of(filterPath2, condition, 1);
+
+      And<FilterExpression> and = And.of(expression1, expression2);
+      DocumentsResolver result = CnfResolver.resolve(and, context, documentProperties);
+
+      // ensure not reordering
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              AllFiltersResolver.class,
+              allOf -> {
+                assertThat(allOf)
+                    .extracting("candidatesResolver")
+                    .isInstanceOfSatisfying(
+                        InMemoryDocumentsResolver.class,
+                        r -> {
+                          assertThat(r)
+                              .extracting("queryBuilder")
+                              .extracting("filterPath")
+                              .isEqualTo(filterPath1);
+                        });
+                assertThat(allOf)
+                    .extracting("candidatesFilters")
+                    .asList()
+                    .singleElement()
+                    .isInstanceOfSatisfying(
+                        InMemoryCandidatesFilter.class,
+                        f -> {
+                          assertThat(f)
+                              .extracting("queryBuilder")
+                              .extracting("filterPath")
+                              .isEqualTo(filterPath2);
+                        });
+              });
+    }
+
+    @Test
+    public void mixed4Expressions() {
+      ExecutionContext context = ExecutionContext.create(true);
+      FilterPath filterPath1 = ImmutableFilterPath.of(Collections.singletonList("field1"));
+      FilterPath filterPath2 = ImmutableFilterPath.of(Collections.singletonList("field2"));
+      BaseCondition persistenceCondition =
+          ImmutableStringCondition.of(GtFilterOperation.of(), "find-me", documentProperties);
+      BaseCondition memoryCondition =
+          ImmutableGenericCondition.of(
+              InFilterOperation.of(),
+              Collections.singletonList("find-me"),
+              documentProperties,
+              false);
+      FilterExpression expression1 =
+          ImmutableFilterExpression.of(filterPath1, persistenceCondition, 0);
+      FilterExpression expression2 =
+          ImmutableFilterExpression.of(filterPath2, persistenceCondition, 1);
+      FilterExpression expression3 = ImmutableFilterExpression.of(filterPath1, memoryCondition, 2);
+      FilterExpression expression4 = ImmutableFilterExpression.of(filterPath2, memoryCondition, 3);
+
+      DocumentsResolver result =
+          CnfResolver.resolve(
+              And.of(expression1, expression2, expression3, expression4),
+              context,
+              documentProperties);
+
+      // |
+      // | -> persistence candidates (1 exp)
+      // | | -> persistence filters (1 exp)
+      // | -> in-memory filters (2 exp)O
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              AllFiltersResolver.class,
+              allOf -> {
+                assertThat(allOf)
+                    .extracting("candidatesResolver")
+                    .isInstanceOfSatisfying(
+                        AllFiltersResolver.class,
+                        allOf2 -> {
+                          assertThat(allOf2)
+                              .extracting("candidatesResolver")
+                              .isInstanceOf(PersistenceDocumentsResolver.class);
+                          assertThat(allOf2)
+                              .extracting("candidatesFilters")
+                              .asList()
+                              .singleElement()
+                              .isInstanceOf(PersistenceCandidatesFilter.class);
+                        });
+                assertThat(allOf)
+                    .extracting("candidatesFilters")
+                    .asList()
+                    .hasSize(2)
+                    .allSatisfy(cf -> assertThat(cf).isInstanceOf(InMemoryCandidatesFilter.class));
+              });
+    }
+  }
+
+  @Test
+  public void mixed4ExpressionsWithOrs() {
+    ExecutionContext context = ExecutionContext.create(true);
+    FilterPath filterPath1 = ImmutableFilterPath.of(Collections.singletonList("field1"));
+    FilterPath filterPath2 = ImmutableFilterPath.of(Collections.singletonList("field2"));
+    BaseCondition prsCondition =
+        ImmutableStringCondition.of(GtFilterOperation.of(), "find-me", documentProperties);
+    BaseCondition memCondition =
+        ImmutableGenericCondition.of(
+            InFilterOperation.of(),
+            Collections.singletonList("find-me"),
+            documentProperties,
+            false);
+    FilterExpression expression1 = ImmutableFilterExpression.of(filterPath1, prsCondition, 0);
+    FilterExpression expression2 = ImmutableFilterExpression.of(filterPath2, prsCondition, 1);
+    FilterExpression expression3 = ImmutableFilterExpression.of(filterPath1, memCondition, 2);
+    FilterExpression expression4 = ImmutableFilterExpression.of(filterPath2, memCondition, 3);
+
+    DocumentsResolver result =
+        CnfResolver.resolve(
+            And.of(expression1, Or.of(expression2, expression3), expression4),
+            context,
+            documentProperties);
+
+    // |
+    // | -> persistence candidates (1 exp)
+    // | -> or filters (2 exp)
+    // | -> in-memory filters (1 exp)
+
+    assertThat(result)
+        .isInstanceOfSatisfying(
+            AllFiltersResolver.class,
+            allOf -> {
+              assertThat(allOf)
+                  .extracting("candidatesResolver")
+                  .isInstanceOfSatisfying(
+                      AnyFiltersResolver.class,
+                      anyOf2 -> {
+                        assertThat(anyOf2)
+                            .extracting("candidatesResolver")
+                            .isInstanceOf(PersistenceDocumentsResolver.class);
+                        assertThat(anyOf2)
+                            .extracting("candidatesFilters")
+                            .asList()
+                            .hasSize(2)
+                            .anySatisfy(
+                                cf -> assertThat(cf).isInstanceOf(InMemoryCandidatesFilter.class))
+                            .anySatisfy(
+                                cf ->
+                                    assertThat(cf).isInstanceOf(PersistenceCandidatesFilter.class));
+                      });
+              assertThat(allOf)
+                  .extracting("candidatesFilters")
+                  .asList()
+                  .singleElement()
+                  .satisfies(cf -> assertThat(cf).isInstanceOf(InMemoryCandidatesFilter.class));
+            });
+  }
+
+  @Test
+  public void onlyInMemoryWithOrs() {
+    ExecutionContext context = ExecutionContext.create(true);
+    FilterPath filterPath1 = ImmutableFilterPath.of(Collections.singletonList("field1"));
+    FilterPath filterPath2 = ImmutableFilterPath.of(Collections.singletonList("field2"));
+    BaseCondition memCondition =
+        ImmutableGenericCondition.of(
+            InFilterOperation.of(),
+            Collections.singletonList("find-me"),
+            documentProperties,
+            false);
+    BaseCondition memCondition2 =
+        ImmutableGenericCondition.of(
+            InFilterOperation.of(),
+            Collections.singletonList("find-me-again"),
+            documentProperties,
+            false);
+    FilterExpression expression1 = ImmutableFilterExpression.of(filterPath1, memCondition, 0);
+    FilterExpression expression2 = ImmutableFilterExpression.of(filterPath2, memCondition, 1);
+    FilterExpression expression3 = ImmutableFilterExpression.of(filterPath1, memCondition2, 2);
+    FilterExpression expression4 = ImmutableFilterExpression.of(filterPath2, memCondition2, 3);
+
+    DocumentsResolver result =
+        CnfResolver.resolve(
+            And.of(expression1, Or.of(expression2, expression3), expression4),
+            context,
+            documentProperties);
+
+    // |
+    // | -> or filters (2 exp)
+    // | -> in-memory filters (2 exp)
+
+    assertThat(result)
+        .isInstanceOfSatisfying(
+            AllFiltersResolver.class,
+            allOf -> {
+              assertThat(allOf)
+                  .extracting("candidatesResolver")
+                  .isInstanceOfSatisfying(
+                      OrExpressionDocumentsResolver.class,
+                      orResolver -> {
+                        assertThat(orResolver).extracting("queryBuilders").asList().hasSize(2);
+                      });
+              assertThat(allOf)
+                  .extracting("candidatesFilters")
+                  .asList()
+                  .hasSize(2)
+                  .allSatisfy(cf -> assertThat(cf).isInstanceOf(InMemoryCandidatesFilter.class));
+            });
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/impl/InMemoryCandidatesFilterTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/impl/InMemoryCandidatesFilterTest.java
@@ -1,0 +1,525 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.resolver.filter.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.DocsApiTestSchemaProvider;
+import io.stargate.sgv2.docsapi.OpenMocksTest;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.bridge.AbstractValidatingStargateBridgeTest;
+import io.stargate.sgv2.docsapi.bridge.ValidatingStargateBridge;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.common.model.RowWrapper;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.FilterPath;
+import io.stargate.sgv2.docsapi.service.query.ImmutableFilterPath;
+import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
+import io.stargate.sgv2.docsapi.service.query.executor.QueryExecutor;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.filter.CandidatesFilter;
+import io.stargate.sgv2.docsapi.testprofiles.MaxDepth8TestProfile;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.inject.Inject;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+@QuarkusTest
+@TestProfile(MaxDepth8TestProfile.class)
+class InMemoryCandidatesFilterTest extends AbstractValidatingStargateBridgeTest {
+
+  private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
+  private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
+
+  @Inject DocumentProperties documentProperties;
+
+  @Inject QueryExecutor queryExecutor;
+
+  @Inject DocsApiTestSchemaProvider schemaProvider;
+
+  ExecutionContext executionContext;
+
+  @BeforeEach
+  public void init() {
+    executionContext = ExecutionContext.create(true);
+  }
+
+  @Nested
+  class Constructor implements OpenMocksTest {
+
+    @Mock FilterExpression filterExpression;
+
+    @Mock BaseCondition baseCondition;
+
+    @Test
+    public void noPersistenceConditions() {
+      when(baseCondition.isPersistenceCondition()).thenReturn(true);
+      when(filterExpression.getCondition()).thenReturn(baseCondition);
+
+      Throwable throwable =
+          catchThrowable(
+              () ->
+                  InMemoryCandidatesFilter.forExpression(filterExpression, documentProperties)
+                      .apply(executionContext));
+
+      assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  class PrepareQuery implements OpenMocksTest {
+
+    @Mock FilterExpression filterExpression;
+
+    @Mock BaseCondition baseCondition;
+
+    @Test
+    public void fixedPath() {
+      // fixed path has limit
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.getCondition()).thenReturn(baseCondition);
+      when(filterExpression.getDescription()).thenReturn("field EQ something");
+
+      CandidatesFilter filter =
+          InMemoryCandidatesFilter.forExpression(filterExpression, documentProperties)
+              .apply(executionContext);
+      QueryOuterClass.Query result =
+          filter
+              .prepareQuery(KEYSPACE_NAME, COLLECTION_NAME)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitItem()
+              .assertCompleted()
+              .getItem();
+
+      String expected =
+          "SELECT key, p0, p1, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND key = ? LIMIT 1 ALLOW FILTERING"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(result.getCql()).isEqualTo(expected);
+
+      // execution context not updated with execution
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description()).isEqualTo("FILTER IN MEMORY: field EQ something");
+                assertThat(nested.queries()).isEmpty();
+              });
+
+      // ignore prepared as we did not execute
+      resetExpectations();
+    }
+
+    @Test
+    public void globComplexPath() {
+      // glob path has no limits and glob px has GT as condition
+      FilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("some", "*", "field"));
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.getCondition()).thenReturn(baseCondition);
+      when(filterExpression.getDescription()).thenReturn("field EQ something");
+
+      CandidatesFilter filter =
+          InMemoryCandidatesFilter.forExpression(filterExpression, documentProperties)
+              .apply(executionContext);
+      QueryOuterClass.Query result =
+          filter
+              .prepareQuery(KEYSPACE_NAME, COLLECTION_NAME)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitItem()
+              .assertCompleted()
+              .getItem();
+
+      String expected =
+          "SELECT key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 > ? AND p2 = ? AND leaf = ? AND p3 = ? AND key = ? ALLOW FILTERING"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(result.getCql()).isEqualTo(expected);
+
+      // execution context not updated with execution
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description()).isEqualTo("FILTER IN MEMORY: field EQ something");
+                assertThat(nested.queries()).isEmpty();
+              });
+
+      // ignore prepared as we did not execute
+      resetExpectations();
+    }
+  }
+
+  @Nested
+  class BindAndFilter implements OpenMocksTest {
+
+    @Mock RawDocument rawDocument;
+
+    @Mock BaseCondition baseCondition;
+
+    @Mock FilterExpression filterExpression;
+
+    @Mock FilterExpression filterExpression2;
+
+    @Captor ArgumentCaptor<List<RowWrapper>> testRowsCaptor;
+
+    @Test
+    public void fixedPath() {
+      // fixed path has limit and page size 2 on the execution
+      String documentId = RandomStringUtils.randomAlphabetic(16);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.getCondition()).thenReturn(baseCondition);
+      when(filterExpression.getDescription()).thenReturn("field EQ something");
+      when(filterExpression.test(anyList())).thenReturn(true);
+      when(rawDocument.id()).thenReturn(documentId);
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, p0, p1, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND key = ? LIMIT 1 ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of(documentId))
+              .withPageSize(2)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(List.of(List.of(Values.of("1"))));
+
+      CandidatesFilter filter =
+          InMemoryCandidatesFilter.forExpression(filterExpression, documentProperties)
+              .apply(executionContext);
+      filter
+          .prepareQuery(KEYSPACE_NAME, COLLECTION_NAME)
+          .flatMap(query -> filter.bindAndFilter(queryExecutor, query, rawDocument))
+          .subscribe()
+          .withSubscriber(UniAssertSubscriber.create())
+          .awaitItem()
+          .assertItem(true)
+          .assertCompleted();
+
+      queryAssert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description()).isEqualTo("FILTER IN MEMORY: field EQ something");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+      verify(rawDocument).id();
+      verify(filterExpression, times(1)).test(testRowsCaptor.capture());
+      verifyNoMoreInteractions(rawDocument);
+
+      // verify that we pass the fetched document to the filter
+      assertThat(testRowsCaptor.getAllValues())
+          .singleElement()
+          .satisfies(
+              rows ->
+                  assertThat(rows)
+                      .singleElement()
+                      .satisfies(
+                          r -> {
+                            assertThat(r.getString("key")).isEqualTo("1");
+                          }));
+    }
+
+    @Test
+    public void globPathMultipleExpressions() {
+      // glob path has no limits and glob px has GT as condition
+      String documentId = RandomStringUtils.randomAlphabetic(16);
+      FilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("some", "*", "field"));
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.getCondition()).thenReturn(baseCondition);
+      when(filterExpression.getDescription()).thenReturn("field LT something");
+      when(filterExpression.test(anyList())).thenReturn(true);
+      when(filterExpression2.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression2.getCondition()).thenReturn(baseCondition);
+      when(filterExpression2.getDescription()).thenReturn("field GT something");
+      when(filterExpression2.test(anyList())).thenReturn(true);
+      when(rawDocument.id()).thenReturn(documentId);
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 > ? AND p2 = ? AND leaf = ? AND p3 = ? AND key = ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("some"),
+                  Values.of(""),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of(documentId))
+              .withPageSize(documentProperties.maxSearchPageSize())
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(List.of(List.of(Values.of("1"))));
+
+      CandidatesFilter filter =
+          InMemoryCandidatesFilter.forExpressions(
+                  Arrays.asList(filterExpression, filterExpression2), documentProperties)
+              .apply(executionContext);
+      filter
+          .prepareQuery(KEYSPACE_NAME, COLLECTION_NAME)
+          .flatMap(query -> filter.bindAndFilter(queryExecutor, query, rawDocument))
+          .subscribe()
+          .withSubscriber(UniAssertSubscriber.create())
+          .awaitItem()
+          .assertItem(true)
+          .assertCompleted();
+
+      queryAssert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo("FILTER IN MEMORY: field LT something AND field GT something");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+      verify(rawDocument).id();
+      verify(filterExpression, times(1)).test(testRowsCaptor.capture());
+      verifyNoMoreInteractions(rawDocument);
+
+      // verify that we pass the fetched document to the filter
+      assertThat(testRowsCaptor.getAllValues())
+          .singleElement()
+          .satisfies(
+              rows ->
+                  assertThat(rows)
+                      .singleElement()
+                      .satisfies(
+                          r -> {
+                            assertThat(r.getString("key")).isEqualTo("1");
+                          }));
+    }
+
+    @Test
+    public void nothingReturned() {
+      String documentId = RandomStringUtils.randomAlphabetic(16);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.getCondition()).thenReturn(baseCondition);
+      when(filterExpression.getDescription()).thenReturn("field EQ something");
+      when(rawDocument.id()).thenReturn(documentId);
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, p0, p1, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND key = ? LIMIT 1 ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of(documentId))
+              .withPageSize(2)
+              .enriched()
+              .returningNothing();
+
+      CandidatesFilter filter =
+          InMemoryCandidatesFilter.forExpression(filterExpression, documentProperties)
+              .apply(executionContext);
+      filter
+          .prepareQuery(KEYSPACE_NAME, COLLECTION_NAME)
+          .flatMap(query -> filter.bindAndFilter(queryExecutor, query, rawDocument))
+          .subscribe()
+          .withSubscriber(UniAssertSubscriber.create())
+          .awaitItem()
+          .assertItem(false)
+          .assertCompleted();
+
+      queryAssert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description()).isEqualTo("FILTER IN MEMORY: field EQ something");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(0);
+                        });
+              });
+      verify(rawDocument).id();
+      verify(filterExpression, never()).test(testRowsCaptor.capture());
+      verifyNoMoreInteractions(rawDocument);
+    }
+
+    @Test
+    public void nothingReturnedButEvalOnMissing() {
+      String documentId = RandomStringUtils.randomAlphabetic(16);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.getCondition()).thenReturn(baseCondition);
+      when(filterExpression.getDescription()).thenReturn("field EQ something");
+      when(filterExpression.test(Collections.emptyList())).thenReturn(true);
+      when(baseCondition.isEvaluateOnMissingFields()).thenReturn(true);
+      when(rawDocument.id()).thenReturn(documentId);
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, p0, p1, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND key = ? LIMIT 1 ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of(documentId))
+              .withPageSize(2)
+              .enriched()
+              .returningNothing();
+
+      CandidatesFilter filter =
+          InMemoryCandidatesFilter.forExpression(filterExpression, documentProperties)
+              .apply(executionContext);
+      filter
+          .prepareQuery(KEYSPACE_NAME, COLLECTION_NAME)
+          .flatMap(query -> filter.bindAndFilter(queryExecutor, query, rawDocument))
+          .subscribe()
+          .withSubscriber(UniAssertSubscriber.create())
+          .awaitItem()
+          .assertItem(true)
+          .assertCompleted();
+
+      queryAssert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description()).isEqualTo("FILTER IN MEMORY: field EQ something");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(0);
+                        });
+              });
+      verify(rawDocument).id();
+      verify(filterExpression).test(Collections.emptyList());
+      verifyNoMoreInteractions(rawDocument);
+    }
+
+    @Test
+    public void testNotPassed() {
+      // fixed path has limit and page size 2 on the execution
+      String documentId = RandomStringUtils.randomAlphabetic(16);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.getCondition()).thenReturn(baseCondition);
+      when(filterExpression.getDescription()).thenReturn("field EQ something");
+      when(filterExpression.test(anyList())).thenReturn(false);
+      when(rawDocument.id()).thenReturn(documentId);
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, p0, p1, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND key = ? LIMIT 1 ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of(documentId))
+              .withPageSize(2)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(List.of(List.of(Values.of("1"))));
+
+      CandidatesFilter filter =
+          InMemoryCandidatesFilter.forExpression(filterExpression, documentProperties)
+              .apply(executionContext);
+      filter
+          .prepareQuery(KEYSPACE_NAME, COLLECTION_NAME)
+          .flatMap(query -> filter.bindAndFilter(queryExecutor, query, rawDocument))
+          .subscribe()
+          .withSubscriber(UniAssertSubscriber.create())
+          .awaitItem()
+          .assertItem(false)
+          .assertCompleted();
+
+      queryAssert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description()).isEqualTo("FILTER IN MEMORY: field EQ something");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+      verify(rawDocument).id();
+      verify(filterExpression, times(1)).test(testRowsCaptor.capture());
+      verifyNoMoreInteractions(rawDocument);
+
+      // verify that we pass the fetched document to the filter
+      assertThat(testRowsCaptor.getAllValues())
+          .singleElement()
+          .satisfies(
+              rows ->
+                  assertThat(rows)
+                      .singleElement()
+                      .satisfies(
+                          r -> {
+                            assertThat(r.getString("key")).isEqualTo("1");
+                          }));
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/impl/PersistenceCandidatesFilterTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/impl/PersistenceCandidatesFilterTest.java
@@ -112,6 +112,7 @@ class PersistenceCandidatesFilterTest extends AbstractValidatingStargateBridgeTe
           ImmutableStringCondition.of(EqFilterOperation.of(), "query-value", documentProperties);
       when(filterExpression.getFilterPath()).thenReturn(filterPath);
       when(filterExpression.getCondition()).thenReturn(condition);
+      when(filterExpression.getDescription()).thenReturn("field EQ something");
 
       CandidatesFilter filter =
           PersistenceCandidatesFilter.forExpression(filterExpression, documentProperties)

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/impl/PersistenceCandidatesFilterTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/impl/PersistenceCandidatesFilterTest.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.resolver.filter.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.DocsApiTestSchemaProvider;
+import io.stargate.sgv2.docsapi.OpenMocksTest;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.bridge.AbstractValidatingStargateBridgeTest;
+import io.stargate.sgv2.docsapi.bridge.ValidatingStargateBridge;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.FilterPath;
+import io.stargate.sgv2.docsapi.service.query.ImmutableFilterPath;
+import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
+import io.stargate.sgv2.docsapi.service.query.condition.impl.ImmutableNumberCondition;
+import io.stargate.sgv2.docsapi.service.query.condition.impl.ImmutableStringCondition;
+import io.stargate.sgv2.docsapi.service.query.executor.QueryExecutor;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.EqFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.GtFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.LtFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.filter.CandidatesFilter;
+import io.stargate.sgv2.docsapi.testprofiles.MaxDepth8TestProfile;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.inject.Inject;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+@QuarkusTest
+@TestProfile(MaxDepth8TestProfile.class)
+class PersistenceCandidatesFilterTest extends AbstractValidatingStargateBridgeTest {
+
+  private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
+  private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
+
+  @Inject DocumentProperties documentProperties;
+
+  @Inject QueryExecutor queryExecutor;
+
+  @Inject DocsApiTestSchemaProvider schemaProvider;
+
+  ExecutionContext executionContext;
+
+  @BeforeEach
+  public void init() {
+    executionContext = ExecutionContext.create(true);
+  }
+
+  @Nested
+  class Constructor implements OpenMocksTest {
+
+    @Mock BaseCondition baseCondition;
+
+    @Mock FilterExpression filterExpression;
+
+    @Test
+    public void noInMemoryConditions() {
+      when(baseCondition.isPersistenceCondition()).thenReturn(false);
+      when(filterExpression.getCondition()).thenReturn(baseCondition);
+
+      Throwable throwable =
+          catchThrowable(
+              () ->
+                  PersistenceCandidatesFilter.forExpression(filterExpression, documentProperties)
+                      .apply(executionContext));
+
+      assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  class PrepareQuery implements OpenMocksTest {
+
+    @Mock FilterExpression filterExpression;
+
+    @Test
+    public void fixedPath() {
+      // fixed path has limit
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(EqFilterOperation.of(), "query-value", documentProperties);
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.getCondition()).thenReturn(condition);
+
+      CandidatesFilter filter =
+          PersistenceCandidatesFilter.forExpression(filterExpression, documentProperties)
+              .apply(executionContext);
+      QueryOuterClass.Query result =
+          filter
+              .prepareQuery(KEYSPACE_NAME, COLLECTION_NAME)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitItem()
+              .assertCompleted()
+              .getItem();
+
+      String expected =
+          "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND text_value = ? AND key = ? LIMIT 1 ALLOW FILTERING"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(result.getCql()).isEqualTo(expected);
+
+      // execution context not updated with execution
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description()).isEqualTo("FILTER: field EQ something");
+                assertThat(nested.queries()).isEmpty();
+              });
+
+      // ignore prepared as we did not execute
+      resetExpectations();
+    }
+
+    @Test
+    public void globComplexPath() {
+      // glob path has no limits and glob px has GT as condition
+      FilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("some", "*", "field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(EqFilterOperation.of(), "query-value", documentProperties);
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.getCondition()).thenReturn(condition);
+      when(filterExpression.getDescription()).thenReturn("field EQ something");
+
+      CandidatesFilter filter =
+          PersistenceCandidatesFilter.forExpression(filterExpression, documentProperties)
+              .apply(executionContext);
+      QueryOuterClass.Query result =
+          filter
+              .prepareQuery(KEYSPACE_NAME, COLLECTION_NAME)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitItem()
+              .assertCompleted()
+              .getItem();
+
+      String expected =
+          "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 > ? AND p2 = ? AND leaf = ? AND p3 = ? AND text_value = ? AND key = ? ALLOW FILTERING"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      assertThat(result.getCql()).isEqualTo(expected);
+
+      // execution context not updated with execution
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description()).isEqualTo("FILTER: field EQ something");
+                assertThat(nested.queries()).isEmpty();
+              });
+
+      // ignore prepared as we did not execute
+      resetExpectations();
+    }
+  }
+
+  @Nested
+  class BindAndFilter implements OpenMocksTest {
+
+    @Mock RawDocument rawDocument;
+
+    @Mock FilterExpression filterExpression;
+
+    @Mock FilterExpression filterExpression2;
+
+    @Test
+    public void fixedPath() {
+      // fixed path has limit and page size 2 on the execution
+      String documentId = RandomStringUtils.randomAlphabetic(16);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(EqFilterOperation.of(), "query-value", documentProperties);
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.getCondition()).thenReturn(condition);
+      when(filterExpression.getDescription()).thenReturn("field EQ something");
+      when(rawDocument.id()).thenReturn(documentId);
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND text_value = ? AND key = ? LIMIT 1 ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of("query-value"),
+                  Values.of(documentId))
+              .withPageSize(2)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(List.of(List.of(Values.of("1"))));
+
+      CandidatesFilter filter =
+          PersistenceCandidatesFilter.forExpression(filterExpression, documentProperties)
+              .apply(executionContext);
+      filter
+          .prepareQuery(KEYSPACE_NAME, COLLECTION_NAME)
+          .flatMap(query -> filter.bindAndFilter(queryExecutor, query, rawDocument))
+          .subscribe()
+          .withSubscriber(UniAssertSubscriber.create())
+          .awaitItem()
+          .assertItem(true)
+          .assertCompleted();
+
+      queryAssert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description()).isEqualTo("FILTER: field EQ something");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+      verify(rawDocument).id();
+      verifyNoMoreInteractions(rawDocument);
+    }
+
+    @Test
+    public void globPathMultipleExpressions() {
+      // glob path has no limits and glob px has GT as condition
+      String documentId = RandomStringUtils.randomAlphabetic(16);
+      FilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("some", "*", "field"));
+      BaseCondition condition =
+          ImmutableNumberCondition.of(LtFilterOperation.of(), 1d, documentProperties);
+      BaseCondition condition2 =
+          ImmutableNumberCondition.of(GtFilterOperation.of(), 2d, documentProperties);
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.getCondition()).thenReturn(condition);
+      when(filterExpression.getDescription()).thenReturn("field LT something");
+      when(filterExpression2.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression2.getCondition()).thenReturn(condition2);
+      when(filterExpression2.getDescription()).thenReturn("field GT something");
+      when(rawDocument.id()).thenReturn(documentId);
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 > ? AND p2 = ? AND leaf = ? AND p3 = ? AND dbl_value < ? AND dbl_value > ? AND key = ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("some"),
+                  Values.of(""),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of(1.0),
+                  Values.of(2.0),
+                  Values.of(documentId))
+              .withPageSize(documentProperties.maxSearchPageSize())
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(List.of(List.of(Values.of("1"))));
+
+      CandidatesFilter filter =
+          PersistenceCandidatesFilter.forExpressions(
+                  Arrays.asList(filterExpression, filterExpression2), documentProperties)
+              .apply(executionContext);
+
+      filter
+          .prepareQuery(KEYSPACE_NAME, COLLECTION_NAME)
+          .flatMap(query -> filter.bindAndFilter(queryExecutor, query, rawDocument))
+          .subscribe()
+          .withSubscriber(UniAssertSubscriber.create())
+          .awaitItem()
+          .assertItem(true)
+          .assertCompleted();
+
+      queryAssert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo("FILTER: field LT something AND field GT something");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+    }
+
+    @Test
+    public void nothingReturned() {
+      String documentId = RandomStringUtils.randomAlphabetic(16);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(EqFilterOperation.of(), "query-value", documentProperties);
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.getCondition()).thenReturn(condition);
+      when(filterExpression.getDescription()).thenReturn("field EQ something");
+      when(rawDocument.id()).thenReturn(documentId);
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND text_value = ? AND key = ? LIMIT 1 ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of("query-value"),
+                  Values.of(documentId))
+              .withPageSize(2)
+              .enriched()
+              .returningNothing();
+
+      CandidatesFilter filter =
+          PersistenceCandidatesFilter.forExpression(filterExpression, documentProperties)
+              .apply(executionContext);
+      filter
+          .prepareQuery(KEYSPACE_NAME, COLLECTION_NAME)
+          .flatMap(query -> filter.bindAndFilter(queryExecutor, query, rawDocument))
+          .subscribe()
+          .withSubscriber(UniAssertSubscriber.create())
+          .awaitItem()
+          .assertItem(false)
+          .assertCompleted();
+
+      queryAssert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description()).isEqualTo("FILTER: field EQ something");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(0);
+                        });
+              });
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/AllFiltersResolverTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/AllFiltersResolverTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.resolver.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.common.cql.builder.QueryBuilder;
+import io.stargate.sgv2.docsapi.OpenMocksTest;
+import io.stargate.sgv2.docsapi.bridge.AbstractValidatingStargateBridgeTest;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.common.model.Paginator;
+import io.stargate.sgv2.docsapi.service.query.executor.QueryExecutor;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.DocumentsResolver;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.filter.CandidatesFilter;
+import java.util.Arrays;
+import javax.inject.Inject;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+@QuarkusTest
+class AllFiltersResolverTest extends AbstractValidatingStargateBridgeTest {
+
+  private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
+  private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
+
+  @Inject QueryExecutor queryExecutor;
+
+  ExecutionContext executionContext;
+
+  @BeforeEach
+  public void init() {
+    executionContext = ExecutionContext.create(true);
+  }
+
+  @Nested
+  class GetDocuments implements OpenMocksTest {
+
+    @Mock CandidatesFilter candidatesFilter;
+
+    @Mock CandidatesFilter candidatesFilter2;
+
+    @Mock RawDocument rawDocument;
+
+    @Mock RawDocument rawDocument2;
+
+    Uni<QueryOuterClass.Query> query1;
+
+    Uni<QueryOuterClass.Query> query2;
+
+    @BeforeEach
+    public void initQueries() {
+      query1 =
+          Uni.createFrom()
+              .item(
+                  () ->
+                      new QueryBuilder()
+                          .select()
+                          .column("text_value")
+                          .from(COLLECTION_NAME)
+                          .build())
+              .memoize()
+              .indefinitely();
+
+      query2 =
+          Uni.createFrom()
+              .item(
+                  () ->
+                      new QueryBuilder().select().column("dbl_value").from(COLLECTION_NAME).build())
+              .memoize()
+              .indefinitely();
+    }
+
+    @Test
+    public void happyPath() throws Exception {
+      withAnySelectFrom(KEYSPACE_NAME, COLLECTION_NAME).returningNothing();
+      QueryOuterClass.Query query1Final = query1.await().indefinitely();
+      QueryOuterClass.Query query2Final = query2.await().indefinitely();
+
+      doAnswer(i -> query1).when(candidatesFilter).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      doAnswer(i -> query2).when(candidatesFilter2).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      doAnswer(i -> Uni.createFrom().item(true))
+          .when(candidatesFilter)
+          .bindAndFilter(queryExecutor, query1Final, rawDocument);
+      doAnswer(i -> Uni.createFrom().item(true))
+          .when(candidatesFilter2)
+          .bindAndFilter(queryExecutor, query2Final, rawDocument);
+      DocumentsResolver candidatesResolver =
+          (queryExecutor1, keyspace, collection, paginator) ->
+              Multi.createFrom().items(rawDocument);
+
+      DocumentsResolver resolver =
+          new AllFiltersResolver(
+              Arrays.asList((c) -> candidatesFilter, (c) -> candidatesFilter2),
+              executionContext,
+              candidatesResolver);
+
+      resolver
+          .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, new Paginator(null, 1))
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(1))
+          .awaitItems(1)
+          .assertLastItem(rawDocument)
+          .awaitCompletion()
+          .assertCompleted();
+
+      resetExpectations();
+
+      verify(candidatesFilter).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      verify(candidatesFilter2).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      verify(candidatesFilter).bindAndFilter(queryExecutor, query1Final, rawDocument);
+      verify(candidatesFilter2).bindAndFilter(queryExecutor, query2Final, rawDocument);
+      verifyNoMoreInteractions(candidatesFilter, candidatesFilter2);
+    }
+
+    @Test
+    public void multipleDocuments() {
+      withAnySelectFrom(KEYSPACE_NAME, COLLECTION_NAME).returningNothing();
+      QueryOuterClass.Query query1Final = query1.await().indefinitely();
+      QueryOuterClass.Query query2Final = query2.await().indefinitely();
+
+      doAnswer(i -> query1).when(candidatesFilter).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      doAnswer(i -> query2).when(candidatesFilter2).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      doAnswer(i -> Uni.createFrom().item(true))
+          .when(candidatesFilter)
+          .bindAndFilter(eq(queryExecutor), eq(query1Final), any());
+      doAnswer(i -> Uni.createFrom().item(true))
+          .when(candidatesFilter2)
+          .bindAndFilter(eq(queryExecutor), eq(query2Final), any());
+      DocumentsResolver candidatesResolver =
+          (queryExecutor1, keyspace, collection, paginator) ->
+              Multi.createFrom().items(rawDocument, rawDocument2);
+
+      DocumentsResolver resolver =
+          new AllFiltersResolver(
+              Arrays.asList((c) -> candidatesFilter, (c) -> candidatesFilter2),
+              executionContext,
+              candidatesResolver);
+
+      resolver
+          .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, new Paginator(null, 1))
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(2))
+          .awaitItems(2)
+          .assertItems(rawDocument, rawDocument2)
+          .awaitCompletion()
+          .assertCompleted();
+
+      resetExpectations();
+
+      verify(candidatesFilter).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      verify(candidatesFilter2).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      verify(candidatesFilter).bindAndFilter(queryExecutor, query1Final, rawDocument);
+      verify(candidatesFilter2).bindAndFilter(queryExecutor, query2Final, rawDocument);
+      verify(candidatesFilter).bindAndFilter(queryExecutor, query1Final, rawDocument2);
+      verify(candidatesFilter2).bindAndFilter(queryExecutor, query2Final, rawDocument2);
+      verifyNoMoreInteractions(candidatesFilter, candidatesFilter2);
+    }
+
+    @Test
+    public void notAllFiltersPassed() {
+      withAnySelectFrom(KEYSPACE_NAME, COLLECTION_NAME).returningNothing();
+      QueryOuterClass.Query query1Final = query1.await().indefinitely();
+      QueryOuterClass.Query query2Final = query2.await().indefinitely();
+
+      doAnswer(i -> query1).when(candidatesFilter).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      doAnswer(i -> query2).when(candidatesFilter2).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      doAnswer(i -> Uni.createFrom().item(true))
+          .when(candidatesFilter)
+          .bindAndFilter(queryExecutor, query1Final, rawDocument);
+      doAnswer(i -> Uni.createFrom().item(false))
+          .when(candidatesFilter2)
+          .bindAndFilter(queryExecutor, query2Final, rawDocument);
+      DocumentsResolver candidatesResolver =
+          (queryExecutor1, keyspace, collection, paginator) ->
+              Multi.createFrom().items(rawDocument);
+
+      DocumentsResolver resolver =
+          new AllFiltersResolver(
+              Arrays.asList((c) -> candidatesFilter, (c) -> candidatesFilter2),
+              executionContext,
+              candidatesResolver);
+
+      resolver
+          .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, new Paginator(null, 1))
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(1))
+          .awaitCompletion()
+          .assertCompleted()
+          .assertHasNotReceivedAnyItem();
+
+      resetExpectations();
+
+      verify(candidatesFilter).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      verify(candidatesFilter2).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      verify(candidatesFilter).bindAndFilter(queryExecutor, query1Final, rawDocument);
+      verify(candidatesFilter2).bindAndFilter(queryExecutor, query2Final, rawDocument);
+      verifyNoMoreInteractions(candidatesFilter, candidatesFilter2);
+    }
+
+    @Test
+    public void noCandidates() {
+      withAnySelectFrom(KEYSPACE_NAME, COLLECTION_NAME).returningNothing();
+
+      DocumentsResolver candidatesResolver =
+          (queryExecutor1, keyspace, collection, paginator) -> Multi.createFrom().empty();
+
+      DocumentsResolver resolver =
+          new AllFiltersResolver(
+              Arrays.asList((c) -> candidatesFilter, (c) -> candidatesFilter2),
+              executionContext,
+              candidatesResolver);
+
+      resolver
+          .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, new Paginator(null, 1))
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(1))
+          .awaitCompletion()
+          .assertCompleted()
+          .assertHasNotReceivedAnyItem();
+
+      resetExpectations();
+      verifyNoMoreInteractions(candidatesFilter, candidatesFilter2);
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/AnyFiltersResolverTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/AnyFiltersResolverTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.resolver.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.common.cql.builder.QueryBuilder;
+import io.stargate.sgv2.docsapi.OpenMocksTest;
+import io.stargate.sgv2.docsapi.bridge.AbstractValidatingStargateBridgeTest;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.common.model.Paginator;
+import io.stargate.sgv2.docsapi.service.query.executor.QueryExecutor;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.DocumentsResolver;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.filter.CandidatesFilter;
+import java.util.Arrays;
+import javax.inject.Inject;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+@QuarkusTest
+class AnyFiltersResolverTest extends AbstractValidatingStargateBridgeTest {
+
+  private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
+  private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
+
+  @Inject QueryExecutor queryExecutor;
+
+  ExecutionContext executionContext;
+
+  @BeforeEach
+  public void init() {
+    executionContext = ExecutionContext.create(true);
+  }
+
+  @Nested
+  class GetDocuments implements OpenMocksTest {
+
+    @Mock CandidatesFilter candidatesFilter;
+
+    @Mock CandidatesFilter candidatesFilter2;
+
+    @Mock RawDocument rawDocument;
+
+    @Mock RawDocument rawDocument2;
+
+    Uni<QueryOuterClass.Query> query1;
+
+    Uni<QueryOuterClass.Query> query2;
+
+    @BeforeEach
+    public void initQueries() {
+      query1 =
+          Uni.createFrom()
+              .item(
+                  () ->
+                      new QueryBuilder()
+                          .select()
+                          .column("text_value")
+                          .from(COLLECTION_NAME)
+                          .build())
+              .memoize()
+              .indefinitely();
+
+      query2 =
+          Uni.createFrom()
+              .item(
+                  () ->
+                      new QueryBuilder().select().column("dbl_value").from(COLLECTION_NAME).build())
+              .memoize()
+              .indefinitely();
+    }
+
+    @Test
+    public void happyPath() throws Exception {
+      withAnySelectFrom(KEYSPACE_NAME, COLLECTION_NAME).returningNothing();
+      QueryOuterClass.Query query1Final = query1.await().indefinitely();
+      QueryOuterClass.Query query2Final = query2.await().indefinitely();
+
+      doAnswer(i -> query1).when(candidatesFilter).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      doAnswer(i -> query2).when(candidatesFilter2).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      doAnswer(i -> Uni.createFrom().item(true))
+          .when(candidatesFilter)
+          .bindAndFilter(queryExecutor, query1Final, rawDocument);
+      doAnswer(i -> Uni.createFrom().item(true))
+          .when(candidatesFilter2)
+          .bindAndFilter(queryExecutor, query2Final, rawDocument);
+      DocumentsResolver candidatesResolver =
+          (queryExecutor1, keyspace, collection, paginator) ->
+              Multi.createFrom().items(rawDocument);
+
+      DocumentsResolver resolver =
+          new AnyFiltersResolver(
+              Arrays.asList((c) -> candidatesFilter, (c) -> candidatesFilter2),
+              executionContext,
+              candidatesResolver);
+      resolver
+          .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, new Paginator(null, 1))
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(1))
+          .awaitItems(1)
+          .assertLastItem(rawDocument)
+          .awaitCompletion()
+          .assertCompleted();
+
+      resetExpectations();
+
+      verify(candidatesFilter).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      verify(candidatesFilter2).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      verify(candidatesFilter).bindAndFilter(queryExecutor, query1Final, rawDocument);
+      verify(candidatesFilter2).bindAndFilter(queryExecutor, query2Final, rawDocument);
+      verifyNoMoreInteractions(candidatesFilter, candidatesFilter2);
+    }
+
+    @Test
+    public void multipleDocumentsOneFilterPassing() {
+      withAnySelectFrom(KEYSPACE_NAME, COLLECTION_NAME).returningNothing();
+      QueryOuterClass.Query query1Final = query1.await().indefinitely();
+      QueryOuterClass.Query query2Final = query2.await().indefinitely();
+
+      doAnswer(i -> query1).when(candidatesFilter).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      doAnswer(i -> query2).when(candidatesFilter2).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      doAnswer(i -> Uni.createFrom().item(false))
+          .when(candidatesFilter)
+          .bindAndFilter(eq(queryExecutor), eq(query1Final), any());
+      doAnswer(i -> Uni.createFrom().item(true))
+          .when(candidatesFilter2)
+          .bindAndFilter(eq(queryExecutor), eq(query2Final), any());
+      DocumentsResolver candidatesResolver =
+          (queryExecutor1, keyspace, collection, paginator) ->
+              Multi.createFrom().items(rawDocument, rawDocument2);
+
+      DocumentsResolver resolver =
+          new AnyFiltersResolver(
+              Arrays.asList((c) -> candidatesFilter, (c) -> candidatesFilter2),
+              executionContext,
+              candidatesResolver);
+      resolver
+          .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, new Paginator(null, 1))
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(2))
+          .awaitItems(2)
+          .assertItems(rawDocument, rawDocument2)
+          .awaitCompletion()
+          .assertCompleted();
+
+      resetExpectations();
+
+      verify(candidatesFilter).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      verify(candidatesFilter2).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      verify(candidatesFilter).bindAndFilter(queryExecutor, query1Final, rawDocument);
+      verify(candidatesFilter2).bindAndFilter(queryExecutor, query2Final, rawDocument);
+      verify(candidatesFilter).bindAndFilter(queryExecutor, query1Final, rawDocument2);
+      verify(candidatesFilter2).bindAndFilter(queryExecutor, query2Final, rawDocument2);
+      verifyNoMoreInteractions(candidatesFilter, candidatesFilter2);
+    }
+
+    @Test
+    public void allFiltersNotPassed() {
+      withAnySelectFrom(KEYSPACE_NAME, COLLECTION_NAME).returningNothing();
+      QueryOuterClass.Query query1Final = query1.await().indefinitely();
+      QueryOuterClass.Query query2Final = query2.await().indefinitely();
+
+      doAnswer(i -> query1).when(candidatesFilter).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      doAnswer(i -> query2).when(candidatesFilter2).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      doAnswer(i -> Uni.createFrom().item(false))
+          .when(candidatesFilter)
+          .bindAndFilter(queryExecutor, query1Final, rawDocument);
+      doAnswer(i -> Uni.createFrom().item(false))
+          .when(candidatesFilter2)
+          .bindAndFilter(queryExecutor, query2Final, rawDocument);
+      DocumentsResolver candidatesResolver =
+          (queryExecutor1, keyspace, collection, paginator) ->
+              Multi.createFrom().items(rawDocument);
+
+      DocumentsResolver resolver =
+          new AnyFiltersResolver(
+              Arrays.asList((c) -> candidatesFilter, (c) -> candidatesFilter2),
+              executionContext,
+              candidatesResolver);
+      resolver
+          .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, new Paginator(null, 1))
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(1))
+          .awaitCompletion()
+          .assertCompleted()
+          .assertHasNotReceivedAnyItem();
+
+      resetExpectations();
+
+      verify(candidatesFilter).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      verify(candidatesFilter2).prepareQuery(KEYSPACE_NAME, COLLECTION_NAME);
+      verify(candidatesFilter).bindAndFilter(queryExecutor, query1Final, rawDocument);
+      verify(candidatesFilter2).bindAndFilter(queryExecutor, query2Final, rawDocument);
+      verifyNoMoreInteractions(candidatesFilter, candidatesFilter2);
+    }
+
+    @Test
+    public void noCandidates() {
+      withAnySelectFrom(KEYSPACE_NAME, COLLECTION_NAME).returningNothing();
+
+      DocumentsResolver candidatesResolver =
+          (queryExecutor1, keyspace, collection, paginator) -> Multi.createFrom().empty();
+
+      DocumentsResolver resolver =
+          new AnyFiltersResolver(
+              Arrays.asList((c) -> candidatesFilter, (c) -> candidatesFilter2),
+              executionContext,
+              candidatesResolver);
+      resolver
+          .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, new Paginator(null, 1))
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(1))
+          .awaitCompletion()
+          .assertCompleted()
+          .assertHasNotReceivedAnyItem();
+
+      resetExpectations();
+      verifyNoMoreInteractions(candidatesFilter, candidatesFilter2);
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/InMemoryDocumentsResolverTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/InMemoryDocumentsResolverTest.java
@@ -1,0 +1,474 @@
+package io.stargate.sgv2.docsapi.service.query.search.resolver.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.DocsApiTestSchemaProvider;
+import io.stargate.sgv2.docsapi.OpenMocksTest;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.bridge.AbstractValidatingStargateBridgeTest;
+import io.stargate.sgv2.docsapi.bridge.ValidatingStargateBridge;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.common.model.Paginator;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.FilterPath;
+import io.stargate.sgv2.docsapi.service.query.ImmutableFilterPath;
+import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
+import io.stargate.sgv2.docsapi.service.query.executor.QueryExecutor;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.DocumentsResolver;
+import io.stargate.sgv2.docsapi.testprofiles.MaxDepth8TestProfile;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.inject.Inject;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+@QuarkusTest
+@TestProfile(MaxDepth8TestProfile.class)
+class InMemoryDocumentsResolverTest extends AbstractValidatingStargateBridgeTest {
+
+  private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
+  private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
+
+  @Inject DocumentProperties documentProperties;
+
+  @Inject QueryExecutor queryExecutor;
+
+  @Inject DocsApiTestSchemaProvider schemaProvider;
+
+  @Nested
+  class Constructor implements OpenMocksTest {
+
+    @Mock FilterExpression filterExpression;
+
+    @Mock BaseCondition baseCondition;
+
+    @Test
+    public void noPersistenceConditions() {
+      when(baseCondition.isPersistenceCondition()).thenReturn(true);
+      when(filterExpression.getCondition()).thenReturn(baseCondition);
+
+      Throwable throwable =
+          catchThrowable(
+              () -> new InMemoryDocumentsResolver(filterExpression, null, documentProperties));
+
+      assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  class GetDocuments implements OpenMocksTest {
+
+    @Mock FilterExpression filterExpression;
+
+    @Mock FilterExpression filterExpression2;
+
+    @Mock BaseCondition baseCondition;
+
+    ExecutionContext executionContext;
+
+    @BeforeEach
+    public void init() {
+      executionContext = ExecutionContext.create(true);
+      when(baseCondition.isPersistenceCondition()).thenReturn(false);
+      when(filterExpression.getCondition()).thenReturn(baseCondition);
+    }
+
+    @Test
+    public void happyPath() throws Exception {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.test(Mockito.<RawDocument>any())).thenReturn(true);
+      when(filterExpression.getDescription()).thenReturn("field EQ something");
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, p0, p1, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""))
+              .withPageSize(pageSize + 1)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(Collections.singletonList(ImmutableList.of(Values.of("1"))));
+
+      DocumentsResolver resolver =
+          new InMemoryDocumentsResolver(filterExpression, executionContext, documentProperties);
+      List<RawDocument> result =
+          resolver
+              .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(1))
+              .awaitItems(1)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      assertThat(result)
+          .singleElement()
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(1);
+              });
+
+      // one query only
+      queryAssert.assertExecuteCount().isEqualTo(1);
+      verify(filterExpression, times(1)).test(Mockito.<RawDocument>any());
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description()).isEqualTo("FILTER IN MEMORY: field EQ something");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+    }
+
+    @Test
+    public void happyPathEvalOnMissing() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      when(baseCondition.isEvaluateOnMissingFields()).thenReturn(true);
+      when(filterExpression.test(Mockito.<RawDocument>any())).thenReturn(true);
+      when(filterExpression.getDescription()).thenReturn("field EQ something");
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, p0, p1, p2, p3, p4, p5, p6, p7, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\""
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME))
+              .withPageSize(documentProperties.getApproximateStoragePageSize(pageSize))
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(Collections.singletonList(ImmutableList.of(Values.of("1"))));
+
+      DocumentsResolver resolver =
+          new InMemoryDocumentsResolver(filterExpression, executionContext, documentProperties);
+      List<RawDocument> result =
+          resolver
+              .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(1))
+              .awaitItems(1)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      assertThat(result)
+          .singleElement()
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(1);
+              });
+
+      // one query only
+      queryAssert.assertExecuteCount().isEqualTo(1);
+      verify(filterExpression, times(1)).test(Mockito.<RawDocument>any());
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description()).isEqualTo("FILTER IN MEMORY: field EQ something");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+    }
+
+    @Test
+    public void happyPathMultipleExpressions() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.getDescription()).thenReturn("field EQ something");
+      when(filterExpression2.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression2.getCondition()).thenReturn(baseCondition);
+      when(filterExpression2.getDescription()).thenReturn("field GT something");
+      when(filterExpression.test(Mockito.<RawDocument>any())).thenReturn(true);
+      when(filterExpression2.test(Mockito.<RawDocument>any())).thenReturn(false);
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, p0, p1, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""))
+              .withPageSize(pageSize + 1)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(Collections.singletonList(ImmutableList.of(Values.of("1"))));
+
+      DocumentsResolver resolver =
+          new InMemoryDocumentsResolver(
+              Arrays.asList(filterExpression, filterExpression2),
+              executionContext,
+              documentProperties);
+      resolver
+          .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(1))
+          .awaitCompletion()
+          .assertCompleted()
+          .assertHasNotReceivedAnyItem();
+
+      // one query only
+      queryAssert.assertExecuteCount().isEqualTo(1);
+      verify(filterExpression, times(1)).test(Mockito.<RawDocument>any());
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo("FILTER IN MEMORY: field EQ something AND field GT something");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+    }
+
+    @Test
+    public void multipleDocuments() {
+      int pageSize = 10;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.test(Mockito.<RawDocument>any())).thenReturn(true);
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, p0, p1, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""))
+              .withPageSize(pageSize + 1)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(
+                  Arrays.asList(
+                      ImmutableList.of(Values.of("1")), ImmutableList.of(Values.of("2"))));
+
+      DocumentsResolver resolver =
+          new InMemoryDocumentsResolver(filterExpression, executionContext, documentProperties);
+      List<RawDocument> result =
+          resolver
+              .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(2))
+              .awaitItems(2)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      assertThat(result).hasSize(2);
+      assertThat(result.get(0))
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(1);
+              });
+      assertThat(result.get(1))
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("2");
+                assertThat(doc.rows()).hasSize(1);
+              });
+
+      // one query only
+      queryAssert.assertExecuteCount().isEqualTo(1);
+      verify(filterExpression, times(2)).test(Mockito.<RawDocument>any());
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested ->
+                  assertThat(nested.queries())
+                      .singleElement()
+                      .satisfies(
+                          queryInfo -> {
+                            assertThat(queryInfo.execCount()).isEqualTo(1);
+                            assertThat(queryInfo.rowCount()).isEqualTo(2);
+                          }));
+    }
+
+    @Test
+    public void nothingReturnedFromDataStore() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, p0, p1, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""))
+              .withPageSize(pageSize + 1)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returningNothing();
+
+      DocumentsResolver resolver =
+          new InMemoryDocumentsResolver(filterExpression, executionContext, documentProperties);
+      resolver
+          .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(1))
+          .awaitCompletion()
+          .assertCompleted()
+          .assertHasNotReceivedAnyItem();
+
+      // one query only
+      queryAssert.assertExecuteCount().isEqualTo(1);
+      verify(filterExpression, times(0)).test(Mockito.<RawDocument>any());
+    }
+
+    @Test
+    public void complexFilterPath() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("field", "nested", "value"));
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.test(Mockito.<RawDocument>any())).thenReturn(true);
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 = ? AND p2 = ? AND leaf = ? AND p3 = ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("nested"),
+                  Values.of("value"),
+                  Values.of("value"),
+                  Values.of(""))
+              .withPageSize(pageSize + 1)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(Collections.singletonList(ImmutableList.of(Values.of("1"))));
+
+      DocumentsResolver resolver =
+          new InMemoryDocumentsResolver(filterExpression, executionContext, documentProperties);
+      List<RawDocument> result =
+          resolver
+              .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(1))
+              .awaitItems(1)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      assertThat(result)
+          .singleElement()
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(1);
+              });
+
+      // one query only
+      queryAssert.assertExecuteCount().isEqualTo(1);
+      verify(filterExpression, times(1)).test(Mockito.<RawDocument>any());
+    }
+
+    @Test
+    public void testNotPassed() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.test(Mockito.<RawDocument>any())).thenReturn(false);
+      when(filterExpression.getDescription()).thenReturn("field EQ something");
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, p0, p1, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""))
+              .withPageSize(pageSize + 1)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(Collections.singletonList(ImmutableList.of(Values.of("1"))));
+
+      DocumentsResolver resolver =
+          new InMemoryDocumentsResolver(filterExpression, executionContext, documentProperties);
+      resolver
+          .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(1))
+          .awaitCompletion()
+          .assertCompleted()
+          .assertHasNotReceivedAnyItem();
+
+      // one query only
+      queryAssert.assertExecuteCount().isEqualTo(1);
+      verify(filterExpression, times(1)).test(Mockito.<RawDocument>any());
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description()).isEqualTo("FILTER IN MEMORY: field EQ something");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolverTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/OrExpressionDocumentsResolverTest.java
@@ -1,0 +1,1086 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.resolver.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bpodgursky.jbool_expressions.Or;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.DocsApiTestSchemaProvider;
+import io.stargate.sgv2.docsapi.OpenMocksTest;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.bridge.AbstractValidatingStargateBridgeTest;
+import io.stargate.sgv2.docsapi.bridge.ValidatingStargateBridge;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.common.model.Paginator;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.FilterPath;
+import io.stargate.sgv2.docsapi.service.query.ImmutableFilterExpression;
+import io.stargate.sgv2.docsapi.service.query.ImmutableFilterPath;
+import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
+import io.stargate.sgv2.docsapi.service.query.condition.impl.ImmutableGenericCondition;
+import io.stargate.sgv2.docsapi.service.query.condition.impl.ImmutableNumberCondition;
+import io.stargate.sgv2.docsapi.service.query.condition.impl.ImmutableStringCondition;
+import io.stargate.sgv2.docsapi.service.query.executor.QueryExecutor;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.EqFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.GtFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.InFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.LtFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.NeFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.DocumentsResolver;
+import io.stargate.sgv2.docsapi.testprofiles.MaxDepth4TestProfile;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import javax.inject.Inject;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+@QuarkusTest
+@TestProfile(MaxDepth4TestProfile.class)
+class OrExpressionDocumentsResolverTest extends AbstractValidatingStargateBridgeTest {
+
+  public static final Function<List<QueryOuterClass.Value>, ByteBuffer>
+      FIRST_COLUMN_COMPARABLE_KEY = row -> ByteBuffer.wrap(row.get(0).getString().getBytes());
+
+  private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
+  private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
+
+  @Inject DocumentProperties documentProperties;
+
+  @Inject QueryExecutor queryExecutor;
+
+  @Inject DocsApiTestSchemaProvider schemaProvider;
+
+  @Nested
+  class GetDocuments implements OpenMocksTest {
+
+    ExecutionContext executionContext;
+
+    @BeforeEach
+    public void init() {
+      executionContext = ExecutionContext.create(true);
+    }
+
+    @Test
+    public void twoPersistenceConditions() {
+      int pageSize = 10;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(GtFilterOperation.of(), "query-value", documentProperties);
+      BaseCondition condition2 =
+          ImmutableNumberCondition.of(LtFilterOperation.of(), 1, documentProperties);
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingStargateBridge.QueryAssert query1Assert =
+          withQuery(
+                  "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND text_value > ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of("query-value"))
+              .withPageSize(pageSize + 1)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpecForPathDepth(0))
+              .withComparableKey(FIRST_COLUMN_COMPARABLE_KEY)
+              .returning(Collections.singletonList(ImmutableList.of(Values.of("1"))));
+
+      ValidatingStargateBridge.QueryAssert query2Assert =
+          withQuery(
+                  "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND dbl_value < ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of(1d))
+              .withPageSize(pageSize + 1)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpecForPathDepth(0))
+              .withComparableKey(FIRST_COLUMN_COMPARABLE_KEY)
+              .returning(Collections.singletonList(ImmutableList.of(Values.of("1"))));
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver =
+          new OrExpressionDocumentsResolver(or, executionContext, documentProperties);
+      List<RawDocument> result =
+          resolver
+              .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(1))
+              .awaitItems(1)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      assertThat(result)
+          .singleElement()
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(1);
+              });
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+      query2Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo("MERGING OR: expression '(field GT query-value | field LT 1)'");
+                assertThat(nested.queries())
+                    .hasSize(2)
+                    .allSatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+    }
+
+    @Test
+    public void twoPersistenceConditionsTwoDocuments() {
+      int pageSize = 10;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(GtFilterOperation.of(), "query-value", documentProperties);
+      BaseCondition condition2 =
+          ImmutableNumberCondition.of(LtFilterOperation.of(), 1, documentProperties);
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingStargateBridge.QueryAssert query1Assert =
+          withQuery(
+                  "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND text_value > ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of("query-value"))
+              .withPageSize(pageSize + 1)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpecForPathDepth(0))
+              .withComparableKey(FIRST_COLUMN_COMPARABLE_KEY)
+              .returning(Collections.singletonList(ImmutableList.of(Values.of("2"))));
+
+      ValidatingStargateBridge.QueryAssert query2Assert =
+          withQuery(
+                  "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND dbl_value < ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of(1d))
+              .withPageSize(pageSize + 1)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpecForPathDepth(0))
+              .withComparableKey(FIRST_COLUMN_COMPARABLE_KEY)
+              .returning(Collections.singletonList(ImmutableList.of(Values.of("1"))));
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver =
+          new OrExpressionDocumentsResolver(or, executionContext, documentProperties);
+      List<RawDocument> result =
+          resolver
+              .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(2))
+              .awaitItems(2)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      assertThat(result).hasSize(2);
+      assertThat(result.get(0))
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(1);
+              });
+      assertThat(result.get(1))
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("2");
+                assertThat(doc.rows()).hasSize(1);
+              });
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+      query2Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo("MERGING OR: expression '(field GT query-value | field LT 1)'");
+                assertThat(nested.queries())
+                    .hasSize(2)
+                    .allSatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+    }
+
+    @Test
+    public void twoPersistenceConditionsOneQueryEmpty() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(GtFilterOperation.of(), "query-value", documentProperties);
+      BaseCondition condition2 =
+          ImmutableNumberCondition.of(LtFilterOperation.of(), 1, documentProperties);
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingStargateBridge.QueryAssert query1Assert =
+          withQuery(
+                  "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND text_value > ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of("query-value"))
+              .withPageSize(2)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(Collections.singletonList(ImmutableList.of(Values.of("1"))));
+
+      ValidatingStargateBridge.QueryAssert query2Assert =
+          withQuery(
+                  "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND dbl_value < ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of(1d))
+              .withPageSize(2)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returningNothing();
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver =
+          new OrExpressionDocumentsResolver(or, executionContext, documentProperties);
+      List<RawDocument> result =
+          resolver
+              .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(1))
+              .awaitItems(1)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      assertThat(result)
+          .singleElement()
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(1);
+              });
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+      query2Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo("MERGING OR: expression '(field GT query-value | field LT 1)'");
+                assertThat(nested.queries())
+                    .hasSize(2)
+                    .anySatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        })
+                    .anySatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(0);
+                        });
+              });
+    }
+
+    @Test
+    public void twoPersistenceConditionsNothingReturned() {
+      int pageSize = 2;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(GtFilterOperation.of(), "query-value", documentProperties);
+      BaseCondition condition2 =
+          ImmutableNumberCondition.of(LtFilterOperation.of(), 1, documentProperties);
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingStargateBridge.QueryAssert query1Assert =
+          withQuery(
+                  "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND text_value > ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of("query-value"))
+              .withPageSize(pageSize + 1)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returningNothing();
+
+      ValidatingStargateBridge.QueryAssert query2Assert =
+          withQuery(
+                  "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND dbl_value < ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of(1d))
+              .withPageSize(pageSize + 1)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returningNothing();
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver =
+          new OrExpressionDocumentsResolver(or, executionContext, documentProperties);
+      resolver
+          .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(1))
+          .awaitCompletion()
+          .assertCompleted()
+          .assertHasNotReceivedAnyItem();
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+      query2Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo("MERGING OR: expression '(field GT query-value | field LT 1)'");
+                assertThat(nested.queries())
+                    .hasSize(2)
+                    .allSatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(0);
+                        });
+              });
+    }
+
+    @Test
+    public void persistenceAndInMemoryConditionPersistenceTrue() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(EqFilterOperation.of(), "query-value", documentProperties);
+      BaseCondition condition2 =
+          ImmutableGenericCondition.of(
+              InFilterOperation.of(), Collections.singletonList(1), documentProperties, false);
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingStargateBridge.QueryAssert query1Assert =
+          withQuery(
+                  "SELECT key, p0, p1, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND text_value = ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of("query-value"))
+              .withPageSize(2)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpecForPathDepth(2))
+              .returning(
+                  Collections.singletonList(
+                      ImmutableList.of(
+                          Values.of("1"),
+                          Values.of("field"),
+                          Values.of(""),
+                          Values.of("field"),
+                          Values.of("query-value"),
+                          Values.NULL,
+                          Values.NULL)));
+
+      ValidatingStargateBridge.QueryAssert query2Assert =
+          withQuery(
+                  "SELECT key, p0, p1, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""))
+              .withPageSize(2)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpecForPathDepth(2))
+              .returning(
+                  Collections.singletonList(
+                      ImmutableList.of(
+                          Values.of("1"),
+                          Values.of("field"),
+                          Values.of(""),
+                          Values.of("field"),
+                          Values.NULL,
+                          Values.of(2d),
+                          Values.NULL)));
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver =
+          new OrExpressionDocumentsResolver(or, executionContext, documentProperties);
+      List<RawDocument> result =
+          resolver
+              .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(1))
+              .awaitItems(1)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      assertThat(result)
+          .singleElement()
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(1);
+              });
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+      query2Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo("MERGING OR: expression '(field EQ query-value | field IN [1])'");
+                assertThat(nested.queries())
+                    .hasSize(2)
+                    .allSatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+    }
+
+    @Test
+    public void persistenceAndInMemoryConditionMemoryTrue() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(GtFilterOperation.of(), "query-value", documentProperties);
+      BaseCondition condition2 =
+          ImmutableGenericCondition.of(
+              InFilterOperation.of(), Collections.singletonList(1), documentProperties, false);
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingStargateBridge.QueryAssert query1Assert =
+          withQuery(
+                  "SELECT key, p0, p1, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND text_value > ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of("query-value"))
+              .withPageSize(2)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpecForPathDepth(2))
+              .returningNothing();
+
+      ValidatingStargateBridge.QueryAssert query2Assert =
+          withQuery(
+                  "SELECT key, p0, p1, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""))
+              .withPageSize(2)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpecForPathDepth(2))
+              .returning(
+                  Collections.singletonList(
+                      ImmutableList.of(
+                          Values.of("1"),
+                          Values.of("field"),
+                          Values.of(""),
+                          Values.of("field"),
+                          Values.NULL,
+                          Values.of(1d),
+                          Values.NULL)));
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver =
+          new OrExpressionDocumentsResolver(or, executionContext, documentProperties);
+      List<RawDocument> result =
+          resolver
+              .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(1))
+              .awaitItems(1)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      assertThat(result)
+          .singleElement()
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(1);
+              });
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+      query2Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo("MERGING OR: expression '(field GT query-value | field IN [1])'");
+                assertThat(nested.queries())
+                    .hasSize(2)
+                    .anySatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        })
+                    .anySatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(0);
+                        });
+              });
+    }
+
+    @Test
+    public void persistenceAndInMemoryConditionMemoryFalse() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(GtFilterOperation.of(), "query-value", documentProperties);
+      BaseCondition condition2 =
+          ImmutableGenericCondition.of(
+              InFilterOperation.of(), Collections.singletonList(1), documentProperties, false);
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingStargateBridge.QueryAssert query1Assert =
+          withQuery(
+                  "SELECT key, p0, p1, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND text_value > ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of("query-value"))
+              .withPageSize(2)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpecForPathDepth(2))
+              .returningNothing();
+
+      ValidatingStargateBridge.QueryAssert query2Assert =
+          withQuery(
+                  "SELECT key, p0, p1, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""))
+              .withPageSize(2)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpecForPathDepth(2))
+              .returning(
+                  Collections.singletonList(
+                      ImmutableList.of(
+                          Values.of("1"),
+                          Values.of("field"),
+                          Values.of(""),
+                          Values.of("field"),
+                          Values.NULL,
+                          Values.of(2d),
+                          Values.NULL)));
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver =
+          new OrExpressionDocumentsResolver(or, executionContext, documentProperties);
+      resolver
+          .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(1))
+          .awaitCompletion()
+          .assertCompleted()
+          .assertHasNotReceivedAnyItem();
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+      query2Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo("MERGING OR: expression '(field GT query-value | field IN [1])'");
+                assertThat(nested.queries())
+                    .hasSize(2)
+                    .anySatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        })
+                    .anySatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(0);
+                        });
+              });
+    }
+
+    @Test
+    public void persistenceAndInMemoryConditionNothingReturned() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("path", "field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(GtFilterOperation.of(), "query-value", documentProperties);
+      BaseCondition condition2 =
+          ImmutableGenericCondition.of(
+              InFilterOperation.of(), Collections.singletonList(1), documentProperties, false);
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingStargateBridge.QueryAssert query1Assert =
+          withQuery(
+                  "SELECT key, p0, p1, p2, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 = ? AND leaf = ? AND p2 = ? AND text_value > ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("path"),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of("query-value"))
+              .withPageSize(2)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpecForPathDepth(3))
+              .returningNothing();
+
+      ValidatingStargateBridge.QueryAssert query2Assert =
+          withQuery(
+                  "SELECT key, p0, p1, p2, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 = ? AND leaf = ? AND p2 = ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("path"),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""))
+              .withPageSize(2)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpecForPathDepth(3))
+              .returningNothing();
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver =
+          new OrExpressionDocumentsResolver(or, executionContext, documentProperties);
+      resolver
+          .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(1))
+          .awaitCompletion()
+          .assertCompleted()
+          .assertHasNotReceivedAnyItem();
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+      query2Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo(
+                        "MERGING OR: expression '(path.field GT query-value | path.field IN [1])'");
+                assertThat(nested.queries())
+                    .hasSize(2)
+                    .allSatisfy(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(0);
+                        });
+              });
+    }
+
+    @Test
+    public void persistenceAndEvaluateOnMissing() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(GtFilterOperation.of(), "query-value", documentProperties);
+      BaseCondition condition2 =
+          ImmutableStringCondition.of(NeFilterOperation.of(), "not-me", documentProperties);
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingStargateBridge.QueryAssert query1Assert =
+          withQuery(
+                  "SELECT key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\""
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME))
+              .withPageSize(documentProperties.getApproximateStoragePageSize(pageSize))
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpecForPathDepth(3))
+              .returning(
+                  Collections.singletonList(
+                      ImmutableList.of(
+                          Values.of("1"),
+                          Values.of("field"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("field"),
+                          Values.of("whatever"),
+                          Values.NULL,
+                          Values.NULL)));
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver =
+          new OrExpressionDocumentsResolver(or, executionContext, documentProperties);
+      List<RawDocument> result =
+          resolver
+              .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(1))
+              .awaitItems(1)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      assertThat(result)
+          .singleElement()
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(1);
+              });
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo("MERGING OR: expression '(field GT query-value | field NE not-me)'");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+    }
+
+    @Test
+    public void persistenceAndEvaluateOnMissingNotMatched() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(GtFilterOperation.of(), "query-value", documentProperties);
+      BaseCondition condition2 =
+          ImmutableStringCondition.of(NeFilterOperation.of(), "not-me", documentProperties);
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingStargateBridge.QueryAssert query1Assert =
+          withQuery(
+                  "SELECT key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\""
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME))
+              .withPageSize(documentProperties.getApproximateStoragePageSize(pageSize))
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpecForPathDepth(3))
+              .returning(
+                  Collections.singletonList(
+                      ImmutableList.of(
+                          Values.of("1"),
+                          Values.of("field"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("field"),
+                          Values.of("not-me"),
+                          Values.NULL,
+                          Values.NULL)));
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver =
+          new OrExpressionDocumentsResolver(or, executionContext, documentProperties);
+      resolver
+          .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(1))
+          .awaitCompletion()
+          .assertCompleted()
+          .assertHasNotReceivedAnyItem();
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo("MERGING OR: expression '(field GT query-value | field NE not-me)'");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+    }
+
+    @Test
+    public void inMemoryAndEvaluateOnMissing() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition =
+          ImmutableGenericCondition.of(
+              InFilterOperation.of(),
+              Collections.singletonList("query-value"),
+              documentProperties,
+              false);
+      BaseCondition condition2 =
+          ImmutableStringCondition.of(NeFilterOperation.of(), "not-me", documentProperties);
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingStargateBridge.QueryAssert query1Assert =
+          withQuery(
+                  "SELECT key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\""
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME))
+              .withPageSize(documentProperties.getApproximateStoragePageSize(pageSize))
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpecForPathDepth(3))
+              .returning(
+                  Collections.singletonList(
+                      ImmutableList.of(
+                          Values.of("1"),
+                          Values.of("field"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("field"),
+                          Values.of("query-value"),
+                          Values.NULL,
+                          Values.NULL)));
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver =
+          new OrExpressionDocumentsResolver(or, executionContext, documentProperties);
+      List<RawDocument> result =
+          resolver
+              .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(1))
+              .awaitItems(1)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      assertThat(result)
+          .singleElement()
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(1);
+              });
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo(
+                        "MERGING OR: expression '(field IN [query-value] | field NE not-me)'");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+    }
+
+    @Test
+    public void inMemoryAndEvaluateOnMissingNotMatching() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singletonList("field"));
+      BaseCondition condition =
+          ImmutableGenericCondition.of(
+              InFilterOperation.of(),
+              Collections.singletonList("query-value"),
+              documentProperties,
+              false);
+      BaseCondition condition2 =
+          ImmutableStringCondition.of(NeFilterOperation.of(), "not-me", documentProperties);
+      ImmutableFilterExpression filterExpression1 =
+          ImmutableFilterExpression.of(filterPath, condition, 0);
+      ImmutableFilterExpression filterExpression2 =
+          ImmutableFilterExpression.of(filterPath, condition2, 1);
+
+      ValidatingStargateBridge.QueryAssert query1Assert =
+          withQuery(
+                  "SELECT key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\""
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME))
+              .withPageSize(documentProperties.getApproximateStoragePageSize(pageSize))
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpecForPathDepth(3))
+              .returning(
+                  Collections.singletonList(
+                      ImmutableList.of(
+                          Values.of("1"),
+                          Values.of("field"),
+                          Values.of(""),
+                          Values.of(""),
+                          Values.of("field"),
+                          Values.of("not-me"),
+                          Values.NULL,
+                          Values.NULL)));
+
+      Or<FilterExpression> or = Or.of(filterExpression1, filterExpression2);
+      DocumentsResolver resolver =
+          new OrExpressionDocumentsResolver(or, executionContext, documentProperties);
+      resolver
+          .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(1))
+          .awaitCompletion()
+          .assertCompleted()
+          .assertHasNotReceivedAnyItem();
+
+      // each query run
+      query1Assert.assertExecuteCount().isEqualTo(1);
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo(
+                        "MERGING OR: expression '(field IN [query-value] | field NE not-me)'");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/PersistenceDocumentsResolverTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/PersistenceDocumentsResolverTest.java
@@ -1,0 +1,395 @@
+package io.stargate.sgv2.docsapi.service.query.search.resolver.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.DocsApiTestSchemaProvider;
+import io.stargate.sgv2.docsapi.OpenMocksTest;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.bridge.AbstractValidatingStargateBridgeTest;
+import io.stargate.sgv2.docsapi.bridge.ValidatingStargateBridge;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.common.model.Paginator;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.FilterPath;
+import io.stargate.sgv2.docsapi.service.query.ImmutableFilterPath;
+import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
+import io.stargate.sgv2.docsapi.service.query.condition.impl.ImmutableNumberCondition;
+import io.stargate.sgv2.docsapi.service.query.condition.impl.ImmutableStringCondition;
+import io.stargate.sgv2.docsapi.service.query.executor.QueryExecutor;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.EqFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.GtFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.GteFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.LtFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.filter.operation.impl.LteFilterOperation;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.DocumentsResolver;
+import io.stargate.sgv2.docsapi.testprofiles.MaxDepth8TestProfile;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.inject.Inject;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+@QuarkusTest
+@TestProfile(MaxDepth8TestProfile.class)
+class PersistenceDocumentsResolverTest extends AbstractValidatingStargateBridgeTest {
+
+  private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
+  private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
+
+  @Inject DocumentProperties documentProperties;
+
+  @Inject QueryExecutor queryExecutor;
+
+  @Inject DocsApiTestSchemaProvider schemaProvider;
+
+  @Nested
+  class Constructor implements OpenMocksTest {
+
+    @Mock FilterExpression filterExpression;
+
+    @Mock BaseCondition baseCondition;
+
+    @Test
+    public void noInMemoryConditions() {
+      when(baseCondition.isPersistenceCondition()).thenReturn(false);
+      when(filterExpression.getCondition()).thenReturn(baseCondition);
+
+      Throwable throwable =
+          catchThrowable(
+              () -> new PersistenceDocumentsResolver(filterExpression, null, documentProperties));
+
+      assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  class GetDocuments implements OpenMocksTest {
+
+    @Mock FilterExpression filterExpression;
+
+    @Mock FilterExpression filterExpression2;
+
+    ExecutionContext executionContext;
+
+    @BeforeEach
+    public void init() {
+      executionContext = ExecutionContext.create(true);
+    }
+
+    @Test
+    public void happyPath() throws Exception {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(GtFilterOperation.of(), "query-value", documentProperties);
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.getCondition()).thenReturn(condition);
+      when(filterExpression.getDescription()).thenReturn("field EQ something");
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND text_value > ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of("query-value"))
+              .withPageSize(pageSize + 1)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(Collections.singletonList(ImmutableList.of(Values.of("1"))));
+
+      DocumentsResolver resolver =
+          new PersistenceDocumentsResolver(filterExpression, executionContext, documentProperties);
+      List<RawDocument> result =
+          resolver
+              .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(1))
+              .awaitItems(1)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      assertThat(result)
+          .singleElement()
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(1);
+              });
+
+      // one query only
+      queryAssert.assertExecuteCount().isEqualTo(1);
+      verify(filterExpression, never()).test(Mockito.<RawDocument>any());
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description()).isEqualTo("FILTER: field EQ something");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+    }
+
+    @Test
+    public void happyPathMultipleExpressions() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      BaseCondition condition =
+          ImmutableNumberCondition.of(GteFilterOperation.of(), 1d, documentProperties);
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.getCondition()).thenReturn(condition);
+      when(filterExpression.getDescription()).thenReturn("field LTE something");
+      BaseCondition condition2 =
+          ImmutableNumberCondition.of(LteFilterOperation.of(), 2d, documentProperties);
+      when(filterExpression2.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression2.getCondition()).thenReturn(condition2);
+      when(filterExpression2.getDescription()).thenReturn("field GTE something");
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND dbl_value >= ? AND dbl_value <= ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of(1.0),
+                  Values.of(2.0))
+              .withPageSize(pageSize + 1)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(Collections.singletonList(ImmutableList.of(Values.of("1"))));
+
+      DocumentsResolver resolver =
+          new PersistenceDocumentsResolver(
+              Arrays.asList(filterExpression, filterExpression2),
+              executionContext,
+              documentProperties);
+      List<RawDocument> result =
+          resolver
+              .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(1))
+              .awaitItems(1)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      assertThat(result)
+          .singleElement()
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(1);
+              });
+
+      // one query only
+      queryAssert.assertExecuteCount().isEqualTo(1);
+      verify(filterExpression, never()).test(Mockito.<RawDocument>any());
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .isEqualTo("FILTER: field LTE something AND field GTE something");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(1);
+                        });
+              });
+    }
+
+    @Test
+    public void multipleDocuments() {
+      int pageSize = 10;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(LtFilterOperation.of(), "query-value", documentProperties);
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.getCondition()).thenReturn(condition);
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND text_value < ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of("query-value"))
+              .withPageSize(pageSize + 1)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(
+                  Arrays.asList(
+                      ImmutableList.of(Values.of("1")), ImmutableList.of(Values.of("2"))));
+
+      DocumentsResolver resolver =
+          new PersistenceDocumentsResolver(filterExpression, executionContext, documentProperties);
+      List<RawDocument> result =
+          resolver
+              .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(2))
+              .awaitItems(2)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      assertThat(result).hasSize(2);
+      assertThat(result.get(0))
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(1);
+              });
+      assertThat(result.get(1))
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("2");
+                assertThat(doc.rows()).hasSize(1);
+              });
+
+      // one query only
+      queryAssert.assertExecuteCount().isEqualTo(1);
+      verify(filterExpression, never()).test(Mockito.<RawDocument>any());
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested ->
+                  assertThat(nested.queries())
+                      .singleElement()
+                      .satisfies(
+                          queryInfo -> {
+                            assertThat(queryInfo.execCount()).isEqualTo(1);
+                            assertThat(queryInfo.rowCount()).isEqualTo(2);
+                          }));
+    }
+
+    @Test
+    public void nothingReturnedFromDataStore() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Collections.singleton("field"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(EqFilterOperation.of(), "query-value", documentProperties);
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.getCondition()).thenReturn(condition);
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND leaf = ? AND p1 = ? AND text_value = ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("field"),
+                  Values.of(""),
+                  Values.of("query-value"))
+              .withPageSize(pageSize + 1)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returningNothing();
+
+      DocumentsResolver resolver =
+          new PersistenceDocumentsResolver(filterExpression, executionContext, documentProperties);
+      resolver
+          .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(1))
+          .awaitCompletion()
+          .assertCompleted()
+          .assertHasNotReceivedAnyItem();
+
+      // one query only
+      queryAssert.assertExecuteCount().isEqualTo(1);
+      verify(filterExpression, never()).test(Mockito.<RawDocument>any());
+    }
+
+    @Test
+    public void complexFilterPath() {
+      int pageSize = 1;
+      Paginator paginator = new Paginator(null, pageSize);
+      FilterPath filterPath = ImmutableFilterPath.of(Arrays.asList("field", "nested", "value"));
+      BaseCondition condition =
+          ImmutableStringCondition.of(EqFilterOperation.of(), "query-value", documentProperties);
+      when(filterExpression.getFilterPath()).thenReturn(filterPath);
+      when(filterExpression.getCondition()).thenReturn(condition);
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, leaf, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND p1 = ? AND p2 = ? AND leaf = ? AND p3 = ? AND text_value = ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("field"),
+                  Values.of("nested"),
+                  Values.of("value"),
+                  Values.of("value"),
+                  Values.of(""),
+                  Values.of("query-value"))
+              .withPageSize(pageSize + 1)
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_PARTITION)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(Collections.singletonList(ImmutableList.of(Values.of("1"))));
+
+      DocumentsResolver resolver =
+          new PersistenceDocumentsResolver(filterExpression, executionContext, documentProperties);
+      List<RawDocument> result =
+          resolver
+              .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(1))
+              .awaitItems(1)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      assertThat(result)
+          .singleElement()
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(1);
+              });
+
+      // one query only
+      queryAssert.assertExecuteCount().isEqualTo(1);
+      verify(filterExpression, never()).test(Mockito.<RawDocument>any());
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/SubDocumentsResolverTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/SubDocumentsResolverTest.java
@@ -1,0 +1,525 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.query.search.resolver.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.bpodgursky.jbool_expressions.Or;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.docsapi.DocsApiTestSchemaProvider;
+import io.stargate.sgv2.docsapi.OpenMocksTest;
+import io.stargate.sgv2.docsapi.api.common.properties.document.DocumentProperties;
+import io.stargate.sgv2.docsapi.bridge.AbstractValidatingStargateBridgeTest;
+import io.stargate.sgv2.docsapi.bridge.ValidatingStargateBridge;
+import io.stargate.sgv2.docsapi.service.ExecutionContext;
+import io.stargate.sgv2.docsapi.service.common.model.Paginator;
+import io.stargate.sgv2.docsapi.service.common.model.RowWrapper;
+import io.stargate.sgv2.docsapi.service.query.FilterExpression;
+import io.stargate.sgv2.docsapi.service.query.condition.BaseCondition;
+import io.stargate.sgv2.docsapi.service.query.executor.QueryExecutor;
+import io.stargate.sgv2.docsapi.service.query.model.RawDocument;
+import io.stargate.sgv2.docsapi.service.query.search.resolver.DocumentsResolver;
+import io.stargate.sgv2.docsapi.testprofiles.MaxDepth4TestProfile;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.inject.Inject;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+@QuarkusTest
+@TestProfile(MaxDepth4TestProfile.class)
+class SubDocumentsResolverTest extends AbstractValidatingStargateBridgeTest {
+
+  private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
+  private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
+
+  @Inject DocumentProperties documentProperties;
+
+  @Inject QueryExecutor queryExecutor;
+
+  @Inject DocsApiTestSchemaProvider schemaProvider;
+
+  @Nested
+  class GetDocuments implements OpenMocksTest {
+
+    @Mock FilterExpression filterExpression;
+
+    @Mock FilterExpression filterExpression2;
+
+    @Mock BaseCondition condition;
+
+    @Captor ArgumentCaptor<List<RowWrapper>> rowsCaptor;
+
+    ExecutionContext executionContext;
+
+    @BeforeEach
+    public void init() {
+      executionContext = ExecutionContext.create(true);
+      lenient().when(filterExpression.getExprType()).thenReturn(FilterExpression.EXPR_TYPE);
+      lenient().when(filterExpression.getCondition()).thenReturn(condition);
+      lenient().when(filterExpression2.getExprType()).thenReturn(FilterExpression.EXPR_TYPE);
+      lenient().when(filterExpression2.getCondition()).thenReturn(condition);
+    }
+
+    @Test
+    public void happyPath() throws Exception {
+      int pageSize = 1;
+      String documentId = RandomStringUtils.randomAlphanumeric(16);
+      List<String> subDocumentPath = Collections.singletonList("parent");
+      Paginator paginator = new Paginator(null, pageSize);
+      when(filterExpression.test(anyList())).thenReturn(true);
+      when(filterExpression.matchesFilterPath(any())).thenReturn(true);
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND key = ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("parent"),
+                  Values.of(documentId))
+              .withPageSize(documentProperties.getApproximateStoragePageSize(pageSize))
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_ROW)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(
+                  Arrays.asList(
+                      ImmutableList.of(Values.of("1"), Values.of("parent"), Values.of("first")),
+                      ImmutableList.of(Values.of("1"), Values.of("parent"), Values.of("second"))));
+
+      DocumentsResolver resolver =
+          new SubDocumentsResolver(
+              filterExpression, documentId, subDocumentPath, executionContext, documentProperties);
+      List<RawDocument> result =
+          resolver
+              .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(1))
+              .awaitItems(1)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      assertThat(result)
+          .singleElement()
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.rows()).hasSize(2);
+              });
+
+      // one query only
+      queryAssert.assertExecuteCount().isEqualTo(1);
+      verify(filterExpression, times(1)).test(rowsCaptor.capture());
+
+      assertThat(rowsCaptor.getAllValues())
+          .hasSize(1)
+          .anySatisfy(
+              rows ->
+                  assertThat(rows)
+                      .hasSize(2)
+                      .anySatisfy(
+                          row -> {
+                            assertThat(row.getString("p1")).isEqualTo("first");
+                          })
+                      .anySatisfy(
+                          row -> {
+                            assertThat(row.getString("p1")).isEqualTo("second");
+                          }));
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .startsWith("SearchSubDocuments: sub-path 'parent'");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(2);
+                        });
+              });
+    }
+
+    @Test
+    public void complexPathWithMoreRows() {
+      int pageSize = 1;
+      String documentId = RandomStringUtils.randomAlphanumeric(16);
+      List<String> subDocumentPath = Arrays.asList("*", "reviews");
+      Paginator paginator = new Paginator(null, pageSize);
+      when(filterExpression.test(anyList())).thenReturn(true);
+      when(filterExpression.matchesFilterPath(any())).thenReturn(true);
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 > ? AND p1 = ? AND key = ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of(""),
+                  Values.of("reviews"),
+                  Values.of(documentId))
+              .withPageSize(documentProperties.getApproximateStoragePageSize(pageSize))
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_ROW)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(
+                  Arrays.asList(
+                      ImmutableList.of(
+                          Values.of("1"),
+                          Values.of("x60"),
+                          Values.of("reviews"),
+                          Values.of("[000001]"),
+                          Values.of("text")),
+                      ImmutableList.of(
+                          Values.of("1"),
+                          Values.of("x60"),
+                          Values.of("reviews"),
+                          Values.of("[000001]"),
+                          Values.of("date")),
+                      ImmutableList.of(
+                          Values.of("1"),
+                          Values.of("x90"),
+                          Values.of("reviews"),
+                          Values.of("[000001]"),
+                          Values.of("text")),
+                      ImmutableList.of(
+                          Values.of("1"),
+                          Values.of("x90"),
+                          Values.of("reviews"),
+                          Values.of("[000001]"),
+                          Values.of("date"))));
+
+      DocumentsResolver resolver =
+          new SubDocumentsResolver(
+              filterExpression, documentId, subDocumentPath, executionContext, documentProperties);
+      List<RawDocument> result =
+          resolver
+              .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(2))
+              .awaitItems(2)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      assertThat(result).hasSize(2);
+      assertThat(result.get(0))
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.documentKeys()).containsExactly("1", "x60", "reviews");
+                assertThat(doc.rows()).hasSize(2);
+              });
+      assertThat(result.get(1))
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.documentKeys()).containsExactly("1", "x90", "reviews");
+                assertThat(doc.rows()).hasSize(2);
+              });
+
+      // one query only
+      queryAssert.assertExecuteCount().isEqualTo(1);
+      verify(filterExpression, times(2)).test(rowsCaptor.capture());
+
+      assertThat(rowsCaptor.getAllValues())
+          .hasSize(2)
+          .anySatisfy(
+              rows -> {
+                assertThat(rows.get(0).getString("p0")).isEqualTo("x60");
+                assertThat(rows.get(0).getString("p2")).isEqualTo("[000001]");
+                assertThat(rows.get(0).getString("p3")).isEqualTo("text");
+                assertThat(rows.get(0).getString("p0")).isEqualTo("x60");
+                assertThat(rows.get(1).getString("p2")).isEqualTo("[000001]");
+                assertThat(rows.get(1).getString("p3")).isEqualTo("date");
+              })
+          .anySatisfy(
+              rows -> {
+                assertThat(rows.get(0).getString("p0")).isEqualTo("x90");
+                assertThat(rows.get(0).getString("p2")).isEqualTo("[000001]");
+                assertThat(rows.get(0).getString("p3")).isEqualTo("text");
+                assertThat(rows.get(0).getString("p0")).isEqualTo("x90");
+                assertThat(rows.get(1).getString("p2")).isEqualTo("[000001]");
+                assertThat(rows.get(1).getString("p3")).isEqualTo("date");
+              });
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .startsWith("SearchSubDocuments: sub-path '*.reviews'");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(4);
+                        });
+              });
+    }
+
+    @Test
+    public void orConditionOneTrue() {
+      int pageSize = 1;
+      String documentId = RandomStringUtils.randomAlphanumeric(16);
+      List<String> subDocumentPath = Collections.singletonList("*");
+      Paginator paginator = new Paginator(null, pageSize);
+      when(filterExpression.test(anyList())).thenReturn(true);
+      when(filterExpression.matchesFilterPath(any())).thenReturn(true);
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 > ? AND key = ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of(""),
+                  Values.of(documentId))
+              .withPageSize(documentProperties.getApproximateStoragePageSize(pageSize))
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_ROW)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(
+                  Arrays.asList(
+                      ImmutableList.of(Values.of("1"), Values.of("parent1"), Values.of("first")),
+                      ImmutableList.of(Values.of("1"), Values.of("parent2"), Values.of("second"))));
+
+      DocumentsResolver resolver =
+          new SubDocumentsResolver(
+              Or.of(filterExpression, filterExpression2),
+              documentId,
+              subDocumentPath,
+              executionContext,
+              documentProperties);
+      List<RawDocument> result =
+          resolver
+              .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(2))
+              .awaitItems(2)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      assertThat(result).hasSize(2);
+      assertThat(result.get(0))
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.documentKeys()).containsExactly("1", "parent1");
+                assertThat(doc.rows()).hasSize(1);
+              });
+      assertThat(result.get(1))
+          .satisfies(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.documentKeys()).containsExactly("1", "parent2");
+                assertThat(doc.rows()).hasSize(1);
+              });
+
+      // one query only
+      queryAssert.assertExecuteCount().isEqualTo(1);
+      verify(filterExpression, times(2)).test(rowsCaptor.capture());
+
+      assertThat(rowsCaptor.getAllValues())
+          .hasSize(2)
+          .anySatisfy(
+              rows ->
+                  assertThat(rows)
+                      .singleElement()
+                      .satisfies(
+                          row -> {
+                            assertThat(row.getString("p1")).isEqualTo("first");
+                          }))
+          .anySatisfy(
+              rows ->
+                  assertThat(rows)
+                      .singleElement()
+                      .satisfies(
+                          row -> {
+                            assertThat(row.getString("p1")).isEqualTo("second");
+                          }));
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description()).startsWith("SearchSubDocuments: sub-path '*'");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(2);
+                        });
+              });
+    }
+
+    @Test
+    public void orConditionNoneTrue() {
+      int pageSize = 1;
+      String documentId = RandomStringUtils.randomAlphanumeric(16);
+      List<String> subDocumentPath = Collections.singletonList("*");
+      Paginator paginator = new Paginator(null, pageSize);
+      when(filterExpression.matchesFilterPath(any())).thenReturn(true);
+      when(filterExpression2.matchesFilterPath(any())).thenReturn(true);
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 > ? AND key = ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of(""),
+                  Values.of(documentId))
+              .withPageSize(documentProperties.getApproximateStoragePageSize(pageSize))
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_ROW)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returning(
+                  Arrays.asList(
+                      ImmutableList.of(Values.of("1"), Values.of("parent1"), Values.of("first")),
+                      ImmutableList.of(Values.of("1"), Values.of("parent2"), Values.of("second"))));
+
+      DocumentsResolver resolver =
+          new SubDocumentsResolver(
+              Or.of(filterExpression, filterExpression2),
+              documentId,
+              subDocumentPath,
+              executionContext,
+              documentProperties);
+      resolver
+          .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(1))
+          .awaitCompletion()
+          .assertCompleted()
+          .assertHasNotReceivedAnyItem();
+
+      // one query only
+      queryAssert.assertExecuteCount().isEqualTo(1);
+      verify(filterExpression, times(2)).test(rowsCaptor.capture());
+
+      assertThat(rowsCaptor.getAllValues())
+          .hasSize(2)
+          .anySatisfy(
+              rows ->
+                  assertThat(rows)
+                      .singleElement()
+                      .satisfies(
+                          row -> {
+                            assertThat(row.getString("p1")).isEqualTo("first");
+                          }))
+          .anySatisfy(
+              rows ->
+                  assertThat(rows)
+                      .singleElement()
+                      .satisfies(
+                          row -> {
+                            assertThat(row.getString("p1")).isEqualTo("second");
+                          }));
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description()).startsWith("SearchSubDocuments: sub-path '*'");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(2);
+                        });
+              });
+    }
+
+    @Test
+    public void nothingFound() {
+      int pageSize = 1;
+      String documentId = RandomStringUtils.randomAlphanumeric(16);
+      List<String> subDocumentPath = Collections.singletonList("parent");
+      Paginator paginator = new Paginator(null, pageSize);
+
+      ValidatingStargateBridge.QueryAssert queryAssert =
+          withQuery(
+                  "SELECT key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value, WRITETIME(leaf) FROM \"%s\".\"%s\" WHERE p0 = ? AND key = ? ALLOW FILTERING"
+                      .formatted(KEYSPACE_NAME, COLLECTION_NAME),
+                  Values.of("parent"),
+                  Values.of(documentId))
+              .withPageSize(documentProperties.getApproximateStoragePageSize(pageSize))
+              .withResumeMode(QueryOuterClass.ResumeMode.NEXT_ROW)
+              .enriched()
+              .withColumnSpec(schemaProvider.allColumnSpec())
+              .returningNothing();
+
+      DocumentsResolver resolver =
+          new SubDocumentsResolver(
+              Or.of(filterExpression, filterExpression2),
+              documentId,
+              subDocumentPath,
+              executionContext,
+              documentProperties);
+      resolver
+          .getDocuments(queryExecutor, KEYSPACE_NAME, COLLECTION_NAME, paginator)
+          .subscribe()
+          .withSubscriber(AssertSubscriber.create(1))
+          .awaitCompletion()
+          .assertCompleted()
+          .assertHasNotReceivedAnyItem();
+
+      // one query only
+      queryAssert.assertExecuteCount().isEqualTo(1);
+      verify(filterExpression, never()).test(rowsCaptor.capture());
+
+      // execution context
+      assertThat(executionContext.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description())
+                    .startsWith("SearchSubDocuments: sub-path 'parent'");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.execCount()).isEqualTo(1);
+                          assertThat(queryInfo.rowCount()).isEqualTo(0);
+                        });
+              });
+    }
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/util/ByteBufferUtilsTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/util/ByteBufferUtilsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.service.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/** @author Dmitri Bourlatchkov */
+class ByteBufferUtilsTest {
+
+  @Nested
+  class ToBase64ForUrl {
+
+    @Test
+    void roundTrip() {
+      for (byte i = Byte.MIN_VALUE; i < Byte.MAX_VALUE; i++) {
+        for (byte j = Byte.MIN_VALUE; j < Byte.MAX_VALUE; j++) {
+          byte[] data = {i, j};
+          String str = ByteBufferUtils.toBase64ForUrl(ByteBuffer.wrap(data));
+          assertThat(str).doesNotContain("+");
+          assertThat(str).doesNotContain("/");
+          assertThat(ByteBufferUtils.fromBase64UrlParam(str).array()).isEqualTo(data);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**What this PR does**:

Completes the move of the reading service for the Docs V2. Includes:

* all resolvers and filters
* all eval helpers and rules
* main service

Some classes in this PR were copied as-is from V1, and thus don't require any review. I'll try to mark them in order to speed the reviews.

**Which issue(s) this PR fixes**:
Fixes #1738

**Checklist**
- [x] Changes manually tested