### PR TITLE
Update java-driver-code dependency from 4.13.0 to 4.14.1

### DIFF
--- a/persistence-api/pom.xml
+++ b/persistence-api/pom.xml
@@ -51,6 +51,14 @@
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-core</artifactId>
     </dependency>
+    <!-- 14-Jun-2022, tatu: with java-driver-core 4.14.1 this dependency is optional
+              and not brought as compile-time dependency, so needs to be explicitly added
+             (see [stargate#1889] for details)
+        -->
+    <dependency>
+      <groupId>com.esri.geometry</groupId>
+      <artifactId>esri-geometry-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-shaded-guava</artifactId>

--- a/persistence-api/pom.xml
+++ b/persistence-api/pom.xml
@@ -50,7 +50,6 @@
     <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-core</artifactId>
-      <version>${driver.version}</version>
     </dependency>
     <dependency>
       <groupId>com.datastax.oss</groupId>

--- a/persistence-cassandra-3.11/pom.xml
+++ b/persistence-cassandra-3.11/pom.xml
@@ -91,7 +91,6 @@
     <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-core</artifactId>
-      <version>${driver.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/persistence-cassandra-4.0/pom.xml
+++ b/persistence-cassandra-4.0/pom.xml
@@ -82,7 +82,6 @@
     <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-core</artifactId>
-      <version>${driver.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -721,6 +721,15 @@
         <artifactId>java-driver-core</artifactId>
         <version>${driver.version}</version>
       </dependency>
+      <!-- 14-Jun-2022, tatu: with java-driver-core 4.14.1 this dependency is optional
+            and not brought as compile-time dependency, so needs to be explicitly added
+           (see [stargate#1889] for details). But we better use consistent version
+        -->
+      <dependency>
+        <groupId>com.esri.geometry</groupId>
+        <artifactId>esri-geometry-api</artifactId>
+        <version>1.2.1</version>
+      </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-query-builder</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.scm.id>github</project.scm.id>
     <doclint>none</doclint>
-    <driver.version>4.13.0</driver.version>
+    <driver.version>4.14.1</driver.version>
     <xml-format.skip>true</xml-format.skip>
 
     <!-- First DropWizard version and things it directly depends on that make sense to sync -->

--- a/pom.xml
+++ b/pom.xml
@@ -717,6 +717,16 @@
         <version>25.1-jre</version>
       </dependency>
       <dependency>
+        <groupId>com.datastax.oss</groupId>
+        <artifactId>java-driver-core</artifactId>
+        <version>${driver.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.datastax.oss</groupId>
+        <artifactId>java-driver-query-builder</artifactId>
+        <version>${driver.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
         <version>${errorprone.version}</version>

--- a/restapi/pom.xml
+++ b/restapi/pom.xml
@@ -99,7 +99,6 @@
     <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-core</artifactId>
-      <version>${driver.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -63,12 +63,10 @@
     <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-core</artifactId>
-      <version>${driver.version}</version>
     </dependency>
     <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-query-builder</artifactId>
-      <version>${driver.version}</version>
     </dependency>
 
     <!-- 3rd party dependencies -->


### PR DESCRIPTION
**What this PR does**:

Updates `java-driver-core` dependency from 4.13.0 to 4.14.1 (latest), to address CVEs due to its dependencies.

**Which issue(s) this PR fixes**:
Fixes #1889

**Checklist**
- [x] Changes manually tested -- actually tested via CI
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
