### PR TITLE
Add `ttl()` method to persistence backends

### DIFF
--- a/persistence-api/src/main/java/io/stargate/db/schema/AbstractTable.java
+++ b/persistence-api/src/main/java/io/stargate/db/schema/AbstractTable.java
@@ -41,6 +41,8 @@ public abstract class AbstractTable implements Index, QualifiedSchemaEntity {
 
   public abstract String comment();
 
+  public abstract int ttl();
+
   @Value.Lazy
   Map<String, Column> columnMap() {
     return columns().stream().collect(Collectors.toMap(Column::name, Function.identity()));

--- a/persistence-api/src/main/java/io/stargate/db/schema/MaterializedView.java
+++ b/persistence-api/src/main/java/io/stargate/db/schema/MaterializedView.java
@@ -23,11 +23,11 @@ public abstract class MaterializedView extends AbstractTable implements Index {
   private static final long serialVersionUID = -2999120284516448661L;
 
   public static MaterializedView create(String keyspace, String name, Iterable<Column> columns) {
-    return create(keyspace, name, columns, "");
+    return create(keyspace, name, columns, "", 0);
   }
 
   public static MaterializedView create(
-      String keyspace, String name, Iterable<Column> columns, String comment) {
+      String keyspace, String name, Iterable<Column> columns, String comment, int ttl) {
     columns.forEach(
         c -> {
           Preconditions.checkState(
@@ -38,6 +38,7 @@ public abstract class MaterializedView extends AbstractTable implements Index {
         .name(name)
         .addAllColumns(columns)
         .comment(comment)
+        .ttl(ttl)
         .build();
   }
 

--- a/persistence-api/src/main/java/io/stargate/db/schema/MaterializedView.java
+++ b/persistence-api/src/main/java/io/stargate/db/schema/MaterializedView.java
@@ -46,6 +46,18 @@ public abstract class MaterializedView extends AbstractTable implements Index {
     return ImmutableMaterializedView.builder().keyspace(keyspace).name(name).addColumns().build();
   }
 
+  @Value.Default
+  @Override
+  public String comment() {
+    return "";
+  }
+
+  @Value.Default
+  @Override
+  public int ttl() {
+    return 0;
+  }
+
   @Override
   public int priority() {
     return 1;

--- a/persistence-api/src/main/java/io/stargate/db/schema/Table.java
+++ b/persistence-api/src/main/java/io/stargate/db/schema/Table.java
@@ -41,13 +41,15 @@ public abstract class Table extends AbstractTable {
       String name,
       Iterable<Column> columns,
       Iterable<Index> indexes,
-      String comment) {
+      String comment,
+      int ttl) {
     return ImmutableTable.builder()
         .keyspace(keyspace)
         .name(name)
         .columns(columns)
         .indexes(indexes)
         .comment(comment)
+        .ttl(ttl)
         .build();
   }
 
@@ -65,6 +67,12 @@ public abstract class Table extends AbstractTable {
   @Override
   public String comment() {
     return "";
+  }
+
+  @Value.Default
+  @Override
+  public int ttl() {
+    return 0;
   }
 
   @Override
@@ -98,6 +106,7 @@ public abstract class Table extends AbstractTable {
     if (!comment().isEmpty()) {
       tableBuilder.append("\n  Table '").append(name).append("' comment: " + comment());
     }
+    tableBuilder.append("\n  Table '").append(name).append("' ttl: " + ttl());
     tableBuilder.append("\n");
     return tableBuilder.toString();
   }

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/SchemaConverter.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/SchemaConverter.java
@@ -125,6 +125,11 @@ public class SchemaConverter
   }
 
   @Override
+  protected int ttl(CFMetaData table) {
+    return table.params.defaultTimeToLive;
+  }
+
+  @Override
   protected String indexName(IndexMetadata index) {
     return index.name;
   }

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/SchemaConverter.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/SchemaConverter.java
@@ -125,6 +125,11 @@ public class SchemaConverter
   }
 
   @Override
+  protected int ttl(TableMetadata table) {
+    return table.params.defaultTimeToLive;
+  }
+
+  @Override
   protected String indexName(IndexMetadata index) {
     return index.name;
   }

--- a/persistence-common/src/main/java/io/stargate/db/datastore/common/AbstractCassandraSchemaConverter.java
+++ b/persistence-common/src/main/java/io/stargate/db/datastore/common/AbstractCassandraSchemaConverter.java
@@ -267,7 +267,8 @@ public abstract class AbstractCassandraSchemaConverter<K, T, C, U, I, V> {
     T table = asTable(view);
     List<Column> columns = convertColumns(keyspaceName, table).collect(Collectors.toList());
     String comment = comment(table);
-    return MaterializedView.create(keyspaceName, tableName(table), columns, comment);
+    int ttl = ttl(table);
+    return MaterializedView.create(keyspaceName, tableName(table), columns, comment, ttl);
   }
 
   private Stream<UserDefinedType> convertUserTypes(String keyspaceName, Iterable<U> userTypes) {

--- a/persistence-common/src/main/java/io/stargate/db/datastore/common/AbstractCassandraSchemaConverter.java
+++ b/persistence-common/src/main/java/io/stargate/db/datastore/common/AbstractCassandraSchemaConverter.java
@@ -89,6 +89,9 @@ public abstract class AbstractCassandraSchemaConverter<K, T, C, U, I, V> {
   /** The comment on the provided internal table. * */
   protected abstract String comment(T table);
 
+  /** The TTL on the provided internal table. * */
+  protected abstract int ttl(T table);
+
   /** The (unquoted) name of the provided internal index. */
   protected abstract String indexName(I index);
 
@@ -146,12 +149,14 @@ public abstract class AbstractCassandraSchemaConverter<K, T, C, U, I, V> {
     Stream<Index> secondaryIndexes = convertSecondaryIndexes(keyspaceName, table, columns);
     Stream<Index> materializedViews = convertMVIndexes(keyspaceName, table, views);
     String comment = comment(table);
+    int ttl = ttl(table);
     return Table.create(
         keyspaceName,
         tableName(table),
         columns,
         Stream.concat(secondaryIndexes, materializedViews).collect(Collectors.toList()),
-        comment);
+        comment,
+        ttl);
   }
 
   private Stream<Column> convertColumns(String keyspaceName, T table) {

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/SchemaConverter.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/SchemaConverter.java
@@ -132,6 +132,11 @@ public class SchemaConverter
   }
 
   @Override
+  protected int ttl(TableMetadata table) {
+    return table.params.get(TableParams.DEFAULT_TTL);
+  }
+
+  @Override
   protected String indexName(IndexMetadata index) {
     return index.name;
   }

--- a/persistence-test/src/main/java/io/stargate/it/PersistenceTest.java
+++ b/persistence-test/src/main/java/io/stargate/it/PersistenceTest.java
@@ -1364,7 +1364,7 @@ public abstract class PersistenceTest {
   }
 
   @Test
-  public void testTableDefaultTTLSelect() {
+  public void testTableDefaultTTL() {
     createKeyspace();
     dataStore
         .queryBuilder()

--- a/persistence-test/src/main/java/io/stargate/it/PersistenceTest.java
+++ b/persistence-test/src/main/java/io/stargate/it/PersistenceTest.java
@@ -1364,6 +1364,37 @@ public abstract class PersistenceTest {
   }
 
   @Test
+  public void testTableDefaultTTLSelect() {
+    createKeyspace();
+    dataStore
+        .queryBuilder()
+        .create()
+        .table(keyspace, table)
+        .column("id", Column.Type.Int, PartitionKey)
+        .column("name", Column.Type.Text)
+        .withDefaultTTL(1234)
+        .build()
+        .execute()
+        .join();
+    dataStore.waitForSchemaAgreement();
+    Table theTable = dataStore.schema().keyspace(keyspace).table(table);
+    assertThat(theTable.ttl()).isEqualTo(1234);
+
+    dataStore
+        .queryBuilder()
+        .alter()
+        .table(keyspace, table)
+        .withDefaultTTL(5000)
+        .build()
+        .execute()
+        .join();
+    dataStore.waitForSchemaAgreement();
+
+    theTable = dataStore.schema().keyspace(keyspace).table(table);
+    assertThat(theTable.ttl()).isEqualTo(5000);
+  }
+
+  @Test
   public void testInsertWithTTL() throws ExecutionException, InterruptedException {
     createKeyspace();
     dataStore


### PR DESCRIPTION
**What this PR does**:

Exposes "default time-to-live" setting for Tables via Persistence API.

**Which issue(s) this PR fixes**:
Fixes #1896

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
