### PR TITLE
Reduce GraphQLJava induced log noise

### DIFF
--- a/graphqlapi/pom.xml
+++ b/graphqlapi/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.graphql-java</groupId>
       <artifactId>graphql-java</artifactId>
-      <version>17.3</version>
+      <version>18.1</version>
     </dependency>
     <dependency>
       <groupId>io.dropwizard</groupId>
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>com.apollographql.federation</groupId>
       <artifactId>federation-graphql-java-support</artifactId>
-      <version>0.9.0</version>
+      <version>2.0.3</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/CassandraFetcherExceptionHandler.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/CassandraFetcherExceptionHandler.java
@@ -41,6 +41,5 @@ public class CassandraFetcherExceptionHandler extends SimpleDataFetcherException
   protected void logException(ExceptionWhileDataFetching error, Throwable exception) {
     // 24-Jun-2022, tatu: [stargate#1279] Since we handle exception at an outer level,
     //    should not log it here.
-    ;
   }
 }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/CassandraFetcherExceptionHandler.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/CassandraFetcherExceptionHandler.java
@@ -15,6 +15,7 @@
  */
 package io.stargate.graphql.schema;
 
+import graphql.ExceptionWhileDataFetching;
 import graphql.execution.DataFetcherExceptionHandlerParameters;
 import graphql.execution.DataFetcherExceptionHandlerResult;
 import graphql.execution.SimpleDataFetcherExceptionHandler;
@@ -34,5 +35,12 @@ public class CassandraFetcherExceptionHandler extends SimpleDataFetcherException
     }
 
     return super.onException(handlerParameters);
+  }
+
+  @Override
+  protected void logException(ExceptionWhileDataFetching error, Throwable exception) {
+    // 24-Jun-2022, tatu: [stargate#1279] Since we handle exception at an outer level,
+    //    should not log it here.
+    ;
   }
 }

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/QueryFetcher.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/fetchers/deployed/QueryFetcher.java
@@ -40,7 +40,7 @@ public class QueryFetcher extends DeployedFetcher<Object> {
 
   @SuppressWarnings("unchecked")
   private static final Coercing<ByteBuffer, String> BLOB_COERCING =
-      CqlScalar.BLOB.getGraphqlType().getCoercing();
+      (Coercing<ByteBuffer, String>) CqlScalar.BLOB.getGraphqlType().getCoercing();
 
   private final QueryModel model;
 

--- a/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/CqlDirectives.java
+++ b/graphqlapi/src/main/java/io/stargate/graphql/schema/graphqlfirst/processor/CqlDirectives.java
@@ -635,7 +635,7 @@ public class CqlDirectives {
     ALL_AS_STRING =
         new SchemaPrinter(
                 SchemaPrinter.Options.defaultOptions()
-                    .includeDirectives(d -> !defaultDirectives.contains(d.getName()))
+                    .includeDirectives(d -> !defaultDirectives.contains(d))
                     .includeSchemaElement(e -> e != dummyQueryType))
             .print(schema);
 

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/GraphQlTestBase.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/GraphQlTestBase.java
@@ -97,6 +97,9 @@ public abstract class GraphQlTestBase {
         GraphQL.newGraphQL(graphQlSchema)
             // Use parallel execution strategy for mutations (serial is default)
             .mutationExecutionStrategy(new AsyncExecutionStrategy())
+            // 24-Jun-2022, tatu: As per [stargate#1279] prevent graphql-java from adding
+            //    spurious logs at low level. Will not affect propagation of exceptions
+            .defaultDataFetcherExceptionHandler(CassandraFetcherExceptionHandler.INSTANCE)
             .build();
   }
 

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/GraphQlTestBase.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/GraphQlTestBase.java
@@ -99,7 +99,8 @@ public abstract class GraphQlTestBase {
             //    spurious logs at low level. Will not affect propagation of exceptions
             .defaultDataFetcherExceptionHandler(CassandraFetcherExceptionHandler.INSTANCE)
             // Use parallel execution strategy for mutations (serial is default)
-            .mutationExecutionStrategy(new AsyncExecutionStrategy(CassandraFetcherExceptionHandler.INSTANCE))
+            .mutationExecutionStrategy(
+                new AsyncExecutionStrategy(CassandraFetcherExceptionHandler.INSTANCE))
             .build();
   }
 

--- a/graphqlapi/src/test/java/io/stargate/graphql/schema/GraphQlTestBase.java
+++ b/graphqlapi/src/test/java/io/stargate/graphql/schema/GraphQlTestBase.java
@@ -95,11 +95,11 @@ public abstract class GraphQlTestBase {
     graphQlSchema = createGraphQlSchema();
     graphQl =
         GraphQL.newGraphQL(graphQlSchema)
-            // Use parallel execution strategy for mutations (serial is default)
-            .mutationExecutionStrategy(new AsyncExecutionStrategy())
             // 24-Jun-2022, tatu: As per [stargate#1279] prevent graphql-java from adding
             //    spurious logs at low level. Will not affect propagation of exceptions
             .defaultDataFetcherExceptionHandler(CassandraFetcherExceptionHandler.INSTANCE)
+            // Use parallel execution strategy for mutations (serial is default)
+            .mutationExecutionStrategy(new AsyncExecutionStrategy(CassandraFetcherExceptionHandler.INSTANCE))
             .build();
   }
 


### PR DESCRIPTION
**What this PR does**:

Upgrades version of `graphql-java` used and then uses new 18.x mechanism to override logging to reduce noise that currently clogs logs on cases where code handles exceptions already.
There is some positive impact for our CI/IT logs (gets rid of 73 non-error cases that look like errors), but more importantly should reduce production log noise.

Graphql-java fix itself here:

https://github.com/graphql-java/graphql-java/pull/2569

**Which issue(s) this PR fixes**:
Fixes #1279

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
