### PR TITLE
Publish new Stargate-builder (1.0.8) for DSE core 6.8.24

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -1,7 +1,7 @@
 HOSTNAME        := gcr.io
 PROJECT         := stargateio
 NAME            := stargate-builder
-VERSION         := v1.0.7
+VERSION         := v1.0.8
 TAG             := ${VERSION}
 IMG             := ${NAME}:${TAG}
 IMG_GCP         := ${HOSTNAME}/${PROJECT}/${IMG}

--- a/cloudbuild-3_11.yaml
+++ b/cloudbuild-3_11.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.7'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.8'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'
@@ -30,7 +30,7 @@ steps:
         name: 'm2_cache'
   - id: 'cassandra-3.11'
     waitFor: [ 'fetch_secret', 'init_cache' ]
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.7'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.8'
     entrypoint: 'bash'
     args: [ 'ci/test.sh' ]
     volumes:

--- a/cloudbuild-4_0.yaml
+++ b/cloudbuild-4_0.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.7'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.8'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'
@@ -30,7 +30,7 @@ steps:
         name: 'm2_cache'
   - id: 'cassandra-4.0'
     waitFor: [ 'fetch_secret', 'init_cache' ]
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.7'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.8'
     entrypoint: 'bash'
     args: [ 'ci/test.sh' ]
     volumes:

--- a/cloudbuild-dse.yaml
+++ b/cloudbuild-dse.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.7'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.8'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'
@@ -30,7 +30,7 @@ steps:
         name: 'm2_cache'
   - id: 'dse-6.8'
     waitFor: [ 'fetch_secret', 'init_cache' ]
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.7'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.8'
     entrypoint: 'bash'
     args: [ 'ci/test.sh' ]
     volumes:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.7'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.8'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'


### PR DESCRIPTION
**What this PR does**:

Uses newly built Stargate CI image for workflows, as per

https://github.com/stargate/stargate/tree/master/ci

**Which issue(s) this PR fixes**:
None

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
