### PR TITLE
closes #1887: fixed consistency for reads, added consistency checks in tests

### DIFF
--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/ReadBridgeService.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/ReadBridgeService.java
@@ -19,6 +19,7 @@ package io.stargate.sgv2.docsapi.service.query;
 
 import com.bpodgursky.jbool_expressions.Expression;
 import com.bpodgursky.jbool_expressions.Literal;
+import io.opentelemetry.extension.annotations.WithSpan;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.grpc.Values;
@@ -57,8 +58,9 @@ public class ReadBridgeService {
    * @param expression Expression tree
    * @param paginator {@link Paginator}
    * @param context Context for recording profiling information
-   * @return Flowable of {@link RawDocument}s.
+   * @return Multi of {@link RawDocument}s, limited to a size defined in the #paginator.
    */
+  @WithSpan
   public Multi<RawDocument> searchDocuments(
       String keyspace,
       String collection,
@@ -112,9 +114,10 @@ public class ReadBridgeService {
    *     included in the {@link FilterExpression}s)
    * @param paginator {@link Paginator}
    * @param context Context for recording profiling information
-   * @return Flowable of {@link RawDocument}s representing sub-documents in the given
-   *     #subDocumentPath.
+   * @return Multi of {@link RawDocument}s representing sub-documents in the given #subDocumentPath,
+   *     limited to a size defined in the #paginator
    */
+  @WithSpan
   public Multi<RawDocument> searchSubDocuments(
       String keyspace,
       String collection,
@@ -142,16 +145,17 @@ public class ReadBridgeService {
   }
 
   /**
-   * Gets a single document optionally limit to the the #subDocumentPath.
+   * Gets a single document optionally limited to the #subDocumentPath.
    *
    * @param keyspace Keyspace to search in.
    * @param collection Collection to search in.
    * @param documentId Document ID to search in
    * @param subDocumentPath Path where to find the document
    * @param context Context for recording profiling information
-   * @return Flowable of {@link RawDocument}s representing a document or sub-document in the given
-   *     #subDocumentPath.
+   * @return Multi with a single {@link RawDocument} representing a document or sub-document in the
+   *     given #subDocumentPath, or empty if not found.
    */
+  @WithSpan
   public Multi<RawDocument> getDocument(
       String keyspace,
       String collection,
@@ -174,8 +178,10 @@ public class ReadBridgeService {
    * @param collection Collection to search in.
    * @param documentId Document ID to search in
    * @param context Context for recording profiling information
-   * @return Flowable of {@link RawDocument}s representing a document's rows with TTL as a column
+   * @return Uni with a single {@link RawDocument} representing a document's rows with TTL as a
+   *     column, or null if document not found
    */
+  @WithSpan
   public Uni<RawDocument> getDocumentTtlInfo(
       String keyspace, String collection, String documentId, ExecutionContext context) {
     return documentTtl(keyspace, collection, documentId, context).select().first().toUni();

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/executor/QueryExecutorTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/executor/QueryExecutorTest.java
@@ -20,6 +20,7 @@ package io.stargate.sgv2.docsapi.service.query.executor;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
@@ -41,6 +42,7 @@ import io.stargate.sgv2.docsapi.testprofiles.MaxDepth4TestProfile;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -1120,6 +1122,59 @@ class QueryExecutorTest extends AbstractValidatingStargateBridgeTest {
       assertThat(failureOverMax)
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("Invalid document identity depth: 6");
+    }
+  }
+
+  @Nested
+  @TestProfile(WithDifferentConsistency.Profile.class)
+  class WithDifferentConsistency {
+
+    public static class Profile extends MaxDepth4TestProfile {
+
+      @Override
+      public Map<String, String> getConfigOverrides() {
+        return ImmutableMap.<String, String>builder()
+            .putAll(super.getConfigOverrides())
+            .put("stargate.queries.consistency.reads", "ONE")
+            .build();
+      }
+    }
+
+    @Test
+    public void fullScan() {
+      List<List<QueryOuterClass.Value>> rows =
+          ImmutableList.of(row("1", "x", 1.0d), row("1", "y", 2.0d), row("2", "x", 3.0d));
+
+      withQuery(allDocsQuery.getCql())
+          .enriched()
+          .withColumnSpec(columnSpec)
+          .withConsistency(QueryOuterClass.Consistency.ONE)
+          .returning(rows);
+
+      List<RawDocument> result =
+          queryExecutor
+              .queryDocs(allDocsQuery, 100, false, null, false, context)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create())
+              .awaitNextItems(2)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      assertThat(result)
+          .hasSize(2)
+          .anySatisfy(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("1");
+                assertThat(doc.documentKeys()).containsExactly("1");
+                assertThat(doc.rows()).hasSize(2);
+              })
+          .anySatisfy(
+              doc -> {
+                assertThat(doc.id()).isEqualTo("2");
+                assertThat(doc.documentKeys()).containsExactly("2");
+                assertThat(doc.rows()).hasSize(1);
+              });
     }
   }
 }

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/write/WriteBridgeServiceTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/write/WriteBridgeServiceTest.java
@@ -19,11 +19,13 @@ package io.stargate.sgv2.docsapi.service.write;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.junit.mockito.InjectMock;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.bridge.proto.QueryOuterClass.Batch;
 import io.stargate.sgv2.docsapi.DocsApiTestSchemaProvider;
 import io.stargate.sgv2.docsapi.api.common.properties.datastore.DataStoreProperties;
@@ -1290,6 +1292,104 @@ class WriteBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
                         queryInfo -> {
                           assertThat(queryInfo.preparedCQL()).isEqualTo(deleteThird);
                           assertThat(queryInfo.execCount()).isEqualTo(1);
+                        });
+              });
+    }
+  }
+
+  @Nested
+  @TestProfile(WithDifferentConsistency.Profile.class)
+  class WithDifferentConsistency {
+
+    public static class Profile extends MaxDepth4TestProfile {
+
+      @Override
+      public Map<String, String> getConfigOverrides() {
+        return ImmutableMap.<String, String>builder()
+            .putAll(super.getConfigOverrides())
+            .put("stargate.queries.consistency.writes", "ONE")
+            .build();
+      }
+    }
+
+    @Test
+    public void happyPath() {
+      JsonShreddedRow row1 =
+          ImmutableJsonShreddedRow.builder()
+              .maxDepth(documentProperties.maxDepth())
+              .addPath("key1")
+              .stringValue("value1")
+              .build();
+      JsonShreddedRow row2 =
+          ImmutableJsonShreddedRow.builder()
+              .maxDepth(documentProperties.maxDepth())
+              .addPath("key2")
+              .addPath("nested")
+              .doubleValue(2.2d)
+              .build();
+      List<JsonShreddedRow> rows = Arrays.asList(row1, row2);
+
+      String insertCql =
+          String.format(
+              "INSERT INTO %s.%s "
+                  + "(key, p0, p1, p2, p3, leaf, text_value, dbl_value, bool_value) "
+                  + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) USING TIMESTAMP ?",
+              keyspaceName, tableName);
+      ValidatingStargateBridge.QueryAssert row1QueryAssert =
+          withQuery(
+                  insertCql,
+                  Values.of(documentId),
+                  Values.of("key1"),
+                  Values.of(""),
+                  Values.of(""),
+                  Values.of(""),
+                  Values.of("key1"),
+                  Values.of("value1"),
+                  Values.NULL,
+                  Values.NULL,
+                  Values.of(timestamp))
+              .inBatch(expectedBatchType)
+              .withConsistency(QueryOuterClass.Consistency.ONE)
+              .returningNothing();
+      ValidatingStargateBridge.QueryAssert row2QueryAssert =
+          withQuery(
+                  insertCql,
+                  Values.of(documentId),
+                  Values.of("key2"),
+                  Values.of("nested"),
+                  Values.of(""),
+                  Values.of(""),
+                  Values.of("nested"),
+                  Values.NULL,
+                  Values.of(2.2d),
+                  Values.NULL,
+                  Values.of(timestamp))
+              .withConsistency(QueryOuterClass.Consistency.ONE)
+              .inBatch(expectedBatchType)
+              .returningNothing();
+
+      service
+          .writeDocument(keyspaceName, tableName, documentId, rows, null, context)
+          .subscribe()
+          .withSubscriber(UniAssertSubscriber.create())
+          .awaitItem()
+          .assertCompleted();
+
+      row1QueryAssert.assertExecuteCount().isEqualTo(1);
+      row2QueryAssert.assertExecuteCount().isEqualTo(1);
+
+      assertThat(context.toProfile().nested())
+          .singleElement()
+          .satisfies(
+              nested -> {
+                assertThat(nested.description()).isEqualTo("ASYNC INSERT");
+                assertThat(nested.queries())
+                    .singleElement()
+                    .satisfies(
+                        queryInfo -> {
+                          assertThat(queryInfo.preparedCQL()).isEqualTo(insertCql);
+                          assertThat(queryInfo.execCount()).isEqualTo(2);
+                          assertThat(queryInfo.rowCount()).isEqualTo(2);
                         });
               });
     }


### PR DESCRIPTION
**What this PR does**:
Ensures read consistency is used in the `QueryExecutor`. Improves testing in the area, by extending support in the `ValidatingStargateBridge`.  

In addition adds span annotations to the read bridge service and improves the java docs.

**Which issue(s) this PR fixes**:
Fixes #1887 

**Checklist**
- [x] Automated Tests added/updated

