### PR TITLE
Fix #1836 (expose default TTL for Table resource)

### DIFF
--- a/restapi/src/main/java/io/stargate/web/restapi/resources/v2/schemas/TablesResource.java
+++ b/restapi/src/main/java/io/stargate/web/restapi/resources/v2/schemas/TablesResource.java
@@ -451,10 +451,7 @@ public class TablesResource {
             .collect(Collectors.toList());
 
     final PrimaryKey primaryKey = new PrimaryKey(partitionKey, clusteringKey);
-    final int ttl =
-        0; // TODO: [doug] 2020-09-1, Tue, 0:08 get this from schema (select default_time_to_live
-    // from tables;)
-    final TableOptions tableOptions = new TableOptions(ttl, clusteringExpression);
+    final TableOptions tableOptions = new TableOptions(tableMetadata.ttl(), clusteringExpression);
 
     return new TableResponse(
         tableMetadata.name(),

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2SchemaTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2SchemaTest.java
@@ -430,6 +430,23 @@ public class RestApiv2SchemaTest extends BaseIntegrationTest {
         String.format("%s/v2/schemas/keyspaces/%s/tables/%s", restUrlBase, keyspaceName, tableName),
         objectMapper.writeValueAsString(tableUpdate),
         HttpStatus.SC_OK);
+
+    // Let's also verify that TTL is updated (related to [stargate#1836])
+    String body =
+        RestUtils.get(
+            authToken,
+            String.format(
+                "%s/v2/schemas/keyspaces/%s/tables/%s?raw=true",
+                restUrlBase, keyspaceName, tableName),
+            HttpStatus.SC_OK);
+
+    TableResponse table = objectMapper.readValue(body, TableResponse.class);
+    assertThat(table.getKeyspace()).isEqualTo(keyspaceName);
+    assertThat(table.getName()).isEqualTo(tableName);
+    assertThat(table.getColumnDefinitions()).isNotNull().isNotEmpty();
+
+    assertThat(table.getTableOptions()).isNotNull();
+    assertThat(table.getTableOptions().getDefaultTimeToLive()).isEqualTo(5);
   }
 
   @Test


### PR DESCRIPTION
**What this PR does**:

Updates `TablesResource` to access now available default-TTL info, adds a test to verify information correct and accessible

**Which issue(s) this PR fixes**:
Fixes #1836

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
