### PR TITLE
Fix #1923: expose Table "default TTL" for SGv2/REST API too

### DIFF
--- a/bridge/src/main/java/io/stargate/bridge/service/SchemaHandler.java
+++ b/bridge/src/main/java/io/stargate/bridge/service/SchemaHandler.java
@@ -158,10 +158,7 @@ class SchemaHandler {
     if (table.comment() != null) {
       cqlTableBuilder.putOptions("comment", table.comment());
     }
-    int ttl = table.ttl();
-    if (ttl != 0) { // any other markers (is -1 used as indicator?)
-      cqlTableBuilder.putOptions("ttl", String.valueOf(ttl));
-    }
+    cqlTableBuilder.putOptions("ttl", String.valueOf(table.ttl()));
 
     for (Index index : table.indexes()) {
       if (index instanceof SecondaryIndex) {

--- a/bridge/src/main/java/io/stargate/bridge/service/SchemaHandler.java
+++ b/bridge/src/main/java/io/stargate/bridge/service/SchemaHandler.java
@@ -158,6 +158,10 @@ class SchemaHandler {
     if (table.comment() != null) {
       cqlTableBuilder.putOptions("comment", table.comment());
     }
+    int ttl = table.ttl();
+    if (ttl != 0) { // any other markers (is -1 used as indicator?)
+      cqlTableBuilder.putOptions("ttl", String.valueOf(ttl));
+    }
 
     for (Index index : table.indexes()) {
       if (index instanceof SecondaryIndex) {

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2TablesResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2TablesResourceImpl.java
@@ -218,7 +218,6 @@ public class Sgv2TablesResourceImpl extends ResourceBase implements Sgv2TablesRe
     }
     List<Sgv2Table.ClusteringExpression> clustering =
         clustering2clustering(grpcTable.getClusteringOrdersMap());
-    // !!! TODO: figure out where to find TTL? Persistence does provide it [stargate#1816]
     Integer defaultTTL = null;
     String defaultTTLString = grpcTable.getOptionsOrDefault("ttl", null);
     if (defaultTTLString != null) {

--- a/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2TablesResourceImpl.java
+++ b/sgv2-restapi/src/main/java/io/stargate/sgv2/restsvc/resources/schemas/Sgv2TablesResourceImpl.java
@@ -29,12 +29,16 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Path("/v2/schemas/keyspaces/{keyspaceName}/tables")
 @Produces(MediaType.APPLICATION_JSON)
 @Singleton
 @CreateStargateBridgeClient
 public class Sgv2TablesResourceImpl extends ResourceBase implements Sgv2TablesResourceApi {
+  private static final Logger LOGGER = LoggerFactory.getLogger(Sgv2TablesResourceImpl.class);
+
   @Override
   public Response getAllTables(
       final StargateBridgeClient bridge,
@@ -216,6 +220,18 @@ public class Sgv2TablesResourceImpl extends ResourceBase implements Sgv2TablesRe
         clustering2clustering(grpcTable.getClusteringOrdersMap());
     // !!! TODO: figure out where to find TTL? Persistence does provide it [stargate#1816]
     Integer defaultTTL = null;
+    String defaultTTLString = grpcTable.getOptionsOrDefault("ttl", null);
+    if (defaultTTLString != null) {
+      try {
+        defaultTTL = Integer.parseInt(defaultTTLString);
+      } catch (NumberFormatException e) {
+        LOGGER.warn(
+            "Internal problem: invalid default TTL value '{}' for table '{}:{}', not a valid Integer",
+            defaultTTLString,
+            keyspace,
+            grpcTable.getName());
+      }
+    }
     final Sgv2Table.TableOptions tableOptions = new Sgv2Table.TableOptions(defaultTTL, clustering);
     return new Sgv2Table(grpcTable.getName(), keyspace, columns, primaryKeys, tableOptions);
   }

--- a/testing/src/main/java/io/stargate/it/http/RestApiv2SchemaTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2SchemaTest.java
@@ -456,12 +456,7 @@ public class RestApiv2SchemaTest extends BaseRestApiTest {
     assertThat(table.getColumnDefinitions()).isNotNull().isNotEmpty();
 
     assertThat(table.getTableOptions()).isNotNull();
-    // 28-Jun-2022, tatu: [stargate#1836] fixed for SGv1 but not yet SGv2, and that's why
-    //    need to either disable check, or check for incorrect value. Let's do latter
-    //    until we can fix it; this way fix will trigger test fail so we won't forget
-    //    to fix the test too.
-    //    assertThat(table.getTableOptions().getDefaultTimeToLive()).isEqualTo(5);
-    assertThat(table.getTableOptions().getDefaultTimeToLive()).isEqualTo(0);
+    assertThat(table.getTableOptions().getDefaultTimeToLive()).isEqualTo(5);
   }
 
   @Test


### PR DESCRIPTION
**What this PR does**:

Makes "getTable()" REST API of StargateV2 expose Default TTL of the table as expected (follow up to #1836 that fixed SGv1/REST)

**Which issue(s) this PR fixes**:
Fixes #1923

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
