### PR TITLE
relates to #1730, #1734: api documents for write paths updated

### DIFF
--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentDeleteResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentDeleteResource.java
@@ -63,22 +63,13 @@ public class DocumentDeleteResource {
   @Operation(description = "Delete a document with a given ID.")
   @Parameters(
       value = {
-        @Parameter(
-            name = "namespace",
-            ref = OpenApiConstants.Parameters.NAMESPACE,
-            description = "The namespace to write the document to."),
-        @Parameter(
-            name = "collection",
-            ref = OpenApiConstants.Parameters.COLLECTION,
-            description = "The collection to write the document to."),
+        @Parameter(name = "namespace", ref = OpenApiConstants.Parameters.NAMESPACE),
+        @Parameter(name = "collection", ref = OpenApiConstants.Parameters.COLLECTION),
         @Parameter(
             name = "document-id",
             ref = OpenApiConstants.Parameters.DOCUMENT_ID,
-            description = "The ID of the document that you'd like to write"),
-        @Parameter(
-            name = "profile",
-            ref = OpenApiConstants.Parameters.PROFILE,
-            description = "Include profiling information from execution."),
+            description = "The ID of the document to delete."),
+        @Parameter(name = "profile", ref = OpenApiConstants.Parameters.PROFILE),
       })
   @APIResponses(
       value = {
@@ -123,26 +114,14 @@ public class DocumentDeleteResource {
   @Operation(description = "Delete the data at a path in a document by ID.")
   @Parameters(
       value = {
-        @Parameter(
-            name = "namespace",
-            ref = OpenApiConstants.Parameters.NAMESPACE,
-            description = "The namespace to write the document to."),
-        @Parameter(
-            name = "collection",
-            ref = OpenApiConstants.Parameters.COLLECTION,
-            description = "The collection to write the document to."),
+        @Parameter(name = "namespace", ref = OpenApiConstants.Parameters.NAMESPACE),
+        @Parameter(name = "collection", ref = OpenApiConstants.Parameters.COLLECTION),
         @Parameter(
             name = "document-id",
             ref = OpenApiConstants.Parameters.DOCUMENT_ID,
-            description = "The ID of the document that you'd like to write"),
-        @Parameter(
-            name = "document-path",
-            ref = OpenApiConstants.Parameters.DOCUMENT_PATH,
-            description = "The path within the document you would like to write to"),
-        @Parameter(
-            name = "profile",
-            ref = OpenApiConstants.Parameters.PROFILE,
-            description = "Include profiling information from execution."),
+            description = "The ID of the document to delete."),
+        @Parameter(name = "document-path", ref = OpenApiConstants.Parameters.DOCUMENT_PATH),
+        @Parameter(name = "profile", ref = OpenApiConstants.Parameters.PROFILE),
       })
   @APIResponses(
       value = {

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentPatchResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentPatchResource.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.proto.Schema;
 import io.stargate.sgv2.docsapi.api.common.exception.model.dto.ApiError;
-import io.stargate.sgv2.docsapi.api.v2.model.dto.SimpleResponseWrapper;
 import io.stargate.sgv2.docsapi.config.constants.OpenApiConstants;
+import io.stargate.sgv2.docsapi.models.ExecutionProfile;
 import io.stargate.sgv2.docsapi.service.ExecutionContext;
 import io.stargate.sgv2.docsapi.service.schema.TableManager;
 import io.stargate.sgv2.docsapi.service.write.WriteDocumentsService;
@@ -45,6 +45,7 @@ import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
 import org.eclipse.microprofile.openapi.annotations.media.SchemaProperty;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameters;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
@@ -71,41 +72,39 @@ public class DocumentPatchResource {
           "Patch a document with a given ID. Merges data at the root with requested data. Note that operation is not allowed if a JSON schema exist for a target collection.")
   @Parameters(
       value = {
-        @Parameter(
-            name = "namespace",
-            ref = OpenApiConstants.Parameters.NAMESPACE,
-            description = "The namespace of the document."),
+        @Parameter(name = "namespace", ref = OpenApiConstants.Parameters.NAMESPACE),
         @Parameter(
             name = "collection",
             ref = OpenApiConstants.Parameters.COLLECTION,
-            description = "The collection of the document (Will be created if it does not exist)."),
+            description = "The collection of the document. Will be created if it does not exist."),
         @Parameter(
             name = "document-id",
             ref = OpenApiConstants.Parameters.DOCUMENT_ID,
             description = "The ID of the document that you'd like to patch"),
-        @Parameter(
-            name = "ttl-auto",
-            ref = OpenApiConstants.Parameters.TTL_AUTO,
-            description =
-                "Include this to make the TTL match that of the parent document. Requires read-before-write if set to true"),
-        @Parameter(
-            name = "profile",
-            ref = OpenApiConstants.Parameters.PROFILE,
-            description = "Include profiling information from execution."),
+        @Parameter(name = "ttl-auto", ref = OpenApiConstants.Parameters.TTL_AUTO),
+        @Parameter(name = "profile", ref = OpenApiConstants.Parameters.PROFILE),
       })
+  @RequestBody(ref = OpenApiConstants.RequestBodies.PATCH)
   @APIResponses(
       value = {
         @APIResponse(
             responseCode = "200",
-            description =
-                "Document updated or created with the provided document-id. The document-id will be returned.",
+            description = "Document patched. The document-id will be returned.",
             content = {
               @Content(
                   schema =
                       @org.eclipse.microprofile.openapi.annotations.media.Schema(
-                          implementation = SimpleResponseWrapper.class,
-                          properties =
-                              @SchemaProperty(name = "documentId", type = SchemaType.STRING)))
+                          properties = {
+                            @SchemaProperty(
+                                name = "documentId",
+                                type = SchemaType.STRING,
+                                description = "The ID of the patched document."),
+                            @SchemaProperty(
+                                name = "profile",
+                                implementation = ExecutionProfile.class,
+                                nullable = true),
+                          }),
+                  examples = @ExampleObject(ref = OpenApiConstants.Examples.DOCUMENT_WRITE))
             }),
         @APIResponse(
             responseCode = "404",
@@ -151,8 +150,7 @@ public class DocumentPatchResource {
         @Parameter(
             name = "collection",
             ref = OpenApiConstants.Parameters.COLLECTION,
-            description =
-                "The collection to write the document to (Will be created if it does not exist)."),
+            description = "The collection of the document. Will be created if it does not exist."),
         @Parameter(
             name = "document-id",
             ref = OpenApiConstants.Parameters.DOCUMENT_ID,
@@ -171,19 +169,27 @@ public class DocumentPatchResource {
             ref = OpenApiConstants.Parameters.PROFILE,
             description = "Include profiling information from execution."),
       })
+  @RequestBody(ref = OpenApiConstants.RequestBodies.PATCH)
   @APIResponses(
       value = {
         @APIResponse(
             responseCode = "200",
-            description =
-                "Document updated or created with the provided document-id. The document-id will be returned.",
+            description = "Document path patched. The document-id will be returned.",
             content = {
               @Content(
                   schema =
                       @org.eclipse.microprofile.openapi.annotations.media.Schema(
-                          implementation = SimpleResponseWrapper.class,
-                          properties =
-                              @SchemaProperty(name = "documentId", type = SchemaType.STRING)))
+                          properties = {
+                            @SchemaProperty(
+                                name = "documentId",
+                                type = SchemaType.STRING,
+                                description = "The ID of the patched document."),
+                            @SchemaProperty(
+                                name = "profile",
+                                implementation = ExecutionProfile.class,
+                                nullable = true),
+                          }),
+                  examples = @ExampleObject(ref = OpenApiConstants.Examples.DOCUMENT_WRITE))
             }),
         @APIResponse(
             responseCode = "404",

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentReadResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentReadResource.java
@@ -59,12 +59,12 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.resteasy.reactive.RestResponse;
 
 /** Read resource. */
-@Path(ReadResource.BASE_PATH)
+@Path(DocumentReadResource.BASE_PATH)
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @SecurityRequirement(name = OpenApiConstants.SecuritySchemes.TOKEN)
 @Tag(ref = OpenApiConstants.Tags.DOCUMENTS)
-public class ReadResource {
+public class DocumentReadResource {
 
   public static final String BASE_PATH =
       "/v2/namespaces/{namespace:\\w+}/collections/{collection:\\w+}";
@@ -105,7 +105,7 @@ public class ReadResource {
           @Content(
               mediaType = MediaType.APPLICATION_JSON,
               schema =
-                  @org.eclipse.microprofile.openapi.annotations.media.Schema(
+                  @Schema(
                       name = "SearchDocsResult",
                       properties = {
                         @SchemaProperty(
@@ -134,9 +134,7 @@ public class ReadResource {
                   @ExampleObject(ref = OpenApiConstants.Examples.NAMESPACE_DOES_NOT_EXIST),
                   @ExampleObject(ref = OpenApiConstants.Examples.COLLECTION_DOES_NOT_EXIST)
                 },
-                schema =
-                    @org.eclipse.microprofile.openapi.annotations.media.Schema(
-                        implementation = ApiError.class))),
+                schema = @Schema(implementation = ApiError.class))),
     @APIResponse(ref = OpenApiConstants.Responses.GENERAL_401),
     @APIResponse(ref = OpenApiConstants.Responses.GENERAL_500),
     @APIResponse(ref = OpenApiConstants.Responses.GENERAL_503),
@@ -213,7 +211,7 @@ public class ReadResource {
           @Content(
               mediaType = MediaType.APPLICATION_JSON,
               schema =
-                  @org.eclipse.microprofile.openapi.annotations.media.Schema(
+                  @Schema(
                       implementation = DocumentResponseWrapper.class,
                       properties = @SchemaProperty(name = "data", type = SchemaType.DEFAULT)),
               examples = {
@@ -233,9 +231,7 @@ public class ReadResource {
                   @ExampleObject(ref = OpenApiConstants.Examples.COLLECTION_DOES_NOT_EXIST),
                   @ExampleObject(ref = OpenApiConstants.Examples.DOCUMENT_DOES_NOT_EXIST),
                 },
-                schema =
-                    @org.eclipse.microprofile.openapi.annotations.media.Schema(
-                        implementation = ApiError.class))),
+                schema = @Schema(implementation = ApiError.class))),
     @APIResponse(ref = OpenApiConstants.Responses.GENERAL_401),
     @APIResponse(ref = OpenApiConstants.Responses.GENERAL_500),
     @APIResponse(ref = OpenApiConstants.Responses.GENERAL_503),
@@ -299,7 +295,7 @@ public class ReadResource {
           @Content(
               mediaType = MediaType.APPLICATION_JSON,
               schema =
-                  @org.eclipse.microprofile.openapi.annotations.media.Schema(
+                  @Schema(
                       implementation = DocumentResponseWrapper.class,
                       properties = @SchemaProperty(name = "data", type = SchemaType.DEFAULT)),
               examples = {
@@ -319,9 +315,7 @@ public class ReadResource {
                   @ExampleObject(ref = OpenApiConstants.Examples.COLLECTION_DOES_NOT_EXIST),
                   @ExampleObject(ref = OpenApiConstants.Examples.DOCUMENT_DOES_NOT_EXIST),
                 },
-                schema =
-                    @org.eclipse.microprofile.openapi.annotations.media.Schema(
-                        implementation = ApiError.class))),
+                schema = @Schema(implementation = ApiError.class))),
     @APIResponse(ref = OpenApiConstants.Responses.GENERAL_401),
     @APIResponse(ref = OpenApiConstants.Responses.GENERAL_500),
     @APIResponse(ref = OpenApiConstants.Responses.GENERAL_503),

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentUpdateResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentUpdateResource.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.proto.Schema;
 import io.stargate.sgv2.docsapi.api.common.exception.model.dto.ApiError;
-import io.stargate.sgv2.docsapi.api.v2.model.dto.SimpleResponseWrapper;
 import io.stargate.sgv2.docsapi.config.constants.OpenApiConstants;
+import io.stargate.sgv2.docsapi.models.ExecutionProfile;
 import io.stargate.sgv2.docsapi.service.ExecutionContext;
 import io.stargate.sgv2.docsapi.service.schema.TableManager;
 import io.stargate.sgv2.docsapi.service.write.WriteDocumentsService;
@@ -45,6 +45,7 @@ import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
 import org.eclipse.microprofile.openapi.annotations.media.SchemaProperty;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameters;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
@@ -71,27 +72,19 @@ public class DocumentUpdateResource {
           "Create or update a document with a given ID. If the collection does not exist, it will be created. If the document already exists, it will be overwritten.")
   @Parameters(
       value = {
-        @Parameter(
-            name = "namespace",
-            ref = OpenApiConstants.Parameters.NAMESPACE,
-            description = "The namespace to write the document to."),
+        @Parameter(name = "namespace", ref = OpenApiConstants.Parameters.NAMESPACE),
         @Parameter(
             name = "collection",
             ref = OpenApiConstants.Parameters.COLLECTION,
-            description = "The collection to write the document to."),
+            description = "The collection of the document. Will be created if it does not exist."),
         @Parameter(
             name = "document-id",
             ref = OpenApiConstants.Parameters.DOCUMENT_ID,
-            description = "The ID of the document that you'd like to write"),
-        @Parameter(
-            name = "ttl",
-            ref = OpenApiConstants.Parameters.TTL,
-            description = "The time-to-live (in seconds) of the document."),
-        @Parameter(
-            name = "profile",
-            ref = OpenApiConstants.Parameters.PROFILE,
-            description = "Include profiling information from execution."),
+            description = "The ID of the document to update."),
+        @Parameter(name = "ttl", ref = OpenApiConstants.Parameters.TTL),
+        @Parameter(name = "profile", ref = OpenApiConstants.Parameters.PROFILE),
       })
+  @RequestBody(ref = OpenApiConstants.RequestBodies.WRITE)
   @APIResponses(
       value = {
         @APIResponse(
@@ -102,9 +95,17 @@ public class DocumentUpdateResource {
               @Content(
                   schema =
                       @org.eclipse.microprofile.openapi.annotations.media.Schema(
-                          implementation = SimpleResponseWrapper.class,
-                          properties =
-                              @SchemaProperty(name = "documentId", type = SchemaType.STRING)))
+                          properties = {
+                            @SchemaProperty(
+                                name = "documentId",
+                                type = SchemaType.STRING,
+                                description = "The ID of the updated document."),
+                            @SchemaProperty(
+                                name = "profile",
+                                implementation = ExecutionProfile.class,
+                                nullable = true),
+                          }),
+                  examples = @ExampleObject(ref = OpenApiConstants.Examples.DOCUMENT_WRITE))
             }),
         @APIResponse(
             responseCode = "404",
@@ -143,32 +144,20 @@ public class DocumentUpdateResource {
           "Create or update a path in a document by ID. If the collection does not exist, it will be created. If data exists at the path, it will be overwritten.")
   @Parameters(
       value = {
-        @Parameter(
-            name = "namespace",
-            ref = OpenApiConstants.Parameters.NAMESPACE,
-            description = "The namespace to write the document to."),
+        @Parameter(name = "namespace", ref = OpenApiConstants.Parameters.NAMESPACE),
         @Parameter(
             name = "collection",
             ref = OpenApiConstants.Parameters.COLLECTION,
-            description = "The collection to write the document to."),
+            description = "The collection of the document. Will be created if it does not exist."),
         @Parameter(
             name = "document-id",
             ref = OpenApiConstants.Parameters.DOCUMENT_ID,
-            description = "The ID of the document that you'd like to write"),
-        @Parameter(
-            name = "document-path",
-            ref = OpenApiConstants.Parameters.DOCUMENT_PATH,
-            description = "The path within the document you would like to write to"),
-        @Parameter(
-            name = "ttl-auto",
-            ref = OpenApiConstants.Parameters.TTL_AUTO,
-            description =
-                "Include this to make the TTL match that of the parent document. Requires read-before-write if set to true"),
-        @Parameter(
-            name = "profile",
-            ref = OpenApiConstants.Parameters.PROFILE,
-            description = "Include profiling information from execution."),
+            description = "The ID of the document to update."),
+        @Parameter(name = "document-path", ref = OpenApiConstants.Parameters.DOCUMENT_PATH),
+        @Parameter(name = "ttl-auto", ref = OpenApiConstants.Parameters.TTL_AUTO),
+        @Parameter(name = "profile", ref = OpenApiConstants.Parameters.PROFILE),
       })
+  @RequestBody(ref = OpenApiConstants.RequestBodies.WRITE_SUB_DOCUMENT)
   @APIResponses(
       value = {
         @APIResponse(
@@ -179,9 +168,17 @@ public class DocumentUpdateResource {
               @Content(
                   schema =
                       @org.eclipse.microprofile.openapi.annotations.media.Schema(
-                          implementation = SimpleResponseWrapper.class,
-                          properties =
-                              @SchemaProperty(name = "documentId", type = SchemaType.STRING)))
+                          properties = {
+                            @SchemaProperty(
+                                name = "documentId",
+                                type = SchemaType.STRING,
+                                description = "The ID of the updated document."),
+                            @SchemaProperty(
+                                name = "profile",
+                                implementation = ExecutionProfile.class,
+                                nullable = true),
+                          }),
+                  examples = @ExampleObject(ref = OpenApiConstants.Examples.DOCUMENT_WRITE))
             }),
         @APIResponse(
             responseCode = "404",

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/config/constants/OpenApiConstants.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/config/constants/OpenApiConstants.java
@@ -46,7 +46,6 @@ public interface OpenApiConstants {
     String PAGE_STATE = "page-state";
     String PROFILE = "profile";
     String RAW = "raw";
-    String ID_PATH = "id-path";
     String TTL = "ttl";
     String TTL_AUTO = "ttl-auto";
   }
@@ -64,6 +63,10 @@ public interface OpenApiConstants {
     String NAMESPACE_DOES_NOT_EXIST = "Namespace does not exist";
     String COLLECTION_DOES_NOT_EXIST = "Collection does not exist";
     String DOCUMENT_DOES_NOT_EXIST = "Document does not exist";
+
+    // document examples
+    String DOCUMENT_WRITE = "Document write";
+    String DOCUMENT_WRITE_BATCH = "Batch documents write";
     String DOCUMENT_SINGLE = "Single document";
     String DOCUMENT_SINGLE_UNWRAPPED = "Single document unwrapped";
     String DOCUMENT_SINGLE_WITH_WHERE = "Single document with where condition";
@@ -72,6 +75,15 @@ public interface OpenApiConstants {
     String SUB_DOCUMENT_SINGLE_WITH_WHERE = "Sub-document with where condition";
     String SEARCH_DOCUMENTS = "Search documents result";
     String SEARCH_DOCUMENTS_UNWRAPPED = "Search documents result unwrapped";
+  }
+
+  /** Request bodies reference names. */
+  interface RequestBodies {
+
+    String PATCH = "PATCH";
+    String WRITE = "WRITE";
+    String WRITE_SUB_DOCUMENT = "WRITE_SUB_DOCUMENT";
+    String WRITE_BATCH = "WRITE_BATCH";
   }
 
   /** Response reference names. */


### PR DESCRIPTION
**What this PR does**:

Corrects the open api docs after merging #1916 and #1921:

* request bodies examples
* corrects types for responses
* more examples
* less code in case of the referenced parameters

This should more or less be it wrt to the open api, but we will have another check in #1823.

**Which issue(s) this PR fixes**:

Relates to #1730 & #1734.
