### PR TITLE
relates to #1737: docs api V2 action workflow updates

### DIFF
--- a/.github/workflows/v2-docs-api.yaml
+++ b/.github/workflows/v2-docs-api.yaml
@@ -119,16 +119,18 @@ jobs:
       # same as in build_docker_images.sh
       - name: Prepare LIBDIR
         run: |
-          LIBDIR=./tmp-${RANDOM}
+          LIBDIR=tmp-${RANDOM}
           mkdir ${LIBDIR}
           cp ./stargate-lib/*.jar $LIBDIR
           cp ./stargate-lib/logback.xml $LIBDIR
           rm ${LIBDIR}/persistence*.jar
+          ls -all
+          ls -all ${LIBDIR}
 
       # same as in build_docker_images.sh
       # just builds a single image
       - name: Build Docker Image
-        run: docker buildx build --target ${{ matrix.image }} --build-arg LIBDIR="$LIBDIR" -t stargateio/${{ matrix.image }}:${{ github.sha }} --load .
+        run: docker buildx build --target ${{ matrix.image }} --build-arg LIBDIR=${LIBDIR} -t stargateio/${{ matrix.image }}:${{ github.sha }} --load .
 
       # this will export a file in form image-commitsha.tar
       - name: Export Docker Image

--- a/.github/workflows/v2-docs-api.yaml
+++ b/.github/workflows/v2-docs-api.yaml
@@ -154,18 +154,26 @@ jobs:
         include:
           - name: cassandra-40
             profile: cassandra-40
+            repository-login: false
             image-file: coordinator-4_0-${{ github.sha }}.tar
             image: stargateio/coordinator-4_0:${{ github.sha }}
 
           - name: cassandra-311
             profile: cassandra-311
+            repository-login: false
             image-file: coordinator-3_11-${{ github.sha }}.tar
             image: stargateio/coordinator-3_11:${{ github.sha }}
-            
+
           - name: dse-68
             profile: dse-68
+            repository-login: false
             image-file: coordinator-dse-68-${{ github.sha }}.tar
             image: stargateio/coordinator-dse-68:${{ github.sha }}
+
+          - name: c2-dse-68
+            profile: dse-68
+            repository-login: true
+            image: '237073351946.dkr.ecr.us-east-1.amazonaws.com/c2/c2-6_8:v2.0.0-ALPHA-14'
 
     steps:
       - uses: actions/checkout@v3
@@ -224,7 +232,32 @@ jobs:
           path: ~/.m2/repository
           key: snapshots-${{ github.sha }}
 
+      - name: Configure AWS credentials
+        if: ${{ matrix.repository-login }} == true
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.ECR_SECRET_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        if: ${{ matrix.repository-login }} == true
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
       - name: Integration Test
         run: |
           cd sgv2-docsapi/
           ./mvnw -B verify -DskipUnitTests -P ${{ matrix.profile }} -Dtesting.containers.stargate-image=${{ matrix.image }}
+
+  clean-up:
+    name: Clean up
+    runs-on: ubuntu-latest
+    needs: int-tests
+    if: ${{ always() }}
+
+    steps:
+      - uses: geekyeggo/delete-artifact@v1
+        with:
+          name: |
+            coordinator-images

--- a/.github/workflows/v2-docs-api.yaml
+++ b/.github/workflows/v2-docs-api.yaml
@@ -333,4 +333,6 @@ jobs:
       - uses: geekyeggo/delete-artifact@v1
         with:
           name: |
-            coordinator-images
+            img-coordinator-4_0-${{ github.sha }}
+            img-coordinator-3_11-${{ github.sha }}
+            img-coordinator-dse-68-${{ github.sha }}

--- a/.github/workflows/v2-docs-api.yaml
+++ b/.github/workflows/v2-docs-api.yaml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build
         if: steps.cache-coordinator-snapshots.outputs.cache-hit != 'true'
-        run: ./mvnw install -P dse -DskipTests
+        run: MAVEN_OPTS="-Xmx4g" ./mvnw install -P dse -DskipTests
 
       - name: Set up QEMU
         if: steps.cache-coordinator-snapshots.outputs.cache-hit != 'true'

--- a/.github/workflows/v2-docs-api.yaml
+++ b/.github/workflows/v2-docs-api.yaml
@@ -117,20 +117,15 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       # same as in build_docker_images.sh
-      - name: Prepare LIBDIR
+      # just builds a single image
+      - name: Build Docker Image
         run: |
-          LIBDIR=tmp-${RANDOM}
+          LIBDIR=./tmp-${RANDOM}
           mkdir ${LIBDIR}
           cp ./stargate-lib/*.jar $LIBDIR
           cp ./stargate-lib/logback.xml $LIBDIR
           rm ${LIBDIR}/persistence*.jar
-          ls -all
-          ls -all ${LIBDIR}
-
-      # same as in build_docker_images.sh
-      # just builds a single image
-      - name: Build Docker Image
-        run: docker buildx build --target ${{ matrix.image }} --build-arg LIBDIR=${LIBDIR} -t stargateio/${{ matrix.image }}:${{ github.sha }} --load .
+          docker buildx build --target ${{ matrix.image }} --build-arg LIBDIR=${LIBDIR} -t stargateio/${{ matrix.image }}:${{ github.sha }} --load .
 
       # this will export a file in form image-commitsha.tar
       - name: Export Docker Image
@@ -146,7 +141,7 @@ jobs:
 
   # runs unit tests for the sgv2-docsapi
   build:
-    name: Build and test
+    name: Unit tests
     needs: build-coordinator
     runs-on: ubuntu-latest
 

--- a/.github/workflows/v2-docs-api.yaml
+++ b/.github/workflows/v2-docs-api.yaml
@@ -66,12 +66,16 @@ jobs:
         env:
           cache-name: cache-coordinator-libs
         with:
-          path: ./stargate-libs
+          path: stargate-libs
           key: stargate-libs-${{ github.sha }}
 
       - name: Build
         if: steps.cache-coordinator-snapshots.outputs.cache-hit != 'true'
-        run: MAVEN_OPTS="-Xmx4g" ./mvnw install -P dse -DskipTests
+        run: |
+          pwd
+          ls
+          echo $HOME
+          MAVEN_OPTS="-Xmx4g" ./mvnw install -P dse -DskipTests
 
   build-coordinator-docker:
     name: Coordinator docker
@@ -91,7 +95,7 @@ jobs:
         env:
           cache-name: cache-coordinator-libs
         with:
-          path: ./stargate-libs
+          path: stargate-libs
           key: stargate-libs-${{ github.sha }}
 
       - name: Set up QEMU
@@ -123,7 +127,7 @@ jobs:
     name: Build and test
     needs: build-coordinator
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v3
 
@@ -240,18 +244,18 @@ jobs:
           EOF
 
       - name: Set up Docker Buildx
-        if: ${{ matrix.image-file }} != null
+        if: ${{ matrix.image-file }}
         uses: docker/setup-buildx-action@v2
 
       - name: Download Docker Images
-        if: ${{ matrix.image-artifact}} != null
+        if: ${{ matrix.image-artifact}}
         uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.image-artifact }}
           path: /tmp
 
       - name: Load image
-        if: ${{ matrix.image-file }} != null
+        if: ${{ matrix.image-file }}
         run: docker load --input /tmp/${{ matrix.image-file }}
 
       - name: Restore Snapshots
@@ -272,7 +276,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Login to Amazon ECR
-        if: ${{ matrix.repository-login }} == true
+        if: ${{ matrix.repository-login }}
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 

--- a/.github/workflows/v2-docs-api.yaml
+++ b/.github/workflows/v2-docs-api.yaml
@@ -61,13 +61,14 @@ jobs:
           </settings>
           EOF
 
+      # ensure snapshots from this build are used in next jobs
       - name: Cache Snapshots
         uses: actions/cache@v3
         id: cache-coordinator-snapshots
         env:
           cache-name: cache-coordinator-snapshots
         with:
-          path: ~/.m2/repository
+          path: ~/.m2/repository/io/stargate
           key: snapshots-${{ github.sha }}
           restore-keys: |
             snapshots-
@@ -125,7 +126,7 @@ jobs:
           cp ./stargate-lib/*.jar $LIBDIR
           cp ./stargate-lib/logback.xml $LIBDIR
           rm ${LIBDIR}/persistence*.jar
-          docker buildx build --target ${{ matrix.image }} --build-arg LIBDIR=${LIBDIR} -t stargateio/${{ matrix.image }}:${{ github.sha }} --load .
+          docker buildx build --target ${{ matrix.image }} --build-arg LIBDIR="$LIBDIR" -t stargateio/${{ matrix.image }}:${{ github.sha }} --load .
 
       # this will export a file in form image-commitsha.tar
       - name: Export Docker Image
@@ -184,7 +185,7 @@ jobs:
         env:
           cache-name: cache-coordinator-snapshots
         with:
-          path: ~/.m2/repository
+          path: ~/.m2/repository/io/stargate
           key: snapshots-${{ github.sha }}
 
       - name: Build & Test
@@ -295,7 +296,7 @@ jobs:
         env:
           cache-name: cache-coordinator-snapshots
         with:
-          path: ~/.m2/repository
+          path: ~/.m2/repository/io/stargate
           key: snapshots-${{ github.sha }}
 
       # configure AWS credentials if repo login is needed

--- a/.github/workflows/v2-docs-api.yaml
+++ b/.github/workflows/v2-docs-api.yaml
@@ -1,16 +1,31 @@
+# @author Ivan Senic
 name: Documents API V2
 
-on:
+# runs on
+# * pushes and pull requests on the v2.0.0.
+# * manual trigger
 
+on:
   push:
     branches: [ "v2.0.0" ]
-
   pull_request:
     branches: [ "v2.0.0" ]
-
   workflow_dispatch:
 
+# Jobs structure:
+#
+# 1. Builds the coordinator without tests in order to get snapshot jar versions
+# 2. Then 4 jobs in parallel
+#  a) Build and test the sgv2-docsapi
+#  b) Build coordinator docker images (x3)
+# 3. Runs INT tests for sgv2-docsapi (x4 in parallel, C*3, C*4, dse, c2)
+# 4. Clean-up - deletes created docker image artifacts
+
 jobs:
+
+  # runs install for building the coordinator jars
+  # caches the stargate-lib folder (needed for the docker images)
+  # cached .m2/repository in order to pass SG snapshots to other jobs
 
   build-coordinator:
     name: Coordinator build
@@ -61,6 +76,7 @@ jobs:
             snapshots-
 
       - name: Cache Libs
+        if: steps.cache-coordinator-snapshots.outputs.cache-hit != 'true'
         uses: actions/cache@v3
         id: cache-coordinator-libs
         env:
@@ -73,11 +89,15 @@ jobs:
         if: steps.cache-coordinator-snapshots.outputs.cache-hit != 'true'
         run: MAVEN_OPTS="-Xmx4g" ./mvnw install -P dse -DskipTests
 
+  # Builds C*3, C*4 and DSE coordinator images using matrix
+  # Exports image to a file and then uploads it using action artifacts
+
   build-coordinator-docker:
     name: Coordinator docker
     needs: build-coordinator
     runs-on: ubuntu-latest
 
+    # image name needed only
     strategy:
       matrix:
         image: [ coordinator-4_0 , coordinator-3_11, coordinator-dse-68]
@@ -100,6 +120,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      # same as in build_docker_images.sh
       - name: Prepare LIBDIR
         run: |
           LIBDIR=./tmp-${RANDOM}
@@ -108,13 +129,17 @@ jobs:
           cp ./stargate-lib/logback.xml $LIBDIR
           rm ${LIBDIR}/persistence*.jar
 
+      # same as in build_docker_images.sh
+      # just builds a single image
       - name: Build Docker Image
-        run: docker buildx build --target ${{ matrix.image }} --build-arg LIBDIR="$LIBDIR" -t stargateio/${{ matrix.image }}:${{ github.sha }} .
+        run: docker buildx build --target ${{ matrix.image }} --build-arg LIBDIR="$LIBDIR" -t stargateio/${{ matrix.image }}:${{ github.sha }} --load .
 
+      # this will export a file in form image-commitsha.tar
       - name: Export Docker Image
         run: |
           docker save --output ${{ matrix.image }}-${{ github.sha }}.tar stargateio/${{ matrix.image }}:${{ github.sha }}
 
+      # this will upload a file from previous step as an artifact named img-image-commitsha
       - name: Upload Docker Images
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/v2-docs-api.yaml
+++ b/.github/workflows/v2-docs-api.yaml
@@ -150,14 +150,22 @@ jobs:
 
     strategy:
       matrix:
-        profile: [ cassandra-40, cassandra-311, dse-68 ]
+        name: [ cassandra-40, cassandra-311, dse-68 ]
         include:
-          - profile: cassandra-40
-            image: coordinator-4_0-${{ github.sha }}.tar
-          - profile: cassandra-311
-            image: coordinator-3_11-${{ github.sha }}.tar
-          - profile: dse-68
-            image: coordinator-dse-68-${{ github.sha }}.tar
+          - name: cassandra-40
+            profile: cassandra-40
+            image-file: coordinator-4_0-${{ github.sha }}.tar
+            image: stargateio/coordinator-4_0:${{ github.sha }}
+
+          - name: cassandra-311
+            profile: cassandra-311
+            image-file: coordinator-3_11-${{ github.sha }}.tar
+            image: stargateio/coordinator-3_11:${{ github.sha }}
+            
+          - name: dse-68
+            profile: dse-68
+            image-file: coordinator-dse-68-${{ github.sha }}.tar
+            image: stargateio/coordinator-dse-68:${{ github.sha }}
 
     steps:
       - uses: actions/checkout@v3
@@ -193,16 +201,19 @@ jobs:
           EOF
 
       - name: Set up Docker Buildx
+        if: ${{ matrix.image-file }} != null
         uses: docker/setup-buildx-action@v2
 
       - name: Download Docker Images
+        if: ${{ matrix.image-file }} != null
         uses: actions/download-artifact@v3
         with:
           name: coordinator-images
           path: /tmp
 
       - name: Load image
-        run: docker load --input /tmp/${{ matrix.image }}
+        if: ${{ matrix.image-file }} != null
+        run: docker load --input /tmp/${{ matrix.image-file }}
 
       - name: Restore Snapshots
         uses: actions/cache@v3
@@ -216,4 +227,4 @@ jobs:
       - name: Integration Test
         run: |
           cd sgv2-docsapi/
-          ./mvnw -B integration-test -DskipUnitTests -P ${{ matrix.profile }}
+          ./mvnw -B verify -DskipUnitTests -P ${{ matrix.profile }} -Dtesting.containers.stargate-image=${{ matrix.image }}

--- a/.github/workflows/v2-docs-api.yaml
+++ b/.github/workflows/v2-docs-api.yaml
@@ -4,7 +4,6 @@ name: Documents API V2
 # runs on
 # * pushes and pull requests on the v2.0.0.
 # * manual trigger
-
 on:
   push:
     branches: [ "v2.0.0" ]
@@ -20,13 +19,11 @@ on:
 #  b) Build coordinator docker images (x3)
 # 3. Runs INT tests for sgv2-docsapi (x4 in parallel, C*3, C*4, dse, c2)
 # 4. Clean-up - deletes created docker image artifacts
-
 jobs:
 
-  # runs install for building the coordinator jars
+  # runs mvnw install for building the coordinator jars
   # caches the stargate-lib folder (needed for the docker images)
   # cached .m2/repository in order to pass SG snapshots to other jobs
-
   build-coordinator:
     name: Coordinator build
     runs-on: ubuntu-latest
@@ -91,16 +88,15 @@ jobs:
 
   # Builds C*3, C*4 and DSE coordinator images using matrix
   # Exports image to a file and then uploads it using action artifacts
-
   build-coordinator-docker:
-    name: Coordinator docker
+    name: Docker image
     needs: build-coordinator
     runs-on: ubuntu-latest
 
     # image name needed only
     strategy:
       matrix:
-        image: [ coordinator-4_0 , coordinator-3_11, coordinator-dse-68]
+        image: [ coordinator-4_0 , coordinator-3_11, coordinator-dse-68 ]
 
     steps:
       - uses: actions/checkout@v3
@@ -144,8 +140,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: img-${{ matrix.image }}-${{ github.sha }}
-          path:  ${{ matrix.image }}-${{ github.sha }}.tar
+          path: ${{ matrix.image }}-${{ github.sha }}.tar
 
+  # runs unit tests for the sgv2-docsapi
   build:
     name: Build and test
     needs: build-coordinator
@@ -198,33 +195,45 @@ jobs:
           cd sgv2-docsapi/
           ./mvnw -B test
 
+  # runs int tests for the sgv2-docsapi
+  # supports two modes:
+  # 1. by downloading and importing the built docker image
+  # 2. by logging into ECR and fetching images directly
   int-tests:
     name: Integration tests
     needs: [ build-coordinator-docker, build ]
     runs-on: ubuntu-latest
 
     strategy:
+
+      # props:
+      # name - human-readable name
+      # profile - what profile should be activated when running int tests
+      # repository-login (optional) - if login to the ECR docker repo is needed
+      # image-artifact (optional) - name of the artifact containing the image file
+      # image-file - file name of the image to import (must be in the artifact)
+      # image - final image name to use when running int tests (-Dtesting.containers.stargate-image)
       matrix:
         name: [ cassandra-40, cassandra-311, dse-68, c2-dse-68 ]
         include:
           - name: cassandra-40
             profile: cassandra-40
             repository-login: false
-            image-artifact: img-coordinator-4_0-${{ github.sha }}.tar
+            image-artifact: img-coordinator-4_0-${{ github.sha }}
             image-file: coordinator-4_0-${{ github.sha }}.tar
             image: stargateio/coordinator-4_0:${{ github.sha }}
 
           - name: cassandra-311
             profile: cassandra-311
             repository-login: false
-            image-artifact: img-coordinator-3_11-${{ github.sha }}.tar
+            image-artifact: img-coordinator-3_11-${{ github.sha }}
             image-file: coordinator-3_11-${{ github.sha }}.tar
             image: stargateio/coordinator-3_11:${{ github.sha }}
 
           - name: dse-68
             profile: dse-68
             repository-login: false
-            image-artifact: img-coordinator-dse-68-${{ github.sha }}.tar
+            image-artifact: img-coordinator-dse-68-${{ github.sha }}
             image-file: coordinator-dse-68-${{ github.sha }}.tar
             image: stargateio/coordinator-dse-68:${{ github.sha }}
 
@@ -270,13 +279,15 @@ jobs:
         if: ${{ matrix.image-file }}
         uses: docker/setup-buildx-action@v2
 
-      - name: Download Docker Images
+      # downloads the artifact if one is defined
+      - name: Download Docker Image
         if: ${{ matrix.image-artifact}}
         uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.image-artifact }}
           path: /tmp
 
+      # loads the image from the .tar
       - name: Load image
         if: ${{ matrix.image-file }}
         run: docker load --input /tmp/${{ matrix.image-file }}
@@ -290,6 +301,7 @@ jobs:
           path: ~/.m2/repository
           key: snapshots-${{ github.sha }}
 
+      # configure AWS credentials if repo login is needed
       - name: Configure AWS credentials
         if: ${{ matrix.repository-login }} == true
         uses: aws-actions/configure-aws-credentials@v1
@@ -298,16 +310,19 @@ jobs:
           aws-secret-access-key: ${{ secrets.ECR_SECRET_KEY }}
           aws-region: us-east-1
 
+      # login to the ECR if needed
       - name: Login to Amazon ECR
         if: ${{ matrix.repository-login }}
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
+      # run finally the int tests
       - name: Integration Test
         run: |
           cd sgv2-docsapi/
           ./mvnw -B verify -DskipUnitTests -P ${{ matrix.profile }} -Dtesting.containers.stargate-image=${{ matrix.image }}
 
+  # runs always, deletes built docker image artifacts
   clean-up:
     name: Clean up
     runs-on: ubuntu-latest

--- a/.github/workflows/v2-docs-api.yaml
+++ b/.github/workflows/v2-docs-api.yaml
@@ -1,4 +1,4 @@
-name: CI for Docs API V2
+name: Documents API V2
 
 on:
 
@@ -13,8 +13,9 @@ on:
 jobs:
 
   build-coordinator:
-    name: Build coordinator
+    name: Coordinator build
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v3
 
@@ -59,43 +60,70 @@ jobs:
           restore-keys: |
             snapshots-
 
+      - name: Cache Libs
+        uses: actions/cache@v3
+        id: cache-coordinator-libs
+        env:
+          cache-name: cache-coordinator-libs
+        with:
+          path: ./stargate-libs
+          key: stargate-libs-${{ github.sha }}
+
       - name: Build
         if: steps.cache-coordinator-snapshots.outputs.cache-hit != 'true'
         run: MAVEN_OPTS="-Xmx4g" ./mvnw install -P dse -DskipTests
 
+  build-coordinator-docker:
+    name: Coordinator docker
+    needs: build-coordinator
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        image: [ coordinator-4_0 , coordinator-3_11, coordinator-dse-68]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Restore Libs
+        uses: actions/cache@v3
+        id: cache-coordinator-libs
+        env:
+          cache-name: cache-coordinator-libs
+        with:
+          path: ./stargate-libs
+          key: stargate-libs-${{ github.sha }}
+
       - name: Set up QEMU
-        if: steps.cache-coordinator-snapshots.outputs.cache-hit != 'true'
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        if: steps.cache-coordinator-snapshots.outputs.cache-hit != 'true'
         uses: docker/setup-buildx-action@v2
 
-      - name: Build Docker Images
-        if: steps.cache-coordinator-snapshots.outputs.cache-hit != 'true'
-        run: ./build_docker_images.sh -t ${{ github.sha }}
-
-      - name: Export Docker Images
-        if: steps.cache-coordinator-snapshots.outputs.cache-hit != 'true'
+      - name: Build Docker Image
         run: |
-          docker save --output coordinator-3_11-${{ github.sha }}.tar stargateio/coordinator-3_11:${{ github.sha }}
-          docker save --output coordinator-4_0-${{ github.sha }}.tar stargateio/coordinator-4_0:${{ github.sha }}
-          docker save --output coordinator-dse-68-${{ github.sha }}.tar stargateio/coordinator-dse-68:${{ github.sha }}
+          LIBDIR=./tmp-${RANDOM}
+          mkdir ${LIBDIR}
+          cp ./stargate-lib/*.jar $LIBDIR
+          cp ./stargate-lib/logback.xml $LIBDIR
+          rm ${LIBDIR}/persistence*.jar
+          docker buildx build --target ${{ matrix.image }} --build-arg LIBDIR="$LIBDIR" -t stargateio/${{ matrix.image }}:${{ github.sha }}
+
+      - name: Export Docker Image
+        run: |
+          docker save --output ${{ matrix.image }}-${{ github.sha }}.tar stargateio/${{ matrix.image }}:${{ github.sha }}
 
       - name: Upload Docker Images
-        if: steps.cache-coordinator-snapshots.outputs.cache-hit != 'true'
         uses: actions/upload-artifact@v3
         with:
-          name: coordinator-images
-          path: |
-            coordinator-3_11-${{ github.sha }}.tar
-            coordinator-4_0-${{ github.sha }}.tar
-            coordinator-dse-68-${{ github.sha }}.tar
+          name: img-${{ matrix.image }}-${{ github.sha }}
+          path:  ${{ matrix.image }}-${{ github.sha }}.tar
 
   build:
     name: Build and test
     needs: build-coordinator
     runs-on: ubuntu-latest
+    
     steps:
       - uses: actions/checkout@v3
 
@@ -145,28 +173,31 @@ jobs:
 
   int-tests:
     name: Integration tests
-    needs: [ build-coordinator, build ]
+    needs: [ build-coordinator-docker, build ]
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        name: [ cassandra-40, cassandra-311, dse-68 ]
+        name: [ cassandra-40, cassandra-311, dse-68, c2-dse-68 ]
         include:
           - name: cassandra-40
             profile: cassandra-40
             repository-login: false
+            image-artifact: img-coordinator-4_0-${{ github.sha }}.tar
             image-file: coordinator-4_0-${{ github.sha }}.tar
             image: stargateio/coordinator-4_0:${{ github.sha }}
 
           - name: cassandra-311
             profile: cassandra-311
             repository-login: false
+            image-artifact: img-coordinator-3_11-${{ github.sha }}.tar
             image-file: coordinator-3_11-${{ github.sha }}.tar
             image: stargateio/coordinator-3_11:${{ github.sha }}
 
           - name: dse-68
             profile: dse-68
             repository-login: false
+            image-artifact: img-coordinator-dse-68-${{ github.sha }}.tar
             image-file: coordinator-dse-68-${{ github.sha }}.tar
             image: stargateio/coordinator-dse-68:${{ github.sha }}
 
@@ -213,10 +244,10 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Download Docker Images
-        if: ${{ matrix.image-file }} != null
+        if: ${{ matrix.image-artifact}} != null
         uses: actions/download-artifact@v3
         with:
-          name: coordinator-images
+          name: ${{ matrix.image-artifact }}
           path: /tmp
 
       - name: Load image

--- a/.github/workflows/v2-docs-api.yaml
+++ b/.github/workflows/v2-docs-api.yaml
@@ -238,7 +238,7 @@ jobs:
           - name: c2-dse-68
             profile: dse-68
             repository-login: true
-            image: '237073351946.dkr.ecr.us-east-1.amazonaws.com/c2/c2-6_8:v2.0.0-ALPHA-14'
+            image: '237073351946.dkr.ecr.us-east-1.amazonaws.com/c2/c2-6_8:v2.0.0-ALPHA-15'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/v2-docs-api.yaml
+++ b/.github/workflows/v2-docs-api.yaml
@@ -100,14 +100,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build Docker Image
+      - name: Prepare LIBDIR
         run: |
           LIBDIR=./tmp-${RANDOM}
           mkdir ${LIBDIR}
           cp ./stargate-lib/*.jar $LIBDIR
           cp ./stargate-lib/logback.xml $LIBDIR
           rm ${LIBDIR}/persistence*.jar
-          docker buildx build --target ${{ matrix.image }} --build-arg LIBDIR="$LIBDIR" -t stargateio/${{ matrix.image }}:${{ github.sha }}
+
+      - name: Build Docker Image
+        run: docker buildx build --target ${{ matrix.image }} --build-arg LIBDIR="$LIBDIR" -t stargateio/${{ matrix.image }}:${{ github.sha }} .
 
       - name: Export Docker Image
         run: |

--- a/.github/workflows/v2-docs-api.yaml
+++ b/.github/workflows/v2-docs-api.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
 
   build-coordinator:
+    name: Build coordinator
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -91,8 +92,8 @@ jobs:
             coordinator-4_0-${{ github.sha }}.tar
             coordinator-dse-68-${{ github.sha }}.tar
 
-
   build:
+    name: Build and test
     needs: build-coordinator
     runs-on: ubuntu-latest
     steps:
@@ -143,6 +144,7 @@ jobs:
           ./mvnw -B test
 
   int-tests:
+    name: Integration tests
     needs: [ build-coordinator, build ]
     runs-on: ubuntu-latest
 
@@ -158,17 +160,7 @@ jobs:
             image: coordinator-dse-68-${{ github.sha }}.tar
 
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Download Docker Images
-        uses: actions/download-artifact@v3
-        with:
-          name: coordinator-images
-          path: /tmp
-
-      - name: Load image
-        run: docker load --input /tmp/${{ matrix.image }}
+      - uses: actions/checkout@v3
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -198,7 +190,19 @@ jobs:
              </server>
            </servers>
           </settings>
-          EOF
+          EOF        
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Download Docker Images
+        uses: actions/download-artifact@v3
+        with:
+          name: coordinator-images
+          path: /tmp
+
+      - name: Load image
+        run: docker load --input /tmp/${{ matrix.image }}
 
       - name: Restore Snapshots
         uses: actions/cache@v3

--- a/.github/workflows/v2-docs-api.yaml
+++ b/.github/workflows/v2-docs-api.yaml
@@ -66,16 +66,12 @@ jobs:
         env:
           cache-name: cache-coordinator-libs
         with:
-          path: stargate-libs
-          key: stargate-libs-${{ github.sha }}
+          path: ./stargate-lib
+          key: stargate-lib-${{ github.sha }}
 
       - name: Build
         if: steps.cache-coordinator-snapshots.outputs.cache-hit != 'true'
-        run: |
-          pwd
-          ls
-          echo $HOME
-          MAVEN_OPTS="-Xmx4g" ./mvnw install -P dse -DskipTests
+        run: MAVEN_OPTS="-Xmx4g" ./mvnw install -P dse -DskipTests
 
   build-coordinator-docker:
     name: Coordinator docker
@@ -95,8 +91,8 @@ jobs:
         env:
           cache-name: cache-coordinator-libs
         with:
-          path: stargate-libs
-          key: stargate-libs-${{ github.sha }}
+          path: ./stargate-lib
+          key: stargate-lib-${{ github.sha }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/v2-docs-api.yaml
+++ b/.github/workflows/v2-docs-api.yaml
@@ -190,7 +190,7 @@ jobs:
              </server>
            </servers>
           </settings>
-          EOF        
+          EOF
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/v2-docs-api.yaml
+++ b/.github/workflows/v2-docs-api.yaml
@@ -2,12 +2,11 @@ name: CI for Docs API V2
 
 on:
 
-# for now only manual trigger
-#  push:
-#    branches: [ "v2.0.0" ]
-#
-#  pull_request:
-#    branches: [ "v2.0.0" ]
+  push:
+    branches: [ "v2.0.0" ]
+
+  pull_request:
+    branches: [ "v2.0.0" ]
 
   workflow_dispatch:
 
@@ -54,8 +53,10 @@ jobs:
         env:
           cache-name: cache-coordinator-snapshots
         with:
-          path: ~/.m2/repository/io/stargate/
+          path: ~/.m2/repository
           key: snapshots-${{ github.sha }}
+          restore-keys: |
+            snapshots-
 
       - name: Build
         if: steps.cache-coordinator-snapshots.outputs.cache-hit != 'true'
@@ -133,7 +134,7 @@ jobs:
         env:
           cache-name: cache-coordinator-snapshots
         with:
-          path: ~/.m2/repository/io/stargate/
+          path: ~/.m2/repository
           key: snapshots-${{ github.sha }}
 
       - name: Build & Test
@@ -205,7 +206,7 @@ jobs:
         env:
           cache-name: cache-coordinator-snapshots
         with:
-          path: ~/.m2/repository/io/stargate/
+          path: ~/.m2/repository
           key: snapshots-${{ github.sha }}
 
       - name: Integration Test

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -50,14 +50,6 @@ mvn -B install verify --file pom.xml \
 -P default \
 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
-echoinfo "Testing Java 17 projects"
-
-cd sgv2-docsapi/
-JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./mvnw -B verify --file ./pom.xml \
--DskipITs \
--Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-cd ../
-
 echoinfo "Test complete"
 
 echoinfo "Uploading test results"

--- a/sgv2-docsapi/pom.xml
+++ b/sgv2-docsapi/pom.xml
@@ -225,6 +225,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${surefire-plugin.version}</version>
         <configuration>
+          <argLine>-Xmx4g</argLine>
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <maven.home>${maven.home}</maven.home>

--- a/sgv2-docsapi/pom.xml
+++ b/sgv2-docsapi/pom.xml
@@ -20,6 +20,8 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>2.10.0.Final</quarkus.platform.version>
+    <skipTests>false</skipTests>
+    <skipUnitTests>${skipTests}</skipUnitTests>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
   </properties>
   <dependencyManagement>
@@ -231,6 +233,7 @@
             <exclude>**/*IntegrationTest.*</exclude>
             <exclude>**/*EndToEndTest.*</exclude>
           </excludes>
+          <skip>${skipUnitTests}</skip>
         </configuration>
       </plugin>
       <plugin>

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentDeleteResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentDeleteResource.java
@@ -53,8 +53,7 @@ import org.jboss.resteasy.reactive.RestResponse;
 @Tag(ref = OpenApiConstants.Tags.DOCUMENTS)
 public class DocumentDeleteResource {
 
-  public static final String BASE_PATH =
-      "/v2/namespaces/{namespace:\\w+}/collections/{collection:\\w+}";
+  public static final String BASE_PATH = "/v2/namespaces/{namespace:\\w+}/collections";
 
   @Inject WriteDocumentsService documentWriteService;
 
@@ -94,7 +93,7 @@ public class DocumentDeleteResource {
         @APIResponse(ref = OpenApiConstants.Responses.GENERAL_503),
       })
   @DELETE
-  @Path("{document-id}")
+  @Path("{collection:\\w+}/{document-id}")
   public Uni<RestResponse<Object>> deleteDocument(
       @PathParam("namespace") String namespace,
       @PathParam("collection") String collection,
@@ -148,7 +147,7 @@ public class DocumentDeleteResource {
         @APIResponse(ref = OpenApiConstants.Responses.GENERAL_503),
       })
   @DELETE
-  @Path("{document-id}/{document-path:.*}")
+  @Path("{collection:\\w+}/{document-id}/{document-path:.*}")
   public Uni<RestResponse<Object>> deleteSubDocument(
       @PathParam("namespace") String namespace,
       @PathParam("collection") String collection,

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentPatchResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentPatchResource.java
@@ -60,8 +60,7 @@ import org.jboss.resteasy.reactive.RestResponse;
 @Tag(ref = OpenApiConstants.Tags.DOCUMENTS)
 public class DocumentPatchResource {
 
-  public static final String BASE_PATH =
-      "/v2/namespaces/{namespace:\\w+}/collections/{collection:\\w+}";
+  public static final String BASE_PATH = "/v2/namespaces/{namespace:\\w+}/collections";
 
   @Inject WriteDocumentsService documentWriteService;
 
@@ -123,7 +122,7 @@ public class DocumentPatchResource {
         @APIResponse(ref = OpenApiConstants.Responses.GENERAL_503),
       })
   @PATCH
-  @Path("{document-id}")
+  @Path("{collection:\\w+}/{document-id}")
   public Uni<RestResponse<Object>> patchDocument(
       @PathParam("namespace") String namespace,
       @PathParam("collection") String collection,
@@ -209,7 +208,7 @@ public class DocumentPatchResource {
         @APIResponse(ref = OpenApiConstants.Responses.GENERAL_503),
       })
   @PATCH
-  @Path("{document-id}/{document-path:.*}")
+  @Path("{collection:\\w+}/{document-id}/{document-path:.*}")
   public Uni<RestResponse<Object>> patchSubDocument(
       @PathParam("namespace") String namespace,
       @PathParam("collection") String collection,

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentReadResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentReadResource.java
@@ -66,8 +66,7 @@ import org.jboss.resteasy.reactive.RestResponse;
 @Tag(ref = OpenApiConstants.Tags.DOCUMENTS)
 public class DocumentReadResource {
 
-  public static final String BASE_PATH =
-      "/v2/namespaces/{namespace:\\w+}/collections/{collection:\\w+}";
+  public static final String BASE_PATH = "/v2/namespaces/{namespace:\\w+}/collections";
 
   @Inject ReadDocumentsService readDocumentsService;
 
@@ -140,6 +139,7 @@ public class DocumentReadResource {
     @APIResponse(ref = OpenApiConstants.Responses.GENERAL_503),
   })
   @GET
+  @Path("{collection:\\w+}")
   public Uni<RestResponse<Object>> searchDocuments(
       @PathParam("namespace") String namespace,
       @PathParam("collection") String collection,
@@ -237,7 +237,7 @@ public class DocumentReadResource {
     @APIResponse(ref = OpenApiConstants.Responses.GENERAL_503),
   })
   @GET
-  @Path("{document-id}")
+  @Path("{collection:\\w+}/{document-id}")
   public Uni<RestResponse<Object>> getDocument(
       @PathParam("namespace") String namespace,
       @PathParam("collection") String collection,
@@ -321,7 +321,7 @@ public class DocumentReadResource {
     @APIResponse(ref = OpenApiConstants.Responses.GENERAL_503),
   })
   @GET
-  @Path("{document-id}/{document-path:.*}")
+  @Path("{collection:\\w+}/{document-id}/{document-path:.*}")
   public Uni<RestResponse<Object>> getDocumentPath(
       @PathParam("namespace") String namespace,
       @PathParam("collection") String collection,

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentUpdateResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentUpdateResource.java
@@ -60,8 +60,7 @@ import org.jboss.resteasy.reactive.RestResponse;
 @Tag(ref = OpenApiConstants.Tags.DOCUMENTS)
 public class DocumentUpdateResource {
 
-  public static final String BASE_PATH =
-      "/v2/namespaces/{namespace:\\w+}/collections/{collection:\\w+}";
+  public static final String BASE_PATH = "/v2/namespaces/{namespace:\\w+}/collections";
 
   @Inject WriteDocumentsService documentWriteService;
 
@@ -124,7 +123,7 @@ public class DocumentUpdateResource {
         @APIResponse(ref = OpenApiConstants.Responses.GENERAL_503),
       })
   @PUT
-  @Path("{document-id}")
+  @Path("{collection:\\w+}/{document-id}")
   public Uni<RestResponse<Object>> updateDocument(
       @PathParam("namespace") String namespace,
       @PathParam("collection") String collection,
@@ -198,7 +197,7 @@ public class DocumentUpdateResource {
         @APIResponse(ref = OpenApiConstants.Responses.GENERAL_503),
       })
   @PUT
-  @Path("{document-id}/{document-path:.*}")
+  @Path("{collection:\\w+}/{document-id}/{document-path:.*}")
   public Uni<RestResponse<Object>> updateSubDocument(
       @PathParam("namespace") String namespace,
       @PathParam("collection") String collection,

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentWriteResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentWriteResource.java
@@ -64,8 +64,7 @@ import org.jboss.resteasy.reactive.RestResponse.ResponseBuilder;
 @Tag(ref = OpenApiConstants.Tags.DOCUMENTS)
 public class DocumentWriteResource {
 
-  public static final String BASE_PATH =
-      "/v2/namespaces/{namespace:\\w+}/collections/{collection:\\w+}";
+  public static final String BASE_PATH = "/v2/namespaces/{namespace:\\w+}/collections";
 
   @Inject WriteDocumentsService documentWriteService;
 
@@ -126,6 +125,7 @@ public class DocumentWriteResource {
         @APIResponse(ref = OpenApiConstants.Responses.GENERAL_503),
       })
   @POST
+  @Path("{collection:\\w+}")
   public Uni<RestResponse<Object>> createDocument(
       @Context UriInfo uriInfo,
       @PathParam("namespace") String namespace,
@@ -150,7 +150,6 @@ public class DocumentWriteResource {
             });
   }
 
-  @Path("batch")
   @Operation(
       description =
           "Create multiple new documents. If the collection does not exist, it will be created.")
@@ -201,6 +200,7 @@ public class DocumentWriteResource {
         @APIResponse(ref = OpenApiConstants.Responses.GENERAL_503),
       })
   @POST
+  @Path("{collection:\\w+}/batch")
   public Uni<RestResponse<Object>> createDocuments(
       @PathParam("namespace") String namespace,
       @PathParam("collection") String collection,

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/TableManagerTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/TableManagerTest.java
@@ -24,6 +24,7 @@ import io.stargate.sgv2.docsapi.api.exception.ErrorCode;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCodeRuntimeException;
 import io.stargate.sgv2.docsapi.grpc.GrpcClients;
 import io.stargate.sgv2.docsapi.service.schema.query.CollectionQueryProvider;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -251,14 +252,17 @@ class TableManagerTest extends BridgeTest {
           .when(bridgeService)
           .describeKeyspace(any(), any());
 
-      tableManager
-          .getValidCollectionTables(namespace)
-          .subscribe()
-          .withSubscriber(AssertSubscriber.create(1))
-          .awaitNextItem()
-          .assertItems(keyspace.getTables(0))
-          .awaitCompletion()
-          .assertCompleted();
+      List<Schema.CqlTable> result =
+          tableManager
+              .getValidCollectionTables(namespace)
+              .subscribe()
+              .withSubscriber(AssertSubscriber.create(2))
+              .awaitItems(1)
+              .awaitCompletion()
+              .assertCompleted()
+              .getItems();
+
+      assertThat(result).singleElement().isEqualTo(keyspace.getTables(0));
 
       verify(bridgeService).describeKeyspace(any(), any());
       verifyNoMoreInteractions(bridgeService);


### PR DESCRIPTION
**What this PR does**:

Finalizes the CI for the Docs API 2..

**Which issue(s) this PR fixes**:
Fixes #1737

**Checklist**
- [x] Name steps in human readable mode
- [x] Maven memory increase to all steps 
- [x] C2 testing included
- [x] Run time optimization 
    * :heavy_check_mark:  increase max memory for the coordinator build in order to solve 
      `INFO] persistence-dse-6.8 ................................ SUCCESS [11:36 min]`
    * :heavy_check_mark: split docker building in parallel job (maybe impossible)
    * :heavy_check_mark: upload download single images, with sha
    * :heavy_check_mark: don't build restapi/graphql v2 at all
    * :heavy_check_mark: cache restored for the maven repository to avoid full downloads (maybe only `stargateio`)
    * better profiles organization
    * grpc channel tests, spin and stop on the end of tests, not each time
- [x] Documentation added to workflow
- [x] Remove V2 from main CI
- [x] Delete artifacts after run 