### PR TITLE
Change generic NPE to IllegalArgumentException with descriptive message

### DIFF
--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/interceptors/ProxyProtocolQueryInterceptor.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/interceptors/ProxyProtocolQueryInterceptor.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -60,8 +59,7 @@ import org.slf4j.LoggerFactory;
 public class ProxyProtocolQueryInterceptor implements QueryInterceptor {
   public static final String SYSPROP_PROXY_DNS_NAME = "stargate.proxy_protocol.dns_name";
 
-  public static final String PROXY_DNS_NAME =
-      System.getProperty(SYSPROP_PROXY_DNS_NAME);
+  public static final String PROXY_DNS_NAME = System.getProperty(SYSPROP_PROXY_DNS_NAME);
   public static final String INTERNAL_PROXY_DNS_NAME =
       System.getProperty("stargate.proxy_protocol.internal_dns_name");
   public static final int PROXY_PORT =
@@ -129,7 +127,9 @@ public class ProxyProtocolQueryInterceptor implements QueryInterceptor {
       QueryInterceptor wrapped) {
     this.resolver = resolver;
     if (proxyDnsName == null) {
-      throw new IllegalArgumentException(String.format("System property '%s' undefined, cannot create %s",
+      throw new IllegalArgumentException(
+          String.format(
+              "System property '%s' undefined, cannot create %s",
               SYSPROP_PROXY_DNS_NAME, getClass().getName()));
     }
     this.proxyDnsName = proxyDnsName;

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/interceptors/ProxyProtocolQueryInterceptor.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/interceptors/ProxyProtocolQueryInterceptor.java
@@ -58,8 +58,10 @@ import org.slf4j.LoggerFactory;
  * `system.local`. `system.peers` is populated with A-records from a provided DNS name.
  */
 public class ProxyProtocolQueryInterceptor implements QueryInterceptor {
+  public static final String SYSPROP_PROXY_DNS_NAME = "stargate.proxy_protocol.dns_name";
+
   public static final String PROXY_DNS_NAME =
-      System.getProperty("stargate.proxy_protocol.dns_name");
+      System.getProperty(SYSPROP_PROXY_DNS_NAME);
   public static final String INTERNAL_PROXY_DNS_NAME =
       System.getProperty("stargate.proxy_protocol.internal_dns_name");
   public static final int PROXY_PORT =
@@ -126,7 +128,11 @@ public class ProxyProtocolQueryInterceptor implements QueryInterceptor {
       long resolveDelaySecs,
       QueryInterceptor wrapped) {
     this.resolver = resolver;
-    this.proxyDnsName = Objects.requireNonNull(proxyDnsName);
+    if (proxyDnsName == null) {
+      throw new IllegalArgumentException(String.format("System property '%s' undefined, cannot create %s",
+              SYSPROP_PROXY_DNS_NAME, getClass().getName()));
+    }
+    this.proxyDnsName = proxyDnsName;
     this.internalProxyDnsName =
         (internalProxyDnsName == null) ? "internal-" + proxyDnsName : internalProxyDnsName;
     this.proxyPort = proxyPort;


### PR DESCRIPTION
**What this PR does**:

Improves error handling for case of missing System property "stargate.proxy_protocol.dns_name" so that instead of getting a non-descriptive `NullPointerException` there is now `IllegalArgumentException` with message indicating the root cause.
See issue #1934 for details

**Which issue(s) this PR fixes**:
Fixes #1934

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
