### PR TITLE
Revert "Fix `ByteBuf` leak caused by not releasing `HAProxyMessage` (…

### DIFF
--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/HAProxyProtocolDetectingDecoder.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/HAProxyProtocolDetectingDecoder.java
@@ -66,15 +66,11 @@ public class HAProxyProtocolDetectingDecoder extends ByteToMessageDecoder {
               new SimpleChannelInboundHandler<HAProxyMessage>() {
                 @Override
                 protected void channelRead0(ChannelHandlerContext ctx, HAProxyMessage msg) {
-                  try {
-                    Attribute<ProxyInfo> attrProxy = ctx.channel().attr(ProxyInfo.attributeKey);
-                    attrProxy.set(
-                        new ProxyInfo(
-                            new InetSocketAddress(msg.destinationAddress(), msg.destinationPort()),
-                            new InetSocketAddress(msg.sourceAddress(), msg.sourcePort())));
-                  } finally {
-                    msg.release();
-                  }
+                  Attribute<ProxyInfo> attrProxy = ctx.channel().attr(ProxyInfo.attributeKey);
+                  attrProxy.set(
+                      new ProxyInfo(
+                          new InetSocketAddress(msg.destinationAddress(), msg.destinationPort()),
+                          new InetSocketAddress(msg.sourceAddress(), msg.sourcePort())));
                 }
               });
     } else {


### PR DESCRIPTION
…#1910)"

This reverts commit 1effa1a984eb82ea773b16992600a5d9d970cdaa.

**Important**: Releases `v1.0.59` and `v2.0.0-ALPHA-15` are broken releases because of this. We're going to need to do new releases: `v1.0.60` and `v2.0.0-ALPHA-16`.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #1941

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
