### PR TITLE
update docs api V2 traget C* and DSE versions

### DIFF
--- a/sgv2-docsapi/pom.xml
+++ b/sgv2-docsapi/pom.xml
@@ -347,7 +347,7 @@
       <properties>
         <!-- Please maintain default values for int-test in sync with io.stargate.sgv2.docsapi.testresource.StargateTestResource.Defaults -->
         <stargate.int-test.cassandra.image>cassandra</stargate.int-test.cassandra.image>
-        <stargate.int-test.cassandra.image-tag>4.0.3</stargate.int-test.cassandra.image-tag>
+        <stargate.int-test.cassandra.image-tag>4.0.4</stargate.int-test.cassandra.image-tag>
         <stargate.int-test.coordinator.image>stargateio/coordinator-4_0</stargate.int-test.coordinator.image>
         <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
         <stargate.int-test.cluster.name>cass-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
@@ -359,7 +359,7 @@
       <id>cassandra-311</id>
       <properties>
         <stargate.int-test.cassandra.image>cassandra</stargate.int-test.cassandra.image>
-        <stargate.int-test.cassandra.image-tag>3.11.12</stargate.int-test.cassandra.image-tag>
+        <stargate.int-test.cassandra.image-tag>3.11.13</stargate.int-test.cassandra.image-tag>
         <stargate.int-test.coordinator.image>stargateio/coordinator-3_11</stargate.int-test.coordinator.image>
         <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
         <stargate.int-test.cluster.name>cass-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
@@ -371,7 +371,7 @@
       <id>dse-68</id>
       <properties>
         <stargate.int-test.cassandra.image>datastax/dse-server</stargate.int-test.cassandra.image>
-        <stargate.int-test.cassandra.image-tag>6.8.21</stargate.int-test.cassandra.image-tag>
+        <stargate.int-test.cassandra.image-tag>6.8.24</stargate.int-test.cassandra.image-tag>
         <stargate.int-test.coordinator.image>stargateio/coordinator-dse-68</stargate.int-test.coordinator.image>
         <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
         <stargate.int-test.cluster.name>dse-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/testresource/StargateTestResource.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/testresource/StargateTestResource.java
@@ -68,7 +68,7 @@ public class StargateTestResource
   interface Defaults {
 
     String CASSANDRA_IMAGE = "cassandra";
-    String CASSANDRA_IMAGE_TAG = "4.0.3";
+    String CASSANDRA_IMAGE_TAG = "4.0.4";
 
     String STARGATE_IMAGE = "stargateio/coordinator-4_0";
     String STARGATE_IMAGE_TAG = "latest";


### PR DESCRIPTION
**What this PR does**:

Small PR to update the target C* and DSE versions for the Docs API V2 int tests.

**Which issue(s) this PR fixes**:
Relates to #1737 

**Checklist**
- [x] Automated Tests added/updated