### PR TITLE
Change CODEOWNERS to use "core" team, not individual accounts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mpenick @EricBorczuk @olim7t @ivansenic @tatu-at-datastax @jeffreyscarpenter
+* @stargate/Core


### PR DESCRIPTION
**What this PR does**:

Improves maintenance of CODEOWNERS by using `core` team, not individual accounts

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
