### PR TITLE
closes #1928: web app exceptions to be intercepted

### DIFF
--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/exception/WebApplicationExceptionMapper.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/exception/WebApplicationExceptionMapper.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.api.common.exception;
+
+import io.stargate.sgv2.docsapi.api.common.exception.model.dto.ApiError;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+
+/**
+ * Simple exception mapper for the {@link WebApplicationException}. Needed due to the existence of
+ * the {@link RuntimeExceptionMapper} that must not be used for these exceptions.
+ */
+public class WebApplicationExceptionMapper {
+
+  @ServerExceptionMapper
+  public Response webApplicationException(WebApplicationException exception) {
+    Response response = exception.getResponse();
+    ApiError error = new ApiError(exception.getMessage(), response.getStatus());
+    return Response.fromResponse(response).entity(error).build();
+  }
+}

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/exception/WebApplicationExceptionMapperTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/exception/WebApplicationExceptionMapperTest.java
@@ -43,7 +43,7 @@ public class WebApplicationExceptionMapperTest {
   public void happyPath() {
     given()
         .when()
-        .post("/runtime-exception-mapper-test")
+        .post("/web-application-exception-mapper-test")
         .then()
         .statusCode(405)
         .body("code", is(405))

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/exception/WebApplicationExceptionMapperTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/exception/WebApplicationExceptionMapperTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.api.common.exception;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import io.quarkus.test.junit.QuarkusTest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class WebApplicationExceptionMapperTest {
+
+  @Path("web-application-exception-mapper-test")
+  public static class TestingResource {
+
+    @GET
+    @Produces("text/plain")
+    public String greet() {
+      return "hello";
+    }
+  }
+
+  @Test
+  public void happyPath() {
+    given()
+        .when()
+        .post("/runtime-exception-mapper-test")
+        .then()
+        .statusCode(405)
+        .body("code", is(405))
+        .body("description", is("HTTP 405 Method Not Allowed"));
+  }
+}


### PR DESCRIPTION
**What this PR does**:
Intercepts the `javax.ws.rs.WebApplicationException` in order that they are not ending up in the `io.stargate.sgv2.docsapi.api.common.exception.RuntimeExceptionMapper`. This way these exception are not returning correct responses.

**Which issue(s) this PR fixes**:
Fixes #1928

**Checklist**
- [x] Automated Tests added/updated
