### PR TITLE
closes #1903: decrease fetch of the comparable bytes

### DIFF
--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/executor/DocumentProperty.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/executor/DocumentProperty.java
@@ -26,7 +26,7 @@ import io.stargate.sgv2.docsapi.service.common.model.RowWrapper;
 import io.stargate.sgv2.docsapi.service.query.model.paging.CombinedPagingState;
 import io.stargate.sgv2.docsapi.service.query.model.paging.PagingStateSupplier;
 import java.nio.ByteBuffer;
-import java.util.Comparator;
+import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
 /**
@@ -40,15 +40,6 @@ import org.immutables.value.Value;
  */
 @Value.Immutable(lazyhash = true)
 public abstract class DocumentProperty implements PagingStateSupplier {
-
-  /**
-   * Comparator for comparing {@link DocumentProperty}s by the output of the {@link
-   * DocumentProperty#comparableKey()}. Compares bytes in unsigned way.
-   */
-  public static final Comparator<DocumentProperty> COMPARABLE_BYTES_COMPARATOR =
-      (docProperty1, docProperty2) ->
-          ByteString.unsignedLexicographicalComparator()
-              .compare(docProperty1.comparableKey(), docProperty2.comparableKey());
 
   /**
    * A result set that points to a page where the row that describes this document property
@@ -70,11 +61,20 @@ public abstract class DocumentProperty implements PagingStateSupplier {
    */
   abstract int queryIndex();
 
-  /** @return Comparable key that can be used for comparing the partition belonging for this row. */
-  @Value.Lazy
+  /**
+   * @return Comparable key that can be used for comparing the partition belonging for this row. Or
+   *     <code>null</code> if row does not contain it.
+   */
+  @Value.Lazy()
+  @Nullable
   ByteString comparableKey() {
     QueryOuterClass.Row row = rowWrapper().row();
-    return row.getComparableBytes().getValue();
+
+    if (row.hasComparableBytes()) {
+      return row.getComparableBytes().getValue();
+    } else {
+      return null;
+    }
   }
 
   /**

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/executor/DocumentPropertyComparator.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/executor/DocumentPropertyComparator.java
@@ -1,11 +1,19 @@
 package io.stargate.sgv2.docsapi.service.query.executor;
 
+import com.google.protobuf.ByteString;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
 public class DocumentPropertyComparator implements Comparator<DocumentProperty> {
+
+  /**
+   * Comparator for comparing {@link DocumentProperty#comparableKey()}s. Compares bytes in unsigned
+   * way.
+   */
+  public static final Comparator<ByteString> COMPARABLE_BYTES_COMPARATOR =
+      Comparator.nullsLast(ByteString.unsignedLexicographicalComparator());
 
   private final List<String> documentPathsColumns;
 
@@ -17,7 +25,7 @@ public class DocumentPropertyComparator implements Comparator<DocumentProperty> 
   @Override
   public int compare(DocumentProperty p1, DocumentProperty p2) {
     // always first compare by using COMPARABLE_BYTES_COMPARATOR
-    int byteCompare = DocumentProperty.COMPARABLE_BYTES_COMPARATOR.compare(p1, p2);
+    int byteCompare = COMPARABLE_BYTES_COMPARATOR.compare(p1.comparableKey(), p2.comparableKey());
     if (byteCompare != 0) {
       return byteCompare;
     }

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/ReadBridgeServiceTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/ReadBridgeServiceTest.java
@@ -96,7 +96,6 @@ class ReadBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
       ValidatingStargateBridge.QueryAssert populateFirstAssert =
           withQuery(populateCql, Values.of("1"))
               .withPageSize(documentProperties.maxSearchPageSize())
-              .enriched()
               .withColumnSpec(schemaProvider.allColumnSpec())
               .returning(
                   Arrays.asList(
@@ -124,7 +123,6 @@ class ReadBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
       ValidatingStargateBridge.QueryAssert populateSecondAssert =
           withQuery(populateCql, Values.of("2"))
               .withPageSize(documentProperties.maxSearchPageSize())
-              .enriched()
               .withColumnSpec(schemaProvider.allColumnSpec())
               .returning(
                   Arrays.asList(
@@ -276,7 +274,6 @@ class ReadBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
       ValidatingStargateBridge.QueryAssert populateFirstAssert =
           withQuery(populateCql, Values.of("1"))
               .withPageSize(documentProperties.maxSearchPageSize())
-              .enriched()
               .withColumnSpec(schemaProvider.allColumnSpec())
               .returning(
                   Arrays.asList(
@@ -593,7 +590,6 @@ class ReadBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
       ValidatingStargateBridge.QueryAssert cqlAssert =
           withQuery(cql, Values.of(documentId))
               .withPageSize(documentProperties.getApproximateStoragePageSize(paginator.docPageSize))
-              .enriched()
               .withColumnSpec(schemaProvider.allColumnSpec())
               .returning(
                   Arrays.asList(
@@ -997,7 +993,6 @@ class ReadBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
       ValidatingStargateBridge.QueryAssert cqlAssert =
           withQuery(cql, Values.of(documentId))
               .withPageSize(documentProperties.maxSearchPageSize())
-              .enriched()
               .withColumnSpec(
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder().setName("key").build(),
@@ -1082,7 +1077,6 @@ class ReadBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
               Values.of(""),
               Values.of("find-me"),
               Values.of("1"))
-          .enriched()
           .withColumnSpec(schemaProvider.allColumnSpec())
           .returning(Collections.singletonList(List.of(Values.of("1"))));
 
@@ -1092,7 +1086,6 @@ class ReadBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
 
       withQuery(populateCql, Values.of("1"))
           .withPageSize(documentProperties.maxSearchPageSize())
-          .enriched()
           .withColumnSpec(schemaProvider.allColumnSpec())
           .returning(
               Arrays.asList(

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/executor/DocumentPropertyComparatorTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/executor/DocumentPropertyComparatorTest.java
@@ -41,6 +41,21 @@ class DocumentPropertyComparatorTest {
     }
 
     @Test
+    public void onByteCompareNull() {
+      when(p1.comparableKey()).thenReturn(ByteString.copyFromUtf8("a"));
+      when(p2.comparableKey()).thenReturn(null);
+
+      DocumentPropertyComparator comparator =
+          new DocumentPropertyComparator(Collections.singletonList("path"));
+
+      assertThat(comparator.compare(p1, p2)).isLessThan(0);
+      assertThat(comparator.compare(p2, p1)).isGreaterThan(0);
+      verify(p1, times(2)).comparableKey();
+      verify(p2, times(2)).comparableKey();
+      verifyNoMoreInteractions(p1, p2);
+    }
+
+    @Test
     public void onKey() {
       String path = "path";
       when(p1.comparableKey()).thenReturn(ByteString.copyFromUtf8("a"));

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/executor/QueryExecutorTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/executor/QueryExecutorTest.java
@@ -132,7 +132,6 @@ class QueryExecutorTest extends AbstractValidatingStargateBridgeTest {
 
   void withFiveTestDocIds(QueryOuterClass.Query query, int pageSize) {
     withQuery(query.getCql())
-        .enriched()
         .withPageSize(pageSize)
         .withColumnSpec(columnSpec)
         .returning(
@@ -152,7 +151,7 @@ class QueryExecutorTest extends AbstractValidatingStargateBridgeTest {
       List<List<QueryOuterClass.Value>> rows =
           ImmutableList.of(row("1", "x", 1.0d), row("1", "y", 2.0d), row("2", "x", 3.0d));
 
-      withQuery(allDocsQuery.getCql()).enriched().withColumnSpec(columnSpec).returning(rows);
+      withQuery(allDocsQuery.getCql()).withColumnSpec(columnSpec).returning(rows);
 
       List<RawDocument> result =
           queryExecutor
@@ -233,7 +232,6 @@ class QueryExecutorTest extends AbstractValidatingStargateBridgeTest {
 
       withQuery(query.getCql())
           .withPageSize(pageSize)
-          .enriched()
           .withColumnSpec(columnSpec)
           .returning(rows.build());
 
@@ -350,13 +348,11 @@ class QueryExecutorTest extends AbstractValidatingStargateBridgeTest {
 
       withQuery(selectDocQuery.getCql(), Values.of("2"))
           .withPageSize(pageSize)
-          .enriched()
           .withColumnSpec(columnSpec)
           .returning(ImmutableList.of(row("2", "x", 3.0d), row("2", "y", 1.0d)));
 
       withQuery(selectDocQuery.getCql(), Values.of("5"))
           .withPageSize(pageSize)
-          .enriched()
           .withColumnSpec(columnSpec)
           .returning(
               ImmutableList.of(
@@ -436,7 +432,6 @@ class QueryExecutorTest extends AbstractValidatingStargateBridgeTest {
 
       QueryOuterClass.Value[] values = {Values.of("b")};
       withQuery(query.getCql(), values)
-          .enriched()
           .withPageSize(3)
           .withColumnSpec(columnSpec)
           .returning(
@@ -1208,7 +1203,6 @@ class QueryExecutorTest extends AbstractValidatingStargateBridgeTest {
           ImmutableList.of(row("1", "x", 1.0d), row("1", "y", 2.0d), row("2", "x", 3.0d));
 
       withQuery(allDocsQuery.getCql())
-          .enriched()
           .withColumnSpec(columnSpec)
           .withConsistency(QueryOuterClass.Consistency.ONE)
           .returning(rows);

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/impl/InMemoryCandidatesFilterTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/impl/InMemoryCandidatesFilterTest.java
@@ -217,7 +217,6 @@ class InMemoryCandidatesFilterTest extends AbstractValidatingStargateBridgeTest 
                   Values.of(""),
                   Values.of(documentId))
               .withPageSize(2)
-              .enriched()
               .withColumnSpec(schemaProvider.allColumnSpec())
               .returning(List.of(List.of(Values.of("1"))));
 
@@ -292,7 +291,6 @@ class InMemoryCandidatesFilterTest extends AbstractValidatingStargateBridgeTest 
                   Values.of(""),
                   Values.of(documentId))
               .withPageSize(documentProperties.maxSearchPageSize())
-              .enriched()
               .withColumnSpec(schemaProvider.allColumnSpec())
               .returning(List.of(List.of(Values.of("1"))));
 
@@ -361,7 +359,6 @@ class InMemoryCandidatesFilterTest extends AbstractValidatingStargateBridgeTest 
                   Values.of(""),
                   Values.of(documentId))
               .withPageSize(2)
-              .enriched()
               .returningNothing();
 
       CandidatesFilter filter =
@@ -417,7 +414,6 @@ class InMemoryCandidatesFilterTest extends AbstractValidatingStargateBridgeTest 
                   Values.of(""),
                   Values.of(documentId))
               .withPageSize(2)
-              .enriched()
               .returningNothing();
 
       CandidatesFilter filter =
@@ -473,7 +469,6 @@ class InMemoryCandidatesFilterTest extends AbstractValidatingStargateBridgeTest 
                   Values.of(""),
                   Values.of(documentId))
               .withPageSize(2)
-              .enriched()
               .withColumnSpec(schemaProvider.allColumnSpec())
               .returning(List.of(List.of(Values.of("1"))));
 

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/impl/PersistenceCandidatesFilterTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/filter/impl/PersistenceCandidatesFilterTest.java
@@ -216,7 +216,6 @@ class PersistenceCandidatesFilterTest extends AbstractValidatingStargateBridgeTe
                   Values.of("query-value"),
                   Values.of(documentId))
               .withPageSize(2)
-              .enriched()
               .withColumnSpec(schemaProvider.allColumnSpec())
               .returning(List.of(List.of(Values.of("1"))));
 
@@ -282,7 +281,6 @@ class PersistenceCandidatesFilterTest extends AbstractValidatingStargateBridgeTe
                   Values.of(2.0),
                   Values.of(documentId))
               .withPageSize(documentProperties.maxSearchPageSize())
-              .enriched()
               .withColumnSpec(schemaProvider.allColumnSpec())
               .returning(List.of(List.of(Values.of("1"))));
 
@@ -340,7 +338,6 @@ class PersistenceCandidatesFilterTest extends AbstractValidatingStargateBridgeTe
                   Values.of("query-value"),
                   Values.of(documentId))
               .withPageSize(2)
-              .enriched()
               .returningNothing();
 
       CandidatesFilter filter =


### PR DESCRIPTION
**What this PR does**:
Decreases the usage of generating comparable bytes, by setting enriched only when we have two queries or resume mode.. This will have considerable impact, especially in cases when we are populating documents..

Note that the resume mode could be isolated, and we can safely only request comparable bytes once we have multiple queries.. But currently bridge inspects the enriched flag for deciding if resume mode will be handled or not, thus we have a separate ticket for this (#1967).

**Which issue(s) this PR fixes**:
Fixes #1960

**Checklist**
- [x] Automated Tests added/updated

