### PR TITLE
Fix #1968: update DropWizard dep 2.0.28->2.0.32, its dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,20 +20,20 @@
     <xml-format.skip>true</xml-format.skip>
 
     <!-- First DropWizard version and things it directly depends on that make sense to sync -->
-    <dropwizard.version>2.0.28</dropwizard.version>
+    <dropwizard.version>2.0.32</dropwizard.version>
     <!--
       Note that this is currently aligned with the metrics version that DropWizard transitively depends on.
       It's probably a good idea to keep the two versions in sync.
     -->
-    <dropwizard.metrics.version>4.1.29</dropwizard.metrics.version>
+    <dropwizard.metrics.version>4.1.32</dropwizard.metrics.version>
     <!--
       Note that this is currently aligned with the Jetty version that DropWizard transitively depends on.
       It's probably a good idea to keep the two versions in sync.
     -->
-    <jetty.version>9.4.44.v20210927</jetty.version>
+    <jetty.version>9.4.48.v20220622</jetty.version>
     <!-- Logging framework likewise in sync -->
     <slf4j.version>1.7.36</slf4j.version>
-    <logback.version>1.2.9</logback.version>
+    <logback.version>1.2.11</logback.version>
 
     <!-- And then other 3rd party version dependencies, compile/runtime -->
 
@@ -41,12 +41,7 @@
     <commons-io.version>2.7</commons-io.version>
     <grpc.version>1.45.1</grpc.version>
     <immutables.version>2.8.8</immutables.version>
-    <!-- 28-Mar-2022, tatu: BOM for "micro-patch" 2.12.6.1 of jackson-databind
-        is bit unusual wrt version; normally would be "x.y.z": when updating see:
-          https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom
-        for available versions
-      -->
-    <jackson.version>2.12.6.20220326</jackson.version>
+    <jackson.version>2.12.7</jackson.version>
     <javatuples.version>1.2</javatuples.version>
     <!-- Make sure micrometer and prometheus versions are in sync  -->
     <micrometer.version>1.7.3</micrometer.version>


### PR DESCRIPTION
**What this PR does**:

Updates DropWizard to the latest (2.0.32), its dependencies similarly

**Which issue(s) this PR fixes**:
Fixes #1968

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated -- relying on IT/CI against regression
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
