### PR TITLE
relates to #1823: final setup for the docs api v2

### DIFF
--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/StargateDocsApi.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/StargateDocsApi.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi;
 
 import io.stargate.sgv2.docsapi.api.common.exception.model.dto.ApiError;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/properties/datastore/impl/DataStorePropertiesImpl.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/properties/datastore/impl/DataStorePropertiesImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.api.common.properties.datastore.impl;
 
 import io.stargate.sgv2.docsapi.api.common.properties.datastore.DataStoreProperties;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/properties/document/DocumentTableColumns.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/properties/document/DocumentTableColumns.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.api.common.properties.document;
 
 import io.stargate.sgv2.common.cql.builder.Column;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/properties/document/configuration/DocumentPropertiesConfiguration.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/common/properties/document/configuration/DocumentPropertiesConfiguration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.api.common.properties.document.configuration;
 
 import io.quarkus.runtime.Startup;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/model/dto/MultiDocsResponse.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/model/dto/MultiDocsResponse.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.api.v2.model.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResource.java
@@ -78,7 +78,9 @@ public class CollectionsResource {
 
   @Inject @Authorized TableManager tableManager;
 
-  @Operation(description = "List collections in a namespace.")
+  @Operation(
+      summary = "List collections",
+      description = "List all available collections in a namespace.")
   @Parameters(
       value = {
         @Parameter(
@@ -147,7 +149,9 @@ public class CollectionsResource {
         .map(RestResponse::ok);
   }
 
-  @Operation(description = "Create a new empty collection in a namespace.")
+  @Operation(
+      summary = "Create a collection",
+      description = "Create a new empty collection in a namespace.")
   @Parameters(
       value = {
         @Parameter(
@@ -256,6 +260,7 @@ public class CollectionsResource {
   }
 
   @Operation(
+      summary = "Upgrade a collection",
       description =
           """
           Upgrade a collection in a namespace.
@@ -320,7 +325,7 @@ public class CollectionsResource {
                         new ErrorCodeRuntimeException(ErrorCode.DOCS_API_GENERAL_UPGRADE_INVALID)));
   }
 
-  @Operation(description = "Delete a collection in a namespace.")
+  @Operation(summary = "Delete a collection", description = "Delete a collection in a namespace.")
   @Parameters(
       value = {
         @Parameter(name = "namespace", ref = OpenApiConstants.Parameters.NAMESPACE),

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResource.java
@@ -28,7 +28,7 @@ import io.stargate.sgv2.docsapi.api.v2.namespaces.collections.model.dto.Collecti
 import io.stargate.sgv2.docsapi.api.v2.namespaces.collections.model.dto.CreateCollectionDto;
 import io.stargate.sgv2.docsapi.api.v2.namespaces.collections.model.dto.UpgradeCollectionDto;
 import io.stargate.sgv2.docsapi.config.constants.OpenApiConstants;
-import io.stargate.sgv2.docsapi.service.schema.TableManager;
+import io.stargate.sgv2.docsapi.service.schema.CollectionManager;
 import io.stargate.sgv2.docsapi.service.schema.qualifier.Authorized;
 import java.net.URI;
 import java.util.Collections;
@@ -76,7 +76,7 @@ public class CollectionsResource {
 
   public static final String BASE_PATH = "/v2/namespaces/{namespace:\\w+}/collections";
 
-  @Inject @Authorized TableManager tableManager;
+  @Inject @Authorized CollectionManager collectionManager;
 
   @Operation(
       summary = "List collections",
@@ -129,7 +129,7 @@ public class CollectionsResource {
       @PathParam("namespace") String namespace, @QueryParam("raw") boolean raw) {
 
     // get all valid collection tables
-    return tableManager
+    return collectionManager
         .getValidCollectionTables(namespace)
 
         // map to DTO and collect list
@@ -221,7 +221,7 @@ public class CollectionsResource {
     String collection = body.name();
 
     // go get the existing table
-    return tableManager
+    return collectionManager
         .getValidCollectionTable(namespace, collection)
 
         // in case there is a table, ensure we report as error
@@ -245,7 +245,7 @@ public class CollectionsResource {
             })
         .recoverWithUni(
             () ->
-                tableManager
+                collectionManager
                     .createCollectionTable(namespace, collection)
                     .map(
                         created -> {
@@ -314,7 +314,7 @@ public class CollectionsResource {
 
     // currently no upgrade possible
     // fetch the table and if valid signal exception
-    return tableManager
+    return collectionManager
         .getValidCollectionTable(namespace, collection)
 
         // fail with DOCS_API_GENERAL_UPGRADE_INVALID
@@ -355,7 +355,7 @@ public class CollectionsResource {
   public Uni<RestResponse<Object>> deleteCollection(
       @PathParam("namespace") String namespace, @PathParam("collection") String collection) {
     // go delete the table
-    return tableManager
+    return collectionManager
         .dropCollectionTable(namespace, collection)
         .map(any -> RestResponse.noContent());
   }

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/BuiltInFunctionResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/BuiltInFunctionResource.java
@@ -24,7 +24,7 @@ import io.stargate.sgv2.docsapi.api.v2.namespaces.collections.documents.model.dt
 import io.stargate.sgv2.docsapi.config.constants.OpenApiConstants;
 import io.stargate.sgv2.docsapi.service.ExecutionContext;
 import io.stargate.sgv2.docsapi.service.function.FunctionService;
-import io.stargate.sgv2.docsapi.service.schema.TableManager;
+import io.stargate.sgv2.docsapi.service.schema.CollectionManager;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -65,7 +65,7 @@ public class BuiltInFunctionResource {
 
   @Inject FunctionService functionService;
 
-  @Inject TableManager tableManager;
+  @Inject CollectionManager collectionManager;
 
   @Operation(
       summary = "Executes a a built-in function",
@@ -127,7 +127,7 @@ public class BuiltInFunctionResource {
         documentPath.stream().map(PathSegment::getPath).collect(Collectors.toList());
 
     // call table manager for valid table
-    return tableManager
+    return collectionManager
         .getValidCollectionTable(namespace, collection)
 
         // if there execute the function

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/BuiltInFunctionResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/BuiltInFunctionResource.java
@@ -68,6 +68,7 @@ public class BuiltInFunctionResource {
   @Inject TableManager tableManager;
 
   @Operation(
+      summary = "Executes a a built-in function",
       description =
           "Execute a built-in function (e.g. `$push` and `$pop`) against a value in this document. Performance may vary.")
   @Parameters(

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentDeleteResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentDeleteResource.java
@@ -21,7 +21,7 @@ import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.docsapi.api.common.exception.model.dto.ApiError;
 import io.stargate.sgv2.docsapi.config.constants.OpenApiConstants;
 import io.stargate.sgv2.docsapi.service.ExecutionContext;
-import io.stargate.sgv2.docsapi.service.schema.TableManager;
+import io.stargate.sgv2.docsapi.service.schema.CollectionManager;
 import io.stargate.sgv2.docsapi.service.write.WriteDocumentsService;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -57,7 +57,7 @@ public class DocumentDeleteResource {
 
   @Inject WriteDocumentsService documentWriteService;
 
-  @Inject TableManager tableManager;
+  @Inject CollectionManager collectionManager;
 
   @Operation(summary = "Delete a document", description = "Delete a document with a given ID.")
   @Parameters(
@@ -100,7 +100,7 @@ public class DocumentDeleteResource {
       @PathParam("document-id") String documentId,
       @QueryParam("profile") boolean profile) {
     ExecutionContext context = ExecutionContext.create(profile);
-    return tableManager
+    return collectionManager
         .getValidCollectionTable(namespace, collection)
         .onItem()
         .transformToUni(
@@ -159,7 +159,7 @@ public class DocumentDeleteResource {
     ExecutionContext context = ExecutionContext.create(profile);
     List<String> subPath =
         documentPath.stream().map(PathSegment::getPath).collect(Collectors.toList());
-    return tableManager
+    return collectionManager
         .getValidCollectionTable(namespace, collection)
         .onItem()
         .transformToUni(

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentDeleteResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentDeleteResource.java
@@ -59,7 +59,7 @@ public class DocumentDeleteResource {
 
   @Inject TableManager tableManager;
 
-  @Operation(description = "Delete a document with a given ID.")
+  @Operation(summary = "Delete a document", description = "Delete a document with a given ID.")
   @Parameters(
       value = {
         @Parameter(name = "namespace", ref = OpenApiConstants.Parameters.NAMESPACE),
@@ -111,7 +111,9 @@ public class DocumentDeleteResource {
                     .transform(result -> RestResponse.ResponseBuilder.noContent().build()));
   }
 
-  @Operation(description = "Delete the data at a path in a document by ID.")
+  @Operation(
+      summary = "Delete a path in a document",
+      description = "Delete the data at a path in a document by ID.")
   @Parameters(
       value = {
         @Parameter(name = "namespace", ref = OpenApiConstants.Parameters.NAMESPACE),

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentPatchResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentPatchResource.java
@@ -67,6 +67,7 @@ public class DocumentPatchResource {
   @Inject TableManager tableManager;
 
   @Operation(
+      summary = "Patch a document",
       description =
           "Patch a document with a given ID. Merges data at the root with requested data. Note that operation is not allowed if a JSON schema exist for a target collection.")
   @Parameters(
@@ -139,6 +140,7 @@ public class DocumentPatchResource {
   }
 
   @Operation(
+      summary = "Patch a path in a document",
       description =
           "Patch data at a path in a document by ID. Merges data at the path with requested data, assumes that the data at the path is already an object. Note that operation is not allowed if a JSON schema exist for a target collection.")
   @Parameters(

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentPatchResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentPatchResource.java
@@ -24,7 +24,7 @@ import io.stargate.sgv2.docsapi.api.common.exception.model.dto.ApiError;
 import io.stargate.sgv2.docsapi.config.constants.OpenApiConstants;
 import io.stargate.sgv2.docsapi.models.ExecutionProfile;
 import io.stargate.sgv2.docsapi.service.ExecutionContext;
-import io.stargate.sgv2.docsapi.service.schema.TableManager;
+import io.stargate.sgv2.docsapi.service.schema.CollectionManager;
 import io.stargate.sgv2.docsapi.service.write.WriteDocumentsService;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -64,7 +64,7 @@ public class DocumentPatchResource {
 
   @Inject WriteDocumentsService documentWriteService;
 
-  @Inject TableManager tableManager;
+  @Inject CollectionManager collectionManager;
 
   @Operation(
       summary = "Patch a document",
@@ -132,7 +132,7 @@ public class DocumentPatchResource {
       @QueryParam("profile") boolean profile,
       @NotNull(message = "payload must not be empty") JsonNode body) {
     ExecutionContext context = ExecutionContext.create(profile);
-    Uni<Schema.CqlTable> table = tableManager.ensureValidDocumentTable(namespace, collection);
+    Uni<Schema.CqlTable> table = collectionManager.ensureValidDocumentTable(namespace, collection);
     return documentWriteService
         .patchDocument(table, namespace, collection, documentId, body, ttlAuto, context)
         .onItem()
@@ -222,7 +222,7 @@ public class DocumentPatchResource {
     ExecutionContext context = ExecutionContext.create(profile);
     List<String> subPath =
         documentPath.stream().map(PathSegment::getPath).collect(Collectors.toList());
-    Uni<Schema.CqlTable> table = tableManager.ensureValidDocumentTable(namespace, collection);
+    Uni<Schema.CqlTable> table = collectionManager.ensureValidDocumentTable(namespace, collection);
     return documentWriteService
         .patchSubDocument(table, namespace, collection, documentId, subPath, body, ttlAuto, context)
         .onItem()

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentReadResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentReadResource.java
@@ -26,7 +26,7 @@ import io.stargate.sgv2.docsapi.models.ExecutionProfile;
 import io.stargate.sgv2.docsapi.service.ExecutionContext;
 import io.stargate.sgv2.docsapi.service.common.model.Paginator;
 import io.stargate.sgv2.docsapi.service.query.ReadDocumentsService;
-import io.stargate.sgv2.docsapi.service.schema.TableManager;
+import io.stargate.sgv2.docsapi.service.schema.CollectionManager;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -70,7 +70,7 @@ public class DocumentReadResource {
 
   @Inject ReadDocumentsService readDocumentsService;
 
-  @Inject TableManager tableManager;
+  @Inject CollectionManager collectionManager;
 
   @Operation(
       summary = "Search documents in a collection",
@@ -154,7 +154,7 @@ public class DocumentReadResource {
       @QueryParam("raw") boolean raw) {
 
     // fetch a valid table to ensure read is from a collection table
-    return tableManager
+    return collectionManager
         .getValidCollectionTable(namespace, collection)
 
         // if exists, then map to the read action
@@ -337,7 +337,7 @@ public class DocumentReadResource {
       @QueryParam("raw") boolean raw) {
 
     // fetch a valid table to ensure read is from a collection table
-    return tableManager
+    return collectionManager
         .getValidCollectionTable(namespace, collection)
 
         // if exists, then map to the read action

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentUpdateResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentUpdateResource.java
@@ -68,6 +68,7 @@ public class DocumentUpdateResource {
   @Inject TableManager tableManager;
 
   @Operation(
+      summary = "Create or update a document",
       description =
           "Create or update a document with a given ID. If the collection does not exist, it will be created. If the document already exists, it will be overwritten.")
   @Parameters(
@@ -142,6 +143,7 @@ public class DocumentUpdateResource {
   }
 
   @Operation(
+      summary = "Create or update a path in a document",
       description =
           "Create or update a path in a document by ID. If the collection does not exist, it will be created. If data exists at the path, it will be overwritten.")
   @Parameters(

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentUpdateResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentUpdateResource.java
@@ -24,7 +24,7 @@ import io.stargate.sgv2.docsapi.api.common.exception.model.dto.ApiError;
 import io.stargate.sgv2.docsapi.config.constants.OpenApiConstants;
 import io.stargate.sgv2.docsapi.models.ExecutionProfile;
 import io.stargate.sgv2.docsapi.service.ExecutionContext;
-import io.stargate.sgv2.docsapi.service.schema.TableManager;
+import io.stargate.sgv2.docsapi.service.schema.CollectionManager;
 import io.stargate.sgv2.docsapi.service.write.WriteDocumentsService;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -65,7 +65,7 @@ public class DocumentUpdateResource {
 
   @Inject WriteDocumentsService documentWriteService;
 
-  @Inject TableManager tableManager;
+  @Inject CollectionManager collectionManager;
 
   @Operation(
       summary = "Create or update a document",
@@ -135,7 +135,7 @@ public class DocumentUpdateResource {
       @QueryParam("profile") boolean profile,
       @NotNull(message = "payload must not be empty") JsonNode body) {
     ExecutionContext context = ExecutionContext.create(profile);
-    Uni<Schema.CqlTable> table = tableManager.ensureValidDocumentTable(namespace, collection);
+    Uni<Schema.CqlTable> table = collectionManager.ensureValidDocumentTable(namespace, collection);
     return documentWriteService
         .updateDocument(table, namespace, collection, documentId, body, ttl, context)
         .onItem()
@@ -213,7 +213,7 @@ public class DocumentUpdateResource {
     ExecutionContext context = ExecutionContext.create(profile);
     List<String> subPath =
         documentPath.stream().map(PathSegment::getPath).collect(Collectors.toList());
-    Uni<Schema.CqlTable> table = tableManager.ensureValidDocumentTable(namespace, collection);
+    Uni<Schema.CqlTable> table = collectionManager.ensureValidDocumentTable(namespace, collection);
     return documentWriteService
         .updateSubDocument(
             table, namespace, collection, documentId, subPath, body, ttlAuto, context)

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentWriteResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentWriteResource.java
@@ -25,7 +25,7 @@ import io.stargate.sgv2.docsapi.api.v2.model.dto.MultiDocsResponse;
 import io.stargate.sgv2.docsapi.config.constants.OpenApiConstants;
 import io.stargate.sgv2.docsapi.models.ExecutionProfile;
 import io.stargate.sgv2.docsapi.service.ExecutionContext;
-import io.stargate.sgv2.docsapi.service.schema.TableManager;
+import io.stargate.sgv2.docsapi.service.schema.CollectionManager;
 import io.stargate.sgv2.docsapi.service.write.WriteDocumentsService;
 import java.net.URI;
 import javax.inject.Inject;
@@ -69,7 +69,7 @@ public class DocumentWriteResource {
 
   @Inject WriteDocumentsService documentWriteService;
 
-  @Inject TableManager tableManager;
+  @Inject CollectionManager collectionManager;
 
   @Operation(
       summary = "Create a document",
@@ -138,7 +138,7 @@ public class DocumentWriteResource {
       @QueryParam("profile") boolean profile,
       @NotNull(message = "payload must not be empty") JsonNode body) {
     ExecutionContext context = ExecutionContext.create(profile);
-    Uni<Schema.CqlTable> table = tableManager.ensureValidDocumentTable(namespace, collection);
+    Uni<Schema.CqlTable> table = collectionManager.ensureValidDocumentTable(namespace, collection);
     return documentWriteService
         .writeDocument(table, namespace, collection, body, ttl, context)
         .onItem()
@@ -221,7 +221,7 @@ public class DocumentWriteResource {
       @QueryParam("profile") boolean profile,
       @NotNull(message = "payload must not be empty") JsonNode body) {
     ExecutionContext context = ExecutionContext.create(profile);
-    Uni<Schema.CqlTable> table = tableManager.ensureValidDocumentTable(namespace, collection);
+    Uni<Schema.CqlTable> table = collectionManager.ensureValidDocumentTable(namespace, collection);
     return documentWriteService
         .writeDocuments(table, namespace, collection, body, idPath, ttl, context)
         .onItem()

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentWriteResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentWriteResource.java
@@ -72,7 +72,9 @@ public class DocumentWriteResource {
   @Inject TableManager tableManager;
 
   @Operation(
-      description = "Create a new document. If the collection does not exist, it will be created.")
+      summary = "Create a document",
+      description =
+          "Create a new document with the generated ID. If the collection does not exist, it will be created.")
   @Parameters(
       value = {
         @Parameter(name = "namespace", ref = OpenApiConstants.Parameters.NAMESPACE),
@@ -153,8 +155,15 @@ public class DocumentWriteResource {
   }
 
   @Operation(
+      summary = "Create documents",
       description =
-          "Create multiple new documents. If the collection does not exist, it will be created.")
+          """
+              Create multiple new documents. If the collection does not exist, it will be created.
+
+              > Include the `id-path` parameter to extract the ID for each document from the document itself.
+              The `id-path` should be given as path to the document property containing the id, for example `a.b.c.[0]`.
+              Note that document IDs will be auto-generated     in case there is no `id-path` parameter defined.
+              """)
   @Parameters(
       value = {
         @Parameter(name = "namespace", ref = OpenApiConstants.Parameters.NAMESPACE),

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/jsonschema/JsonSchemaResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/jsonschema/JsonSchemaResource.java
@@ -24,8 +24,8 @@ import io.stargate.sgv2.docsapi.api.exception.ErrorCode;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCodeRuntimeException;
 import io.stargate.sgv2.docsapi.api.v2.namespaces.collections.model.dto.JsonSchemaDto;
 import io.stargate.sgv2.docsapi.config.constants.OpenApiConstants;
+import io.stargate.sgv2.docsapi.service.schema.CollectionManager;
 import io.stargate.sgv2.docsapi.service.schema.JsonSchemaManager;
-import io.stargate.sgv2.docsapi.service.schema.TableManager;
 import io.stargate.sgv2.docsapi.service.schema.qualifier.Authorized;
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
@@ -63,7 +63,7 @@ public class JsonSchemaResource {
   public static final String BASE_PATH =
       "/v2/namespaces/{namespace:\\w+}/collections/{collection:\\w+}/json-schema";
 
-  @Inject @Authorized TableManager tableManager;
+  @Inject @Authorized CollectionManager collectionManager;
 
   @Inject JsonSchemaManager jsonSchemaManager;
 
@@ -136,7 +136,7 @@ public class JsonSchemaResource {
       @NotNull(message = "json schema not provided") JsonNode body) {
     return jsonSchemaManager
         .attachJsonSchema(
-            namespace, tableManager.getValidCollectionTable(namespace, collection), body)
+            namespace, collectionManager.getValidCollectionTable(namespace, collection), body)
         .map(schema -> RestResponse.ok(new JsonSchemaDto(schema)));
   }
 
@@ -188,7 +188,7 @@ public class JsonSchemaResource {
 
     // get schema from the existing table
     return jsonSchemaManager
-        .getJsonSchema(tableManager.getValidCollectionTable(namespace, collection))
+        .getJsonSchema(collectionManager.getValidCollectionTable(namespace, collection))
         .flatMap(
             schema -> {
               if (schema == null) {

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/jsonschema/JsonSchemaResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/jsonschema/JsonSchemaResource.java
@@ -68,6 +68,7 @@ public class JsonSchemaResource {
   @Inject JsonSchemaManager jsonSchemaManager;
 
   @Operation(
+      summary = "Attach a JSON schema",
       description =
           "Assign a JSON schema to a collection. This will erase any schema that already exists.")
   @Parameters(
@@ -80,6 +81,16 @@ public class JsonSchemaResource {
             name = "collection",
             ref = OpenApiConstants.Parameters.COLLECTION,
             description = "The collection to assign a JSON schema to.")
+      })
+  @RequestBody(
+      required = true,
+      description = "The JSON schema to attach",
+      content = {
+        @Content(
+            mediaType = "application/json",
+            examples =
+                @ExampleObject(
+                    ref = "{\"$schema\": \"https://json-schema.org/draft/2019-09/schema\"}"))
       })
   @APIResponses(
       value = {
@@ -122,26 +133,14 @@ public class JsonSchemaResource {
   public Uni<RestResponse<Object>> putJsonSchema(
       @PathParam("namespace") String namespace,
       @PathParam("collection") String collection,
-      @NotNull(message = "json schema not provided")
-          @RequestBody(
-              required = true,
-              description = "The JSON schema to attach",
-              content = {
-                @Content(
-                    mediaType = "application/json",
-                    examples =
-                        @ExampleObject(
-                            ref =
-                                "{\"$schema\": \"https://json-schema.org/draft/2019-09/schema\"}"))
-              })
-          JsonNode body) {
+      @NotNull(message = "json schema not provided") JsonNode body) {
     return jsonSchemaManager
         .attachJsonSchema(
             namespace, tableManager.getValidCollectionTable(namespace, collection), body)
         .map(schema -> RestResponse.ok(new JsonSchemaDto(schema)));
   }
 
-  @Operation(description = "Get a JSON schema from a collection.")
+  @Operation(summary = "Get a JSON schema", description = "Get a JSON schema from a collection.")
   @Parameters(
       value = {
         @Parameter(

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/jsonschema/model/dto/JsonSchemaDto.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/jsonschema/model/dto/JsonSchemaDto.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.model.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/CollectionDto.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/CollectionDto.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.model.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/CreateCollectionDto.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/CreateCollectionDto.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.model.dto;
 
 import javax.validation.constraints.NotBlank;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/UpgradeCollectionDto.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/UpgradeCollectionDto.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.model.dto;
 
 import javax.validation.constraints.NotNull;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/schemas/namespaces/NamespacesResource.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/schemas/namespaces/NamespacesResource.java
@@ -88,7 +88,10 @@ public class NamespacesResource {
 
   @Inject ObjectMapper objectMapper;
 
-  @Operation(description = "Retrieve all available namespaces.")
+  @Operation(
+      summary = "List namespaces",
+      description =
+          "List all available namespaces. Note that a namespace is an equivalent to the Cassandra keyspace.")
   @Parameters(
       value = {
         @Parameter(name = "raw", ref = OpenApiConstants.Parameters.RAW),
@@ -140,7 +143,10 @@ public class NamespacesResource {
         .map(RestResponse::ok);
   }
 
-  @Operation(description = "Retrieve a single namespace specification.")
+  @Operation(
+      summary = "Get a namespace",
+      description =
+          "Retrieve a single namespace specification. Note that a namespace is an equivalent to the Cassandra keyspace.")
   @Parameters(
       value = {
         @Parameter(
@@ -202,7 +208,10 @@ public class NamespacesResource {
         .map(RestResponse::ok);
   }
 
-  @Operation(description = "Create a new namespace.")
+  @Operation(
+      summary = "Create a namespace",
+      description =
+          "Create a new namespace using given replication strategy. Note that a namespace is an equivalent to the Cassandra keyspace.")
   @RequestBody(
       description = "Request body",
       content =
@@ -311,7 +320,10 @@ public class NamespacesResource {
                         }));
   }
 
-  @Operation(description = "Delete a namespace.")
+  @Operation(
+      summary = "Delete a namespace",
+      description =
+          "Delete a namespace if exists. Note that a namespace is an equivalent to the Cassandra keyspace.")
   @Parameters(
       value = {
         @Parameter(

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/schemas/namespaces/model/dto/Datacenter.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/schemas/namespaces/model/dto/Datacenter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.api.v2.schemas.namespaces.model.dto;
 
 import javax.validation.constraints.Min;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/config/AuthConfig.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/config/AuthConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.config;
 
 import io.smallrye.config.ConfigMapping;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/config/MultiTenancyConfig.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/config/MultiTenancyConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.config;
 
 import io.smallrye.config.ConfigMapping;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/config/QueriesConfig.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/config/QueriesConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.config;
 
 import io.smallrye.config.ConfigMapping;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/grpc/GrpcClients.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/grpc/GrpcClients.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.grpc;
 
 import io.grpc.Metadata;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/json/DeadLeaf.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/json/DeadLeaf.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.json;
 
 import io.stargate.sgv2.docsapi.config.constants.Constants;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/json/DeadLeafCollector.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/json/DeadLeafCollector.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.json;
 
 /**

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/json/DeadLeafCollectorImpl.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/json/DeadLeafCollectorImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.json;
 
 import java.util.HashMap;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/json/JsonConverter.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/json/JsonConverter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.json;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/json/NoOpDeadLeafCollector.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/json/NoOpDeadLeafCollector.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.json;
 
 public class NoOpDeadLeafCollector implements DeadLeafCollector {}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/executor/DocumentPropertyComparator.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/executor/DocumentPropertyComparator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.query.executor;
 
 import com.google.protobuf.ByteString;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/AuthorizedCollectionManager.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/AuthorizedCollectionManager.java
@@ -24,14 +24,15 @@ import java.util.function.Function;
 import javax.enterprise.context.ApplicationScoped;
 
 /**
- * A version of the {@link TableManager} that ensures authorized schema reads are performed on each
- * op.
+ * A version of the {@link CollectionManager} that ensures authorized schema reads are performed on
+ * each op.
  *
- * <p>You can auto-wire this bean using: <code>@Inject @Authorized TableManager tableManager.</code>
+ * <p>You can auto-wire this bean using: <code>
+ * @Inject @Authorized CollectionManager collectionManager.</code>
  */
 @ApplicationScoped
 @Authorized
-public class AuthorizedTableManager extends TableManager {
+public class AuthorizedCollectionManager extends CollectionManager {
 
   /**
    * {@inheritDoc}

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/AuthorizedTableManager.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/AuthorizedTableManager.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.schema;
 
 import io.smallrye.mutiny.Multi;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/CollectionManager.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/CollectionManager.java
@@ -37,9 +37,9 @@ import java.util.function.Function;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-/** Table manager provides basic operations on tables that are used for storing collections. */
+/** Collection manager provides basic operations on tables that are used for storing collections. */
 @ApplicationScoped
-public class TableManager {
+public class CollectionManager {
 
   private static final Function<String, Uni<? extends Schema.CqlKeyspaceDescribe>>
       MISSING_KEYSPACE_FUNCTION =

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/JsonSchemaManager.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/JsonSchemaManager.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.schema;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/qualifier/Authorized.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/qualifier/Authorized.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.schema.qualifier;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/query/CollectionQueryProvider.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/query/CollectionQueryProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.schema.query;
 
 import io.stargate.bridge.proto.QueryOuterClass;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/query/JsonSchemaQueryProvider.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/query/JsonSchemaQueryProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.schema.query;
 
 import io.stargate.bridge.proto.QueryOuterClass;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/query/NamespaceQueryProvider.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/query/NamespaceQueryProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.schema.query;
 
 import io.stargate.bridge.proto.QueryOuterClass;

--- a/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/write/WriteDocumentsService.java
+++ b/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/write/WriteDocumentsService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.write;
 
 import com.fasterxml.jackson.core.JsonPointer;

--- a/sgv2-docsapi/src/main/resources/application.yaml
+++ b/sgv2-docsapi/src/main/resources/application.yaml
@@ -107,9 +107,18 @@ quarkus:
 
         # due to the https://github.com/quarkusio/quarkus/issues/24938
         # we need to define uri templating on our own for now
+        # note that order is important
         match-patterns: |
-          /v2/namespaces/[\\w]+/collections=/v2/namespaces/{namespace}/collections,
-          /v2/namespaces/[\\w]+/collections/\w+=/v2/namespaces/{namespace}/collections/{collection}
+          /v2/namespaces/[\\w]+/collections=/v2/namespaces/{namespace:\\w+}/collections,
+          /v2/namespaces/[\\w]+/collections/[\\w]+=/v2/namespaces/{namespace:\\w+}/collections/{collection:\\w+},
+          /v2/namespaces/[\\w]+/collections/[\\w]+/batch=/v2/namespaces/{namespace:\\w+}/collections/{collection:\\w+}/batch,
+          /v2/namespaces/[\\w]+/collections/[\\w]+/json-schema=/v2/namespaces/{namespace:\\w+}/collections/{collection:\\w+}/json-schema,
+          /v2/namespaces/[\\w]+/collections/[\\w]+/upgrade=/v2/namespaces/{namespace:\\w+}/collections/{collection:\\w+}/upgrade,
+          /v2/namespaces/[\\w]+/collections/[\\w]+/(.*?)/.*/function=/v2/namespaces/{namespace:\\w+}/collections/{collection:\\w+}/{document-id}/{document-path:.*}/function,
+          /v2/namespaces/[\\w]+/collections/[\\w]+/(.*?)/.*=/v2/namespaces/{namespace:\\w+}/collections/{collection:\\w+}/{document-id}/{document-path:.*},
+          /v2/namespaces/[\\w]+/collections/[\\w]+/.*=/v2/namespaces/{namespace:\\w+}/collections/{collection:\\w+}/{document-id},
+          /v2/schemas/namespaces/[\\w]+=/v2/schemas/namespaces/{namespace:\\w+}
+
     # exports at prometheus default path
     export:
       prometheus:

--- a/sgv2-docsapi/src/main/resources/application.yaml
+++ b/sgv2-docsapi/src/main/resources/application.yaml
@@ -32,7 +32,7 @@ stargate:
   # see io.stargate.sgv2.docsapi.config.MetricsConfig for all config properties and options
   metrics:
     global-tags:
-      module: docsapi
+      module: sgv2-docsapi
     tenant-request-counter:
       enabled: ${stargate.multi-tenancy.enabled}
 

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/exception/StatusRuntimeExceptionMapperTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/exception/StatusRuntimeExceptionMapperTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.api.common.exception;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/metrics/TenantRequestMetricsFilterTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/metrics/TenantRequestMetricsFilterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.api.common.metrics;
 
 import static io.restassured.RestAssured.given;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/properties/datastore/configuration/BridgeDataStorePropertiesConfigurationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/properties/datastore/configuration/BridgeDataStorePropertiesConfigurationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.api.common.properties.datastore.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/properties/datastore/configuration/DefaultDataStorePropertiesConfigurationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/properties/datastore/configuration/DefaultDataStorePropertiesConfigurationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.api.common.properties.datastore.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/properties/document/configuration/DefaultDocumentPropertiesConfigurationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/common/properties/document/configuration/DefaultDocumentPropertiesConfigurationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.api.common.properties.document.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/exception/ErrorCodeRuntimeExceptionMapperTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/exception/ErrorCodeRuntimeExceptionMapperTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.api.exception;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/BuiltInFunctionResourceIntegrationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/BuiltInFunctionResourceIntegrationTest.java
@@ -27,8 +27,8 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.common.cql.builder.Replication;
 import io.stargate.sgv2.docsapi.config.constants.Constants;
+import io.stargate.sgv2.docsapi.service.schema.CollectionManager;
 import io.stargate.sgv2.docsapi.service.schema.NamespaceManager;
-import io.stargate.sgv2.docsapi.service.schema.TableManager;
 import io.stargate.sgv2.docsapi.testprofiles.IntegrationTestProfile;
 import java.time.Duration;
 import javax.enterprise.context.control.ActivateRequestContext;
@@ -55,7 +55,7 @@ class BuiltInFunctionResourceIntegrationTest {
 
   @Inject NamespaceManager namespaceManager;
 
-  @Inject TableManager tableManager;
+  @Inject CollectionManager collectionManager;
 
   @BeforeAll
   public void init() {
@@ -66,7 +66,7 @@ class BuiltInFunctionResourceIntegrationTest {
         .await()
         .atMost(Duration.ofSeconds(10));
 
-    tableManager
+    collectionManager
         .createCollectionTable(DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
         .await()
         .atMost(Duration.ofSeconds(10));

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/BuiltInFunctionResourceIntegrationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/BuiltInFunctionResourceIntegrationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.documents;
 
 import static io.restassured.RestAssured.given;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentDeleteResourceIntegrationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentDeleteResourceIntegrationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.documents;
 
 import static io.restassured.RestAssured.given;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentDeleteResourceIntegrationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentDeleteResourceIntegrationTest.java
@@ -26,8 +26,8 @@ import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
 import io.stargate.sgv2.common.cql.builder.Replication;
 import io.stargate.sgv2.docsapi.config.constants.Constants;
+import io.stargate.sgv2.docsapi.service.schema.CollectionManager;
 import io.stargate.sgv2.docsapi.service.schema.NamespaceManager;
-import io.stargate.sgv2.docsapi.service.schema.TableManager;
 import io.stargate.sgv2.docsapi.testprofiles.IntegrationTestProfile;
 import java.time.Duration;
 import javax.enterprise.context.control.ActivateRequestContext;
@@ -55,7 +55,7 @@ class DocumentDeleteResourceIntegrationTest {
 
   @Inject NamespaceManager namespaceManager;
 
-  @Inject TableManager tableManager;
+  @Inject CollectionManager collectionManager;
 
   @BeforeAll
   public void init() {
@@ -67,7 +67,7 @@ class DocumentDeleteResourceIntegrationTest {
         .await()
         .atMost(Duration.ofSeconds(10));
 
-    tableManager
+    collectionManager
         .createCollectionTable(DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
         .await()
         .atMost(Duration.ofSeconds(10));

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentPatchResourceIntegrationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentPatchResourceIntegrationTest.java
@@ -30,8 +30,8 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.common.cql.builder.Replication;
 import io.stargate.sgv2.docsapi.config.constants.Constants;
+import io.stargate.sgv2.docsapi.service.schema.CollectionManager;
 import io.stargate.sgv2.docsapi.service.schema.NamespaceManager;
-import io.stargate.sgv2.docsapi.service.schema.TableManager;
 import io.stargate.sgv2.docsapi.testprofiles.IntegrationTestProfile;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -62,7 +62,7 @@ class DocumentPatchResourceIntegrationTest {
 
   @Inject NamespaceManager namespaceManager;
 
-  @Inject TableManager tableManager;
+  @Inject CollectionManager collectionManager;
 
   @Inject ObjectMapper objectMapper;
 
@@ -76,7 +76,7 @@ class DocumentPatchResourceIntegrationTest {
         .await()
         .atMost(Duration.ofSeconds(10));
 
-    tableManager
+    collectionManager
         .createCollectionTable(DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
         .await()
         .atMost(Duration.ofSeconds(10));

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentPatchResourceIntegrationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentPatchResourceIntegrationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.documents;
 
 import static io.restassured.RestAssured.given;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentReadResourceIntegrationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentReadResourceIntegrationTest.java
@@ -37,8 +37,8 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.common.cql.builder.Replication;
 import io.stargate.sgv2.docsapi.config.constants.Constants;
+import io.stargate.sgv2.docsapi.service.schema.CollectionManager;
 import io.stargate.sgv2.docsapi.service.schema.NamespaceManager;
-import io.stargate.sgv2.docsapi.service.schema.TableManager;
 import io.stargate.sgv2.docsapi.testprofiles.IntegrationTestProfile;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -74,7 +74,7 @@ class DocumentReadResourceIntegrationTest {
 
   @Inject NamespaceManager namespaceManager;
 
-  @Inject TableManager tableManager;
+  @Inject CollectionManager collectionManager;
 
   @Inject ObjectMapper objectMapper;
 
@@ -87,7 +87,7 @@ class DocumentReadResourceIntegrationTest {
         .await()
         .atMost(Duration.ofSeconds(10));
 
-    tableManager
+    collectionManager
         .createCollectionTable(DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
         .await()
         .atMost(Duration.ofSeconds(10));

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentUpdateResourceIntegrationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentUpdateResourceIntegrationTest.java
@@ -32,8 +32,8 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.common.cql.builder.Replication;
 import io.stargate.sgv2.docsapi.config.constants.Constants;
+import io.stargate.sgv2.docsapi.service.schema.CollectionManager;
 import io.stargate.sgv2.docsapi.service.schema.NamespaceManager;
-import io.stargate.sgv2.docsapi.service.schema.TableManager;
 import io.stargate.sgv2.docsapi.testprofiles.IntegrationTestProfile;
 import java.time.Duration;
 import javax.enterprise.context.control.ActivateRequestContext;
@@ -63,7 +63,7 @@ class DocumentUpdateResourceIntegrationTest {
 
   @Inject NamespaceManager namespaceManager;
 
-  @Inject TableManager tableManager;
+  @Inject CollectionManager collectionManager;
 
   @BeforeAll
   public void init() {
@@ -74,7 +74,7 @@ class DocumentUpdateResourceIntegrationTest {
         .await()
         .atMost(Duration.ofSeconds(10));
 
-    tableManager
+    collectionManager
         .createCollectionTable(DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
         .await()
         .atMost(Duration.ofSeconds(10));

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentWriteResourceIntegrationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentWriteResourceIntegrationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.documents;
 
 import static io.restassured.RestAssured.given;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentWriteResourceIntegrationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentWriteResourceIntegrationTest.java
@@ -37,8 +37,8 @@ import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import io.stargate.sgv2.common.cql.builder.Replication;
 import io.stargate.sgv2.docsapi.config.constants.Constants;
+import io.stargate.sgv2.docsapi.service.schema.CollectionManager;
 import io.stargate.sgv2.docsapi.service.schema.NamespaceManager;
-import io.stargate.sgv2.docsapi.service.schema.TableManager;
 import io.stargate.sgv2.docsapi.testprofiles.IntegrationTestProfile;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -66,7 +66,7 @@ class DocumentWriteResourceIntegrationTest {
 
   @Inject NamespaceManager namespaceManager;
 
-  @Inject TableManager tableManager;
+  @Inject CollectionManager collectionManager;
 
   @Inject ObjectMapper objectMapper;
 
@@ -80,7 +80,7 @@ class DocumentWriteResourceIntegrationTest {
         .await()
         .atMost(Duration.ofSeconds(10));
 
-    tableManager
+    collectionManager
         .createCollectionTable(DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
         .await()
         .atMost(Duration.ofSeconds(10));

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/jsonschema/JsonSchemaResourceIntegrationTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/jsonschema/JsonSchemaResourceIntegrationTest.java
@@ -26,8 +26,8 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.common.cql.builder.Replication;
 import io.stargate.sgv2.docsapi.config.constants.Constants;
+import io.stargate.sgv2.docsapi.service.schema.CollectionManager;
 import io.stargate.sgv2.docsapi.service.schema.NamespaceManager;
-import io.stargate.sgv2.docsapi.service.schema.TableManager;
 import io.stargate.sgv2.docsapi.testprofiles.IntegrationTestProfile;
 import java.time.Duration;
 import javax.enterprise.context.control.ActivateRequestContext;
@@ -57,7 +57,7 @@ public class JsonSchemaResourceIntegrationTest {
   public static final String DEFAULT_COLLECTION = RandomStringUtils.randomAlphanumeric(16);
 
   @Inject NamespaceManager namespaceManager;
-  @Inject TableManager tableManager;
+  @Inject CollectionManager collectionManager;
 
   @BeforeAll
   public void init() {
@@ -68,7 +68,7 @@ public class JsonSchemaResourceIntegrationTest {
         .await()
         .atMost(Duration.ofSeconds(10));
 
-    tableManager
+    collectionManager
         .createCollectionTable(DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
         .await()
         .atMost(Duration.ofSeconds(10));
@@ -234,7 +234,7 @@ public class JsonSchemaResourceIntegrationTest {
     @Order(2)
     public void noSchemaAvailable() {
       // Create a fresh table for this test, to have no schema
-      tableManager
+      collectionManager
           .createCollectionTable(DEFAULT_NAMESPACE, "freshtable")
           .await()
           .atMost(Duration.ofSeconds(10));

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/grpc/GrpcClientsTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/grpc/GrpcClientsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.grpc;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/json/JsonConverterTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/json/JsonConverterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.json;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/condition/impl/ExistsConditionTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/condition/impl/ExistsConditionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.query.condition.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/executor/DocumentPropertyComparatorTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/executor/DocumentPropertyComparatorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.query.executor;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/InMemoryDocumentsResolverTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/InMemoryDocumentsResolverTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.query.search.resolver.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/PersistenceDocumentsResolverTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/PersistenceDocumentsResolverTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.query.search.resolver.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/AuthorizedCollectionManagerTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/AuthorizedCollectionManagerTest.java
@@ -47,11 +47,11 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 @QuarkusTest
-class AuthorizedTableManagerTest extends BridgeTest {
+class AuthorizedCollectionManagerTest extends BridgeTest {
 
   // only one test to assert authorized schema fetch
 
-  @Inject @Authorized TableManager tableManager;
+  @Inject @Authorized CollectionManager collectionManager;
 
   @Inject DocumentProperties documentProperties;
 
@@ -134,7 +134,7 @@ class AuthorizedTableManagerTest extends BridgeTest {
           .when(bridgeService)
           .describeKeyspace(any(), any());
 
-      tableManager
+      collectionManager
           .getValidCollectionTable(namespace, collection)
           .subscribe()
           .withSubscriber(UniAssertSubscriber.create())
@@ -181,7 +181,7 @@ class AuthorizedTableManagerTest extends BridgeTest {
           .when(bridgeService)
           .authorizeSchemaReads(any(), any());
 
-      tableManager
+      collectionManager
           .getValidCollectionTable(namespace, collection)
           .subscribe()
           .withSubscriber(UniAssertSubscriber.create())
@@ -232,7 +232,7 @@ class AuthorizedTableManagerTest extends BridgeTest {
           .when(bridgeService)
           .describeKeyspace(any(), any());
 
-      tableManager
+      collectionManager
           .getValidCollectionTables(namespace)
           .subscribe()
           .withSubscriber(AssertSubscriber.create(1))

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/AuthorizedTableManagerTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/AuthorizedTableManagerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.schema;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/CollectionManagerTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/CollectionManagerTest.java
@@ -53,9 +53,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 @QuarkusTest
-class TableManagerTest extends BridgeTest {
+class CollectionManagerTest extends BridgeTest {
 
-  @Inject TableManager tableManager;
+  @Inject CollectionManager collectionManager;
 
   @Inject CollectionQueryProvider queryProvider;
 
@@ -126,7 +126,7 @@ class TableManagerTest extends BridgeTest {
           .describeKeyspace(any(), any());
 
       UniAssertSubscriber<Schema.CqlTable> result =
-          tableManager
+          collectionManager
               .getValidCollectionTable(namespace, collection)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create());
@@ -161,7 +161,7 @@ class TableManagerTest extends BridgeTest {
           .describeKeyspace(any(), any());
 
       UniAssertSubscriber<Schema.CqlTable> result =
-          tableManager
+          collectionManager
               .getValidCollectionTable(namespace, collection)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create());
@@ -198,7 +198,7 @@ class TableManagerTest extends BridgeTest {
           .describeKeyspace(any(), any());
 
       UniAssertSubscriber<Schema.CqlTable> result =
-          tableManager
+          collectionManager
               .getValidCollectionTable(namespace, collection)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create());
@@ -229,7 +229,7 @@ class TableManagerTest extends BridgeTest {
           .describeKeyspace(any(), any());
 
       UniAssertSubscriber<Schema.CqlTable> result =
-          tableManager
+          collectionManager
               .getValidCollectionTable(namespace, collection)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create());
@@ -269,7 +269,7 @@ class TableManagerTest extends BridgeTest {
           .describeKeyspace(any(), any());
 
       List<Schema.CqlTable> result =
-          tableManager
+          collectionManager
               .getValidCollectionTables(namespace)
               .subscribe()
               .withSubscriber(AssertSubscriber.create(2))
@@ -307,7 +307,7 @@ class TableManagerTest extends BridgeTest {
           .describeKeyspace(any(), any());
 
       Schema.CqlTable result =
-          tableManager
+          collectionManager
               .ensureValidDocumentTable(namespace, collection)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
@@ -372,7 +372,7 @@ class TableManagerTest extends BridgeTest {
           .executeQuery(any(), any());
 
       Schema.CqlTable result =
-          tableManager
+          collectionManager
               .ensureValidDocumentTable(namespace, collection)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
@@ -420,7 +420,7 @@ class TableManagerTest extends BridgeTest {
           .executeQuery(any(), any());
 
       UniAssertSubscriber<Boolean> result =
-          tableManager
+          collectionManager
               .createCollectionTable(namespace, collection)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create());
@@ -439,7 +439,7 @@ class TableManagerTest extends BridgeTest {
       String namespace = RandomStringUtils.randomAlphanumeric(16);
 
       UniAssertSubscriber<Boolean> result =
-          tableManager
+          collectionManager
               .createCollectionTable(namespace, "not-valid-name")
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create());
@@ -493,7 +493,7 @@ class TableManagerTest extends BridgeTest {
           .executeQuery(any(), any());
 
       UniAssertSubscriber<Void> result =
-          tableManager
+          collectionManager
               .dropCollectionTable(namespace, collection)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create());
@@ -514,7 +514,7 @@ class TableManagerTest extends BridgeTest {
     public void wrongPartitionSize() {
       Schema.CqlTable table = Schema.CqlTable.newBuilder().build();
 
-      boolean result = tableManager.isValidCollectionTable(table);
+      boolean result = collectionManager.isValidCollectionTable(table);
 
       assertThat(result).isFalse();
     }
@@ -527,7 +527,7 @@ class TableManagerTest extends BridgeTest {
                   QueryOuterClass.ColumnSpec.newBuilder().setName("my-name").build())
               .build();
 
-      boolean result = tableManager.isValidCollectionTable(table);
+      boolean result = collectionManager.isValidCollectionTable(table);
 
       assertThat(result).isFalse();
     }
@@ -542,7 +542,7 @@ class TableManagerTest extends BridgeTest {
                       .build())
               .build();
 
-      boolean result = tableManager.isValidCollectionTable(table);
+      boolean result = collectionManager.isValidCollectionTable(table);
 
       assertThat(result).isFalse();
     }
@@ -565,7 +565,7 @@ class TableManagerTest extends BridgeTest {
                       .collect(Collectors.toSet()))
               .build();
 
-      boolean result = tableManager.isValidCollectionTable(table);
+      boolean result = collectionManager.isValidCollectionTable(table);
 
       assertThat(result).isFalse();
     }
@@ -589,7 +589,7 @@ class TableManagerTest extends BridgeTest {
                       .collect(Collectors.toSet()))
               .build();
 
-      boolean result = tableManager.isValidCollectionTable(table);
+      boolean result = collectionManager.isValidCollectionTable(table);
 
       assertThat(result).isFalse();
     }
@@ -627,7 +627,7 @@ class TableManagerTest extends BridgeTest {
                   QueryOuterClass.ColumnSpec.newBuilder().setName("my-double-column").build())
               .build();
 
-      boolean result = tableManager.isValidCollectionTable(table);
+      boolean result = collectionManager.isValidCollectionTable(table);
 
       assertThat(result).isFalse();
     }

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/JsonSchemaManagerTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/JsonSchemaManagerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.schema;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/TableManagerTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/TableManagerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.schema;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/query/CollectionQueryProviderTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/query/CollectionQueryProviderTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.schema.query;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/query/JsonSchemaQueryProviderTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/query/JsonSchemaQueryProviderTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.schema.query;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/write/WriteDocumentsServiceTest.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/write/WriteDocumentsServiceTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.service.write;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/testprofiles/IntegrationTestProfile.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/testprofiles/IntegrationTestProfile.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.testprofiles;
 
 import io.quarkus.test.junit.QuarkusTestProfile;

--- a/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/testprofiles/SaiEnabledTestProfile.java
+++ b/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/testprofiles/SaiEnabledTestProfile.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.stargate.sgv2.docsapi.testprofiles;
 
 import com.google.common.collect.ImmutableMap;


### PR DESCRIPTION
**What this PR does**:
Final setup tasks for the docs api V2. Each commit is one task from #1825 

1. name module in metrics as `svg2-docsapi` 
2. uri templating for the metrics
3. copyright headers in all files
4. Revisit OpenAPI documentation
5. Rename `TableManager` to `CollectionManager`

**Which issue(s) this PR fixes**:
Relates to #1823
