### PR TITLE
Briefest way to implement TLS configuration for CQL

### DIFF
--- a/cql/src/main/java/io/stargate/cql/CqlActivator.java
+++ b/cql/src/main/java/io/stargate/cql/CqlActivator.java
@@ -91,9 +91,7 @@ public class CqlActivator extends BaseActivator {
     try {
       Config c;
 
-      // This is the same system property as used by persistence backends for custom configuration
-      // using `cassandra.yaml`.
-      String cassandraConfigPath = System.getProperty("stargate.unsafe.cassandra_config_path", "");
+      String cassandraConfigPath = System.getProperty("stargate.cql.cassandra_config_path", "");
       if (cassandraConfigPath.isEmpty()) {
         c = new Config();
       } else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This is one possible way of enable client encryption (TLS) for CQL. This uses the existing system property "stargate.unsafe.cassandra_config_path" to load the client encryption options from a `cassandra.yaml` (format) type file. 

It could be argued that a another approach would be to implement this in a way that's specific to Stargate using either CLI flags and/or a Stargate-specific configuration file. That approach might be nice, but it will not be a quick or simple to implement.

**Which issue(s) this PR fixes**:
Fixes #1001 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
