### PR TITLE
remove codacy result upload in CI

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -52,27 +52,6 @@ export CCM_CLUSTER_START_TIMEOUT_OVERRIDE=600
 
 echoinfo "Test complete"
 
-echoinfo "Uploading test results"
-
-# We don't care too much if this intermittently fails,
-# so don't fail the entirety of CI if anything below this line fails using set +e
-set +e
-# Determine CODACY_REPORTER_VERSION once to avoid hitting the "get latest" API too frequently
-# in the get.sh commands below. Note: the sed command was copied from get.sh
-export CODACY_REPORTER_VERSION="$(curl https://artifacts.codacy.com/bin/codacy-coverage-reporter/latest)"
-echoinfo "Using Codacy Reporter version \$CODACY_REPORTER_VERSION"
-export CODACY_PROJECT_TOKEN="$(cat /workspace/ci/codacy-project-token | sed -e 's/\n//g')"
-curl -Ls https://coverage.codacy.com/get.sh > get.sh
-chmod +x get.sh
-for f in \$(find . -type f -name 'jacoco.xml'); do
-    ./get.sh report -l Java -r \$f --commit-uuid $COMMIT_ID --partial
-done
-
-if [[ -n \$(find . -type f -name 'jacoco.xml') ]]
-then
-    ./get.sh final --commit-uuid $COMMIT_ID
-fi
-
 EOF
 
 


### PR DESCRIPTION
**What this PR does**:
Removes upload of test results to Codacy, due to the consistent failures.

If we also want to remove the Codacy check as part of the actions, I guess we only need to disable a webhook.

**Which issue(s) this PR fixes**:
Internal issue