### PR TITLE
updated release workflow for V2

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -17,12 +17,16 @@ on:
         required: true
         type: string
 
+# global env vars, available in all jobs and steps
 env:
+  ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+  ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
   MAVEN_OPTS: '-Xmx4g'
 
 jobs:
 
   # creates a new release if it's not existing
+  # outputs the resolved release tag value in the release-tag output var
   # outputs the upload URL in the release-upload-url output var
   create-release:
     name: Create release
@@ -65,9 +69,6 @@ jobs:
           cache: maven
 
       - name: Setup Maven
-        env:
-          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
         run: |
           mkdir -p ~/.m2
           cat <<EOF > ~/.m2/settings.xml
@@ -123,8 +124,6 @@ jobs:
 
       - name: Setup Maven
         env:
-          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
         run: |
@@ -188,9 +187,6 @@ jobs:
       - run: echo "JAVA_17=$JAVA_HOME" >> $GITHUB_ENV
 
       - name: Setup Maven
-        env:
-          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
         run: |
           mkdir -p ~/.m2
           cat <<EOF > ~/.m2/settings.xml
@@ -301,9 +297,6 @@ jobs:
           cache: maven
 
       - name: Setup Maven
-        env:
-          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
         run: |
           mkdir -p ~/.m2
           cat <<EOF > ~/.m2/settings.xml

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -8,10 +8,17 @@ on:
   workflow_dispatch:
     inputs:
       publish:
-        description: 'Should the publishing of docker images and JARs to OSSRH happen?'
+        description: 'Publish docker images and JARs to OSSRH?'
         required: true
         default: false
         type: boolean
+      tag:
+        description: 'Custom release tag value.'
+        required: true
+        type: string
+
+env:
+  MAVEN_OPTS: '-Xmx4g'
 
 jobs:
 
@@ -21,16 +28,24 @@ jobs:
     name: Create release
     runs-on: ubuntu-latest
     outputs:
+      release-tag: ${{ steps.resolve_tag.outputs.tag }}
       release-upload-url: ${{ steps.create_release.outputs.upload_url }}
     steps:
-      - name: Create Release
+      - name: Resolve tag
+        id: resolve_tag
+        run: |
+          TAG=${{ inputs.tag != null && inputs.tag || github.ref }}
+          echo "Resolved tag for the release $TAG"
+          echo "::set-output name=tag::${TAG}"
+
+      - name: Create release
         id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          tag_name: ${{ steps.resolve_tag.outputs.tag }}
+          release_name: Release ${{ steps.resolve_tag.outputs.tag }}
           draft: false
           prerelease: true
 
@@ -53,7 +68,6 @@ jobs:
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-          MAVEN_OPTS: '-Xmx4g'
         run: |
           mkdir -p ~/.m2
           cat <<EOF > ~/.m2/settings.xml
@@ -98,15 +112,7 @@ jobs:
     name: Publish to OSSRH
     runs-on: ubuntu-latest
     steps:
-
       - uses: actions/checkout@v3
-
-      # TODO this below is some magic I don't get, why not using ${{ github.ref }} as in create-release
-      - name: Set version
-        id: vars
-        run: |
-          echo "DEBUG: github ref points to ${{ github.ref }}"
-          echo ::set-output name=tag::${GITHUB_REF#refs/*/}
 
       - name: Set up JDK 8
         uses: actions/setup-java@v3
@@ -121,7 +127,6 @@ jobs:
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
-          MAVEN_OPTS: '-Xmx4g'
         run: |
           mkdir -p ~/.m2
           cat <<EOF > ~/.m2/settings.xml
@@ -160,17 +165,10 @@ jobs:
   # publishes the docker images for the coordinator and the APIs
   publish-docker:
     name: Publish docker images
+    needs: create-release
     runs-on: ubuntu-latest
     steps:
-
       - uses: actions/checkout@v3
-
-      # TODO this below is some magic I don't get, why not using ${{ github.ref }} as in create-release
-      - name: Set version
-        id: vars
-        run: |
-          echo "DEBUG: github ref points to ${{ github.ref }}"
-          echo ::set-output name=tag::${GITHUB_REF#refs/*/}
 
       # install both Java 8 & Java 17, keep paths in vars
       - name: Set up JDK 8
@@ -193,7 +191,6 @@ jobs:
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-          MAVEN_OPTS: '-Xmx4g'
         run: |
           mkdir -p ~/.m2
           cat <<EOF > ~/.m2/settings.xml
@@ -243,25 +240,25 @@ jobs:
       - name: Build and push (coordinator, DockerHub)
         if: ${{ inputs.publish != false }}
         run: |
-          ./build_docker_images.sh -p -t ${{ steps.vars.outputs.tag }}
+          ./build_docker_images.sh -p -t ${{needs.create-release.outputs.release-upload-url}}
 
       - name: Build without push (coordinator, DockerHub)
         if: ${{ inputs.publish == false }}
         run: |
-          ./build_docker_images.sh -t ${{ steps.vars.outputs.tag }}
+          ./build_docker_images.sh -t ${{needs.create-release.outputs.release-upload-url}}
 
       - name: Build and push (apis, DockerHub)
         if: ${{ inputs.publish != false }}
         run: |
           cd apis/
-          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.tag=${{ steps.vars.outputs.tag }}
+          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.tag=${{needs.create-release.outputs.release-upload-url}}
           cd ../
 
       - name: Build without push (apis, DockerHub)
         if: ${{ inputs.publish == false }}
         run: |
           cd apis/
-          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.tag=${{ steps.vars.outputs.tag }}
+          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.tag=${{needs.create-release.outputs.release-upload-url}}
           cd ../
 
       # repeat the same for the AWS ECR
@@ -279,13 +276,13 @@ jobs:
       - name: Build and push (coordinator, Amazon ECR)
         if: ${{ inputs.publish != false }}
         run: |
-          ./build_docker_images.sh -p -t ${{ steps.vars.outputs.tag }} -r ${{ secrets.ECR_REPOSITORY }} -a
+          ./build_docker_images.sh -p -t ${{needs.create-release.outputs.release-upload-url}} -r ${{ secrets.ECR_REPOSITORY }} -a
 
       - name: Build and push (apis, Amazon ECR)
         if: ${{ inputs.publish != false }}
         run: |
           cd apis/
-          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{ steps.vars.outputs.tag }}
+          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{needs.create-release.outputs.release-upload-url}}
           cd ../
 
   # creates a PR for bumping the versions to the next snapshot
@@ -293,7 +290,6 @@ jobs:
     name: Version upgrade PR
     runs-on: ubuntu-latest
     steps:
-
       - uses: actions/checkout@v3
 
       # since we only bump the versions, Java 17 only is fine here

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -6,9 +6,14 @@ on:
       - 'v2.*.*'
 
 jobs:
+
+  # creates a new release if it's not existing
+  # outputs the upload URL in the releaseUploadUrl output var
   create-release:
-    name: create release
+    name: Create release
     runs-on: ubuntu-latest
+    outputs:
+      release-upload-url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - name: Create Release
         id: create_release
@@ -20,31 +25,30 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: true
-      - name: Copy release URL into file
-        run: |
-          mkdir release
-          printf "%s" "${{ steps.create_release.outputs.upload_url }}" > release/url.txt
-      - name: Stash file containing the release URL as an artifact
-        uses: actions/upload-artifact@v1
-        with:
-          name: release-url
-          path: ./release
 
+  # builds coordinator, zips stargate-lib folder and uploads the zip to the created release
   build:
-    name: Build
+    name: Build coordinator
+    needs: create-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        ## TODO why do we need a reference here, it would point to the current ref
         with:
           ref: "v2.0.0"
-      - name: Setup Java JDK
-        uses: actions/setup-java@v1
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
+          cache: maven
+
       - name: Setup Maven
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          MAVEN_OPTS: '-Xmx4g'
         run: |
           mkdir -p ~/.m2
           cat <<EOF > ~/.m2/settings.xml
@@ -63,48 +67,57 @@ jobs:
            </servers>
           </settings>
           EOF
+
       - name: Build with Maven
         run: |
-          mvn versions:set -DremoveSnapshot versions:commit
-          mvn -P dse -q -ff clean package -DskipTests
-      - name: zip-up
+          ./mvnw versions:set -DremoveSnapshot versions:commit
+          ./mvnw -P dse -q -ff clean package -DskipTests
+
+      - name: Zip-up `stargate-lib`
         run: |
           zip -r stargate-jars.zip starctl* stargate-lib
-      - name: Retrieve stashed release URL
-        uses: actions/download-artifact@v1
-        with:
-          name: release-url
-      - name: Read release URL
-        id: get_release_url
-        run: echo ::set-output name=URL::$(cat release-url/url.txt)
+
+      # uploads the jars by referencing the release-upload-url from create-release job
       - name: Upload jars
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.get_release_url.outputs.URL }}
+          upload_url: ${{needs.create-release.outputs.release-upload-url}}
           asset_path: stargate-jars.zip
           asset_name: stargate-jars.zip
-          asset_content_type: text/html
+          asset_content_type: application/zip
 
-  publish:
+  # publish coordinator JARs to the OSSRH
+  publish-ossrh:
+    name: Publish to OSSRH
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+
+      # TODO same here, why do we need the ref?
+      - uses: actions/checkout@v3
         with:
           ref: "v2.0.0"
+
+      # TODO this below is some magic I don't get, why not using ${{ github.ref }} as in create-release
       - name: Set version
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-      - uses: actions/setup-java@v1
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
+          cache: maven
+
       - name: Setup Maven
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_OPTS: '-Xmx4g'
         run: |
           mkdir -p ~/.m2
           cat <<EOF > ~/.m2/settings.xml
@@ -128,45 +141,185 @@ jobs:
            </servers>
           </settings>
           EOF
+
       - id: install-secret-key
         name: Install gpg secret key
         run: |
           cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
+
       - name: Publish package
         run: |
-          mvn versions:set -DremoveSnapshot versions:commit && \
-          mvn -B -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy,dse
+          ./mvnw versions:set -DremoveSnapshot versions:commit
+          ./mvnw -B -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy,dse
+
+  # publishes the docker images for the coordinator and the APIs
+  publish-docker:
+    name: Publish docker images
+    runs-on: ubuntu-latest
+    steps:
+
+      # TODO same here, why do we need the ref?
+      - uses: actions/checkout@v3
+        with:
+          ref: "v2.0.0"
+
+      # TODO this below is some magic I don't get, why not using ${{ github.ref }} as in create-release
+      - name: Set version
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+
+      # install both Java 8 & Java 17, keep paths in vars
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+          cache: maven
+      - run: echo "JAVA_8=$JAVA_HOME" >> $GITHUB_ENV
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: maven
+      - run: echo "JAVA_17=$JAVA_HOME" >> $GITHUB_ENV
+
+      - name: Setup Maven
+        env:
+          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          MAVEN_OPTS: '-Xmx4g'
+        run: |
+          mkdir -p ~/.m2
+          cat <<EOF > ~/.m2/settings.xml
+          <settings>
+            <servers>
+              <server>
+                <id>artifactory-snapshots</id>
+                <username>${ARTIFACTORY_USERNAME}</username>
+                <password>${ARTIFACTORY_PASSWORD}</password>
+              </server>
+              <server>
+                <id>artifactory-releases</id>
+                <username>${ARTIFACTORY_USERNAME}</username>
+                <password>${ARTIFACTORY_PASSWORD}</password>
+             </server>
+           </servers>
+          </settings>
+          EOF
+
+      - name: Install coordinator
+        run: |
+          JAVA_HOME=$JAVA_8 ./mvnw versions:set -DremoveSnapshot versions:commit
+          JAVA_HOME=$JAVA_8 ./mvnw -B clean install -P dse -DskipTests 
+
+      # only set version here
+      - name: Install APIs
+        run: |
+          cd apis/
+          JAVA_HOME=$JAVA_17 ./mvnw versions:set -DremoveSnapshot versions:commit
+          cd ../
+
       - name: Set up Docker QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      # build and push images to Docker buh
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          install: true
-      - name: Build and push
+
+      - name: Build and push (coordinator, DockerHub)
         run: |
           ./build_docker_images.sh -p -t ${{ steps.vars.outputs.tag }}
+
+      - name: Build and push (apis, DockerHub)
+        run: |
+          cd apis/
+          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.tag=${{ steps.vars.outputs.tag }}
+          cd ../
+
+      # repeat the same for the AWS ECR
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.ECR_SECRET_KEY }}
           aws-region: us-east-1
+
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
-      - name: Build and push (ECR)
+
+      - name: Build and push (coordinator, Amazon ECR)
         run: |
           ./build_docker_images.sh -p -t ${{ steps.vars.outputs.tag }} -r ${{ secrets.ECR_REPOSITORY }} -a
-      - name: Update version numbers for next release
+
+      - name: Build and push (apis, Amazon ECR)
         run: |
-          mvn -B release:update-versions -DautoVersionSubmodules=true versions:commit -Pdse && \
-          mvn xml-format:xml-format fmt:format -Pdse
+          cd apis/
+          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{ steps.vars.outputs.tag }}
+          cd ../
+
+  # creates a PR for bumping the versions to the next snapshot
+  create-pr:
+    name: Version upgrade PR
+    runs-on: ubuntu-latest
+    steps:
+
+      # TODO same here, why do we need the ref?
+      - uses: actions/checkout@v3
+        with:
+          ref: "v2.0.0"
+
+      # since we only bump the versions, Java 17 only is fine here
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: maven
+
+      - name: Setup Maven
+        env:
+          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+        run: |
+          mkdir -p ~/.m2
+          cat <<EOF > ~/.m2/settings.xml
+          <settings>
+            <servers>
+              <server>
+                <id>artifactory-snapshots</id>
+                <username>${ARTIFACTORY_USERNAME}</username>
+                <password>${ARTIFACTORY_PASSWORD}</password>
+              </server>
+              <server>
+                <id>artifactory-releases</id>
+                <username>${ARTIFACTORY_USERNAME}</username>
+                <password>${ARTIFACTORY_PASSWORD}</password>
+             </server>
+           </servers>
+          </settings>
+          EOF
+
+      - name: Update version numbers (coordinator)
+        run: |
+          ./mvnw -B release:update-versions -DautoVersionSubmodules=true versions:commit -Pdse
+          ./mvnw xml-format:xml-format fmt:format -Pdse
+
+      - name: Update version numbers (apis)
+        run: |
+          cd apis/
+          ./mvnw -B release:update-versions -DautoVersionSubmodules=true versions:commit
+          ./mvnw xml-format:xml-format fmt:format
+          cd ../
+
       - name: Rev Version
         if: success()
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -5,6 +5,14 @@ on:
     tags:
       - 'v2.*.*'
 
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Should the publishing of docker images and JARs to OSSRH happen?'
+        required: true
+        default: false
+        type: boolean
+
 jobs:
 
   # creates a new release if it's not existing
@@ -148,6 +156,7 @@ jobs:
           cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
 
       - name: Publish package
+        if: ${{ inputs.publish != false }}
         run: |
           ./mvnw versions:set -DremoveSnapshot versions:commit
           ./mvnw -B -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy,dse
@@ -235,10 +244,12 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build and push (coordinator, DockerHub)
+        if: ${{ inputs.publish != false }}
         run: |
           ./build_docker_images.sh -p -t ${{ steps.vars.outputs.tag }}
 
       - name: Build and push (apis, DockerHub)
+        if: ${{ inputs.publish != false }}
         run: |
           cd apis/
           JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.tag=${{ steps.vars.outputs.tag }}
@@ -257,10 +268,12 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Build and push (coordinator, Amazon ECR)
+        if: ${{ inputs.publish != false }}
         run: |
           ./build_docker_images.sh -p -t ${{ steps.vars.outputs.tag }} -r ${{ secrets.ECR_REPOSITORY }} -a
 
       - name: Build and push (apis, Amazon ECR)
+        if: ${{ inputs.publish != false }}
         run: |
           cd apis/
           JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{ steps.vars.outputs.tag }}

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -240,25 +240,25 @@ jobs:
       - name: Build and push (coordinator, DockerHub)
         if: ${{ inputs.publish != false }}
         run: |
-          ./build_docker_images.sh -p -t ${{needs.create-release.outputs.release-upload-url}}
+          ./build_docker_images.sh -p -t ${{needs.create-release.outputs.release-tag}}
 
       - name: Build without push (coordinator, DockerHub)
         if: ${{ inputs.publish == false }}
         run: |
-          ./build_docker_images.sh -t ${{needs.create-release.outputs.release-upload-url}}
+          ./build_docker_images.sh -t ${{needs.create-release.outputs.release-tag}}
 
       - name: Build and push (apis, DockerHub)
         if: ${{ inputs.publish != false }}
         run: |
           cd apis/
-          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.tag=${{needs.create-release.outputs.release-upload-url}}
+          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.tag=${{needs.create-release.outputs.release-tag}}
           cd ../
 
       - name: Build without push (apis, DockerHub)
         if: ${{ inputs.publish == false }}
         run: |
           cd apis/
-          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.tag=${{needs.create-release.outputs.release-upload-url}}
+          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.tag=${{needs.create-release.outputs.release-tag}}
           cd ../
 
       # repeat the same for the AWS ECR
@@ -276,13 +276,13 @@ jobs:
       - name: Build and push (coordinator, Amazon ECR)
         if: ${{ inputs.publish != false }}
         run: |
-          ./build_docker_images.sh -p -t ${{needs.create-release.outputs.release-upload-url}} -r ${{ secrets.ECR_REPOSITORY }} -a
+          ./build_docker_images.sh -p -t ${{needs.create-release.outputs.release-tag}} -r ${{ secrets.ECR_REPOSITORY }} -a
 
       - name: Build and push (apis, Amazon ECR)
         if: ${{ inputs.publish != false }}
         run: |
           cd apis/
-          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{needs.create-release.outputs.release-upload-url}}
+          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{needs.create-release.outputs.release-tag}}
           cd ../
 
   # creates a PR for bumping the versions to the next snapshot

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -16,7 +16,7 @@ on:
 jobs:
 
   # creates a new release if it's not existing
-  # outputs the upload URL in the releaseUploadUrl output var
+  # outputs the upload URL in the release-upload-url output var
   create-release:
     name: Create release
     runs-on: ubuntu-latest
@@ -41,9 +41,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        ## TODO why do we need a reference here, it would point to the current ref
-        with:
-          ref: "v2.0.0"
 
       - name: Set up JDK 8
         uses: actions/setup-java@v3
@@ -102,15 +99,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # TODO same here, why do we need the ref?
       - uses: actions/checkout@v3
-        with:
-          ref: "v2.0.0"
 
       # TODO this below is some magic I don't get, why not using ${{ github.ref }} as in create-release
       - name: Set version
         id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        run: |
+          echo "DEBUG: github ref points to ${{ github.ref }}"
+          echo ::set-output name=tag::${GITHUB_REF#refs/*/}
 
       - name: Set up JDK 8
         uses: actions/setup-java@v3
@@ -167,15 +163,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # TODO same here, why do we need the ref?
       - uses: actions/checkout@v3
-        with:
-          ref: "v2.0.0"
 
       # TODO this below is some magic I don't get, why not using ${{ github.ref }} as in create-release
       - name: Set version
         id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        run: |
+          echo "DEBUG: github ref points to ${{ github.ref }}"
+          echo ::set-output name=tag::${GITHUB_REF#refs/*/}
 
       # install both Java 8 & Java 17, keep paths in vars
       - name: Set up JDK 8
@@ -186,7 +181,7 @@ jobs:
           cache: maven
       - run: echo "JAVA_8=$JAVA_HOME" >> $GITHUB_ENV
 
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
@@ -236,7 +231,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      # build and push images to Docker buh
+      # build and push images to Docker hub
+      # if input.publish is false we are still having tasks for building images without push
+      # this enables build docker check without pushing
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -248,11 +245,23 @@ jobs:
         run: |
           ./build_docker_images.sh -p -t ${{ steps.vars.outputs.tag }}
 
+      - name: Build without push (coordinator, DockerHub)
+        if: ${{ inputs.publish == false }}
+        run: |
+          ./build_docker_images.sh -t ${{ steps.vars.outputs.tag }}
+
       - name: Build and push (apis, DockerHub)
         if: ${{ inputs.publish != false }}
         run: |
           cd apis/
           JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.tag=${{ steps.vars.outputs.tag }}
+          cd ../
+
+      - name: Build without push (apis, DockerHub)
+        if: ${{ inputs.publish == false }}
+        run: |
+          cd apis/
+          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.tag=${{ steps.vars.outputs.tag }}
           cd ../
 
       # repeat the same for the AWS ECR
@@ -285,10 +294,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # TODO same here, why do we need the ref?
       - uses: actions/checkout@v3
-        with:
-          ref: "v2.0.0"
 
       # since we only bump the versions, Java 17 only is fine here
       - name: Set up JDK 17


### PR DESCRIPTION
**What this PR does**:

Main goal was to include `apis/` projects in the release by:
 * publishing docker images
 * bumping versions in the PR

However, I ended-up with a complete refactor of a release workflow.. Here is the overview on the jobs and updates made:

1. Create release
    * still creates release in the same way
    * however, `uploadUrl` is shared to other jobs as the output, no need for upload/download stuff
2. Build coordinator
    * still main task to upload `stargate-libs.zip` to the created release
    * now correctly depends on the `create-release` job and it's output
    * updated actions versions to latest (`actions/checkout@v3`, `actions/setup-java@v3`)
    * uses maven wrapper instead of maven
    * extra memory for maven for faster builds `MAVEN_OPTS: '-Xmx4g'`
3. Publish to OSSRH
    * part of the previous job `publish`, but just handling publishing the coordinator jars to the OSSRH
    * updated actions versions, use wrapper, etc
4. Publish docker images
    * part of the previous job `publish`, but just handling publishing the docker images
    * added support for publishing the `/api` as well, done with installing two java versions
    * same updates as everywhere else
5. Create PR for version update
    * part of the previous job `publish`, but just handling new PR for the new version
    * added support for updating the versions of `/api` as well
    * same updates as everywhere else

In addition I defined a manual trigger with the possibility to skip the publishing of the artifacts and docker images.

**Which issue(s) this PR fixes**:
Internal issue.

**Checklist**
- [x] Manual trigger inputs with no push
