### PR TITLE
improving release v1 github workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # TODO remove after testing
+      - name: Warn publish
+        if: ${{ inputs.publish != false }}
+        run: |
+          echo "ATTENTION: This job will publish JARs to the OOSRH!"
+
       # TODO resolve if this is needed at all
       - name: Set version
         id: vars

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,23 @@ on:
     tags:
       - 'v1.*.*'
 
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Should the publishing JARs to OSSRH happen?'
+        required: true
+        default: false
+        type: boolean
+
 jobs:
+
+  # creates a new release if it's not existing
+  # outputs the upload URL in the release-upload-url output var
   create-release:
-    name: create release
+    name: Create release
     runs-on: ubuntu-latest
+    outputs:
+      release-upload-url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - name: Create Release
         id: create_release
@@ -20,31 +33,27 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
-      - name: Copy release URL into file
-        run: |
-          mkdir release
-          printf "%s" "${{ steps.create_release.outputs.upload_url }}" > release/url.txt
-      - name: Stash file containing the release URL as an artifact
-        uses: actions/upload-artifact@v1
-        with:
-          name: release-url
-          path: ./release
 
+  # builds coordinator, zips stargate-lib folder and uploads the zip to the created release
   build:
     name: Build
+    needs: create-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         with:
-          ref: "master"
-      - name: Setup Java JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
+          cache: maven
+
       - name: Setup Maven
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          MAVEN_OPTS: '-Xmx4g'
         run: |
           mkdir -p ~/.m2
           cat <<EOF > ~/.m2/settings.xml
@@ -63,48 +72,53 @@ jobs:
            </servers>
           </settings>
           EOF
+
       - name: Build with Maven
         run: |
           mvn versions:set -DremoveSnapshot versions:commit
           mvn -P dse -q -ff clean package -DskipTests
-      - name: zip-up
+
+      - name: Zip-up `stargate-lib`
         run: |
           zip stargate-jars.zip starctl stargate-lib/logback.xml stargate-lib/*.jar
-      - name: Retrieve stashed release URL
-        uses: actions/download-artifact@v1
-        with:
-          name: release-url
-      - name: Read release URL
-        id: get_release_url
-        run: echo ::set-output name=URL::$(cat release-url/url.txt)
+          
+      # uploads the jars by referencing the release-upload-url from create-release job
       - name: Upload jars
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.get_release_url.outputs.URL }}
+          upload_url: ${{needs.create-release.outputs.release-upload-url}}
           asset_path: stargate-jars.zip
           asset_name: stargate-jars.zip
           asset_content_type: text/html
 
+  # publish coordinator JARs to the OSSRH
   publish:
+    name: Publish to OSSRH
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: "master"
+      - uses: actions/checkout@v3
+
+      # TODO resolve if this is needed at all
       - name: Set version
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-      - uses: actions/setup-java@v1
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
+          cache: maven
+
       - name: Setup Maven
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_OPTS: '-Xmx4g'
         run: |
           mkdir -p ~/.m2
           cat <<EOF > ~/.m2/settings.xml
@@ -128,16 +142,22 @@ jobs:
            </servers>
           </settings>
           EOF
-      - id: install-secret-key
-        name: Install gpg secret key
+
+      - name: Install gpg secret key
         run: |
           cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
+
       - name: Publish package
+        if: ${{ inputs.publish != false }}
         run: |
           mvn versions:set -DremoveSnapshot versions:commit && \
           mvn -B -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy,dse && \
+
+      - name: Bump versions
+        run: |
           mvn -B release:update-versions -DautoVersionSubmodules=true versions:commit -Pdse && \
           mvn xml-format:xml-format fmt:format -Pdse
+
       - name: Rev Version
         if: success()
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
**What this PR does**:

Ported a subset of Release V2 improvements to the V1 as well.. V1 workflow is considerably simpler:

* introduced the manual trigger with the input that can disable pushing of the jars
* sharing upload url via the outputs
* fixed potential bug with referencing master branch in the release
* updated action version, improved maven setup, etc
* proper naming and deletion of unnecessary stuff

**Unfortunately testing a manual trigger is only possible when this is merged..**

**Which issue(s) this PR fixes**:
Internal issue

**Checklist**
- [ ] Changes manually tested

