### PR TITLE
Add ability to load `dse.yaml` when using DSE persistence

### DIFF
--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -117,6 +117,9 @@ public class DsePersistence
         UserType,
         IndexMetadata,
         ViewTableMetadata> {
+
+  // Visible for testing
+  static final String SYSPROP_UNSAFE_DSE_CONFIG_PATH = "stargate.unsafe.dse_config_path";
   private static final Logger logger = LoggerFactory.getLogger(DsePersistence.class);
 
   public static final Boolean USE_PROXY_PROTOCOL =
@@ -202,8 +205,10 @@ public class DsePersistence
 
     DatabaseDescriptor.daemonInitialization(true, config);
 
-    String dseConfigPath = System.getProperty("stargate.unsafe.dse_config_path", "");
+    String dseConfigPath = System.getProperty(SYSPROP_UNSAFE_DSE_CONFIG_PATH, "");
     if (!dseConfigPath.isEmpty()) {
+      // {@link com.datastax.bdp.config.DseConfigYamlLoader} uses a {@link URL} so it expects
+      // a `file:` prefix for the "dse.config" system property.
       System.setProperty("dse.config", new File(dseConfigPath).toURI().toString());
       DseConfig.init();
     }

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -203,8 +203,6 @@ public class DsePersistence
           "com.sun.management.jmxremote.host", System.getProperty("stargate.listen_address"));
     }
 
-    DatabaseDescriptor.daemonInitialization(true, config);
-
     String dseConfigPath = System.getProperty(SYSPROP_UNSAFE_DSE_CONFIG_PATH, "");
     if (!dseConfigPath.isEmpty()) {
       // {@link com.datastax.bdp.config.DseConfigYamlLoader} uses a {@link URL} so it expects
@@ -212,6 +210,8 @@ public class DsePersistence
       System.setProperty("dse.config", new File(dseConfigPath).toURI().toString());
       DseConfig.init();
     }
+
+    DatabaseDescriptor.daemonInitialization(true, config);
 
     String hostId = System.getProperty("stargate.host_id");
     if (hostId != null && !hostId.isEmpty()) {

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -3,6 +3,7 @@ package io.stargate.db.dse.impl;
 import static io.stargate.db.dse.impl.Conversion.toPreparedMetadata;
 import static io.stargate.db.dse.impl.Conversion.toResultMetadata;
 
+import com.datastax.bdp.config.DseConfig;
 import com.datastax.bdp.db.nodes.Nodes;
 import com.datastax.bdp.db.util.ProductType;
 import com.datastax.bdp.db.util.ProductVersion;
@@ -33,6 +34,7 @@ import io.stargate.db.dse.impl.interceptors.DefaultQueryInterceptor;
 import io.stargate.db.dse.impl.interceptors.ProxyProtocolQueryInterceptor;
 import io.stargate.db.dse.impl.interceptors.QueryInterceptor;
 import io.stargate.db.schema.TableName;
+import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
@@ -199,6 +201,12 @@ public class DsePersistence
     }
 
     DatabaseDescriptor.daemonInitialization(true, config);
+
+    String dseConfigPath = System.getProperty("stargate.unsafe.dse_config_path", "");
+    if (!dseConfigPath.isEmpty()) {
+      System.setProperty("dse.config", new File(dseConfigPath).toURI().toString());
+      DseConfig.init();
+    }
 
     String hostId = System.getProperty("stargate.host_id");
     if (hostId != null && !hostId.isEmpty()) {

--- a/persistence-dse-6.8/src/test/resources/dse-test.yaml
+++ b/persistence-dse-6.8/src/test/resources/dse-test.yaml
@@ -1,0 +1,4 @@
+audit_logging_options:
+  retention_time: 12345 # Test value
+internode_messaging_options:
+  port: 54321 # Another test value


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Allows a dse.yaml to be passed to the persistence backend will allow for configuring DSE-specific settings (e.g. LDAP authn/authz). 

**Which issue(s) this PR fixes**:
Fixes #2011 

**Checklist**
- [X] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
