### PR TITLE
Separate executor in BridgeImpl

### DIFF
--- a/bridge/src/main/java/io/stargate/bridge/impl/BridgeImpl.java
+++ b/bridge/src/main/java/io/stargate/bridge/impl/BridgeImpl.java
@@ -71,9 +71,7 @@ public class BridgeImpl {
             EXECUTOR_SIZE, GrpcUtil.getThreadFactory("bridge-stargate-executor", true));
     server =
         NettyServerBuilder.forAddress(new InetSocketAddress(listenAddress, port))
-            // `Persistence` operations are done asynchronously so there isn't a need for a separate
-            // thread pool for handling gRPC callbacks in `GrpcService`.
-            .directExecutor()
+            .executor(Executors.newScheduledThreadPool(16))
             .intercept(new NewConnectionInterceptor(persistence, authenticationService))
             .intercept(new MetricCollectingServerInterceptor(metrics.getMeterRegistry()))
             .addService(new BridgeService(persistence, authorizationService, executor))

--- a/bridge/src/main/java/io/stargate/bridge/impl/BridgeImpl.java
+++ b/bridge/src/main/java/io/stargate/bridge/impl/BridgeImpl.java
@@ -71,7 +71,9 @@ public class BridgeImpl {
             EXECUTOR_SIZE, GrpcUtil.getThreadFactory("bridge-stargate-executor", true));
     server =
         NettyServerBuilder.forAddress(new InetSocketAddress(listenAddress, port))
-            .executor(Executors.newScheduledThreadPool(16))
+            // `Persistence` operations are done asynchronously so there isn't a need for a separate
+            // thread pool for handling gRPC callbacks in `GrpcService`.
+            .directExecutor()
             .intercept(new NewConnectionInterceptor(persistence, authenticationService))
             .intercept(new MetricCollectingServerInterceptor(metrics.getMeterRegistry()))
             .addService(new BridgeService(persistence, authorizationService, executor))

--- a/bridge/src/main/java/io/stargate/bridge/service/BridgeService.java
+++ b/bridge/src/main/java/io/stargate/bridge/service/BridgeService.java
@@ -148,7 +148,7 @@ public class BridgeService extends StargateBridgeGrpc.StargateBridgeImplBase {
   public void describeKeyspace(
       Schema.DescribeKeyspaceQuery request,
       StreamObserver<Schema.CqlKeyspaceDescribe> responseObserver) {
-    SchemaHandler.describeKeyspace(request, persistence, responseObserver);
+    executor.execute(() -> SchemaHandler.describeKeyspace(request, persistence, responseObserver));
   }
 
   @Override


### PR DESCRIPTION
This is a prospective change that Ivan and I observed improves performance of both reads and writes for docs API v2...I wanted to make this draft to ask what the prior reasoning on using the direct executor was. I think maybe @mpenick or @olim7t would know about that context!

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
