### PR TITLE
Update DSE dependency to 6.8.25

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -54,7 +54,7 @@ RUN git clone --branch master --single-branch https://github.com/riptano/ccm.git
 # Create clusters to pre-download necessary artifacts
 RUN ccm create -v 4.0.4 stargate_40 && ccm remove stargate_40
 RUN ccm create -v 3.11.13 stargate_311 && ccm remove stargate_311
-RUN ccm create -v 6.8.24 --dse stargate_dse68 && ccm remove stargate_dse68
+RUN ccm create -v 6.8.25 --dse stargate_dse68 && ccm remove stargate_dse68
 
 # init the maven user home dir with correct permissions
 # needed for running maven wrapper

--- a/persistence-dse-6.8/README.md
+++ b/persistence-dse-6.8/README.md
@@ -5,13 +5,13 @@ the DSE (DataStax Enterprise cassandra) `6.8.x` version.
 
 ## Cassandra version update
 
-The current Cassandra version this module depends on is `6.8.24`.
+The current Cassandra version this module depends on is `6.8.25`.
 In order to update to a newer patch version, please follow the guidelines below:
 
 * Update the `dse.version` property in the [pom.xml](pom.xml).
 * Update the `ccm.version` property (`it-dse-6.8` profile section) in [testing/pom.xml](testing/pom.xml)
 * Update the [CI Dockerfile](../ci/Dockerfile) and set the new version in the `ccm create` command related to DSE 6.8.
-Note that this will have no effect until the docker image is rebuilt and pushed to the remote repository, thus creating an issue for that would be a good idea.
+Note that this will have no effect until the docker image is rebuilt and pushed to the remote repository, thus creating an issue for that would be a good idea (see below for one such PR)
 * Make sure everything compiles and CI tests are green.
 * Update this `README.md` file with the new or updated instructions.
 
@@ -19,3 +19,8 @@ It's always good to validate your work against the pull requests that bumped the
 
 * `6.8.16` -> `6.8.20` [stargate/stargate#1652](https://github.com/stargate/stargate/pull/1652)
 * `6.8.20` -> `6.8.21` [stargate/stargate#1699](https://github.com/stargate/stargate/pull/1699)
+* `6.8.21` -> `6.8.24` [stargate/stargate#1898](https://github.com/stargate/stargate/pull/1898)
+
+And PR(s) for Docker image build for Stargate-builders:
+
+* `6.8.24`: [stargate/stargate#1906](https://github.com/stargate/stargate/pull/1906)

--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -10,7 +10,7 @@
   <groupId>io.stargate.db.dse</groupId>
   <artifactId>persistence-dse-6.8</artifactId>
   <properties>
-    <dse.version>6.8.24</dse.version>
+    <dse.version>6.8.25</dse.version>
   </properties>
   <repositories>
     <repository>

--- a/persistence-dse-6.8/src/main/java/com/datastax/bdp/search/solr/Cql3SolrSecondaryIndex.java
+++ b/persistence-dse-6.8/src/main/java/com/datastax/bdp/search/solr/Cql3SolrSecondaryIndex.java
@@ -2,6 +2,7 @@ package com.datastax.bdp.search.solr;
 
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import javax.annotation.Nullable;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
@@ -18,7 +19,6 @@ import org.apache.cassandra.index.transactions.IndexTransaction;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.IndexMetadata;
 import org.apache.cassandra.utils.concurrent.OpOrder;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Empty implementation for DSE search indexes.

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -431,7 +431,7 @@
                 <configuration>
                   <systemPropertyVariables>
                     <ccm.dse>true</ccm.dse>
-                    <ccm.version>6.8.24</ccm.version>
+                    <ccm.version>6.8.25</ccm.version>
                     <stargate.test.nodes>1</stargate.test.nodes>
                   </systemPropertyVariables>
                   <failIfNoTests>true</failIfNoTests>


### PR DESCRIPTION
**What this PR does**:

Update DSE version from 6.8.24 to 6.8.25 for persistence-DSE

**Which issue(s) this PR fixes**:
Fixes #2022

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
