### PR TITLE
Update Stargate-builder image to use DSE 6.8.25

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -1,7 +1,7 @@
 HOSTNAME        := gcr.io
 PROJECT         := stargateio
 NAME            := stargate-builder
-VERSION         := v1.0.9
+VERSION         := v1.0.10
 TAG             := ${VERSION}
 IMG             := ${NAME}:${TAG}
 IMG_GCP         := ${HOSTNAME}/${PROJECT}/${IMG}

--- a/ci/README.md
+++ b/ci/README.md
@@ -22,6 +22,19 @@ gcloud auth configure-docker
 
 That said, it's assumed that `gcloud` is available on the system, as it's going to be used for getting the existing image tags in the [Makefile](./Makefile).
 
+NOTE: if you see warning like this for "gcloud auth configure-docker":
+
+```
+WARNING: `docker-credential-gcloud` not in system PATH.
+gcloud's Docker credential helper can be configured but it will not work until this is corrected.
+```
+
+you will need to resolve this by making sure said command from `gcloud` package:
+
+    ./google-cloud-sdk/bin/docker-credential-gcloud
+
+is in the $PATH.
+
 ### Process
 
 * Perform wanted updates related to the image.

--- a/cloudbuild-3_11.yaml
+++ b/cloudbuild-3_11.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.9'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.10'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'

--- a/cloudbuild-4_0.yaml
+++ b/cloudbuild-4_0.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.9'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.10'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'

--- a/cloudbuild-dse.yaml
+++ b/cloudbuild-dse.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.9'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.10'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.8'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.10'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'


### PR DESCRIPTION
**What this PR does**:

Follow up to #2022 needed to make CI use DSE 6.8.25 as well.

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
