### PR TITLE
fix release workflows input defaults

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -25,15 +25,13 @@ env:
 
 jobs:
 
-  # creates a new release if it's not existing
+  # resolves tag value
   # outputs the resolved release tag value in the release-tag output var
-  # outputs the upload URL in the release-upload-url output var
-  create-release:
-    name: Create release
+  resolve-tag:
+    name: Resolve tag
     runs-on: ubuntu-latest
     outputs:
       release-tag: ${{ steps.resolve_tag.outputs.tag }}
-      release-upload-url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - name: Resolve tag
         id: resolve_tag
@@ -42,14 +40,23 @@ jobs:
           echo "Resolved tag for the release $TAG"
           echo "::set-output name=tag::${TAG}"
 
+  # creates a new release if it's not existing
+  # outputs the upload URL in the release-upload-url output var
+  create-release:
+    name: Create release
+    needs: resolve-tag
+    runs-on: ubuntu-latest
+    outputs:
+      release-upload-url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
       - name: Create release
         id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.resolve_tag.outputs.tag }}
-          release_name: Release ${{ steps.resolve_tag.outputs.tag }}
+          tag_name: ${{needs.resolve-tag.outputs.release-tag}}
+          release_name: Release ${{needs.resolve-tag.outputs.release-tag}}
           draft: false
           prerelease: true
 
@@ -164,7 +171,7 @@ jobs:
   # publishes the docker images for the coordinator and the APIs
   publish-docker:
     name: Publish docker images
-    needs: create-release
+    needs: resolve-tag
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -236,25 +243,25 @@ jobs:
       - name: Build and push (coordinator, DockerHub)
         if: ${{ !inputs.skipPublish }}
         run: |
-          ./build_docker_images.sh -p -t ${{needs.create-release.outputs.release-tag}}
+          ./build_docker_images.sh -p -t ${{needs.resolve-tag.outputs.release-tag}}
 
       - name: Build without push (coordinator, DockerHub)
         if: ${{ inputs.publish == false }}
         run: |
-          ./build_docker_images.sh -t ${{needs.create-release.outputs.release-tag}}
+          ./build_docker_images.sh -t ${{needs.resolve-tag.outputs.release-tag}}
 
       - name: Build and push (apis, DockerHub)
         if: ${{ !inputs.skipPublish }}
         run: |
           cd apis/
-          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.tag=${{needs.create-release.outputs.release-tag}}
+          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.tag=${{needs.resolve-tag.outputs.release-tag}}
           cd ../
 
       - name: Build without push (apis, DockerHub)
         if: ${{ inputs.publish == false }}
         run: |
           cd apis/
-          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.tag=${{needs.create-release.outputs.release-tag}}
+          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.tag=${{needs.resolve-tag.outputs.release-tag}}
           cd ../
 
       # repeat the same for the AWS ECR
@@ -272,13 +279,13 @@ jobs:
       - name: Build and push (coordinator, Amazon ECR)
         if: ${{ !inputs.skipPublish }}
         run: |
-          ./build_docker_images.sh -p -t ${{needs.create-release.outputs.release-tag}} -r ${{ secrets.ECR_REPOSITORY }} -a
+          ./build_docker_images.sh -p -t ${{needs.resolve-tag.outputs.release-tag}} -r ${{ secrets.ECR_REPOSITORY }} -a
 
       - name: Build and push (apis, Amazon ECR)
         if: ${{ !inputs.skipPublish }}
         run: |
           cd apis/
-          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{needs.create-release.outputs.release-tag}}
+          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{needs.resolve-tag.outputs.release-tag}}
           cd ../
 
   # creates a PR for bumping the versions to the next snapshot

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -156,7 +156,7 @@ jobs:
           cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
 
       - name: Publish package
-        if:  ${{ !inputs.skipPublish }}
+        if: ${{ !inputs.skipPublish }}
         run: |
           ./mvnw versions:set -DremoveSnapshot versions:commit
           ./mvnw -B -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy,dse
@@ -234,7 +234,7 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build and push (coordinator, DockerHub)
-        if:  ${{ !inputs.skipPublish }}
+        if: ${{ !inputs.skipPublish }}
         run: |
           ./build_docker_images.sh -p -t ${{needs.create-release.outputs.release-tag}}
 
@@ -244,7 +244,7 @@ jobs:
           ./build_docker_images.sh -t ${{needs.create-release.outputs.release-tag}}
 
       - name: Build and push (apis, DockerHub)
-        if:  ${{ !inputs.skipPublish }}
+        if: ${{ !inputs.skipPublish }}
         run: |
           cd apis/
           JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.tag=${{needs.create-release.outputs.release-tag}}
@@ -270,12 +270,12 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Build and push (coordinator, Amazon ECR)
-        if:  ${{ !inputs.skipPublish }}
+        if: ${{ !inputs.skipPublish }}
         run: |
           ./build_docker_images.sh -p -t ${{needs.create-release.outputs.release-tag}} -r ${{ secrets.ECR_REPOSITORY }} -a
 
       - name: Build and push (apis, Amazon ECR)
-        if:  ${{ !inputs.skipPublish }}
+        if: ${{ !inputs.skipPublish }}
         run: |
           cd apis/
           JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{needs.create-release.outputs.release-tag}}

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -7,9 +7,10 @@ on:
 
   workflow_dispatch:
     inputs:
-      publish:
-        description: 'Publish docker images and JARs to OSSRH?'
+      skipPublish:
+        description: 'Skip publishing docker images and JARs to OSSRH?'
         required: true
+        default: true
         type: boolean
       tag:
         description: 'Custom release tag value.'
@@ -155,7 +156,7 @@ jobs:
           cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
 
       - name: Publish package
-        if: ${{ inputs.publish != false }}
+        if:  ${{ !inputs.skipPublish }}
         run: |
           ./mvnw versions:set -DremoveSnapshot versions:commit
           ./mvnw -B -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy,dse
@@ -233,7 +234,7 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build and push (coordinator, DockerHub)
-        if: ${{ inputs.publish != false }}
+        if:  ${{ !inputs.skipPublish }}
         run: |
           ./build_docker_images.sh -p -t ${{needs.create-release.outputs.release-tag}}
 
@@ -243,7 +244,7 @@ jobs:
           ./build_docker_images.sh -t ${{needs.create-release.outputs.release-tag}}
 
       - name: Build and push (apis, DockerHub)
-        if: ${{ inputs.publish != false }}
+        if:  ${{ !inputs.skipPublish }}
         run: |
           cd apis/
           JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.tag=${{needs.create-release.outputs.release-tag}}
@@ -269,12 +270,12 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Build and push (coordinator, Amazon ECR)
-        if: ${{ inputs.publish != false }}
+        if:  ${{ !inputs.skipPublish }}
         run: |
           ./build_docker_images.sh -p -t ${{needs.create-release.outputs.release-tag}} -r ${{ secrets.ECR_REPOSITORY }} -a
 
       - name: Build and push (apis, Amazon ECR)
-        if: ${{ inputs.publish != false }}
+        if:  ${{ !inputs.skipPublish }}
         run: |
           cd apis/
           JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{needs.create-release.outputs.release-tag}}

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -10,7 +10,6 @@ on:
       publish:
         description: 'Publish docker images and JARs to OSSRH?'
         required: true
-        default: false
         type: boolean
       tag:
         description: 'Custom release tag value.'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,10 @@ on:
 
   workflow_dispatch:
     inputs:
-      publish:
-        description: 'Publishing JARs to OSSRH?'
+      skipPublish:
+        description: 'Skip publishing JARs to OSSRH?'
         required: true
+        default: true
         type: boolean
       tag:
         description: 'Custom release tag value.'
@@ -154,7 +155,7 @@ jobs:
           cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
 
       - name: Publish package
-        if: ${{ inputs.publish != false }}
+        if:  ${{ !inputs.skipPublish }}
         run: |
           ./mvnw versions:set -DremoveSnapshot versions:commit
           ./mvnw -B -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy,dse

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
           cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
 
       - name: Publish package
-        if:  ${{ !inputs.skipPublish }}
+        if: ${{ !inputs.skipPublish }}
         run: |
           ./mvnw versions:set -DremoveSnapshot versions:commit
           ./mvnw -B -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy,dse

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,13 +156,13 @@ jobs:
       - name: Publish package
         if: ${{ inputs.publish != false }}
         run: |
-          mvn versions:set -DremoveSnapshot versions:commit && \
-          mvn -B -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy,dse && \
+          ./mvnw versions:set -DremoveSnapshot versions:commit
+          ./mvnw -B -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy,dse
 
       - name: Bump versions
         run: |
-          mvn -B release:update-versions -DautoVersionSubmodules=true versions:commit -Pdse && \
-          mvn xml-format:xml-format fmt:format -Pdse
+          ./mvnw -B release:update-versions -DautoVersionSubmodules=true versions:commit -Pdse
+          ./mvnw xml-format:xml-format fmt:format -Pdse
 
       - name: Rev Version
         if: success()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ on:
       publish:
         description: 'Publishing JARs to OSSRH?'
         required: true
-        default: false
         type: boolean
       tag:
         description: 'Custom release tag value.'


### PR DESCRIPTION
**What this PR does**:

Seems that there is a bug with github inputs and default values, as when release is trigger with the tag push, the inputs still have the default values.. 

I was following the documentation where it states that context is only available in reusable workflows:

![image](https://user-images.githubusercontent.com/10600041/184306467-4a990773-f2d9-4dd6-b0d6-f590edd08252.png)

I am not sure if this is the solution or if we should explicitly set default to `true`.. I am a bit afraid that this will not work as well, and that bug could be is that as `publish` is of type boolean it gets default false when triggered from the push..

In addition, there was a bug in the publish itself, that made the re-running the release fail, see: https://github.com/stargate/stargate/actions/runs/2845140244

**Which issue(s) this PR fixes**:
Internal issue.