### PR TITLE
sign v2 container images with cosign

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -304,7 +304,7 @@ jobs:
 
     strategy:
       matrix:
-        image: [coordinator-3_11, coordinator-4_0, coordinator-dse-68, restapi, graphqlapi, docsapi]
+        image: [restapi, graphqlapi, docsapi]
 
     env:
       # TODO newest version is 1.10.1, this reflects riptano action target version

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -294,6 +294,54 @@ jobs:
           JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{needs.resolve-tag.outputs.release-tag}}
           cd ../
 
+  # signs all docker images with cosign
+  # skip whole job if we did not push images
+  sign-images:
+    name: Sign container images
+    needs: [resolve-tag, publish-docker]
+    if: ${{ !inputs.skipPublish }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        image: [coordinator-3_11, coordinator-4_0, coordinator-dse-68, restapi, graphqlapi, docsapi]
+
+    env:
+      # TODO newest version is 1.10.1, this reflects riptano action target version
+      COSIGN_VERSION: v1.9.0
+
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: ${COSIGN_VERSION}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.ECR_SECRET_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Sign a docker image
+        shell: bash
+        env:
+          COSIGN_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ matrix.image }}:${{ needs.resolve-tag.outputs.release-tag }}
+          COSIGN_PRIVATE_BASE64: ${{ secrets.COSIGN_PRIVATE_BASE64}}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD}}
+          COSIGN_KEY_FILE: _cosign_key_
+          AUX_KEY: signedby
+          # TODO Sign by stargate, or datastax?
+          AUX_VALUE: stargate
+        run: |
+          echo $COSIGN_PRIVATE_BASE64 | base64 --decode > $COSIGN_KEY_FILE
+          echo "=== signing image [$COSIGN_IMAGE] ..."
+          cosign sign --key $COSIGN_KEY_FILE -a $AUX_KEY=$AUX_VALUE $COSIGN_IMAGE
+
   # creates a PR for bumping the versions to the next snapshot
   create-pr:
     name: Version upgrade PR

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -330,7 +330,7 @@ jobs:
       - name: Sign a docker image
         shell: bash
         env:
-          COSIGN_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ matrix.image }}:${{ needs.resolve-tag.outputs.release-tag }}
+          COSIGN_IMAGE: ${{ secrets.ECR_REPOSITORY }}/stargateio/${{ matrix.image }}:${{ needs.resolve-tag.outputs.release-tag }}
           COSIGN_PRIVATE_BASE64: ${{ secrets.COSIGN_PRIVATE_BASE64}}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD}}
           COSIGN_KEY_FILE: _cosign_key_

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -307,7 +307,7 @@ jobs:
         image: [restapi, graphqlapi, docsapi]
 
     env:
-      # TODO newest version is 1.10.1, this reflects riptano action target version
+      # not a newest version, this reflects riptano action target version
       COSIGN_VERSION: v1.9.0
 
     steps:
@@ -335,7 +335,6 @@ jobs:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD}}
           COSIGN_KEY_FILE: _cosign_key_
           AUX_KEY: signedby
-          # TODO Sign by stargate, or datastax?
           AUX_VALUE: stargate
         run: |
           echo $COSIGN_PRIVATE_BASE64 | base64 --decode > $COSIGN_KEY_FILE


### PR DESCRIPTION
**What this PR does**:
Signs the V2 docer images using cosign.. 

This is based on the `ivansenic-release-fix` branch, otherwise there would be conflicts to solve.. Note that merge target is `master`, thus there is a need for the V2 branch merging after this is in..

**Which issue(s) this PR fixes**:
Internal issues

**Checklist**
- [x] Add secrets to the github actions
- [x] ~Commit public key as well, this would enable others to verify our images?~
- [x] Add password and private key to the stargate store 
- [x] sync with https://github.com/stargate/stargate/pull/2039
