### PR TITLE
making all int test in Docs V2 to use @QuarkusIntegrationTest

### DIFF
--- a/.github/workflows/apis-v2.yaml
+++ b/.github/workflows/apis-v2.yaml
@@ -317,10 +317,13 @@ jobs:
 
       # run finally the int tests
       # runs dedicated project with -pl, but also picks depending projects with -am
+      # container test for docsapi only for now, enable for other when ready
       - name: Integration Test
+        env:
+          CONTAINER_TEST: ${{ matrix.project == 'sgv2-docsapi' && 'true' || 'false' }}
         run: |
           cd apis/
-          ./mvnw -B verify -DskipUnitTests -pl ${{ matrix.project }} -am -P ${{ matrix.profile }} -Dtesting.containers.stargate-image=${{ matrix.image }}
+          ./mvnw -B verify -DskipUnitTests -pl ${{ matrix.project }} -am -P ${{ matrix.profile }} -Dquarkus.container-image.build=$CONTAINER_TEST -Dtesting.containers.stargate-image=${{ matrix.image }}
 
   # runs always, deletes built docker image artifacts
   clean-up:

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/properties/document/configuration/DefaultDocumentPropertiesConfigurationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/properties/document/configuration/DefaultDocumentPropertiesConfigurationTest.java
@@ -19,7 +19,9 @@ package io.stargate.sgv2.docsapi.api.properties.document.configuration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.stargate.sgv2.api.common.cql.builder.Column;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.docsapi.api.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.api.properties.document.DocumentTableColumns;
 import io.stargate.sgv2.docsapi.api.properties.document.DocumentTableProperties;
@@ -29,6 +31,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
 class DefaultDocumentPropertiesConfigurationTest {
 
   @Inject DocumentProperties documentProperties;

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/DocsApiIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/DocsApiIntegrationTest.java
@@ -1,0 +1,115 @@
+package io.stargate.sgv2.docsapi.api.v2;
+
+import static io.restassured.RestAssured.given;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.stargate.sgv2.api.common.config.constants.HttpConstants;
+import io.stargate.sgv2.docsapi.api.v2.namespaces.collections.CollectionsResource;
+import io.stargate.sgv2.docsapi.api.v2.schemas.namespaces.NamespacesResource;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestClassOrder;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+
+/**
+ * Serves as the base class for integration tests that need to create namespace and/or collection
+ * prior to running the tests.
+ *
+ * <p>Note that due to the way how RestAssured is configured in Quarkus tests, we are doing the
+ * initialization as first tests to be run. The {@link BeforeAll} annotation can not be used, as
+ * rest assured is not configured yet. See https://github.com/quarkusio/quarkus/issues/7690 for more
+ * info.
+ */
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class DocsApiIntegrationTest {
+
+  /**
+   * @return Returns the non-empty optional if the namespace with given name should be created
+   *     before all tests.
+   */
+  public Optional<String> createNamespace() {
+    return Optional.empty();
+  }
+
+  /**
+   * @return Returns the non-empty optional if the collection with given name should be created
+   *     before all tests. Note that if collection should be created, the {@link #createNamespace()}
+   *     must not return empty optional.
+   */
+  public Optional<String> createCollection() {
+    return Optional.empty();
+  }
+
+  @BeforeAll
+  public void initRestAssured() {
+    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+  }
+
+  @Nested
+  @Order(Integer.MIN_VALUE)
+  @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+  class Init {
+
+    @Test
+    @Order(1)
+    public void initNamespace() {
+      createNamespace()
+          .ifPresent(
+              namespace -> {
+                String json =
+                    """
+                    {
+                        "name": "%s"
+                    }
+                    """
+                        .formatted(namespace);
+
+                // create
+                given()
+                    .contentType(ContentType.JSON)
+                    .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+                    .body(json)
+                    .post(NamespacesResource.BASE_PATH);
+              });
+    }
+
+    @Test
+    @Order(2)
+    public void initCollection() {
+      createCollection()
+          .ifPresent(
+              collection -> {
+                String namespace =
+                    createNamespace()
+                        .orElseThrow(
+                            () ->
+                                new IllegalStateException(
+                                    "A test collection %s can not be created without specifying the namespace."
+                                        .formatted(collection)));
+
+                String json =
+                    """
+                    {
+                        "name": "%s"
+                    }
+                    """
+                        .formatted(collection);
+
+                // create
+                given()
+                    .contentType(ContentType.JSON)
+                    .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+                    .body(json)
+                    .post(CollectionsResource.BASE_PATH, namespace);
+              });
+    }
+  }
+}

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/DocsApiIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/DocsApiIntegrationTest.java
@@ -1,6 +1,7 @@
 package io.stargate.sgv2.docsapi.api.v2;
 
 import static io.restassured.RestAssured.given;
+import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -75,7 +76,7 @@ public abstract class DocsApiIntegrationTest {
                 // create
                 given()
                     .contentType(ContentType.JSON)
-                    .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+                    .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
                     .body(json)
                     .post(NamespacesResource.BASE_PATH);
               });
@@ -106,7 +107,7 @@ public abstract class DocsApiIntegrationTest {
                 // create
                 given()
                     .contentType(ContentType.JSON)
-                    .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+                    .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
                     .body(json)
                     .post(CollectionsResource.BASE_PATH, namespace);
               });

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResourceIntegrationTest.java
@@ -18,6 +18,7 @@
 package io.stargate.sgv2.docsapi.api.v2.namespaces.collections;
 
 import static io.restassured.RestAssured.given;
+import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
@@ -25,6 +26,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
@@ -40,7 +42,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@QuarkusTestResource(
+    value = StargateTestResource.class,
+    initArgs =
+        @ResourceArg(name = StargateTestResource.Options.DISABLE_FIXED_TOKEN, value = "true"))
 public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
 
   // base path for the test
@@ -71,7 +76,7 @@ public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
 
       given()
           .contentType(ContentType.JSON)
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .body(body)
           .post(BASE_PATH, DEFAULT_NAMESPACE)
           .then()
@@ -96,7 +101,7 @@ public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
 
       given()
           .contentType(ContentType.JSON)
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .body(body)
           .post(BASE_PATH, DEFAULT_NAMESPACE)
           .then()
@@ -121,7 +126,7 @@ public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
       given()
           .contentType(ContentType.JSON)
           .body(body)
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .post(BASE_PATH, namespace)
           .then()
@@ -138,7 +143,7 @@ public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
 
       given()
           .contentType(ContentType.JSON)
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .post(BASE_PATH, namespace)
           .then()
@@ -159,7 +164,7 @@ public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
       given()
           .contentType(ContentType.JSON)
           .body(body)
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .post(BASE_PATH, namespace)
           .then()
@@ -176,7 +181,7 @@ public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
       given()
           .contentType(ContentType.JSON)
           .body(body)
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .post(BASE_PATH, namespace)
           .then()
@@ -193,7 +198,7 @@ public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void happyPath() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE)
           .then()
@@ -207,7 +212,7 @@ public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
     public void happyPathRaw() {
       given()
           .queryParam("raw", true)
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE)
           .then()
@@ -222,7 +227,7 @@ public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
       String namespace = "system";
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH, namespace)
           .then()
@@ -235,7 +240,7 @@ public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
       String namespace = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH, namespace)
           .then()
@@ -263,7 +268,7 @@ public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
               """;
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(json)
           .when()
@@ -278,7 +283,7 @@ public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
     public void upgradeNull() {
       String json = "{}";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(json)
           .when()
@@ -302,7 +307,7 @@ public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
               """;
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(json)
           .when()
@@ -325,7 +330,7 @@ public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
               """;
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(json)
           .when()
@@ -350,7 +355,7 @@ public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
               """;
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(json)
           .when()
@@ -372,7 +377,7 @@ public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void happyPath() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .delete(BASE_PATH + "/{collection}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
           .then()
@@ -384,7 +389,7 @@ public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
       String collection = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .delete(BASE_PATH + "/{collection}", DEFAULT_NAMESPACE, collection)
           .then()
@@ -399,7 +404,7 @@ public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
       String collection = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .delete(BASE_PATH + "/{collection}", namespace, collection)
           .then()
@@ -416,7 +421,7 @@ public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
       String collection = "local";
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .delete(BASE_PATH + "/{collection}", namespace, collection)
           .then()

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResourceIntegrationTest.java
@@ -24,51 +24,33 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
-import io.restassured.RestAssured;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
-import io.stargate.sgv2.api.common.cql.builder.Replication;
-import io.stargate.sgv2.common.testprofiles.IntegrationTestProfile;
-import io.stargate.sgv2.docsapi.service.schema.NamespaceManager;
-import java.time.Duration;
-import javax.enterprise.context.control.ActivateRequestContext;
-import javax.inject.Inject;
+import io.stargate.sgv2.common.testresource.StargateTestResource;
+import io.stargate.sgv2.docsapi.api.v2.DocsApiIntegrationTest;
+import java.util.Optional;
 import javax.ws.rs.core.HttpHeaders;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestClassOrder;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
 
-@QuarkusTest
-@TestProfile(IntegrationTestProfile.class)
-@ActivateRequestContext
-@TestClassOrder(ClassOrderer.OrderAnnotation.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class CollectionsResourceIntegrationTest {
+@QuarkusIntegrationTest
+@QuarkusTestResource(StargateTestResource.class)
+public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
 
   // base path for the test
   public static final String BASE_PATH = "/v2/namespaces/{namespace}/collections";
   public static final String DEFAULT_NAMESPACE = RandomStringUtils.randomAlphanumeric(16);
   public static final String DEFAULT_COLLECTION = RandomStringUtils.randomAlphanumeric(16);
 
-  @Inject NamespaceManager namespaceManager;
-
-  @BeforeAll
-  public void init() {
-    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
-
-    namespaceManager
-        .createNamespace(DEFAULT_NAMESPACE, Replication.simpleStrategy(1))
-        .await()
-        .atMost(Duration.ofSeconds(10));
+  @Override
+  public Optional<String> createNamespace() {
+    return Optional.of(DEFAULT_NAMESPACE);
   }
 
   @Nested

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/BuiltInFunctionResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/BuiltInFunctionResourceIntegrationTest.java
@@ -17,11 +17,13 @@
 package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.documents;
 
 import static io.restassured.RestAssured.given;
+import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonPartEquals;
 import static org.hamcrest.Matchers.equalTo;
 
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
@@ -35,7 +37,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@QuarkusTestResource(
+    value = StargateTestResource.class,
+    initArgs =
+        @ResourceArg(name = StargateTestResource.Options.DISABLE_FIXED_TOKEN, value = "true"))
 class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
 
   public static final String BASE_PATH =
@@ -64,7 +69,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
     @BeforeEach
     public void setup() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"array\": [1, 2, 3], \"object\": {}}")
           .when()
@@ -76,7 +81,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
     @AfterEach
     public void cleanUp() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .delete(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
           .then()
@@ -86,7 +91,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void pop() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(POP_PAYLOAD)
           .when()
@@ -98,7 +103,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // assert whole document
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
           .then()
@@ -110,7 +115,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void popRaw() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .contentType(ContentType.JSON)
           .body(POP_PAYLOAD)
@@ -124,7 +129,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void popEmpty() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(POP_PAYLOAD)
           .when()
@@ -135,7 +140,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
           .body("data", jsonEquals(3));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(POP_PAYLOAD)
           .when()
@@ -146,7 +151,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
           .body("data", jsonEquals(2));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(POP_PAYLOAD)
           .when()
@@ -157,7 +162,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
           .body("data", jsonEquals(1));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(POP_PAYLOAD)
           .when()
@@ -171,7 +176,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void popNoArray() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(POP_PAYLOAD)
           .when()
@@ -185,7 +190,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void push() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(PUSH_PAYLOAD)
           .when()
@@ -197,7 +202,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // assert whole document
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
           .then()
@@ -209,7 +214,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void pushObject() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"operation\": \"$push\", \"value\": { \"p\": true}}")
           .when()
@@ -221,7 +226,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // assert whole document
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
           .then()
@@ -233,7 +238,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void pushArray() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"operation\": \"$push\", \"value\": [4, 5, 6]}")
           .when()
@@ -245,7 +250,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // assert whole document
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
           .then()
@@ -257,7 +262,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void pushRaw() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .contentType(ContentType.JSON)
           .body(PUSH_PAYLOAD)
@@ -273,7 +278,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
       String payload = "{\"operation\": \"$push\", \"value\": null}";
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(payload)
           .when()
@@ -287,7 +292,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void pushNoArray() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(PUSH_PAYLOAD)
           .when()
@@ -301,7 +306,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void invalidOperation() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"operation\": \"$dollar\"}")
           .when()
@@ -319,7 +324,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
       String id = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(PUSH_PAYLOAD)
           .when()
@@ -337,7 +342,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void invalidCollection() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(PUSH_PAYLOAD)
           .when()
@@ -351,7 +356,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void invalidNamespace() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(PUSH_PAYLOAD)
           .when()
@@ -370,7 +375,7 @@ class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
       String collection = "local";
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(PUSH_PAYLOAD)
           .when()

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentDeleteResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentDeleteResourceIntegrationTest.java
@@ -17,11 +17,13 @@
 package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.documents;
 
 import static io.restassured.RestAssured.given;
+import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
@@ -33,7 +35,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@QuarkusTestResource(
+    value = StargateTestResource.class,
+    initArgs =
+        @ResourceArg(name = StargateTestResource.Options.DISABLE_FIXED_TOKEN, value = "true"))
 class DocumentDeleteResourceIntegrationTest extends DocsApiIntegrationTest {
 
   public static final String BASE_PATH =
@@ -56,7 +61,7 @@ class DocumentDeleteResourceIntegrationTest extends DocsApiIntegrationTest {
 
   public void createDocument() {
     given()
-        .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+        .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
         .header("Content-Type", "application/json")
         .body(DEFAULT_PAYLOAD)
         .when()
@@ -76,14 +81,14 @@ class DocumentDeleteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void happyPath() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .delete(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DEFAULT_DOCUMENT_ID)
           .then()
           .statusCode(204);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DEFAULT_DOCUMENT_ID)
@@ -104,14 +109,14 @@ class DocumentDeleteResourceIntegrationTest extends DocsApiIntegrationTest {
     public void deleteNotFound() {
       // When a delete occurs on an unknown document, it still returns 204 No Content
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .delete(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, "no-id")
           .then()
           .statusCode(204);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, "no-id")
@@ -122,7 +127,7 @@ class DocumentDeleteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void keyspaceNotExists() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .delete(BASE_PATH, "notakeyspace", DEFAULT_COLLECTION, DEFAULT_DOCUMENT_ID)
           .then()
@@ -135,7 +140,7 @@ class DocumentDeleteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void tableNotExists() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .delete(BASE_PATH, DEFAULT_NAMESPACE, "notatable", DEFAULT_DOCUMENT_ID)
           .then()
@@ -156,14 +161,14 @@ class DocumentDeleteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void testDeletePath() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .delete(BASE_PATH + "/test", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DEFAULT_DOCUMENT_ID)
           .then()
           .statusCode(204);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .when()
           .get(BASE_PATH + "/test", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DEFAULT_DOCUMENT_ID)
@@ -171,7 +176,7 @@ class DocumentDeleteResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(404);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DEFAULT_DOCUMENT_ID)
@@ -183,7 +188,7 @@ class DocumentDeleteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void testDeleteArrayPath() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .delete(
               BASE_PATH + "/this/[2]", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DEFAULT_DOCUMENT_ID)
@@ -191,7 +196,7 @@ class DocumentDeleteResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(204);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .when()
           .get(BASE_PATH + "/this", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DEFAULT_DOCUMENT_ID)
@@ -200,7 +205,7 @@ class DocumentDeleteResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("[\"is\",1]"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .delete(
               BASE_PATH + "/this/[0]", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DEFAULT_DOCUMENT_ID)
@@ -208,7 +213,7 @@ class DocumentDeleteResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(204);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .when()
           .get(BASE_PATH + "/this", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DEFAULT_DOCUMENT_ID)
@@ -217,7 +222,7 @@ class DocumentDeleteResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("[null,1]"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DEFAULT_DOCUMENT_ID)
@@ -229,14 +234,14 @@ class DocumentDeleteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void testDeletePathNotFound() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .delete(BASE_PATH + "/test/a", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DEFAULT_DOCUMENT_ID)
           .then()
           .statusCode(204);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .when()
           .get(BASE_PATH + "/test", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DEFAULT_DOCUMENT_ID)

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentPatchResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentPatchResourceIntegrationTest.java
@@ -24,32 +24,23 @@ import static org.hamcrest.Matchers.notNullValue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
-import io.restassured.RestAssured;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
-import io.stargate.sgv2.api.common.cql.builder.Replication;
-import io.stargate.sgv2.common.testprofiles.IntegrationTestProfile;
-import io.stargate.sgv2.docsapi.service.schema.CollectionManager;
-import io.stargate.sgv2.docsapi.service.schema.NamespaceManager;
-import java.time.Duration;
+import io.stargate.sgv2.common.testresource.StargateTestResource;
+import io.stargate.sgv2.docsapi.api.v2.DocsApiIntegrationTest;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import javax.enterprise.context.control.ActivateRequestContext;
-import javax.inject.Inject;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 
-@QuarkusTest
-@TestProfile(IntegrationTestProfile.class)
-@ActivateRequestContext
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class DocumentPatchResourceIntegrationTest {
+@QuarkusIntegrationTest
+@QuarkusTestResource(StargateTestResource.class)
+class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
 
   public static final String BASE_PATH =
       "/v2/namespaces/{namespace}/collections/{collection}/{document-id}";
@@ -60,26 +51,16 @@ class DocumentPatchResourceIntegrationTest {
       "{\"test\": \"document\", \"this\": [\"is\", 1, true]}";
   public static final String MALFORMED_PAYLOAD = "{\"malformed\": ";
 
-  @Inject NamespaceManager namespaceManager;
+  final ObjectMapper objectMapper = new ObjectMapper();
 
-  @Inject CollectionManager collectionManager;
+  @Override
+  public Optional<String> createNamespace() {
+    return Optional.of(DEFAULT_NAMESPACE);
+  }
 
-  @Inject ObjectMapper objectMapper;
-
-  @BeforeAll
-  public void init() {
-
-    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
-
-    namespaceManager
-        .createNamespace(DEFAULT_NAMESPACE, Replication.simpleStrategy(1))
-        .await()
-        .atMost(Duration.ofSeconds(10));
-
-    collectionManager
-        .createCollectionTable(DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
-        .await()
-        .atMost(Duration.ofSeconds(10));
+  @Override
+  public Optional<String> createCollection() {
+    return Optional.of(DEFAULT_COLLECTION);
   }
 
   @BeforeEach

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentPatchResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentPatchResourceIntegrationTest.java
@@ -17,6 +17,7 @@
 package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.documents;
 
 import static io.restassured.RestAssured.given;
+import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -25,6 +26,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
@@ -39,7 +41,10 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@QuarkusTestResource(
+    value = StargateTestResource.class,
+    initArgs =
+        @ResourceArg(name = StargateTestResource.Options.DISABLE_FIXED_TOKEN, value = "true"))
 class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
 
   public static final String BASE_PATH =
@@ -73,7 +78,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void happyPath() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(DEFAULT_PAYLOAD)
           .when()
@@ -83,7 +88,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body("documentId", equalTo(documentId));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -95,7 +100,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void happyPathMergeExisting() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"a\":\"b\"}")
           .when()
@@ -105,7 +110,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body("documentId", equalTo(documentId));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(DEFAULT_PAYLOAD)
           .when()
@@ -115,7 +120,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body("documentId", equalTo(documentId));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -128,7 +133,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
     public void happyPathNoCollection() {
       String tableName = RandomStringUtils.randomAlphanumeric(16);
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(DEFAULT_PAYLOAD)
           .when()
@@ -137,7 +142,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, tableName, documentId)
@@ -149,7 +154,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void rootDocumentPatch() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"abc\": 1}")
           .when()
@@ -158,7 +163,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -167,7 +172,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("{\"abc\": 1}"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"bcd\": true}")
           .when()
@@ -176,7 +181,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -185,7 +190,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("{\"abc\": 1, \"bcd\": true}"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"bcd\": {\"a\": {\"b\": 0 }}}")
           .when()
@@ -194,7 +199,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -203,7 +208,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("{ \"abc\": 1, \"bcd\": {\"a\": {\"b\": 0 }} }"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"bcd\": [1,2,3,4]}")
           .when()
@@ -212,7 +217,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -221,7 +226,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("{ \"abc\": 1, \"bcd\": [1,2,3,4] }"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"bcd\": [5,{\"a\": 23},7,8]}")
           .when()
@@ -230,7 +235,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -239,7 +244,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("{ \"abc\": 1, \"bcd\": [5,{\"a\": 23},7,8] }"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"bcd\": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]}")
           .when()
@@ -248,7 +253,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -257,7 +262,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("{ \"abc\": 1, \"bcd\": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] }"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"bcd\": {\"replace\": \"array\"}}")
           .when()
@@ -266,7 +271,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -275,7 +280,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("{ \"abc\": 1, \"bcd\": {\"replace\": \"array\"} }"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"done\": \"done\"}")
           .when()
@@ -284,7 +289,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -297,7 +302,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void rootDocumentPatchNulls() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"abc\": null}")
           .when()
@@ -306,7 +311,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -315,7 +320,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("{\"abc\": null}"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"bcd\": null}")
           .when()
@@ -324,7 +329,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -333,7 +338,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("{\"abc\": null, \"bcd\": null}"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"bcd\": {\"a\": {\"b\": null }}}")
           .when()
@@ -342,7 +347,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -351,7 +356,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("{ \"abc\": null, \"bcd\": {\"a\": {\"b\": null }} }"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"bcd\": [null,null,null,null]}")
           .when()
@@ -360,7 +365,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -369,7 +374,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("{ \"abc\": null, \"bcd\": [null,null,null,null] }"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"bcd\": [null,{\"a\": null},null,null]}")
           .when()
@@ -378,7 +383,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -387,7 +392,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("{ \"abc\": null, \"bcd\": [null,{\"a\": null},null,null] }"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(
               "{\"bcd\": [null, null, null, null, null, null, null, null, null, null, null, null, null]}")
@@ -397,7 +402,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -408,7 +413,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
                   "{ \"abc\": null, \"bcd\": [null, null, null, null, null, null, null, null, null, null, null, null, null] }"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"bcd\": {\"replace\": null}}")
           .when()
@@ -417,7 +422,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -426,7 +431,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("{ \"abc\": null, \"bcd\": {\"replace\": null} }"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"done\": null}")
           .when()
@@ -435,7 +440,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -447,7 +452,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void withProfile() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .queryParam("profile", "true")
           .body(DEFAULT_PAYLOAD)
@@ -461,7 +466,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void withTtlAutoNewDoc() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .queryParam("ttl-auto", "true")
           .body(DEFAULT_PAYLOAD)
@@ -471,7 +476,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
           .then()
@@ -481,7 +486,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void withTtlAutoExistingDoc() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .queryParam("ttl", "5")
           .body("{\"a\":\"b\"}")
@@ -492,7 +497,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body("documentId", equalTo(documentId));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .queryParam("ttl-auto", "true")
           .body(DEFAULT_PAYLOAD)
@@ -506,7 +511,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .untilAsserted(
               () ->
                   given()
-                      .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+                      .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
                       .when()
                       .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
                       .then()
@@ -516,7 +521,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void malformedJson() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(MALFORMED_PAYLOAD)
           .when()
@@ -528,7 +533,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void emptyObject() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{}")
           .when()
@@ -544,7 +549,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void emptyArray() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("[]")
           .when()
@@ -559,7 +564,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void nonEmptyArray() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("[1,2,3]")
           .when()
@@ -574,7 +579,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void singlePrimitive() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("true")
           .when()
@@ -590,7 +595,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void noBody() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .when()
           .patch(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -606,7 +611,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
       String collection = "local";
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(DEFAULT_PAYLOAD)
           .when()
@@ -634,7 +639,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void keyspaceNotExists() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(DEFAULT_PAYLOAD)
           .when()
@@ -653,7 +658,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void happyPath() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(DEFAULT_PAYLOAD)
           .when()
@@ -663,7 +668,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body("documentId", equalTo(documentId));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH + "/path", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -675,7 +680,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void subDocumentPatch() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"abc\": null}")
           .when()
@@ -684,7 +689,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"bcd\": {}}}")
           .when()
@@ -693,7 +698,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -702,7 +707,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("{ \"abc\": { \"bcd\": {} }}}"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("3")
           .when()
@@ -711,7 +716,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -720,7 +725,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("{ \"abc\": { \"bcd\": 3 }}}"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"bcd\": [null,2,null,4]}")
           .when()
@@ -729,7 +734,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -738,7 +743,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("{ \"abc\": {\"bcd\": [null,2,null,4]} }"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"bcd\": [1,{\"a\": null},3,4]}")
           .when()
@@ -747,7 +752,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -756,7 +761,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("{ \"abc\": { \"bcd\": [1,{\"a\": null},3,4] }}"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"bcd\": [null]}")
           .when()
@@ -765,7 +770,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -774,7 +779,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("{ \"abc\": { \"bcd\": [null] }}"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"null\": null}")
           .when()
@@ -783,7 +788,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
@@ -798,7 +803,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
       JsonNode obj2 = objectMapper.readTree("{ \"match the parent\": \"this\", \"a\": \"b\" }");
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .queryParam("ttl", "5")
           .body(obj1)
@@ -808,7 +813,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .queryParam("ttl-auto", "true")
           .body(obj2)
@@ -823,7 +828,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
               () -> {
                 // After the TTL is up, obj1 should be gone, with no remnants
                 given()
-                    .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+                    .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
                     .when()
                     .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
                     .then()
@@ -838,7 +843,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
       JsonNode obj2 = objectMapper.readTree("{ \"match the parent\": \"this\", \"a\": \"b\" }");
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(obj1)
           .when()
@@ -847,7 +852,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .queryParam("ttl-auto", "true")
           .body(obj2)
@@ -857,7 +862,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, documentId)
           .then()
@@ -871,7 +876,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void withProfile() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .queryParam("profile", "true")
           .body(DEFAULT_PAYLOAD)
@@ -885,7 +890,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void malformedJson() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(MALFORMED_PAYLOAD)
           .when()
@@ -906,7 +911,7 @@ class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void keyspaceNotExists() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(DEFAULT_PAYLOAD)
           .when()

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentReadResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentReadResourceIntegrationTest.java
@@ -31,66 +31,45 @@ import static org.hamcrest.Matchers.nullValue;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.CharStreams;
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
-import io.restassured.RestAssured;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
-import io.stargate.sgv2.api.common.cql.builder.Replication;
-import io.stargate.sgv2.common.testprofiles.IntegrationTestProfile;
-import io.stargate.sgv2.docsapi.service.schema.CollectionManager;
-import io.stargate.sgv2.docsapi.service.schema.NamespaceManager;
-import java.time.Duration;
+import io.stargate.sgv2.common.testresource.StargateTestResource;
+import io.stargate.sgv2.docsapi.api.v2.DocsApiIntegrationTest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import javax.enterprise.context.control.ActivateRequestContext;
-import javax.inject.Inject;
+import java.util.Optional;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.assertj.core.api.Condition;
 import org.assertj.core.api.HamcrestCondition;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestClassOrder;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-@QuarkusTest
-@TestProfile(IntegrationTestProfile.class)
-@ActivateRequestContext
-@TestClassOrder(ClassOrderer.OrderAnnotation.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class DocumentReadResourceIntegrationTest {
+@QuarkusIntegrationTest
+@QuarkusTestResource(StargateTestResource.class)
+class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
   public static final String BASE_PATH = "/v2/namespaces/{namespace}/collections/{collection}";
   public static final String DEFAULT_NAMESPACE = RandomStringUtils.randomAlphanumeric(16);
   public static final String DEFAULT_COLLECTION = RandomStringUtils.randomAlphanumeric(16);
 
-  @Inject NamespaceManager namespaceManager;
+  final ObjectMapper objectMapper = new ObjectMapper();
 
-  @Inject CollectionManager collectionManager;
+  @Override
+  public Optional<String> createNamespace() {
+    return Optional.of(DEFAULT_NAMESPACE);
+  }
 
-  @Inject ObjectMapper objectMapper;
-
-  @BeforeAll
-  public void init() {
-    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
-
-    namespaceManager
-        .createNamespace(DEFAULT_NAMESPACE, Replication.simpleStrategy(1))
-        .await()
-        .atMost(Duration.ofSeconds(10));
-
-    collectionManager
-        .createCollectionTable(DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
-        .await()
-        .atMost(Duration.ofSeconds(10));
+  @Override
+  public Optional<String> createCollection() {
+    return Optional.of(DEFAULT_COLLECTION);
   }
 
   @Nested

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentReadResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentReadResourceIntegrationTest.java
@@ -18,6 +18,7 @@
 package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.documents;
 
 import static io.restassured.RestAssured.given;
+import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonPartEquals;
 import static net.javacrumbs.jsonunit.core.util.ResourceUtils.resource;
@@ -32,6 +33,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.CharStreams;
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
@@ -53,7 +55,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@QuarkusTestResource(
+    value = StargateTestResource.class,
+    initArgs =
+        @ResourceArg(name = StargateTestResource.Options.DISABLE_FIXED_TOKEN, value = "true"))
 class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
   public static final String BASE_PATH = "/v2/namespaces/{namespace}/collections/{collection}";
@@ -95,7 +100,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     // simple util to write documents
     private void writeDocument(String id, String json) {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(json)
           .when()
@@ -108,7 +113,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     void deleteDocuments(String... ids) {
       for (String id : ids) {
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .when()
             .delete(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
             .then()
@@ -126,7 +131,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
         // assert
         String expected = "{\"%s\":{\"value\":\"a\"}}".formatted(ids[0]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("where", "{\"value\": {\"$eq\": \"a\"}}")
             .when()
             .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -150,7 +155,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
         // assert
         String expected = "{\"%s\":{\"value\":true}}".formatted(ids[0]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("where", "{\"value\": {\"$eq\": true}}")
             .when()
             .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -175,7 +180,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
         // assert
         String expected = "{\"%s\":{\"value\":\"a\",\"n\":{\"value\":5}}}".formatted(ids[0]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("where", "{\"value\": {\"$eq\": \"a\"}, \"n.value\": {\"$lt\": 6}}")
             .when()
             .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -208,7 +213,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
         // assert
         String expected = "{\"%s\":{\"value\":\"a\",\"n\":{\"value\":5}}}".formatted(ids[0]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("where", where)
             .when()
             .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -239,7 +244,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
                 .formatted(ids[0], ids[1]);
 
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("where", "{\"value\": {\"$in\": [\"a\", \"b\"]}}")
             .when()
             .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -270,7 +275,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
                 .formatted(ids[0], ids[1]);
 
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("where", "{\"value\": {\"$ne\": \"c\"}}")
             .when()
             .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -295,7 +300,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
         // assert
         String expected = "{\"%s\":{\"value\":\"a\",\"n\":{\"value\":5}}}".formatted(ids[0]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam(
                 "where", "{\"value\": {\"$in\": [\"a\", \"b\"]}, \"n.value\": {\"$in\": [5]}}")
             .when()
@@ -322,7 +327,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
         // assert
         String expected = "{\"%s\":{\"value\":\"a\",\"n\":{\"value\":5}}}".formatted(ids[0]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam(
                 "where",
                 "{\"value\": {\"$in\": [\"a\", \"b\"]}, \"n.value\": {\"$gt\": 0, \"$lt\": 10}}")
@@ -349,7 +354,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
         String expected =
             "{\"%s\":{\"someStuff\": {\"someOtherStuff\": {\"value\": \"a\"}}}}".formatted(ids[0]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("where", "{\"someStuff.someOtherStuff.value\": {\"$eq\": \"a\"}}")
             .when()
             .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -381,7 +386,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
                 .formatted(ids[0], ids[1]);
 
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("where", "{\"n,m.value\": {\"$gte\": 5}}")
             .when()
             .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -405,7 +410,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
         // assert
         String expected = "{\"%s\":{\"n\":{\"value\":5}}}".formatted(ids[0]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("where", "{\"n,m.value\": {\"$in\": [5]}}")
             .when()
             .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -433,7 +438,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
             "{\"%s\":{\"someStuff\": {\"1\": {\"value\": \"a\"}, \"2\": {\"value\": \"b\"}}}}"
                 .formatted(ids[1]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("where", "{\"someStuff.*.value\": {\"$eq\": \"b\"}}")
             .when()
             .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -461,7 +466,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
             "{\"%s\":{\"someStuff\": {\"1\": {\"value\": \"a\"}, \"2\": {\"value\": \"b\"}}}}"
                 .formatted(ids[1]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("where", "{\"someStuff.*.value\": {\"$in\": [\"b\"]}}")
             .when()
             .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -489,7 +494,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
             "{\"%s\":{\"value\": \"b\", \"someStuff\": {\"1\": {\"value\": \"a\"}, \"2\": {\"value\": \"b\"}}}}"
                 .formatted(ids[1]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam(
                 "where", "{\"value\": {\"$eq\": \"b\"}, \"someStuff.*.value\": {\"$eq\": \"b\"}}")
             .when()
@@ -518,7 +523,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
             "{\"%s\":{\"value\": \"b\", \"someStuff\": {\"1\": {\"value\": \"a\"}, \"2\": {\"value\": \"b\"}}}}"
                 .formatted(ids[1]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam(
                 "where", "{\"value\": {\"$eq\": \"b\"}, \"someStuff.*.value\": {\"$in\": [\"b\"]}}")
             .when()
@@ -547,7 +552,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
             "{\"%s\":{\"value\": \"b\", \"someStuff\": {\"1\": {\"value\": \"a\"}, \"2\": {\"other\": \"b\"}}}}"
                 .formatted(ids[1]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam(
                 "where",
                 "{\"value\": {\"$eq\": \"b\"}, \"someStuff.*.other\": {\"$exists\": true}}")
@@ -574,7 +579,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
         // assert
         String expected = "{\"%s\":{\"value\":[{\"n\":{\"value\":5}}]}}".formatted(ids[0]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("where", "{\"value.[0].n.value\": {\"$eq\": 5}}")
             .when()
             .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -608,7 +613,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
                 .formatted(ids[0], ids[1]);
 
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("where", "{\"value.[0],[1].n.value\": {\"$lt\": 6}}")
             .when()
             .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -635,7 +640,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
         String expected =
             "{\"%s\":{\"value\":[{\"n\":{\"value\":5}},{\"n\":{\"value\":8}}]}}".formatted(ids[0]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("where", "{\"value.[0],[1].n.value\": {\"$in\": [8]}}")
             .when()
             .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -661,7 +666,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
         String expected =
             "{\"%s\":{\"value\":[{\"n\":{\"value\":5}},{\"n\":{\"value\":8}}]}}".formatted(ids[0]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("where", "{\"value.[*].n.value\": {\"$eq\": 8}}")
             .when()
             .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -688,7 +693,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
             "{\"%s\":{\"first\": 5, \"value\":[{\"n\":{\"value\":5}},{\"n\":{\"value\":8}}]}}"
                 .formatted(ids[0]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("where", "{\"first\": {\"$gt\": 0}, \"value.[*].n.value\": {\"$eq\": 8}}")
             .when()
             .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -714,7 +719,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
         String expected =
             "{\"%s\":{\"value\":[{\"n\":{\"value\":5}},{\"n\":{\"value\":8}}]}}".formatted(ids[0]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("where", "{\"value.[*].n.value\": {\"$in\": [8]}}")
             .when()
             .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -741,7 +746,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
             "{\"%s\":{\"first\": 5, \"value\":[{\"n\":{\"value\":5}},{\"n\":{\"value\":8}}]}}"
                 .formatted(ids[0]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam(
                 "where", "{\"first\": {\"$gte\": 1}, \"value.[*].n.value\": {\"$in\": [8]}}")
             .when()
@@ -769,7 +774,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
             "{\"%s\":{\"first\": 5, \"value\":[{\"n\":{\"value\":5}},{\"m\":{\"value\":8}}]}}"
                 .formatted(ids[0]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam(
                 "where", "{\"first\": {\"$gte\": 1}, \"value.[*].m.value\": {\"$exists\": true}}")
             .when()
@@ -801,7 +806,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
                 .formatted(ids[0], ids[1]);
 
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam(
                 "where",
                 "{\"$or\": [{\"value\": {\"$eq\": \"a\"}}, {\"value\": {\"$eq\": \"b\"}}]}")
@@ -834,7 +839,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
                 .formatted(ids[0], ids[1]);
 
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam(
                 "where",
                 "{\"$or\": [{\"value\": {\"$in\": [\"a\"]}}, {\"value\": {\"$in\": [\"b\"]}}]}")
@@ -867,7 +872,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
                 .formatted(ids[0], ids[1]);
 
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam(
                 "where",
                 "{\"$or\": [{\"value\": {\"$eq\": \"a\"}}, {\"value\": {\"$in\": [\"a\", \"b\"]}}]}")
@@ -894,7 +899,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
         String firstExpected = "{\"a\":{\"value\":\"a\"}}";
         String body =
             given()
-                .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+                .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
                 .queryParam(
                     "where",
                     "{\"$or\": [{\"value\": {\"$eq\": \"b\"}}, {\"value\": {\"$in\": [\"a\"]}}]}")
@@ -913,7 +918,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
         String pageState = objectMapper.readTree(body).requiredAt("/pageState").textValue();
         String secondExpected = "{\"b\":{\"value\":\"b\"}}";
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam(
                 "where",
                 "{\"$or\": [{\"value\": {\"$eq\": \"b\"}}, {\"value\": {\"$in\": [\"a\"]}}]}")
@@ -951,7 +956,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
                 .formatted(ids[0], ids[1]);
 
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam(
                 "where",
                 "{\"$or\": [{\"value\": {\"$eq\": \"a\"}}, {\"count\": {\"$in\": [2,4]}}]}")
@@ -987,7 +992,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
                 .formatted(ids[0], ids[1]);
 
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam(
                 "where",
                 "{\"count\": {\"$gt\": 0}, \"$or\": [{\"value\": {\"$eq\": \"a\"}}, {\"value\": {\"$in\": [\"b\"]}}]}")
@@ -1020,7 +1025,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
                 .formatted(ids[0], ids[1]);
 
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam(
                 "where",
                 "{\"$or\": [{\"value\": {\"$eq\": \"a\"}}, {\"other\": {\"$exists\": true}}]}")
@@ -1053,7 +1058,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
                 .formatted(ids[0], ids[1]);
 
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam(
                 "where",
                 "{\"$or\": [{\"value\": {\"$nin\": [\"b\",\"c\"]}}, {\"value\": {\"$eq\": \"a\"}}]}")
@@ -1089,7 +1094,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
                 .formatted(ids[0], ids[1]);
 
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam(
                 "where",
                 "{\"$or\": [{\"value.[*].*.value\": {\"$eq\": 20}}, {\"value.[1],[2].n,m.value\": {\"$eq\": 8}}]}")
@@ -1108,7 +1113,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void withProfile() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("where", "{\"value\": {\"$eq\": \"a\"}}")
           .queryParam("profile", true)
           .when()
@@ -1128,7 +1133,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
         // assert
         String expected = "{\"%s\":{\"value\":[null,{\"m\":{\"value\":8}}]}}".formatted(ids[0]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("fields", "[\"value.[1].m\"]")
             .queryParam("raw", true)
             .when()
@@ -1152,7 +1157,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
         String expected =
             "{\"%s\":{\"value\":[{\"n\":{\"value\":5}},{\"m\":{\"value\":8}}]}}".formatted(ids[0]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("fields", "[\"value.[*].m,n\"]")
             .queryParam("raw", true)
             .when()
@@ -1175,7 +1180,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
         // assert
         String expected = "{\"%s\":{\"value\":[{\"n\":{\"value\":5}}]}}".formatted(ids[0]);
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("fields", "[\"*.[*].n\"]")
             .queryParam("raw", true)
             .when()
@@ -1197,7 +1202,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
         // assert
         String expected = "{\"a\": {\"value\": 1},\"b\": {\"value\": 2}, \"bb\": {\"value\": 4}}";
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("fields", "[\"a.value\",\"b.value\",\"bb.value\"]")
             .queryParam("raw", true)
             .when()
@@ -1230,7 +1235,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
                 .formatted(ids[0], ids[1]);
 
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("where", "{\"someStuff.*.value\": {\"$exists\": false}}")
             .when()
             .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -1264,7 +1269,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
                 .formatted(ids[0], ids[1]);
 
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam(
                 "where",
                 "{\"value\": {\"$eq\": \"b\"}, \"someStuff.*.value\": {\"$exists\": false}}")
@@ -1290,7 +1295,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
       try {
         // assert
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("where", "{\"a\":{\"$eq\":\"b\"},\"c\":{\"$lt\":3}}")
             .when()
             .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -1301,7 +1306,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
             .body("data", jsonPartEquals(ids[0], firstDocument));
 
         given()
-            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
             .queryParam("where", "{\"a\":{\"$eq\":\"b\"},\"c\":{\"$lt\":0}}")
             .when()
             .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -1313,7 +1318,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
         String body =
             given()
-                .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+                .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
                 .queryParam(
                     "where",
                     "{\"quiz.sport.q1.question\":{\"$in\": [\"Which one is correct team name in NBA?\"]}}")
@@ -1351,7 +1356,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
         for (int i = 0; i < 3; i += pageSize) {
           String body =
               given()
-                  .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+                  .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
                   .queryParam("page-size", pageSize)
                   .queryParam("page-state", pageState)
                   .when()
@@ -1392,7 +1397,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
         for (int i = 0; i < 3; i += pageSize) {
           String body =
               given()
-                  .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+                  .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
                   .queryParam("page-size", pageSize)
                   .queryParam("page-state", pageState)
                   .queryParam("fields", "[\"a\"]")
@@ -1450,7 +1455,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
         for (int i = 0; i < 3; i += pageSize) {
           String body =
               given()
-                  .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+                  .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
                   .queryParam("page-size", pageSize)
                   .queryParam("page-state", pageState)
                   .queryParam("fields", "[\"quiz\"]")
@@ -1484,7 +1489,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void whereMalformed() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("where", "{\"a\":}")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -1500,7 +1505,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void fieldsMalformed() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("fields", "[\"a\"")
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -1516,7 +1521,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
       String namespace = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH, namespace, DEFAULT_COLLECTION)
           .then()
@@ -1532,7 +1537,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
       String collection = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, collection)
           .then()
@@ -1544,7 +1549,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void invalidPageSize() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("page-size", -1)
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -1555,7 +1560,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
               is("Request invalid: the minimum number of documents to return is one."));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("page-size", 21)
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -1582,7 +1587,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
       exampleResource = CharStreams.toString(resource("documents/example.json"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(exampleResource)
           .when()
@@ -1594,7 +1599,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @AfterEach
     public void deleteDoc() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .delete(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
           .then()
@@ -1606,7 +1611,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void happyPath() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
           .then()
@@ -1618,7 +1623,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void happyPathRaw() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .when()
           .get(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
@@ -1630,7 +1635,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void withProfile() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("profile", true)
           .when()
           .get(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
@@ -1642,7 +1647,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void matchEq() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.electronics.Pixel_3a.price\": {\"$eq\": 600}}")
           .when()
@@ -1654,7 +1659,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // not matched
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.electronics.Pixel_3a.price\": {\"$eq\": 700}}")
           .when()
@@ -1666,7 +1671,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void matchEqWithSelection() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.electronics.Pixel_3a.price\": {\"$eq\": 600}}")
           .queryParam("fields", "[\"name\", \"price\", \"model\", \"manufacturer\"]")
@@ -1682,7 +1687,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void matchLt() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.food.*.price\": {\"$lt\": 600}}")
           .when()
@@ -1697,7 +1702,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void matchLtWithSelection() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.food.*.price\": {\"$lt\": 600}}")
           .queryParam("fields", "[\"name\", \"price\", \"model\"]")
@@ -1713,7 +1718,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void matchLte() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.food.*.price\": {\"$lte\": 0.99}}")
           .when()
@@ -1728,7 +1733,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void matchLteWithSelection() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.food.*.price\": {\"$lte\": 0.99}}")
           .queryParam("fields", "[\"price\", \"sku\"]")
@@ -1744,7 +1749,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void matchGt() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.electronics.*.price\": {\"$gt\": 600}}")
           .when()
@@ -1758,7 +1763,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void matchGtWithSelection() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.electronics.*.price\": {\"$gt\": 600}}")
           .queryParam("fields", "[\"price\", \"throwaway\"]")
@@ -1773,7 +1778,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void matchGte() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.electronics.*.price\": {\"$gte\": 600}}")
           .when()
@@ -1788,7 +1793,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void matchGteWithSelection() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.electronics.*.price\": {\"$gte\": 600}}")
           .queryParam("fields", "[\"price\"]")
@@ -1813,7 +1818,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
           ]""";
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.*.*.price\": {\"$exists\": true}}")
           .when()
@@ -1835,7 +1840,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
           ]""";
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.*.*.price\": {\"$exists\": true}}")
           .queryParam("fields", "[\"price\", \"name\", \"manufacturer\", \"model\", \"sku\"]")
@@ -1849,7 +1854,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void matchNot() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam(
               "where", "{\"$not\": {\"products.electronics.Pixel_3a.price\": {\"$ne\": 600}}}")
@@ -1865,7 +1870,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     public void matchNe() {
       // NE with String
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.electronics.*.model\": {\"$ne\": \"3a\"}}")
           .when()
@@ -1878,7 +1883,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // NE with Boolean
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"quiz.nests.q1.options.[3].this\": {\"$ne\": false}}")
           .when()
@@ -1891,7 +1896,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // NE integer compared to double
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"quiz.maths.q1.answer\": {\"$ne\": 12}}")
           .when()
@@ -1902,7 +1907,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // NE with double compared to integer
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"quiz.maths.q2.answer\": {\"$ne\": 4.0}}")
           .when()
@@ -1915,7 +1920,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     public void matchIn() {
       // IN with String
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.electronics.*.model\": {\"$in\": [\"11\", \"3a\"]}}")
           .when()
@@ -1928,7 +1933,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // IN with int
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.*.*.price\": {\"$in\": [600, 900]}}")
           .when()
@@ -1941,7 +1946,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // IN with double
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.*.*.price\": {\"$in\": [0.99, 0.89]}}")
           .when()
@@ -1954,7 +1959,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // IN with null
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.*.*.sku\": {\"$in\": [null]}}")
           .when()
@@ -1968,7 +1973,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     public void matchNin() {
       // NIN with String
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.electronics.*.model\": {\"$nin\": [\"12\"]}}")
           .when()
@@ -1981,7 +1986,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // NIN with int
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.*.*.price\": {\"$nin\": [600, 900]}}")
           .when()
@@ -1994,7 +1999,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // NIN with double
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.*.*.price\": {\"$nin\": [0.99, 0.89]}}")
           .when()
@@ -2007,7 +2012,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // NIN with null
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"products.*.*.sku\": {\"$nin\": [null]}}")
           .when()
@@ -2023,7 +2028,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     public void matchFiltersCombo() {
       // NIN (limited support) with GT (full support)
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam(
               "where", "{\"products.electronics.*.model\": {\"$nin\": [\"11\"], \"$gt\": \"\"}}")
@@ -2037,7 +2042,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // IN (limited support) with NE (limited support)
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam(
               "where", "{\"products.electronics.*.model\": {\"$nin\": [\"11\"], \"$gt\": \"\"}}")
@@ -2053,7 +2058,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void matchMultipleOperators() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam(
               "where", "{\"products.food.Orange.info.price\": {\"$gt\": 600, \"$lt\": 600.05}}")
@@ -2069,7 +2074,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void matchArrayPaths() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"quiz.maths.q1.options.[0]\": {\"$lt\": 13.3}}")
           .when()
@@ -2089,7 +2094,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
               ]""";
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"quiz.nests.q1,q2.options.[0]\": {\"$eq\": \"nest\"}}")
           .when()
@@ -2102,7 +2107,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void matchMultiplePathsAndGlob() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"quiz.nests.q2,q3.options.*.this.them\": {\"$eq\": false}}")
           .when()
@@ -2124,7 +2129,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
               }""";
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", where)
           .when()
@@ -2141,7 +2146,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
       String json = "{\"a\\\\.b\":\"somedata\",\"some,data\":\"something\",\"*\":\"star\"}";
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(json)
           .when()
@@ -2151,7 +2156,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // with escaped period
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"a\\\\.b\": {\"$eq\": \"somedata\"}}")
           .when()
@@ -2162,7 +2167,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // with commas
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"some\\\\,data\": {\"$eq\": \"something\"}}")
           .when()
@@ -2173,7 +2178,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // with asterisk
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam("where", "{\"\\\\*\": {\"$eq\": \"star\"}}")
           .when()
@@ -2189,7 +2194,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
       exampleResource = CharStreams.toString(resource("documents/long-search.json"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(exampleResource)
           .when()
@@ -2198,7 +2203,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("where", "{\"*.value\": {\"$gt\": 0}}")
           .when()
           .get(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
@@ -2214,7 +2219,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
       exampleResource = CharStreams.toString(resource("documents/long-search.json"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(exampleResource)
           .when()
@@ -2224,7 +2229,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       String bodyFirstPage =
           given()
-              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
               .queryParam("where", "{\"*.value\": {\"$gt\": 0}}")
               .queryParam("page-size", 20)
               .when()
@@ -2241,7 +2246,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
       String pageState = objectMapper.readTree(bodyFirstPage).requiredAt("/pageState").textValue();
       String bodySecondPage =
           given()
-              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
               .queryParam("where", "{\"*.value\": {\"$gt\": 0}}")
               .queryParam("page-size", 20)
               .queryParam("page-state", pageState)
@@ -2266,7 +2271,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     public void matchInvalid() {
       // not JSON
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("where", "hello")
           .when()
           .get(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
@@ -2275,7 +2280,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // array
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("where", "[\"a\"]")
           .when()
           .get(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
@@ -2285,7 +2290,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // no-op
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("where", "{\"a\": true}")
           .when()
           .get(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
@@ -2295,7 +2300,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // op not found
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("where", "{\"a\": {\"exists\": true}}}")
           .when()
           .get(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
@@ -2305,7 +2310,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // op value not valid
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("where", "{\"a\": {\"$eq\": null}}}")
           .when()
           .get(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
@@ -2315,7 +2320,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // op value empty
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("where", "{\"a\": {\"$eq\": {}}}}")
           .when()
           .get(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
@@ -2325,7 +2330,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // op value array
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("where", "{\"a\": {\"$eq\": []}}}")
           .when()
           .get(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
@@ -2335,7 +2340,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // in not array
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("where", "{\"a\": {\"$in\": 2}}}")
           .when()
           .get(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
@@ -2345,7 +2350,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // multiple field conditions
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("where", "{\"a\": {\"$eq\": 300}, \"b\": {\"$lt\": 500}}")
           .when()
           .get(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
@@ -2360,7 +2365,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     public void matchWhereAndFieldsDifferentTarget() {
       // not JSON
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("where", "{\"a\": {\"$in\": [1]}}")
           .queryParam("fields", "[\"b\"]")
           .when()
@@ -2377,7 +2382,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     public void matchPageSizeNotPositive() {
       // not JSON
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("page-size", 0)
           .when()
           .get(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
@@ -2391,7 +2396,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void whereMalformed() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("where", "{\"a\":}")
           .when()
           .get(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
@@ -2407,7 +2412,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void fieldsMalformed() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("fields", "[\"a\"")
           .when()
           .get(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
@@ -2423,7 +2428,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
       String namespace = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/{document-id}", namespace, DEFAULT_COLLECTION, DOCUMENT_ID)
           .then()
@@ -2439,7 +2444,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
       String collection = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, collection, DOCUMENT_ID)
           .then()
@@ -2453,7 +2458,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
       String id = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -2468,7 +2473,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
       String collection = "local";
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/{document-id}", namespace, collection, DOCUMENT_ID)
           .then()
@@ -2502,7 +2507,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
       exampleResource = CharStreams.toString(resource("documents/example.json"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(exampleResource)
           .when()
@@ -2514,7 +2519,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @AfterEach
     public void deleteDoc() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .delete(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, DOCUMENT_ID)
           .then()
@@ -2527,7 +2532,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     public void happyPath() throws Exception {
       Object dataMap =
           given()
-              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
               .when()
               .get(
                   BASE_PATH + "/{document-id}/quiz/maths",
@@ -2550,7 +2555,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     public void happyPathRaw() {
       String body =
           given()
-              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
               .queryParam("raw", true)
               .when()
               .get(
@@ -2573,7 +2578,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     public void array() {
       String first =
           given()
-              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
               .queryParam("raw", true)
               .when()
               .get(
@@ -2593,7 +2598,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       String second =
           given()
-              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
               .queryParam("raw", true)
               .when()
               .get(
@@ -2618,7 +2623,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
       String json = "{\"a\\\\.b\":\"somedata\",\"some,data\":\"something\",\"*\":\"star\"}";
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(json)
           .when()
@@ -2627,7 +2632,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .when()
           .get(BASE_PATH + "/{document-id}/a%5C.b", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
@@ -2636,7 +2641,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("somedata"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .when()
           .get(BASE_PATH + "/{document-id}/some%5C,data", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
@@ -2645,7 +2650,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
           .body(jsonEquals("something"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .when()
           .get(BASE_PATH + "/{document-id}/%5C*", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
@@ -2657,7 +2662,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void matchOrWithSelection() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .queryParam(
               "where",
@@ -2680,7 +2685,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     public void matchOrWithPaging() throws Exception {
       String body =
           given()
-              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
               .queryParam(
                   "where",
                   "{\"$or\":[{\"*.name\":{\"$eq\":\"pear\"}},{\"*.name\":{\"$eq\":\"orange\"}}]}")
@@ -2705,7 +2710,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
       // paging only second with state
       String pageState = objectMapper.readTree(body).requiredAt("/pageState").textValue();
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam(
               "where",
               "{\"$or\":[{\"*.name\":{\"$eq\":\"pear\"}},{\"*.name\":{\"$eq\":\"orange\"}}]}")
@@ -2730,7 +2735,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void invalidPath() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .when()
           .get(
@@ -2747,7 +2752,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
                       .formatted(DOCUMENT_ID)));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .when()
           .get(
@@ -2765,7 +2770,7 @@ class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // out of bounds
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .when()
           .get(

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentUpdateResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentUpdateResourceIntegrationTest.java
@@ -18,6 +18,7 @@
 package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.documents;
 
 import static io.restassured.RestAssured.given;
+import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonPartEquals;
 import static net.javacrumbs.jsonunit.core.util.ResourceUtils.resource;
 import static org.hamcrest.Matchers.is;
@@ -27,6 +28,7 @@ import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 import com.google.common.io.CharStreams;
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
@@ -42,7 +44,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@QuarkusTestResource(
+    value = StargateTestResource.class,
+    initArgs =
+        @ResourceArg(name = StargateTestResource.Options.DISABLE_FIXED_TOKEN, value = "true"))
 class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
   public static final String BASE_PATH =
@@ -75,7 +80,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String id = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(exampleResource)
           .when()
@@ -84,7 +89,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
           .body(jsonPartEquals("documentId", id))
@@ -96,7 +101,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String id = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("profile", true)
           .contentType(ContentType.JSON)
           .body(exampleResource)
@@ -112,7 +117,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String id = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("ttl", 3)
           .contentType(ContentType.JSON)
           .body(exampleResource)
@@ -127,7 +132,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .untilAsserted(
               () ->
                   given()
-                      .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+                      .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
                       .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
                       .then()
                       .statusCode(404));
@@ -138,7 +143,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String id = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{ \"periods\\\\.\": \"are allowed if escaped\" }")
           .when()
@@ -147,7 +152,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
           .body(jsonPartEquals("documentId", id))
@@ -156,7 +161,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       // overwrite with asterisks
       String asterisksJson = "{ \"*aste*risks*\": \"are allowed\" }";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(asterisksJson)
           .when()
@@ -165,7 +170,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
           .body(jsonPartEquals("documentId", id))
@@ -178,7 +183,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String id = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(json)
           .when()
@@ -187,7 +192,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
           .body(jsonPartEquals("documentId", id))
@@ -201,7 +206,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           "{\"abc\": [], \"bcd\": {}, \"cde\": null, \"abcd\": { \"nest1\": [], \"nest2\": {}}}";
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(json)
           .when()
@@ -210,21 +215,21 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
           .body(jsonPartEquals("documentId", id))
           .body(jsonPartEquals("data", json));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .get(BASE_PATH + "/abc", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
           .body(jsonPartEquals("documentId", id))
           .body(jsonPartEquals("data", "[]"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .get(BASE_PATH + "/abcd/nest1", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
           .body(jsonPartEquals("documentId", id))
@@ -237,7 +242,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String json = "[1, 2, 3, 4, 5]";
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(json)
           .when()
@@ -246,14 +251,14 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
           .body(jsonPartEquals("documentId", id))
           .body(jsonPartEquals("data", json));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .get(BASE_PATH + "/[000002]", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
           .body(jsonPartEquals("documentId", id))
@@ -267,7 +272,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String id = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("ttl", -1)
           .contentType(ContentType.JSON)
           .body(exampleResource)
@@ -285,7 +290,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String json = CharStreams.toString(resource("documents/too-deep.json"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(json)
           .when()
@@ -301,7 +306,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String id = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{ \"bracketedarraypaths[100]\": \"are not allowed\" }")
           .when()
@@ -315,7 +320,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
                   "Array paths contained in square brackets, periods, single quotes, and backslash are not allowed in field names, invalid field bracketedarraypaths[100]"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{ \"periods.something\": \"are not allowed\" }")
           .when()
@@ -329,7 +334,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
                   "Array paths contained in square brackets, periods, single quotes, and backslash are not allowed in field names, invalid field periods.something"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{ \"single'quotes\": \"are not allowed\" }")
           .when()
@@ -343,7 +348,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
                   "Array paths contained in square brackets, periods, single quotes, and backslash are not allowed in field names, invalid field single'quotes"));
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{ \"back\\\\\\\\slashes\": \"are not allowed\" }")
           .when()
@@ -363,7 +368,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String id = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(primitiveJson)
           .when()
@@ -382,7 +387,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String id = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{\"some\":")
           .when()
@@ -398,7 +403,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String id = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .when()
           .put(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
@@ -414,7 +419,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String namespace = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(exampleResource)
           .when()
@@ -434,7 +439,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String collection = "local";
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(exampleResource)
           .when()
@@ -478,7 +483,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       String updateJson = "{\"q5000\": \"hello?\"}";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("profile", true)
           .contentType(ContentType.JSON)
           .body(updateJson)
@@ -494,7 +499,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String id = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(exampleResource)
           .when()
@@ -504,7 +509,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       String updateJson = "{\"q5000\": \"hello?\"}";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(updateJson)
           .when()
@@ -514,7 +519,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // assert at full doc
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -522,7 +527,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // assert at path
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/quiz/sport", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -534,7 +539,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String id = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(exampleResource)
           .when()
@@ -544,7 +549,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       String updateJson = "{\"q5000\": \"hello?\"}";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(updateJson)
           .when()
@@ -554,7 +559,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // assert at full doc
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -562,7 +567,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // assert at path
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/quiz/nests/q1/options/[0]", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -574,7 +579,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String id = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(exampleResource)
           .when()
@@ -585,7 +590,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       // replace object with array
       String updateJson = "[{\"array\": \"at\"}, \"sub\", \"doc\"]";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(updateJson)
           .when()
@@ -595,7 +600,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // assert at full doc
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -603,7 +608,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // assert at path
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/quiz", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -612,7 +617,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       // then replace array with a pre path
       updateJson = "[0, \"a\", \"2\", true]";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(updateJson)
           .when()
@@ -622,7 +627,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // assert at full doc
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -630,7 +635,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // assert at path
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/quiz/nests/q1", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -639,7 +644,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       // then again with the array
       updateJson = "[{\"array\": \"at\"}, \"\", \"doc\"]";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(updateJson)
           .when()
@@ -649,7 +654,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // assert at full doc
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -657,7 +662,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // assert at path
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/quiz", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -666,7 +671,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       // and then with final object
       updateJson = "{\"we\": {\"are\": \"done\"}}";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(updateJson)
           .when()
@@ -676,7 +681,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // assert at full doc
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -684,7 +689,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // assert at path
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/quiz", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -697,7 +702,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String id = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(exampleResource)
           .when()
@@ -706,7 +711,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(updateJson)
           .when()
@@ -716,7 +721,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // assert at full doc
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -724,7 +729,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // assert at path
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/quiz", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -737,7 +742,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String id = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(exampleResource)
           .when()
@@ -746,7 +751,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(primitiveJson)
           .when()
@@ -756,7 +761,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       String objectJson = "{\"some\": \"value\"}";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(objectJson)
           .when()
@@ -766,7 +771,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // assert at full doc
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -774,7 +779,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // assert at path
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/quiz", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -786,7 +791,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String id = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("ttl", 2)
           .contentType(ContentType.JSON)
           .body("{ \"delete this\": \"in 2 seconds\" }")
@@ -796,7 +801,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .statusCode(200);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("ttl-auto", true)
           .contentType(ContentType.JSON)
           .body("{ \"match the parent\": \"this\", \"a\": \"b\" }")
@@ -810,7 +815,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .untilAsserted(
               () ->
                   given()
-                      .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+                      .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
                       .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
                       .then()
                       .statusCode(404));
@@ -821,7 +826,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String id = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("ttl", 2)
           .contentType(ContentType.JSON)
           .body("{ \"delete this\": \"in 2 seconds\" }")
@@ -832,7 +837,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       String addedJson = "{ \"match the parent\": \"this\", \"a\": \"b\" }";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(addedJson)
           .when()
@@ -845,7 +850,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .untilAsserted(
               () ->
                   given()
-                      .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+                      .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
                       .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
                       .then()
                       .statusCode(200)
@@ -860,7 +865,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       // $
       String json = "{ \"$\": \"weird but allowed\" }";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(json)
           .when()
@@ -868,7 +873,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .then()
           .statusCode(200);
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/path", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -876,7 +881,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       json = "{ \"$30\": \"not as weird\" }";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(json)
           .when()
@@ -884,7 +889,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .then()
           .statusCode(200);
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/path", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -893,7 +898,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       // @
       json = "{ \"@\": \"weird but allowed\" }";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(json)
           .when()
@@ -901,7 +906,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .then()
           .statusCode(200);
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/path", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -909,7 +914,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       json = "{ \"meet me @ the place\": \"not as weird\" }";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(json)
           .when()
@@ -917,7 +922,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .then()
           .statusCode(200);
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/path", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -926,7 +931,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       // ?
       json = "{ \"?\": \"weird but allowed\" }";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(json)
           .when()
@@ -934,7 +939,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .then()
           .statusCode(200);
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/path", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -943,7 +948,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       // spaces
       json = "{ \"spac es\": \"weird but allowed\" }";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(json)
           .when()
@@ -951,7 +956,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .then()
           .statusCode(200);
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/path", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -960,7 +965,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       // number
       json = "{ \"3\": [\"totally allowed\"] }";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(json)
           .when()
@@ -968,13 +973,13 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .then()
           .statusCode(200);
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/path", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
           .body(jsonPartEquals("data", json));
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/path/3/[0]", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -982,7 +987,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
       json = "{ \"-1\": \"totally allowed\" }";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(json)
           .when()
@@ -990,13 +995,13 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .then()
           .statusCode(200);
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/path", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
           .body(jsonPartEquals("data", json));
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/path/-1", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -1005,7 +1010,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       // esc
       json = "{ \"Eric says \\\"hello\\\"\": \"totally allowed\" }";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(json)
           .when()
@@ -1013,7 +1018,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .then()
           .statusCode(200);
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/path", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
           .then()
@@ -1027,7 +1032,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
       String id = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{ \"some\": \"json\" }")
           .when()

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentUpdateResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentUpdateResourceIntegrationTest.java
@@ -26,58 +26,38 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 import com.google.common.io.CharStreams;
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
-import io.restassured.RestAssured;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
-import io.stargate.sgv2.api.common.cql.builder.Replication;
-import io.stargate.sgv2.common.testprofiles.IntegrationTestProfile;
-import io.stargate.sgv2.docsapi.service.schema.CollectionManager;
-import io.stargate.sgv2.docsapi.service.schema.NamespaceManager;
+import io.stargate.sgv2.common.testresource.StargateTestResource;
+import io.stargate.sgv2.docsapi.api.v2.DocsApiIntegrationTest;
 import java.time.Duration;
-import javax.enterprise.context.control.ActivateRequestContext;
-import javax.inject.Inject;
+import java.util.Optional;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestClassOrder;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-@QuarkusTest
-@TestProfile(IntegrationTestProfile.class)
-@ActivateRequestContext
-@TestClassOrder(ClassOrderer.OrderAnnotation.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class DocumentUpdateResourceIntegrationTest {
+@QuarkusIntegrationTest
+@QuarkusTestResource(StargateTestResource.class)
+class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
   public static final String BASE_PATH =
       "/v2/namespaces/{namespace}/collections/{collection}/{document-id}";
   public static final String DEFAULT_NAMESPACE = RandomStringUtils.randomAlphanumeric(16);
   public static final String DEFAULT_COLLECTION = RandomStringUtils.randomAlphanumeric(16);
 
-  @Inject NamespaceManager namespaceManager;
+  @Override
+  public Optional<String> createNamespace() {
+    return Optional.of(DEFAULT_NAMESPACE);
+  }
 
-  @Inject CollectionManager collectionManager;
-
-  @BeforeAll
-  public void init() {
-    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
-
-    namespaceManager
-        .createNamespace(DEFAULT_NAMESPACE, Replication.simpleStrategy(1))
-        .await()
-        .atMost(Duration.ofSeconds(10));
-
-    collectionManager
-        .createCollectionTable(DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
-        .await()
-        .atMost(Duration.ofSeconds(10));
+  @Override
+  public Optional<String> createCollection() {
+    return Optional.of(DEFAULT_COLLECTION);
   }
 
   @Nested

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentWriteResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentWriteResourceIntegrationTest.java
@@ -397,7 +397,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
       String doc2 = "{\"id\": 2, \"name\":\"b\"}";
       String doc3 = "{\"id\": 3, \"name\":\"c\"}";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .queryParam("id-path", "id")
           .body(String.format("[%s, %s, %s]", doc1, doc2, doc3))
@@ -414,7 +414,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
       String doc2 = "{\"id\": 2.2, \"name\":\"b\"}";
       String doc3 = "{\"id\": 3.3, \"name\":\"c\"}";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .queryParam("id-path", "id")
           .body(String.format("[%s, %s, %s]", doc1, doc2, doc3))
@@ -430,7 +430,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
       String doc1 = "{\"id\": true, \"name\":\"a\"}";
       String doc2 = "{\"id\": false, \"name\":\"b\"}";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .queryParam("id-path", "id")
           .body(String.format("[%s, %s]", doc1, doc2))

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentWriteResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentWriteResourceIntegrationTest.java
@@ -17,6 +17,7 @@
 package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.documents;
 
 import static io.restassured.RestAssured.given;
+import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonPartMatches;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,6 +32,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
@@ -45,7 +47,10 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@QuarkusTestResource(
+    value = StargateTestResource.class,
+    initArgs =
+        @ResourceArg(name = StargateTestResource.Options.DISABLE_FIXED_TOKEN, value = "true"))
 class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
 
   public static final String BASE_PATH = "/v2/namespaces/{namespace}/collections/{collection}";
@@ -73,7 +78,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     public void happyPath() {
       Response postResponse =
           given()
-              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
               .contentType(ContentType.JSON)
               .body(DEFAULT_PAYLOAD)
               .when()
@@ -85,7 +90,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
       String location = postResponse.header("location");
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(location)
@@ -98,7 +103,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     public void happyPathNoCollection() {
       Response postResponse =
           given()
-              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
               .contentType(ContentType.JSON)
               .body(DEFAULT_PAYLOAD)
               .when()
@@ -110,7 +115,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
       String location = postResponse.header("location");
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(location)
@@ -123,7 +128,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     public void writeArray() {
       Response postResponse =
           given()
-              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
               .contentType(ContentType.JSON)
               .body("[1, 2, 3]")
               .when()
@@ -135,7 +140,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
       String location = postResponse.header("location");
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(location)
@@ -147,7 +152,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void withProfile() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .queryParam("profile", "true")
           .body(DEFAULT_PAYLOAD)
@@ -162,7 +167,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     public void withTtl() {
       Response postResponse =
           given()
-              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
               .contentType(ContentType.JSON)
               .queryParam("ttl", "1")
               .body(DEFAULT_PAYLOAD)
@@ -179,7 +184,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
           .untilAsserted(
               () ->
                   given()
-                      .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+                      .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
                       .when()
                       .get(location)
                       .then()
@@ -190,7 +195,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     public void withLongerTtl() {
       Response postResponse =
           given()
-              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
               .contentType(ContentType.JSON)
               .queryParam("ttl", "10")
               .body(DEFAULT_PAYLOAD)
@@ -203,7 +208,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
       String location = postResponse.header("location");
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(location)
           .then()
@@ -216,7 +221,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void malformedJson() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(MALFORMED_PAYLOAD)
           .when()
@@ -228,7 +233,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void invalidTtl() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("ttl", -10)
           .contentType(ContentType.JSON)
           .body(DEFAULT_PAYLOAD)
@@ -243,7 +248,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void emptyObject() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("{}")
           .when()
@@ -260,7 +265,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void emptyArray() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("[]")
           .when()
@@ -276,7 +281,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void singlePrimitive() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("true")
           .when()
@@ -292,7 +297,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void noBody() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .when()
           .post(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -308,7 +313,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
       String collection = "local";
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(DEFAULT_PAYLOAD)
           .when()
@@ -336,7 +341,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void keyspaceNotExists() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(DEFAULT_PAYLOAD)
           .when()
@@ -355,7 +360,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void happyPath() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .queryParam("ttl", "1")
           .body(String.format("[%s, %s, %s]", DEFAULT_PAYLOAD, DEFAULT_PAYLOAD, DEFAULT_PAYLOAD))
@@ -375,7 +380,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
       String doc2 = "{\"id\": \"2\", \"name\":\"b\"}";
       String doc3 = "{\"id\": \"3\", \"name\":\"c\"}";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .queryParam("id-path", "id")
           .body(String.format("[%s, %s, %s]", doc1, doc2, doc3))
@@ -439,7 +444,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void idPathOverwrite() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(DEFAULT_PAYLOAD)
           .when()
@@ -451,7 +456,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
       String doc2 = "{\"id\": \"2\", \"name\":\"b\"}";
       String doc3 = "{\"id\": \"3\", \"name\":\"c\"}";
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .queryParam("id-path", "id")
           .body(String.format("[%s, %s, %s]", doc1, doc2, doc3))
@@ -462,7 +467,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
 
       // Check that the data for document ID 1 was overwritten properly
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", "true")
           .when()
           .get(BASE_PATH + "/1", DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
@@ -474,7 +479,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void withProfile() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .queryParam("profile", "true")
           .body("[" + DEFAULT_PAYLOAD + "]")
@@ -489,7 +494,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     public void withTtl() throws JsonProcessingException {
       Response postResponse =
           given()
-              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
               .contentType(ContentType.JSON)
               .queryParam("ttl", "1")
               .body("[" + DEFAULT_PAYLOAD + "]")
@@ -510,7 +515,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
                 for (JsonNode jsonNode : ids) {
                   String id = jsonNode.asText();
                   given()
-                      .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+                      .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
                       .when()
                       .get(BASE_PATH + "/{document-id}", DEFAULT_NAMESPACE, DEFAULT_COLLECTION, id)
                       .then()
@@ -524,7 +529,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void invalidTtl() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .queryParam("ttl", "-10")
           .body("[" + DEFAULT_PAYLOAD + "]")
@@ -539,7 +544,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void illegalDuplicatedId() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .queryParam("id-path", "test")
           .body(String.format("[%s, %s]", DEFAULT_PAYLOAD, DEFAULT_PAYLOAD))
@@ -557,7 +562,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void invalidIdPath() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .queryParam("id-path", "not.valid.path")
           .body(String.format("[%s]", DEFAULT_PAYLOAD))
@@ -575,7 +580,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void malformedJson() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(MALFORMED_PAYLOAD)
           .when()
@@ -596,7 +601,7 @@ class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
     @Test
     public void keyspaceNotExists() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body("[" + DEFAULT_PAYLOAD + "]")
           .when()

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentWriteResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentWriteResourceIntegrationTest.java
@@ -30,32 +30,23 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
-import io.restassured.RestAssured;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
-import io.stargate.sgv2.api.common.cql.builder.Replication;
-import io.stargate.sgv2.common.testprofiles.IntegrationTestProfile;
-import io.stargate.sgv2.docsapi.service.schema.CollectionManager;
-import io.stargate.sgv2.docsapi.service.schema.NamespaceManager;
-import java.time.Duration;
+import io.stargate.sgv2.common.testresource.StargateTestResource;
+import io.stargate.sgv2.docsapi.api.v2.DocsApiIntegrationTest;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import javax.enterprise.context.control.ActivateRequestContext;
-import javax.inject.Inject;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 
-@QuarkusTest
-@TestProfile(IntegrationTestProfile.class)
-@ActivateRequestContext
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class DocumentWriteResourceIntegrationTest {
+@QuarkusIntegrationTest
+@QuarkusTestResource(StargateTestResource.class)
+class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
 
   public static final String BASE_PATH = "/v2/namespaces/{namespace}/collections/{collection}";
   public static final String DEFAULT_NAMESPACE = RandomStringUtils.randomAlphanumeric(16);
@@ -64,26 +55,16 @@ class DocumentWriteResourceIntegrationTest {
       "{\"test\": \"document\", \"this\": [\"is\", 1, true]}";
   public static final String MALFORMED_PAYLOAD = "{\"malformed\": ";
 
-  @Inject NamespaceManager namespaceManager;
+  final ObjectMapper objectMapper = new ObjectMapper();
 
-  @Inject CollectionManager collectionManager;
+  @Override
+  public Optional<String> createNamespace() {
+    return Optional.of(DEFAULT_NAMESPACE);
+  }
 
-  @Inject ObjectMapper objectMapper;
-
-  @BeforeAll
-  public void init() {
-
-    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
-
-    namespaceManager
-        .createNamespace(DEFAULT_NAMESPACE, Replication.simpleStrategy(1))
-        .await()
-        .atMost(Duration.ofSeconds(10));
-
-    collectionManager
-        .createCollectionTable(DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
-        .await()
-        .atMost(Duration.ofSeconds(10));
+  @Override
+  public Optional<String> createCollection() {
+    return Optional.of(DEFAULT_COLLECTION);
   }
 
   @Nested

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/jsonschema/JsonSchemaResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/jsonschema/JsonSchemaResourceIntegrationTest.java
@@ -21,9 +21,11 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
+import io.stargate.sgv2.common.IntegrationTestUtils;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.docsapi.api.v2.DocsApiIntegrationTest;
 import io.stargate.sgv2.docsapi.api.v2.namespaces.collections.CollectionsResource;
@@ -36,7 +38,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@QuarkusTestResource(
+    value = StargateTestResource.class,
+    initArgs =
+        @ResourceArg(name = StargateTestResource.Options.DISABLE_FIXED_TOKEN, value = "true"))
 public class JsonSchemaResourceIntegrationTest extends DocsApiIntegrationTest {
 
   // base path for the test
@@ -70,7 +75,8 @@ public class JsonSchemaResourceIntegrationTest extends DocsApiIntegrationTest {
 
       given()
           .contentType(ContentType.JSON)
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(
+              HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, IntegrationTestUtils.getAuthToken())
           .body(body)
           .put(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
           .then()
@@ -88,7 +94,8 @@ public class JsonSchemaResourceIntegrationTest extends DocsApiIntegrationTest {
 
       given()
           .contentType(ContentType.JSON)
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(
+              HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, IntegrationTestUtils.getAuthToken())
           .body(body)
           .put(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
           .then()
@@ -106,7 +113,8 @@ public class JsonSchemaResourceIntegrationTest extends DocsApiIntegrationTest {
 
       given()
           .contentType(ContentType.JSON)
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(
+              HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, IntegrationTestUtils.getAuthToken())
           .body(body)
           .put(BASE_PATH, DEFAULT_NAMESPACE, "notatable")
           .then()
@@ -125,7 +133,8 @@ public class JsonSchemaResourceIntegrationTest extends DocsApiIntegrationTest {
 
       given()
           .contentType(ContentType.JSON)
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(
+              HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, IntegrationTestUtils.getAuthToken())
           .body(body)
           .put(BASE_PATH, "notexist", DEFAULT_COLLECTION)
           .then()
@@ -150,7 +159,8 @@ public class JsonSchemaResourceIntegrationTest extends DocsApiIntegrationTest {
       given()
           .contentType(ContentType.JSON)
           .body(body)
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(
+              HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, IntegrationTestUtils.getAuthToken())
           .when()
           .put(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
           .then()
@@ -167,7 +177,8 @@ public class JsonSchemaResourceIntegrationTest extends DocsApiIntegrationTest {
     public void noPayload() {
       given()
           .contentType(ContentType.JSON)
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(
+              HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, IntegrationTestUtils.getAuthToken())
           .when()
           .put(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
           .then()
@@ -182,7 +193,8 @@ public class JsonSchemaResourceIntegrationTest extends DocsApiIntegrationTest {
       given()
           .contentType(ContentType.JSON)
           .body("{}")
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(
+              HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, IntegrationTestUtils.getAuthToken())
           .when()
           .put(BASE_PATH, "system", "peers")
           .then()
@@ -203,7 +215,8 @@ public class JsonSchemaResourceIntegrationTest extends DocsApiIntegrationTest {
     @Order(1)
     public void happyPath() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(
+              HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, IntegrationTestUtils.getAuthToken())
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
           .then()
@@ -223,12 +236,14 @@ public class JsonSchemaResourceIntegrationTest extends DocsApiIntegrationTest {
               """;
       given()
           .contentType(ContentType.JSON)
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(
+              HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, IntegrationTestUtils.getAuthToken())
           .body(json)
           .post(CollectionsResource.BASE_PATH, DEFAULT_NAMESPACE);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(
+              HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, IntegrationTestUtils.getAuthToken())
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, "freshtable")
           .then()
@@ -242,7 +257,8 @@ public class JsonSchemaResourceIntegrationTest extends DocsApiIntegrationTest {
     public void tableNotExisting() {
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(
+              HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, IntegrationTestUtils.getAuthToken())
           .when()
           .get(BASE_PATH, DEFAULT_NAMESPACE, "notatable")
           .then()
@@ -256,7 +272,8 @@ public class JsonSchemaResourceIntegrationTest extends DocsApiIntegrationTest {
     public void keyspaceNotExisting() {
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(
+              HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, IntegrationTestUtils.getAuthToken())
           .when()
           .get(BASE_PATH, "notexist", DEFAULT_COLLECTION)
           .then()
@@ -269,7 +286,8 @@ public class JsonSchemaResourceIntegrationTest extends DocsApiIntegrationTest {
     @Order(5)
     public void notDocumentTable() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(
+              HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, IntegrationTestUtils.getAuthToken())
           .when()
           .get(BASE_PATH, "system", "peers")
           .then()

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/jsonschema/JsonSchemaResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/jsonschema/JsonSchemaResourceIntegrationTest.java
@@ -20,35 +20,24 @@ package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.jsonschema;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
-import io.restassured.RestAssured;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
-import io.stargate.sgv2.api.common.cql.builder.Replication;
-import io.stargate.sgv2.common.testprofiles.IntegrationTestProfile;
-import io.stargate.sgv2.docsapi.service.schema.CollectionManager;
-import io.stargate.sgv2.docsapi.service.schema.NamespaceManager;
-import java.time.Duration;
-import javax.enterprise.context.control.ActivateRequestContext;
-import javax.inject.Inject;
+import io.stargate.sgv2.common.testresource.StargateTestResource;
+import io.stargate.sgv2.docsapi.api.v2.DocsApiIntegrationTest;
+import io.stargate.sgv2.docsapi.api.v2.namespaces.collections.CollectionsResource;
+import java.util.Optional;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestClassOrder;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
 
-@QuarkusTest
-@TestProfile(IntegrationTestProfile.class)
-@ActivateRequestContext
-@TestClassOrder(ClassOrderer.OrderAnnotation.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class JsonSchemaResourceIntegrationTest {
+@QuarkusIntegrationTest
+@QuarkusTestResource(StargateTestResource.class)
+public class JsonSchemaResourceIntegrationTest extends DocsApiIntegrationTest {
 
   // base path for the test
   public static final String BASE_PATH =
@@ -56,22 +45,14 @@ public class JsonSchemaResourceIntegrationTest {
   public static final String DEFAULT_NAMESPACE = RandomStringUtils.randomAlphanumeric(16);
   public static final String DEFAULT_COLLECTION = RandomStringUtils.randomAlphanumeric(16);
 
-  @Inject NamespaceManager namespaceManager;
-  @Inject CollectionManager collectionManager;
+  @Override
+  public Optional<String> createNamespace() {
+    return Optional.of(DEFAULT_NAMESPACE);
+  }
 
-  @BeforeAll
-  public void init() {
-    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
-
-    namespaceManager
-        .createNamespace(DEFAULT_NAMESPACE, Replication.simpleStrategy(1))
-        .await()
-        .atMost(Duration.ofSeconds(10));
-
-    collectionManager
-        .createCollectionTable(DEFAULT_NAMESPACE, DEFAULT_COLLECTION)
-        .await()
-        .atMost(Duration.ofSeconds(10));
+  @Override
+  public Optional<String> createCollection() {
+    return Optional.of(DEFAULT_COLLECTION);
   }
 
   @Nested
@@ -234,10 +215,18 @@ public class JsonSchemaResourceIntegrationTest {
     @Order(2)
     public void noSchemaAvailable() {
       // Create a fresh table for this test, to have no schema
-      collectionManager
-          .createCollectionTable(DEFAULT_NAMESPACE, "freshtable")
-          .await()
-          .atMost(Duration.ofSeconds(10));
+      String json =
+          """
+              {
+                  "name": "freshtable"
+              }
+              """;
+      given()
+          .contentType(ContentType.JSON)
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .body(json)
+          .post(CollectionsResource.BASE_PATH, DEFAULT_NAMESPACE);
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
           .when()

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/schemas/namespaces/NamespacesResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/schemas/namespaces/NamespacesResourceIntegrationTest.java
@@ -27,20 +27,20 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
-import io.stargate.sgv2.common.testprofiles.IntegrationTestProfile;
+import io.stargate.sgv2.common.testresource.StargateTestResource;
 import javax.ws.rs.core.HttpHeaders;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@QuarkusTest
-@TestProfile(IntegrationTestProfile.class)
+@QuarkusIntegrationTest
+@QuarkusTestResource(StargateTestResource.class)
 class NamespacesResourceIntegrationTest {
 
   public static final String BASE_PATH = "/v2/schemas/namespaces";

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/schemas/namespaces/NamespacesResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/schemas/namespaces/NamespacesResourceIntegrationTest.java
@@ -18,6 +18,7 @@
 package io.stargate.sgv2.docsapi.api.v2.schemas.namespaces;
 
 import static io.restassured.RestAssured.given;
+import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.endsWith;
@@ -28,6 +29,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -40,7 +42,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@QuarkusTestResource(
+    value = StargateTestResource.class,
+    initArgs =
+        @ResourceArg(name = StargateTestResource.Options.DISABLE_FIXED_TOKEN, value = "true"))
 class NamespacesResourceIntegrationTest {
 
   public static final String BASE_PATH = "/v2/schemas/namespaces";
@@ -58,7 +63,7 @@ class NamespacesResourceIntegrationTest {
       // expect at least one keyspace, like system
       // rest assured does not support wildcards, so validate only first
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH)
           .then()
@@ -70,7 +75,7 @@ class NamespacesResourceIntegrationTest {
     @Test
     public void happyPathRaw() {
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .when()
           .get(BASE_PATH)
@@ -88,7 +93,7 @@ class NamespacesResourceIntegrationTest {
       String namespace = "system";
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .queryParam("raw", true)
           .when()
           .get(BASE_PATH + "/{namespace}", namespace)
@@ -102,7 +107,7 @@ class NamespacesResourceIntegrationTest {
       String namespace = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/{namespace}", namespace)
           .then()
@@ -131,7 +136,7 @@ class NamespacesResourceIntegrationTest {
       // create
       given()
           .contentType(ContentType.JSON)
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .body(json)
           .post(BASE_PATH)
           .then()
@@ -140,7 +145,7 @@ class NamespacesResourceIntegrationTest {
 
       // assert
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/{namespace}", namespace)
           .then()
@@ -165,7 +170,7 @@ class NamespacesResourceIntegrationTest {
       // create
       given()
           .contentType(ContentType.JSON)
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .body(json)
           .post(BASE_PATH)
           .then()
@@ -175,7 +180,7 @@ class NamespacesResourceIntegrationTest {
       // note that in the tests, we only have a single node,
       // so we can not expect 3 replicas
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/{namespace}", namespace)
           .then()
@@ -202,7 +207,7 @@ class NamespacesResourceIntegrationTest {
       // create
       given()
           .contentType(ContentType.JSON)
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .body(json)
           .post(BASE_PATH)
           .then()
@@ -210,7 +215,7 @@ class NamespacesResourceIntegrationTest {
 
       // delete
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .delete(BASE_PATH + "/{namespace}", namespace)
           .then()
@@ -218,7 +223,7 @@ class NamespacesResourceIntegrationTest {
 
       // assert deleted
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .get(BASE_PATH + "/{namespace}", namespace)
           .then()
@@ -230,7 +235,7 @@ class NamespacesResourceIntegrationTest {
       String namespace = RandomStringUtils.randomAlphanumeric(16);
 
       given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "")
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .when()
           .delete(BASE_PATH + "/{namespace}", namespace)
           .then()

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/grpc/StargateBridgeInterceptorTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/grpc/StargateBridgeInterceptorTest.java
@@ -34,6 +34,7 @@ import io.stargate.bridge.proto.Schema;
 import io.stargate.sgv2.api.common.BridgeTest;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
 import io.stargate.sgv2.api.common.testprofiles.FixedTenantTestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.docsapi.api.v2.namespaces.collections.documents.DocumentReadResource;
 import java.util.Map;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -45,7 +46,8 @@ import org.mockito.ArgumentCaptor;
 @TestProfile(StargateBridgeInterceptorTest.Profile.class)
 class StargateBridgeInterceptorTest extends BridgeTest {
 
-  public static class Profile extends FixedTenantTestProfile {
+  public static class Profile extends FixedTenantTestProfile
+      implements NoGlobalResourcesTestProfile {
 
     @Override
     public Map<String, String> getConfigOverrides() {

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/JsonDocumentShredderTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/JsonDocumentShredderTest.java
@@ -27,8 +27,8 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCode;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCodeRuntimeException;
 import io.stargate.sgv2.docsapi.api.properties.document.DocumentProperties;
@@ -52,7 +52,7 @@ class JsonDocumentShredderTest {
 
   @Inject DocumentProperties configuration;
 
-  public static class Profile implements QuarkusTestProfile {
+  public static class Profile implements NoGlobalResourcesTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
       return ImmutableMap.<String, String>builder()

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/json/JsonConverterTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/json/JsonConverterTest.java
@@ -25,11 +25,11 @@ import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import io.stargate.bridge.proto.QueryOuterClass.ColumnSpec;
 import io.stargate.bridge.proto.QueryOuterClass.Row;
 import io.stargate.bridge.proto.QueryOuterClass.Value;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.docsapi.config.constants.Constants;
 import io.stargate.sgv2.docsapi.service.common.model.RowWrapper;
 import java.util.ArrayList;
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.Test;
 @TestProfile(JsonConverterTest.Profile.class)
 public class JsonConverterTest {
 
-  public static class Profile implements QuarkusTestProfile {
+  public static class Profile implements NoGlobalResourcesTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
       return ImmutableMap.<String, String>builder().put("stargate.document.max-depth", "6").build();

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/ExpressionParserTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/ExpressionParserTest.java
@@ -27,9 +27,11 @@ import com.bpodgursky.jbool_expressions.Or;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.junit.mockito.InjectMock;
 import io.stargate.bridge.grpc.Values;
 import io.stargate.sgv2.api.common.cql.builder.Predicate;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCode;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCodeRuntimeException;
 import io.stargate.sgv2.docsapi.api.properties.document.DocumentProperties;
@@ -56,6 +58,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mockito;
 
 @QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
 class ExpressionParserTest {
 
   @Inject ExpressionParser service;

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/condition/ConditionParserTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/condition/ConditionParserTest.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCode;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCodeRuntimeException;
 import io.stargate.sgv2.docsapi.api.properties.document.DocumentProperties;
@@ -48,6 +50,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
 class ConditionParserTest {
 
   // false with the default implementation

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/rules/ExpressionUtilsTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/rules/ExpressionUtilsTest.java
@@ -27,6 +27,8 @@ import com.bpodgursky.jbool_expressions.Expression;
 import com.bpodgursky.jbool_expressions.Not;
 import com.bpodgursky.jbool_expressions.Or;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.docsapi.api.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.service.query.FilterExpression;
 import io.stargate.sgv2.docsapi.service.query.FilterPath;
@@ -44,6 +46,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
 class ExpressionUtilsTest {
 
   @Inject DocumentProperties documentProperties;

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/DocumentTtlQueryBuilderTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/DocumentTtlQueryBuilderTest.java
@@ -20,7 +20,9 @@ package io.stargate.sgv2.docsapi.service.query.search.db.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.docsapi.api.properties.document.DocumentProperties;
 import javax.inject.Inject;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -28,6 +30,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
 class DocumentTtlQueryBuilderTest {
 
   private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FullSearchQueryBuilderTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/FullSearchQueryBuilderTest.java
@@ -20,7 +20,9 @@ package io.stargate.sgv2.docsapi.service.query.search.db.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.docsapi.api.properties.document.DocumentProperties;
 import javax.inject.Inject;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -28,6 +30,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
 class FullSearchQueryBuilderTest {
 
   private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/PopulateSearchQueryBuilderTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/db/impl/PopulateSearchQueryBuilderTest.java
@@ -20,7 +20,9 @@ package io.stargate.sgv2.docsapi.service.query.search.db.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.docsapi.api.properties.document.DocumentProperties;
 import javax.inject.Inject;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -28,6 +30,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
 class PopulateSearchQueryBuilderTest {
 
   private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/BaseResolverTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/BaseResolverTest.java
@@ -24,6 +24,8 @@ import com.bpodgursky.jbool_expressions.Literal;
 import com.bpodgursky.jbool_expressions.Not;
 import com.bpodgursky.jbool_expressions.Or;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.docsapi.api.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.service.ExecutionContext;
 import io.stargate.sgv2.docsapi.service.query.FilterExpression;
@@ -54,6 +56,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 @QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
 class BaseResolverTest {
 
   @Mock DocumentsResolver candidatesResolver;

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/CnfResolverTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/CnfResolverTest.java
@@ -22,6 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.bpodgursky.jbool_expressions.And;
 import com.bpodgursky.jbool_expressions.Or;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.docsapi.api.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.service.ExecutionContext;
 import io.stargate.sgv2.docsapi.service.query.FilterExpression;
@@ -49,6 +51,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
 
 @QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
 class CnfResolverTest {
 
   @Inject DocumentProperties documentProperties;

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/AllFiltersResolverTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/AllFiltersResolverTest.java
@@ -24,11 +24,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.api.common.cql.builder.QueryBuilder;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.docsapi.OpenMocksTest;
 import io.stargate.sgv2.docsapi.bridge.AbstractValidatingStargateBridgeTest;
 import io.stargate.sgv2.docsapi.service.ExecutionContext;
@@ -46,6 +48,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 @QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
 class AllFiltersResolverTest extends AbstractValidatingStargateBridgeTest {
 
   private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/AnyFiltersResolverTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/query/search/resolver/impl/AnyFiltersResolverTest.java
@@ -24,11 +24,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.api.common.cql.builder.QueryBuilder;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.docsapi.OpenMocksTest;
 import io.stargate.sgv2.docsapi.bridge.AbstractValidatingStargateBridgeTest;
 import io.stargate.sgv2.docsapi.service.ExecutionContext;
@@ -46,6 +48,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 @QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
 class AnyFiltersResolverTest extends AbstractValidatingStargateBridgeTest {
 
   private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/AuthorizedCollectionManagerTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/AuthorizedCollectionManagerTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import io.grpc.stub.StreamObserver;
 import io.quarkus.grpc.GrpcClient;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.junit.mockito.InjectMock;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
@@ -34,6 +35,7 @@ import io.stargate.bridge.proto.StargateBridge;
 import io.stargate.sgv2.api.common.BridgeTest;
 import io.stargate.sgv2.api.common.StargateRequestInfo;
 import io.stargate.sgv2.api.common.grpc.UnauthorizedTableException;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.docsapi.api.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.service.schema.qualifier.Authorized;
 import java.util.Arrays;
@@ -47,6 +49,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 @QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
 class AuthorizedCollectionManagerTest extends BridgeTest {
 
   // only one test to assert authorized schema fetch

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/CollectionManagerTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/CollectionManagerTest.java
@@ -28,6 +28,7 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import io.quarkus.grpc.GrpcClient;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.junit.mockito.InjectMock;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
@@ -36,6 +37,7 @@ import io.stargate.bridge.proto.Schema;
 import io.stargate.bridge.proto.StargateBridge;
 import io.stargate.sgv2.api.common.BridgeTest;
 import io.stargate.sgv2.api.common.StargateRequestInfo;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCode;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCodeRuntimeException;
 import io.stargate.sgv2.docsapi.api.properties.document.DocumentProperties;
@@ -53,6 +55,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 @QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
 class CollectionManagerTest extends BridgeTest {
 
   @Inject CollectionManager collectionManager;

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/JsonSchemaManagerTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/JsonSchemaManagerTest.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.grpc.stub.StreamObserver;
 import io.quarkus.grpc.GrpcClient;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.junit.mockito.InjectMock;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
@@ -36,6 +37,7 @@ import io.stargate.bridge.proto.Schema;
 import io.stargate.bridge.proto.StargateBridge;
 import io.stargate.sgv2.api.common.BridgeTest;
 import io.stargate.sgv2.api.common.StargateRequestInfo;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCode;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCodeRuntimeException;
 import javax.inject.Inject;
@@ -46,6 +48,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 @QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
 class JsonSchemaManagerTest extends BridgeTest {
   @Inject JsonSchemaManager jsonSchemaManager;
 

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/NamespaceManagerTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/NamespaceManagerTest.java
@@ -29,6 +29,7 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import io.quarkus.grpc.GrpcClient;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.junit.mockito.InjectMock;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
@@ -40,6 +41,7 @@ import io.stargate.sgv2.api.common.BridgeTest;
 import io.stargate.sgv2.api.common.StargateRequestInfo;
 import io.stargate.sgv2.api.common.cql.builder.Replication;
 import io.stargate.sgv2.api.common.grpc.UnauthorizedKeyspaceException;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCode;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCodeRuntimeException;
 import io.stargate.sgv2.docsapi.service.schema.query.NamespaceQueryProvider;
@@ -53,6 +55,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 @QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
 class NamespaceManagerTest extends BridgeTest {
 
   @Inject NamespaceManager namespaceManager;

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/query/CollectionQueryProviderTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/query/CollectionQueryProviderTest.java
@@ -20,9 +20,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.docsapi.testprofiles.SaiEnabledTestProfile;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 @TestProfile(CollectionQueryProviderTest.Profile.class)
 class CollectionQueryProviderTest {
 
-  public static class Profile implements QuarkusTestProfile {
+  public static class Profile implements NoGlobalResourcesTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
       // adapt consistency, depth and column name(s)

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/query/JsonSchemaQueryProviderTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/query/JsonSchemaQueryProviderTest.java
@@ -19,13 +19,16 @@ package io.stargate.sgv2.docsapi.service.schema.query;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import javax.inject.Inject;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
 public class JsonSchemaQueryProviderTest {
 
   @Inject JsonSchemaQueryProvider queryProvider;

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/query/NamespaceQueryProviderTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/schema/query/NamespaceQueryProviderTest.java
@@ -21,14 +21,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.api.common.cql.builder.Replication;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import javax.inject.Inject;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
 class NamespaceQueryProviderTest {
 
   @Inject NamespaceQueryProvider queryProvider;

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/write/WriteDocumentsServiceTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/write/WriteDocumentsServiceTest.java
@@ -33,13 +33,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.junit.mockito.InjectMock;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.stargate.bridge.proto.QueryOuterClass.ResultSet;
 import io.stargate.bridge.proto.Schema;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.docsapi.OpenMocksTest;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCode;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCodeRuntimeException;
@@ -69,7 +69,7 @@ import org.mockito.Mock;
 @TestProfile(WriteDocumentsServiceTest.Profile.class)
 public class WriteDocumentsServiceTest {
 
-  public static class Profile implements QuarkusTestProfile {
+  public static class Profile implements NoGlobalResourcesTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
       return ImmutableMap.<String, String>builder()

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/testprofiles/MaxDepth8TestProfile.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/testprofiles/MaxDepth8TestProfile.java
@@ -16,10 +16,10 @@
  */
 package io.stargate.sgv2.docsapi.testprofiles;
 
-import io.quarkus.test.junit.QuarkusTestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import java.util.Map;
 
-public class MaxDepth8TestProfile implements QuarkusTestProfile {
+public class MaxDepth8TestProfile implements NoGlobalResourcesTestProfile {
   @Override
   public Map<String, String> getConfigOverrides() {
     return Map.of("stargate.document.max-depth", "8");

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/testprofiles/SaiEnabledTestProfile.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/testprofiles/SaiEnabledTestProfile.java
@@ -17,7 +17,7 @@
 package io.stargate.sgv2.docsapi.testprofiles;
 
 import com.google.common.collect.ImmutableMap;
-import io.quarkus.test.junit.QuarkusTestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import java.util.Map;
 
 /**
@@ -25,7 +25,7 @@ import java.util.Map;
  *
  * <p>Annotate test class with @TestProfile(SaiEnabledTestProfile.class) to use.
  */
-public class SaiEnabledTestProfile implements QuarkusTestProfile {
+public class SaiEnabledTestProfile implements NoGlobalResourcesTestProfile {
 
   @Override
   public Map<String, String> getConfigOverrides() {

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/IntegrationTestUtils.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/IntegrationTestUtils.java
@@ -1,0 +1,25 @@
+package io.stargate.sgv2.common;
+
+/** Utilities for integration test. */
+public final class IntegrationTestUtils {
+
+  public static final String AUTH_TOKEN_PROP = "stargate.int-test.auth-token";
+
+  private IntegrationTestUtils() {}
+
+  /**
+   * @return Returns the auth token from the system property {@value AUTH_TOKEN_PROP}, returning
+   *     empty string if property is not defined.
+   */
+  public static String getAuthToken() {
+    return getAuthToken("");
+  }
+
+  /**
+   * @return Returns the auth token from the system property {@value AUTH_TOKEN_PROP}, returning
+   *     passed default if property is not defined.
+   */
+  public static String getAuthToken(String defaultIfMissing) {
+    return System.getProperty(AUTH_TOKEN_PROP, defaultIfMissing);
+  }
+}

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testprofiles/NoGlobalResourcesTestProfile.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testprofiles/NoGlobalResourcesTestProfile.java
@@ -14,14 +14,19 @@
  * limitations under the License.
  *
  */
-package io.stargate.sgv2.docsapi.testprofiles;
 
-import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
-import java.util.Map;
+package io.stargate.sgv2.common.testprofiles;
 
-public class MaxDepth4TestProfile implements NoGlobalResourcesTestProfile {
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+/** Test profile that ignores global resources. */
+public interface NoGlobalResourcesTestProfile extends QuarkusTestProfile {
+
   @Override
-  public Map<String, String> getConfigOverrides() {
-    return Map.of("stargate.document.max-depth", "4");
+  default boolean disableGlobalTestResources() {
+    return true;
   }
+
+  /** Implementation of the {@link NoGlobalResourcesTestProfile} */
+  class Impl implements NoGlobalResourcesTestProfile {}
 }

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
@@ -28,6 +28,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -117,6 +118,10 @@ public class StargateTestResource
 
   @Override
   public Map<String, String> start() {
+    if (shouldSkip()) {
+      return Collections.emptyMap();
+    }
+
     // TODO make reusable after https://github.com/testcontainers/testcontainers-java/pull/4777
     // boolean reuse = containerNetworkId.isEmpty();
     boolean reuse = false;
@@ -149,6 +154,11 @@ public class StargateTestResource
     ImmutableMap<String, String> props = propsBuilder.build();
     LOG.info("Using props map for the integration tests: %s".formatted(props));
     return props;
+  }
+
+  // skip the resource creation if tests are initiated against the running app
+  private boolean shouldSkip() {
+    return System.getProperty("quarkus.http.test-host") != null;
   }
 
   // start case when api is not a docker image, but app running on host


### PR DESCRIPTION
**What this PR does**:
Makes all integration tests in Docs V2 real end-to-end tests using `@QuarkusIntegrationTest`.. `@QuarkusIntegrationTest` supports executing tests against an already running instance of the application.. This way we can run int tests against any application setup..

All improvements:

* end-to-end tests possible
* fixes in the test resource to enable int test using the docker container of the app (active for docs api CI workflow)
* auth token read from system props, instead of using fixed token
* option to disable fixed token (this is only not to break rest and gql)
* execute tests against the running app

**Which issue(s) this PR fixes**:
Internal issue.

**Checklist**
- [x] Don't break `restapi` and `graphqlapi`
- [x] Auth token instead of fixed token setup
- [x] Resource loading dismiss on `-Dquarkus.http.test-host`
- [x] Test against running app
- [x] INT tests with docker buiild

