### PR TITLE
Add one more IT for RESTv2/DELETE to cover missing/invalid item refs

### DIFF
--- a/testing/src/main/java/io/stargate/it/http/RestApiv2RowsTest.java
+++ b/testing/src/main/java/io/stargate/it/http/RestApiv2RowsTest.java
@@ -1705,17 +1705,28 @@ public class RestApiv2RowsTest extends BaseIntegrationTest {
     assertThat(data.get(0).get("v")).isEqualTo(9);
   }
 
-  /*
-  /************************************************************************
-  /* Test methods for Column CRUD operations
-  /************************************************************************
-   */
+  @Test
+  public void deleteRowNoSuchKey() throws IOException {
+    createTestKeyspace(keyspaceName);
+    createTestTable(keyspaceName, tableName);
 
-  /*
-  /************************************************************************
-  /* Test methods for User-Defined Type (UDT) CRUD operations
-  /************************************************************************
-   */
+    // First, try deleting row with valid UUID but one for which there is no row
+    // We should just get usual "NO_CONTENT" as DELETE is idempotent
+
+    final String rowIdentifier = UUID.randomUUID().toString();
+    RestUtils.delete(
+        authToken,
+        String.format(
+            "%s:8082/v2/keyspaces/%s/%s/%s", host, keyspaceName, tableName, rowIdentifier),
+        HttpStatus.SC_NO_CONTENT);
+
+    // But then see what happens with invalid key (String that is not UUID, in this case)
+    RestUtils.delete(
+        authToken,
+        String.format(
+            "%s:8082/v2/keyspaces/%s/%s/%s", host, keyspaceName, tableName, "not-really-an-uuid"),
+        HttpStatus.SC_BAD_REQUEST);
+  }
 
   /*
   /************************************************************************


### PR DESCRIPTION
**What this PR does**:

Adds one more Integration Test to cover RESTv2/DELETE operation for case of no-such-item. (both via valid id with no row and with invalid id)

**Which issue(s) this PR fixes**:

No issue reported

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
