### PR TITLE
fix tag value resolving on release workflows

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -33,10 +33,16 @@ jobs:
     outputs:
       release-tag: ${{ steps.resolve_tag.outputs.tag }}
     steps:
+      - uses: actions/checkout@v3
+
+      - name: Set reference
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+
       - name: Resolve tag
         id: resolve_tag
         run: |
-          TAG=${{ inputs.tag != null && inputs.tag || github.ref }}
+          TAG=${{ inputs.tag != null && inputs.tag || steps.vars.outputs.tag }}
           echo "Resolved tag for the release $TAG"
           echo "::set-output name=tag::${TAG}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,16 @@ jobs:
       release-tag: ${{ steps.resolve_tag.outputs.tag }}
       release-upload-url: ${{ steps.create_release.outputs.upload_url }}
     steps:
+      - uses: actions/checkout@v3
+
+      - name: Set reference
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+
       - name: Resolve tag
         id: resolve_tag
         run: |
-          TAG=${{ inputs.tag != null && inputs.tag || github.ref }}
+          TAG=${{ inputs.tag != null && inputs.tag || steps.vars.outputs.tag }}
           echo "Resolved tag for the release $TAG"
           echo "::set-output name=tag::${TAG}"
 


### PR DESCRIPTION
**What this PR does**:

Fixes after running v2 release:

* release tag not resolved correctly, somehow not noticed in v1 as create release step does accept the invalid value

**Which issue(s) this PR fixes**:
Internal issue
