### PR TITLE
repository should not include stargateio

### DIFF
--- a/build_docker_images.sh
+++ b/build_docker_images.sh
@@ -43,7 +43,7 @@ while getopts ":t:r:pa" opt; do
       SGTAG=$OPTARG
       ;;
     r)
-      REPO=$OPTARG
+      REPO="$OPTARG/stargateio"
       ;;
     a)
       API_ONLY=true


### PR DESCRIPTION
**What this PR does**:
Proposed fix for having `secrets.ECR_REPOSITORY` only containg repository value, like `gcr.io`, the group should not be part of the repository value.. This is needed for the Quarkus based builds that have distinct values for repository, group and image..

Prior to merging I would update the secret.

**Which issue(s) this PR fixes**:
Internal value

**Checklist**
- [x] Change secret value
