### PR TITLE
update int tests readme

### DIFF
--- a/apis/sgv2-docsapi/README.md
+++ b/apis/sgv2-docsapi/README.md
@@ -121,6 +121,17 @@ Running a test with a different version of the data store or the Stargate coordi
 * `testing.containers.cluster-version` - version of the cluster, for example: `4.0` (should be one of `3.11`, `4.0` or `6.8`)
 * `testing.containers.cluster-dse` - optional and only needed if DSE is used
 
+#### Executing against a running application
+
+The integration tests can also be executed against an already running instance of the application.
+This can be achieved by setting the `quarkus.http.test-host` system property when running the tests.
+You'll most likely need to specify the authentication token to use in the tests, by setting the `stargate.int-test.auth-token` system property. 
+
+```shell
+./mvnw verify -DskipUnitTests -Dquarkus.http.test-host=1.2.3.4 -Dquarkus.http.test-port=4321 -Dstargate.int-test.auth-token=[AUTH_TOKEN]
+
+```
+
 #### Skipping integration tests
 
 You can skip the integration tests during the maven build by disabling the `int-tests` profile using the `-DskipITs` property:

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/DocsApiIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/DocsApiIntegrationTest.java
@@ -78,7 +78,9 @@ public abstract class DocsApiIntegrationTest {
                     .contentType(ContentType.JSON)
                     .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
                     .body(json)
-                    .post(NamespacesResource.BASE_PATH);
+                    .post(NamespacesResource.BASE_PATH)
+                    .then()
+                    .statusCode(201);
               });
     }
 
@@ -109,7 +111,9 @@ public abstract class DocsApiIntegrationTest {
                     .contentType(ContentType.JSON)
                     .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
                     .body(json)
-                    .post(CollectionsResource.BASE_PATH, namespace);
+                    .post(CollectionsResource.BASE_PATH, namespace)
+                    .then()
+                    .statusCode(201);
               });
     }
   }


### PR DESCRIPTION
**What this PR does**:
* marks init phase tests as failed if not `2xx`
* update the documentation to explain how to use integration tests against the running app
