### PR TITLE
closes #2031: dead leaves to accept custom metadata

### DIFF
--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/write/WriteBridgeService.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/write/WriteBridgeService.java
@@ -18,13 +18,15 @@
 package io.stargate.sgv2.docsapi.service.write;
 
 import com.google.common.base.Splitter;
+import io.grpc.Metadata;
 import io.opentelemetry.extension.annotations.WithSpan;
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.grpc.GrpcClientUtils;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.bridge.proto.QueryOuterClass.Batch;
 import io.stargate.bridge.proto.QueryOuterClass.ResultSet;
 import io.stargate.bridge.proto.StargateBridge;
-import io.stargate.sgv2.api.common.StargateRequestInfo;
 import io.stargate.sgv2.api.common.config.QueriesConfig;
 import io.stargate.sgv2.api.common.properties.datastore.DataStoreProperties;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCode;
@@ -57,7 +59,7 @@ public class WriteBridgeService {
   // path splitter on dot
   private static final Splitter PATH_SPLITTER = Splitter.on(".");
 
-  private final StargateRequestInfo requestInfo;
+  private final StargateBridge bridge;
   private final TimeSource timeSource;
   private final InsertQueryBuilder insertQueryBuilder;
   private final boolean useLoggedBatches;
@@ -67,12 +69,12 @@ public class WriteBridgeService {
 
   @Inject
   public WriteBridgeService(
-      StargateRequestInfo requestInfo,
+      @GrpcClient("bridge") StargateBridge bridge,
       TimeSource timeSource,
       DataStoreProperties dataStoreProperties,
       DocumentProperties documentProperties,
       QueriesConfig queriesConfig) {
-    this.requestInfo = requestInfo;
+    this.bridge = bridge;
     this.insertQueryBuilder = new InsertQueryBuilder(documentProperties);
     this.timeSource = timeSource;
     this.useLoggedBatches = dataStoreProperties.loggedBatchesEnabled();
@@ -120,9 +122,7 @@ public class WriteBridgeService {
                   .toList();
             })
         .flatMap(
-            boundQueries ->
-                executeBatch(
-                    requestInfo.getStargateBridge(), boundQueries, context.nested("ASYNC INSERT")));
+            boundQueries -> executeBatch(bridge, boundQueries, context.nested("ASYNC INSERT")));
   }
 
   /**
@@ -220,9 +220,7 @@ public class WriteBridgeService {
               return queries;
             })
         .flatMap(
-            boundQueries ->
-                executeBatch(
-                    requestInfo.getStargateBridge(), boundQueries, context.nested("ASYNC UPDATE")));
+            boundQueries -> executeBatch(bridge, boundQueries, context.nested("ASYNC UPDATE")));
   }
 
   /**
@@ -349,10 +347,7 @@ public class WriteBridgeService {
 
               return queries;
             })
-        .flatMap(
-            boundQueries ->
-                executeBatch(
-                    requestInfo.getStargateBridge(), boundQueries, context.nested("ASYNC PATCH")));
+        .flatMap(boundQueries -> executeBatch(bridge, boundQueries, context.nested("ASYNC PATCH")));
   }
 
   /**
@@ -465,14 +460,14 @@ public class WriteBridgeService {
                           subDocumentPath, false, documentProperties);
               return deleteQueryBuilder.buildAndBind(keyspace, collection, documentId, timestamp);
             })
-        .flatMap(
-            query ->
-                executeSingle(
-                    requestInfo.getStargateBridge(), query, context.nested("ASYNC DELETE")));
+        .flatMap(query -> executeSingle(bridge, query, context.nested("ASYNC DELETE")));
   }
 
   /**
    * Deletes a given dead leaves for a document.
+   *
+   * <p>Since this should be executed as asynchronous action that is not done during the user
+   * request, gRPC {@link Metadata} that have to passed on the bridge must be supplied.
    *
    * @param keyspace Keyspace to delete a dead leaves from.
    * @param collection Collection the document belongs to.
@@ -480,6 +475,7 @@ public class WriteBridgeService {
    * @param microsTimestamp Micros timestamp to use in delete queries.
    * @param deadLeaves A map of JSON paths (f.e. $.some.path) to dead leaves to delete.
    * @param context Execution content for profiling.
+   * @param metadata
    * @return Single containing the {@link ResultSet} of the batch execution.
    */
   public Uni<ResultSet> deleteDeadLeaves(
@@ -488,7 +484,8 @@ public class WriteBridgeService {
       String documentId,
       long microsTimestamp,
       Map<String, Set<DeadLeaf>> deadLeaves,
-      ExecutionContext context) {
+      ExecutionContext context,
+      Metadata metadata) {
     return Uni.createFrom()
         .item(
             () -> {
@@ -508,11 +505,17 @@ public class WriteBridgeService {
               return queries;
             })
         .flatMap(
-            boundQueries ->
-                executeBatch(
-                    requestInfo.getStargateBridge(),
-                    boundQueries,
-                    context.nested("ASYNC DOCUMENT CORRECTION")));
+            boundQueries -> {
+              try {
+                StargateBridge bridgeWithMetadata = GrpcClientUtils.attachHeaders(bridge, metadata);
+                return executeBatch(
+                    bridgeWithMetadata, boundQueries, context.nested("ASYNC DOCUMENT CORRECTION"));
+              } catch (IllegalArgumentException e) {
+                // in case we can not attach metadata, use original client
+                return executeBatch(
+                    bridge, boundQueries, context.nested("ASYNC DOCUMENT CORRECTION"));
+              }
+            });
   }
 
   // creates needed query builders for one path of dead leaves

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/bridge/AbstractValidatingStargateBridgeTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/bridge/AbstractValidatingStargateBridgeTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.BeforeEach;
  */
 public abstract class AbstractValidatingStargateBridgeTest {
 
-  private ValidatingStargateBridge bridge;
+  protected ValidatingStargateBridge bridge;
   @InjectMock protected StargateRequestInfo requestInfo;
 
   @BeforeEach

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/GrpcMetadataResolver.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/GrpcMetadataResolver.java
@@ -1,0 +1,41 @@
+package io.stargate.sgv2.api.common.grpc;
+
+import io.grpc.Metadata;
+import io.stargate.sgv2.api.common.StargateRequestInfo;
+import io.stargate.sgv2.api.common.config.GrpcMetadataConfig;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+/**
+ * Component responsible for resolving needed Metadata to be passed to the Bridge, based on the
+ * {@link StargateRequestInfo}.
+ */
+@ApplicationScoped
+public class GrpcMetadataResolver {
+
+  /** Metadata key for passing the tenant-id to the Bridge. */
+  private final Metadata.Key<String> tenantIdKey;
+
+  /** Metadata key for passing the cassandra token to the Bridge. */
+  private final Metadata.Key<String> cassandraTokenKey;
+
+  @Inject
+  public GrpcMetadataResolver(GrpcMetadataConfig config) {
+    this.tenantIdKey = Metadata.Key.of(config.tenantIdKey(), Metadata.ASCII_STRING_MARSHALLER);
+    this.cassandraTokenKey =
+        Metadata.Key.of(config.cassandraTokenKey(), Metadata.ASCII_STRING_MARSHALLER);
+  }
+
+  /**
+   * Returns GRPC metadata for the given {@link StargateRequestInfo}.
+   *
+   * @param requestInfo Request info.
+   * @return Metadata
+   */
+  public Metadata getMetadata(StargateRequestInfo requestInfo) {
+    Metadata metadata = new Metadata();
+    requestInfo.getTenantId().ifPresent(t -> metadata.put(tenantIdKey, t));
+    requestInfo.getCassandraToken().ifPresent(t -> metadata.put(cassandraTokenKey, t));
+    return metadata;
+  }
+}


### PR DESCRIPTION
**What this PR does**:
Fixes bug described in the #2031.. 

Now this is the quick fix, but introduces a bit of a mixed design now. Should `StargateBridge` be retrieved always from the `StargateRequestInfo` or not? I guess long term we need to have a single approach.. However, it requires some additional work mainly to fix all the tests.. So I am going to create a ticket for it: https://github.com/stargate/stargate/issues/2047

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated

