### PR TITLE
enable population of the token in the swagger-ui

### DIFF
--- a/apis/sgv2-docsapi/src/main/resources/application.yaml
+++ b/apis/sgv2-docsapi/src/main/resources/application.yaml
@@ -147,3 +147,16 @@ quarkus:
     path: /swagger-ui
     always-include: true
     title: ${quarkus.application.name}
+    # function below enables pre-populating the authentication token in the Swagger UI
+    # it's reading the value of the token from the sg-swagger-token cookie, if existing
+    # cookie extraction copied from: https://stackoverflow.com/questions/10730362/get-cookie-by-name
+    # Swagger configuration reference: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
+    on-complete: |
+      function() {
+        const value = '; ' + document.cookie;
+        const parts = value.split('; sg-swagger-token=');
+        if (parts.length === 2) { 
+          const token = parts.pop().split(';').shift();
+          ui.preauthorizeApiKey('Token', token);
+        }
+      }


### PR DESCRIPTION
**What this PR does**:
Enables population of the auth token in the swagger UI, by reading it from the `sg-swagger-token` cookie..

The reviewer must confirm it works by:
* opening `http://localhost:8180/swagger-ui`
* open browser dev tools
* add cookie with name `sg-swagger-token` with arbitrary value
* hit refresh on the page
* confirm that 
    * authorize box has token already (closed lock)
    * try now executes a request with the token having the value of the cookie