### PR TITLE
Fix #2061, problem constructing converter for deeply nested structured type

### DIFF
--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/grpc/FromProtoValueCodecs.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/grpc/FromProtoValueCodecs.java
@@ -50,28 +50,28 @@ public class FromProtoValueCodecs {
     return codecFor(columnSpec, columnSpec.getType());
   }
 
-  public FromProtoValueCodec codecFor(
+  protected FromProtoValueCodec codecFor(
       QueryOuterClass.ColumnSpec columnSpec, QueryOuterClass.TypeSpec type) {
     switch (type.getSpecCase()) {
       case BASIC:
         return basicCodecFor(columnSpec, type.getBasic());
 
       case LIST:
-        return listCodecFor(columnSpec);
+        return listCodecFor(columnSpec, type.getList());
       case MAP:
-        return mapCodecFor(columnSpec);
+        return mapCodecFor(columnSpec, type.getMap());
       case SET:
-        return setCodecFor(columnSpec);
+        return setCodecFor(columnSpec, type.getSet());
       case TUPLE:
-        return tupleCodecFor(columnSpec);
+        return tupleCodecFor(columnSpec, type.getTuple());
       case UDT:
-        return udtCodecFor(columnSpec);
+        return udtCodecFor(columnSpec, type.getUdt());
 
         // Invalid cases:
       case SPEC_NOT_SET:
       default:
         throw new IllegalArgumentException(
-            "Invalid/unsupported ColumnSpec TypeSpec "
+            "Invalid/unsupported TypeSpec "
                 + type.getSpecCase()
                 + " for column '"
                 + columnSpec.getName()
@@ -141,24 +141,24 @@ public class FromProtoValueCodecs {
     throw new IllegalArgumentException("Invalid Basic ColumnSpec value for column: " + columnSpec);
   }
 
-  protected FromProtoValueCodec listCodecFor(QueryOuterClass.ColumnSpec columnSpec) {
-    QueryOuterClass.TypeSpec.List listSpec = columnSpec.getType().getList();
+  protected FromProtoValueCodec listCodecFor(
+      QueryOuterClass.ColumnSpec columnSpec, QueryOuterClass.TypeSpec.List listSpec) {
     return new ListCodec(codecFor(columnSpec, listSpec.getElement()));
   }
 
-  protected FromProtoValueCodec mapCodecFor(QueryOuterClass.ColumnSpec columnSpec) {
-    QueryOuterClass.TypeSpec.Map mapSpec = columnSpec.getType().getMap();
+  protected FromProtoValueCodec mapCodecFor(
+      QueryOuterClass.ColumnSpec columnSpec, QueryOuterClass.TypeSpec.Map mapSpec) {
     return new MapCodec(
         codecFor(columnSpec, mapSpec.getKey()), codecFor(columnSpec, mapSpec.getValue()));
   }
 
-  protected FromProtoValueCodec setCodecFor(QueryOuterClass.ColumnSpec columnSpec) {
-    QueryOuterClass.TypeSpec.Set setSpec = columnSpec.getType().getSet();
+  protected FromProtoValueCodec setCodecFor(
+      QueryOuterClass.ColumnSpec columnSpec, QueryOuterClass.TypeSpec.Set setSpec) {
     return new SetCodec(codecFor(columnSpec, setSpec.getElement()));
   }
 
-  protected FromProtoValueCodec tupleCodecFor(QueryOuterClass.ColumnSpec columnSpec) {
-    QueryOuterClass.TypeSpec.Tuple tupleSpec = columnSpec.getType().getTuple();
+  protected FromProtoValueCodec tupleCodecFor(
+      QueryOuterClass.ColumnSpec columnSpec, QueryOuterClass.TypeSpec.Tuple tupleSpec) {
     List<FromProtoValueCodec> codecs = new ArrayList<>();
     for (QueryOuterClass.TypeSpec elementSpec : tupleSpec.getElementsList()) {
       codecs.add(codecFor(columnSpec, elementSpec));
@@ -166,8 +166,8 @@ public class FromProtoValueCodecs {
     return new TupleCodec(codecs);
   }
 
-  protected FromProtoValueCodec udtCodecFor(QueryOuterClass.ColumnSpec columnSpec) {
-    QueryOuterClass.TypeSpec.Udt udtSpec = columnSpec.getType().getUdt();
+  protected FromProtoValueCodec udtCodecFor(
+      QueryOuterClass.ColumnSpec columnSpec, QueryOuterClass.TypeSpec.Udt udtSpec) {
     Map<String, QueryOuterClass.TypeSpec> fieldSpecs = udtSpec.getFieldsMap();
     Map<String, FromProtoValueCodec> fieldCodecs = new HashMap<>();
     for (Map.Entry<String, QueryOuterClass.TypeSpec> entry : fieldSpecs.entrySet()) {

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowGetIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowGetIT.java
@@ -924,9 +924,9 @@ public class RestApiV2QRowGetIT extends RestApiV2QIntegrationTestBase {
     // First insert no entry in nested "data" column, see decoder gets built ok.
     insertTypedRows(testKeyspaceName(), tableName, Arrays.asList(map("id", 1)));
 
-    ArrayNode rows = findRowsAsJsonNode(testKeyspaceName(), tableName, "2");
+    ArrayNode rows = findRowsAsJsonNode(testKeyspaceName(), tableName, 1);
     assertThat(rows).hasSize(1);
-    assertThat(rows.at("/0/id").asLong()).isEqualTo(Long.valueOf(2L));
+    assertThat(rows.at("/0/id").asLong()).isEqualTo(Long.valueOf(1L));
   }
 
   @Test

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowGetIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowGetIT.java
@@ -912,6 +912,24 @@ public class RestApiV2QRowGetIT extends RestApiV2QIntegrationTestBase {
   }
 
   @Test
+  public void getRowsWithTupleNested() {
+    final String tableName = testTableName();
+    createTestTable(
+        testKeyspaceName(),
+        tableName,
+        Arrays.asList("id bigint", "datamap<text,frozen<list<frozen<tuple<double,double>>>>>"),
+        Arrays.asList("id"),
+        Arrays.asList());
+
+    // First insert no entry in nested "data" column, see decoder gets built ok.
+    insertTypedRows(testKeyspaceName(), tableName, Arrays.asList(map("id", 1)));
+
+    ArrayNode rows = findRowsAsJsonNode(testKeyspaceName(), tableName, "2");
+    assertThat(rows).hasSize(1);
+    assertThat(rows.at("/0/id").asLong()).isEqualTo(Long.valueOf(2L));
+  }
+
+  @Test
   public void getRowsWithUDT() {
     final String tableName = testTableName();
     String udtCreate =

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowGetIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowGetIT.java
@@ -917,7 +917,7 @@ public class RestApiV2QRowGetIT extends RestApiV2QIntegrationTestBase {
     createTestTable(
         testKeyspaceName(),
         tableName,
-        Arrays.asList("id bigint", "datamap<text,frozen<list<frozen<tuple<double,double>>>>>"),
+        Arrays.asList("id bigint", "data map<text,frozen<list<frozen<tuple<double,double>>>>>"),
         Arrays.asList("id"),
         Arrays.asList());
 

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaTablesIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaTablesIT.java
@@ -163,6 +163,22 @@ public class RestApiV2QSchemaTablesIT extends RestApiV2QIntegrationTestBase {
   }
 
   @Test
+  public void tableCreateWithNestedMap() {
+    final String tableName = testTableName();
+    createTestTable(
+        testKeyspaceName(),
+        tableName,
+        Arrays.asList("id bigint", "data map<text, frozen<list<frozen<tuple<double,double>>>>>"),
+        Arrays.asList("id"),
+        Arrays.asList());
+
+    final Sgv2Table table = findTable(testKeyspaceName(), tableName);
+
+    assertThat(table.getKeyspace()).isEqualTo(testKeyspaceName());
+    assertThat(table.getName()).isEqualTo(tableName);
+  }
+
+  @Test
   public void tableCreateWithNullOptions() {
     final String tableName = "t1"; // not sure why but was that way in original test
     final Sgv2TableAddRequest tableAdd = new Sgv2TableAddRequest(tableName);

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaTablesIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaTablesIT.java
@@ -168,7 +168,7 @@ public class RestApiV2QSchemaTablesIT extends RestApiV2QIntegrationTestBase {
     createTestTable(
         testKeyspaceName(),
         tableName,
-        Arrays.asList("id bigint", "data map<text, frozen<list<frozen<tuple<double,double>>>>>"),
+        Arrays.asList("id bigint", "data map<text,frozen<list<frozen<tuple<double,double>>>>>"),
         Arrays.asList("id"),
         Arrays.asList());
 

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/restapi/grpc/FromProtoConverterTest.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/restapi/grpc/FromProtoConverterTest.java
@@ -1,0 +1,138 @@
+package io.stargate.sgv2.restapi.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import io.stargate.bridge.grpc.CqlDuration;
+import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class FromProtoConverterTest {
+  private static final String TEST_COLUMN = "test_column";
+
+  private static final FromProtoValueCodecs FROM_PROTO_VALUE_CODECS = new FromProtoValueCodecs();
+
+  private static Arguments[] fromExternalSamples() {
+    return new Arguments[] {
+      arguments(123, basicType(QueryOuterClass.TypeSpec.Basic.INT), Values.of(123)),
+      arguments(-4567L, basicType(QueryOuterClass.TypeSpec.Basic.BIGINT), Values.of(-4567L)),
+      arguments("abc", basicType(QueryOuterClass.TypeSpec.Basic.VARCHAR), Values.of("abc")),
+      // Binary data is exposes as byte[] by Converter, not Base64-encoded
+      arguments(
+          new byte[] {(byte) 0xFF},
+          basicType(QueryOuterClass.TypeSpec.Basic.BLOB),
+          Values.of(new byte[] {(byte) 0xFF})),
+      arguments(
+          "3d",
+          basicType(QueryOuterClass.TypeSpec.Basic.DURATION),
+          Values.of(CqlDuration.from("3d"))),
+
+      // Lists, Sets
+      arguments(
+          Arrays.asList("foo", "bar"),
+          listType(QueryOuterClass.TypeSpec.Basic.VARCHAR),
+          Values.of(Arrays.asList(Values.of("foo"), Values.of("bar")))),
+      arguments(
+          Arrays.asList(123, 456),
+          listType(QueryOuterClass.TypeSpec.Basic.INT),
+          Values.of(Arrays.asList(Values.of(123), Values.of(456)))),
+      arguments(
+          setOf("foo", "bar"),
+          setType(QueryOuterClass.TypeSpec.Basic.VARCHAR),
+          Values.of(Arrays.asList(Values.of("foo"), Values.of("bar")))),
+      arguments(
+          setOf(123, 456),
+          setType(QueryOuterClass.TypeSpec.Basic.INT),
+          Values.of(Arrays.asList(Values.of(123), Values.of(456)))),
+
+      // Maps
+      arguments(
+          Collections.singletonMap("foo", "bar"),
+          mapType(QueryOuterClass.TypeSpec.Basic.VARCHAR, QueryOuterClass.TypeSpec.Basic.VARCHAR),
+          // since internal representation is just as Collection...
+          Values.of(Arrays.asList(Values.of("foo"), Values.of("bar")))),
+      arguments(
+          Collections.singletonMap(123, Boolean.TRUE),
+          mapType(QueryOuterClass.TypeSpec.Basic.INT, QueryOuterClass.TypeSpec.Basic.BOOLEAN),
+          Values.of(Arrays.asList(Values.of(123), Values.of(true))))
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("fromExternalSamples")
+  @DisplayName("Should converted Bridge/gRPC value into expected external representation")
+  public void strictExternalToBridgeValueTest(
+      Object externalValue, QueryOuterClass.TypeSpec typeSpec, QueryOuterClass.Value bridgeValue) {
+    FromProtoConverter conv = createConverter(typeSpec);
+    Map<String, Object> result = conv.mapFromProtoValues(Arrays.asList(bridgeValue));
+
+    assertThat(result.get(TEST_COLUMN)).isEqualTo(externalValue);
+  }
+
+  /*
+  ///////////////////////////////////////////////////////////////////////
+  // Helper methods for constructing scaffolding for Bridge/gRPC
+  ///////////////////////////////////////////////////////////////////////
+   */
+
+  private static Set<Object> setOf(Object... values) {
+    LinkedHashSet<Object> set = new LinkedHashSet<>();
+    set.addAll(Arrays.asList(values));
+    return set;
+  }
+
+  private static FromProtoConverter createConverter(QueryOuterClass.TypeSpec typeSpec) {
+    QueryOuterClass.ColumnSpec column =
+        QueryOuterClass.ColumnSpec.newBuilder().setName(TEST_COLUMN).setType(typeSpec).build();
+    FromProtoValueCodec codec = FROM_PROTO_VALUE_CODECS.codecFor(column);
+    return FromProtoConverter.construct(
+        new String[] {TEST_COLUMN}, new FromProtoValueCodec[] {codec});
+  }
+
+  private static QueryOuterClass.TypeSpec basicType(QueryOuterClass.TypeSpec.Basic basicType) {
+    return QueryOuterClass.TypeSpec.newBuilder().setBasic(basicType).build();
+  }
+
+  private static QueryOuterClass.TypeSpec listType(
+      QueryOuterClass.TypeSpec.Basic basicElementType) {
+    return listType(basicType(basicElementType));
+  }
+
+  private static QueryOuterClass.TypeSpec listType(QueryOuterClass.TypeSpec elementType) {
+    return QueryOuterClass.TypeSpec.newBuilder()
+        .setList(QueryOuterClass.TypeSpec.List.newBuilder().setElement(elementType).build())
+        .build();
+  }
+
+  private static QueryOuterClass.TypeSpec setType(QueryOuterClass.TypeSpec.Basic basicElementType) {
+    return setType(basicType(basicElementType));
+  }
+
+  private static QueryOuterClass.TypeSpec setType(QueryOuterClass.TypeSpec elementType) {
+    return QueryOuterClass.TypeSpec.newBuilder()
+        .setSet(QueryOuterClass.TypeSpec.Set.newBuilder().setElement(elementType).build())
+        .build();
+  }
+
+  private static QueryOuterClass.TypeSpec mapType(
+      QueryOuterClass.TypeSpec.Basic basicKeyType, QueryOuterClass.TypeSpec.Basic basicValueType) {
+    return mapType(basicType(basicKeyType), basicType(basicValueType));
+  }
+
+  private static QueryOuterClass.TypeSpec mapType(
+      QueryOuterClass.TypeSpec keyType, QueryOuterClass.TypeSpec valueType) {
+    return QueryOuterClass.TypeSpec.newBuilder()
+        .setMap(
+            QueryOuterClass.TypeSpec.Map.newBuilder().setKey(keyType).setValue(valueType).build())
+        .build();
+  }
+}

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/restapi/grpc/ToProtoConverterTest.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/restapi/grpc/ToProtoConverterTest.java
@@ -128,9 +128,9 @@ public class ToProtoConverterTest {
     TypeSpec doubleType = basicType(TypeSpec.Basic.DOUBLE);
     TypeSpec tupleType = tupleType(doubleType, doubleType);
     // Let's assert types from innermost to outermost; failure is via exception
-    // assertThat(createConverter(tupleType)).isNotNull();
+    assertThat(createConverter(tupleType)).isNotNull();
     TypeSpec listType = listType(tupleType);
-    // assertThat(createConverter(listType)).isNotNull();
+    assertThat(createConverter(listType)).isNotNull();
     TypeSpec mapType = mapType(basicType(TypeSpec.Basic.VARCHAR), listType);
     assertThat(createConverter(mapType)).isNotNull();
   }
@@ -142,7 +142,7 @@ public class ToProtoConverterTest {
    */
 
   private static ToProtoConverter createConverter(TypeSpec typeSpec) {
-    ColumnSpec column = ColumnSpec.newBuilder().setName("testColumn").setType(typeSpec).build();
+    ColumnSpec column = ColumnSpec.newBuilder().setName(TEST_COLUMN).setType(typeSpec).build();
     ToProtoValueCodec codec = TO_PROTO_VALUE_CODECS.codecFor(column);
     return new ToProtoConverter(TEST_TABLE, Collections.singletonMap(TEST_COLUMN, codec));
   }


### PR DESCRIPTION
**What this PR does**:

Fixes handling of nested types wrt protobuf type handling; was not properly passing both context ("columnType") AND actual element type. So was only working for shallow structured types; no tests existed for deeper structures.

Also adding bit more unit test coverage for conversion types.

**Which issue(s) this PR fixes**:
Fixes #2061

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
