### PR TITLE
Upgrade Jackson from 2.12.7 to 2.13.4; snakeyaml to 1.0.31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,11 +41,13 @@
     <commons-io.version>2.7</commons-io.version>
     <grpc.version>1.45.1</grpc.version>
     <immutables.version>2.8.8</immutables.version>
-    <jackson.version>2.12.7</jackson.version>
+    <jackson.version>2.13.4</jackson.version>
     <javatuples.version>1.2</javatuples.version>
     <!-- Make sure micrometer and prometheus versions are in sync  -->
     <micrometer.version>1.7.3</micrometer.version>
     <prometheus.version>0.10.0</prometheus.version>
+    <!-- SnakeYAML needs to be synced with jackson-dataformat-yaml -->
+    <snakeyaml.version>1.31</snakeyaml.version>
     <swagger-ui.version>3.52.5</swagger-ui.version>
     <swagger-jersey2-jaxrs.version>1.6.3</swagger-jersey2-jaxrs.version>
     <netty.version>4.1.75.Final</netty.version>
@@ -549,6 +551,15 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- SnakeYAML dependency from Jackson is 1.31 but Persistence backends
+	   try to bring in older versions, so:
+	-->
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>${snakeyaml.version}</version>
+      </dependency>
+
       <!-- BOM/dependencies for dropwizard too: -->
       <dependency>
         <groupId>io.dropwizard</groupId>


### PR DESCRIPTION
**What this PR does**:

Upgrades dependency versions:

* Jackson to 2.13.4 (from 2.12.7)
* Add explicit version override for `snakeyaml` for `1.0.31` (version Jackson 2.13.4 uses, latest released)

Latter is needed because Cassandra 3/4 backends otherwise bring in older SnakeYAML versions in.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Changes manually tested -- checked with `./mvnw dependency:tree` and looking at jars built under `stargate-lib/`
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
