### PR TITLE
Make SGv2/REST/MaterializedView IT retry twice before failing to improve CI stability

### DIFF
--- a/apis/sgv2-restapi/pom.xml
+++ b/apis/sgv2-restapi/pom.xml
@@ -82,6 +82,15 @@
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.junit-pioneer/junit-pioneer
+        for "@RetryingTest"
+      -->
+    <dependency>
+      <groupId>org.junit-pioneer</groupId>
+      <artifactId>junit-pioneer</artifactId>
+      <version>1.7.1</version>
+      <scope>test</scope>
+    </dependency>
     <!-- Couple of ITs require CQL initialization: -->
     <dependency>
       <groupId>com.datastax.oss</groupId>

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/persistence/RestApiV2QMaterializedViewIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/persistence/RestApiV2QMaterializedViewIT.java
@@ -14,7 +14,7 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RetryingTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +40,9 @@ public class RestApiV2QMaterializedViewIT extends RestApiV2QCqlEnabledTestBase {
   /////////////////////////////////////////////////////////////////////////
    */
 
-  @Test
+  // Unfortunately this test sporadically fails with claim that Materialized View
+  // does not exist; let's hope a couple of retries sorts it out
+  @RetryingTest(maxAttempts = 3)
   public void getRowsFromMV() {
     boolean isC4 = IntegrationTestUtils.isCassandra40();
     LOG.info("getAllRowsFromMaterializedView(): is backend Cassandra 4.0? {}", isC4);


### PR DESCRIPTION
**What this PR does**:

Adds annotation to make Materialized View test (for REST API) try 3 times before giving up.
This because test appears to occasionally fail due to some timing issue related to creation (or schema metadata update) of MVs.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
