### PR TITLE
Change sgv2 REST API default port back to 8082

### DIFF
--- a/apis/sgv2-docsapi/src/main/resources/application.yaml
+++ b/apis/sgv2-docsapi/src/main/resources/application.yaml
@@ -78,8 +78,8 @@ quarkus:
 
   # HTTP settings
   http:
-    # TODO update both port and non-app paths after discussions
-    port: 8180
+    # TODO update non-app path after discussions
+    port: 8080
     non-application-root-path: stargate
 
     # every /v2 path is authenticated by default

--- a/apis/sgv2-docsapi/src/main/resources/application.yaml
+++ b/apis/sgv2-docsapi/src/main/resources/application.yaml
@@ -78,8 +78,8 @@ quarkus:
 
   # HTTP settings
   http:
-    # TODO update non-app path after discussions
-    port: 8080
+    # TODO update both port and non-app paths after discussions
+    port: 8180
     non-application-root-path: stargate
 
     # every /v2 path is authenticated by default

--- a/apis/sgv2-restapi/pom.xml
+++ b/apis/sgv2-restapi/pom.xml
@@ -12,6 +12,7 @@
     <failsafe.useModulePath>false</failsafe.useModulePath>
     <quarkus.container-image.group>stargateio</quarkus.container-image.group>
     <quarkus.container-image.name>restapi</quarkus.container-image.name>
+    <quarkus.container-image.tag>v${project.version}</quarkus.container-image.tag>
   </properties>
   <dependencies>
     <dependency>

--- a/apis/sgv2-restapi/src/main/resources/application.yaml
+++ b/apis/sgv2-restapi/src/main/resources/application.yaml
@@ -50,7 +50,7 @@ quarkus:
   http:
     # 21-Jul-2022, tatu: Until we disable/remove main level SGv2/REST (which runs on 8082)
     #    need to use different port
-    port: 9092
+    port: 8080
 
     # every /v2 path is authenticated by default
     # adapt if changing the authentication mechanism

--- a/apis/sgv2-restapi/src/main/resources/application.yaml
+++ b/apis/sgv2-restapi/src/main/resources/application.yaml
@@ -48,9 +48,9 @@ quarkus:
     dev-mode:
       force-server-start: false
   http:
-    # 21-Jul-2022, tatu: Until we disable/remove main level SGv2/REST (which runs on 8082)
-    #    need to use different port
-    port: 8080
+    # 14-Sep-2022, tatu: Use the legacy port (same as SGv1) for now,
+    #   change to "standard" 8080 later on (needs other changes)
+    port: 8082
 
     # every /v2 path is authenticated by default
     # adapt if changing the authentication mechanism

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/persistence/RestApiV2QMaterializedViewIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/persistence/RestApiV2QMaterializedViewIT.java
@@ -41,7 +41,7 @@ public class RestApiV2QMaterializedViewIT extends RestApiV2QCqlEnabledTestBase {
    */
 
   @Test
-  public void getRowsFromMV() {
+  public void getRowsFromMV() throws Exception {
     boolean isC4 = IntegrationTestUtils.isCassandra40();
     LOG.info("getAllRowsFromMaterializedView(): is backend Cassandra 4.0? {}", isC4);
     assumeThat(isC4)
@@ -81,6 +81,14 @@ public class RestApiV2QMaterializedViewIT extends RestApiV2QCqlEnabledTestBase {
     assertThat(resultSet.wasApplied()).isTrue();
 
     // And then read entries using MV:
+
+    // 14-Sep-2022, tatu: Not sure why but there is a transient issue here wrt timing.
+    //   Locally test does not appear to ever fail, but in CI it does, with error suggesting
+    //   MV has not been created or Schema metadata not (yet) updated. In absence of
+    //   better solution, let's try simple wait to give it time; 5 seconds should do it.
+
+    Thread.sleep(5000L);
+
     List<Map<String, Object>> rows = findAllRowsAsList(keyspaceName, materializedViewName);
 
     // Alas, due to "id" as partition key, ordering is arbitrary; so need to

--- a/docker-compose/cassandra-4.0/docker-compose-dev-mode.yml
+++ b/docker-compose/cassandra-4.0/docker-compose-dev-mode.yml
@@ -27,12 +27,11 @@ services:
     networks:
       - stargate
     ports:
-      - 8082:8082
+      - 8082:8080
     mem_limit: 2G
     environment:
       - STARGATE_BRIDGE_HOST=coordinator
       - STARGATE_BRIDGE_PORT=8091
-      - STARGATE_REST_PORT=8082
   graphqlapi:
     image: stargateio/graphqlapi:${SGTAG}
     depends_on:

--- a/docker-compose/cassandra-4.0/docker-compose-dev-mode.yml
+++ b/docker-compose/cassandra-4.0/docker-compose-dev-mode.yml
@@ -27,7 +27,7 @@ services:
     networks:
       - stargate
     ports:
-      - 8082:8080
+      - 8082:8082
     mem_limit: 2G
     environment:
       - STARGATE_BRIDGE_HOST=coordinator

--- a/docker-compose/cassandra-4.0/docker-compose.yml
+++ b/docker-compose/cassandra-4.0/docker-compose.yml
@@ -62,12 +62,11 @@ services:
     networks:
       - stargate
     ports:
-      - 8082:8082
+      - 8082:8080
     mem_limit: 2G
     environment:
       - STARGATE_BRIDGE_HOST=coordinator
       - STARGATE_BRIDGE_PORT=8091
-      - STARGATE_REST_PORT=8082
   graphqlapi:
     image: stargateio/graphqlapi:${SGTAG}
     depends_on:

--- a/docker-compose/cassandra-4.0/docker-compose.yml
+++ b/docker-compose/cassandra-4.0/docker-compose.yml
@@ -62,7 +62,7 @@ services:
     networks:
       - stargate
     ports:
-      - 8082:8080
+      - 8082:8082
     mem_limit: 2G
     environment:
       - STARGATE_BRIDGE_HOST=coordinator


### PR DESCRIPTION
**What this PR does**:

Sets default `quarkus.https.port` to `8082` for REST API to make `docker-compose` work, and should be compatible with Operator settings used for SGv2 rollout.

In future we probably want to change default of all Services/APIs to 8080, but that needs to be coordinated across components we have.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
