### PR TITLE
option to enable auth in the int tests

### DIFF
--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/CqlEnabledIntegrationTestBase.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/CqlEnabledIntegrationTestBase.java
@@ -21,6 +21,7 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.config.OptionsMap;
 import com.datastax.oss.driver.api.core.config.TypedDriverOption;
+import com.datastax.oss.driver.internal.core.auth.PlainTextAuthProvider;
 import com.datastax.oss.driver.internal.core.loadbalancing.DcInferringLoadBalancingPolicy;
 import java.time.Duration;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -50,6 +51,16 @@ public abstract class CqlEnabledIntegrationTestBase {
     config.put(
         TypedDriverOption.LOAD_BALANCING_POLICY_CLASS,
         DcInferringLoadBalancingPolicy.class.getName());
+
+    // resolve auth if enabled
+    if (IntegrationTestUtils.isCassandraAuthEnabled()) {
+      config.put(TypedDriverOption.AUTH_PROVIDER_CLASS, PlainTextAuthProvider.class.getName());
+      config.put(
+          TypedDriverOption.AUTH_PROVIDER_USER_NAME, IntegrationTestUtils.getCassandraUsername());
+      config.put(
+          TypedDriverOption.AUTH_PROVIDER_PASSWORD, IntegrationTestUtils.getCassandraPassword());
+    }
+
     session =
         CqlSession.builder()
             .addContactPoint(IntegrationTestUtils.getCassandraCqlAddress())

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/IntegrationTestUtils.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/IntegrationTestUtils.java
@@ -9,7 +9,10 @@ public final class IntegrationTestUtils {
   public static final String AUTH_TOKEN_PROP = "stargate.int-test.auth-token";
   public static final String CASSANDRA_HOST_PROP = "stargate.int-test.cassandra.host";
   public static final String CASSANDRA_CQL_PORT_PROP = "stargate.int-test.cassandra.cql-port";
-
+  public static final String CASSANDRA_AUTH_ENABLED_PROP =
+      "stargate.int-test.cassandra.auth-enabled";
+  public static final String CASSANDRA_USERNAME_PROP = "stargate.int-test.cassandra.username";
+  public static final String CASSANDRA_PASSWORD_PROP = "stargate.int-test.cassandra.password";
   public static final String CLUSTER_VERSION_PROP = "stargate.int-test.cluster-version";
 
   private IntegrationTestUtils() {}
@@ -42,6 +45,21 @@ public final class IntegrationTestUtils {
         "Expected system property %s to be set to an integer (got %s)"
             .formatted(CASSANDRA_CQL_PORT_PROP, System.getProperty(CASSANDRA_CQL_PORT_PROP)));
     return new InetSocketAddress(host, port);
+  }
+
+  /** @return If Cassandra auth is enabled */
+  public static boolean isCassandraAuthEnabled() {
+    return Boolean.parseBoolean(System.getProperty(CASSANDRA_AUTH_ENABLED_PROP, "false"));
+  }
+
+  /** @return Cassandra username, only meaningful if Cassandra auth is enabled */
+  public static String getCassandraUsername() {
+    return System.getProperty(CASSANDRA_USERNAME_PROP, "cassandra");
+  }
+
+  /** @return Cassandra password, only meaningful if Cassandra auth is enabled */
+  public static String getCassandraPassword() {
+    return System.getProperty(CASSANDRA_PASSWORD_PROP, "cassandra");
   }
 
   /** @return Returns the cluster version (3.11, 4.0, 6.8 (== DSE)) specified for the coordinator */


### PR DESCRIPTION
**What this PR does**:

Adds option to have C* auth in the integration tests.. Turned off by default, can be set using the system props..

**Which issue(s) this PR fixes**:
Internal issue.