### PR TITLE
Add retry for data store properties access; new property to enable use of fallbacks

### DIFF
--- a/apis/sgv2-quarkus-common/pom.xml
+++ b/apis/sgv2-quarkus-common/pom.xml
@@ -43,6 +43,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-security</artifactId>
     </dependency>
     <dependency>

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/DataStoreConfig.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/DataStoreConfig.java
@@ -33,6 +33,13 @@ public interface DataStoreConfig {
   @WithDefault("${stargate.multi-tenancy.enabled}")
   boolean ignoreBridge();
 
+  /**
+   * @return If call(s) to fetch metadata fail, should we just return default settings ({@code
+   *     true}) or throw an exception ({@code false}). Defaults to {@code false}.
+   */
+  @WithDefault("false")
+  boolean useFallbacksIfCallFails();
+
   /** @return If the secondary indexes are enabled, defaults to <code>true</code>. */
   @WithDefault("true")
   boolean secondaryIndexesEnabled();

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/DataStoreConfig.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/DataStoreConfig.java
@@ -38,7 +38,7 @@ public interface DataStoreConfig {
    *     true}) or throw an exception ({@code false}). Defaults to {@code false}.
    */
   @WithDefault("false")
-  boolean useFallbacksIfCallFails();
+  boolean bridgeFallbackEnabled();
 
   /** @return If the secondary indexes are enabled, defaults to <code>true</code>. */
   @WithDefault("true")

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/properties/datastore/configuration/DataStorePropertiesConfiguration.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/properties/datastore/configuration/DataStorePropertiesConfiguration.java
@@ -25,6 +25,7 @@ import io.stargate.sgv2.api.common.config.DataStoreConfig;
 import io.stargate.sgv2.api.common.properties.datastore.DataStoreProperties;
 import io.stargate.sgv2.api.common.properties.datastore.impl.DataStorePropertiesImpl;
 import java.time.temporal.ChronoUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import org.eclipse.microprofile.faulttolerance.Retry;
@@ -56,46 +57,58 @@ public class DataStorePropertiesConfiguration {
 
     LOG.info(
         "DataStoreConfig.ignoreBridge() == false, will try to fetch data store metadata using the Bridge");
+    final AtomicInteger callCount = new AtomicInteger(0);
     try {
       // fire request
-      Schema.SupportedFeaturesResponse supportedFeatures = fetchSupportedFeatures(bridge);
+      Schema.SupportedFeaturesResponse supportedFeatures =
+          fetchSupportedFeatures(bridge, callCount);
 
       // construct props from bridge
-      return new DataStorePropertiesImpl(
-          supportedFeatures.getSecondaryIndexes(),
-          supportedFeatures.getSai(),
-          supportedFeatures.getLoggedBatches());
+      DataStorePropertiesImpl props =
+          new DataStorePropertiesImpl(
+              supportedFeatures.getSecondaryIndexes(),
+              supportedFeatures.getSai(),
+              supportedFeatures.getLoggedBatches());
+      LOG.info("Successfully fetched data store metadata ({} retries)", callCount.get() - 1);
+      return props;
     } catch (Exception e) {
+      final String msgBase =
+          "Failed to fetch data store metadata ({} retries)".formatted(callCount.get() - 1);
       if (dataStoreConfig.bridgeFallbackEnabled()) {
         LOG.warn(
-            "Failed to fetch the data store metadata, 'useFallbacksIfCallFails' == true, will return fallback data store metadata",
+            msgBase + ", 'bridgeFallbackEnabled' == true, will return fallback data store metadata",
             e);
         return fromConfig;
       }
-      LOG.warn(
-          "Failed to fetch the data store metadata, 'useFallbacksIfCallFails' == false, will fail");
+      LOG.warn(msgBase + ", 'bridgeFallbackEnabled' == false, will fail");
       throw e;
     }
   }
 
   /**
-   * Method for fetching data store metadata: will attempt up to 5 retries, for up to 1 minute
+   * Method for fetching data store metadata: will attempt up to 9 retries, for up to 1 minute
    * before failing.
    */
   @Retry(
-      maxRetries = 5,
-      delay = 5,
+      maxRetries = 9,
+      delay = 3,
       delayUnit = ChronoUnit.SECONDS,
       maxDuration = 60,
       durationUnit = ChronoUnit.SECONDS)
   // NOTE: Must NOT be 'private' for annotation to take effect!
   protected Schema.SupportedFeaturesResponse fetchSupportedFeatures(
-      StargateBridgeGrpc.StargateBridgeBlockingStub bridge) {
+      StargateBridgeGrpc.StargateBridgeBlockingStub bridge, AtomicInteger callCount) {
+    callCount.incrementAndGet();
     try {
       return bridge.getSupportedFeatures(Schema.SupportedFeaturesRequest.newBuilder().build());
     } catch (Exception e) {
-      // only log at info() level here; warn()/error() if all retries exhausted
-      LOG.info("Data store metadata fetch using Bridge failed, problem: {}", e.getMessage());
+      // only log at info() level here; warn()/error() if all retries exhausted. Avoid printing
+      // stack trace here
+      LOG.info(
+          "Data store metadata fetch using Bridge failed (call #{}/10), problem: ({}) {}",
+          callCount.get(),
+          e.getClass().getName(),
+          e.getMessage());
       throw e;
     }
   }

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/properties/datastore/configuration/DataStorePropertiesConfiguration.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/properties/datastore/configuration/DataStorePropertiesConfiguration.java
@@ -86,11 +86,11 @@ public class DataStorePropertiesConfiguration {
   }
 
   /**
-   * Method for fetching data store metadata: will attempt up to 9 retries, for up to 1 minute
+   * Method for fetching data store metadata: will attempt up to 5 total calls, for up to 1 minute
    * before failing.
    */
   @Retry(
-      maxRetries = 9,
+      maxRetries = 4,
       delay = 3,
       delayUnit = ChronoUnit.SECONDS,
       maxDuration = 60,
@@ -105,7 +105,7 @@ public class DataStorePropertiesConfiguration {
       // only log at info() level here; warn()/error() if all retries exhausted. Avoid printing
       // stack trace here
       LOG.info(
-          "Data store metadata fetch using Bridge failed (call #{}/10), problem: ({}) {}",
+          "Data store metadata fetch using Bridge failed (call #{}/5), problem: ({}) {}",
           callCount.get(),
           e.getClass().getName(),
           e.getMessage());

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/properties/datastore/configuration/DataStorePropertiesConfiguration.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/properties/datastore/configuration/DataStorePropertiesConfiguration.java
@@ -88,7 +88,8 @@ public class DataStorePropertiesConfiguration {
       delayUnit = ChronoUnit.SECONDS,
       maxDuration = 60,
       durationUnit = ChronoUnit.SECONDS)
-  private Schema.SupportedFeaturesResponse fetchSupportedFeatures(
+  // NOTE: Must NOT be 'private' for annotation to take effect!
+  protected Schema.SupportedFeaturesResponse fetchSupportedFeatures(
       StargateBridgeGrpc.StargateBridgeBlockingStub bridge) {
     try {
       return bridge.getSupportedFeatures(Schema.SupportedFeaturesRequest.newBuilder().build());

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/properties/datastore/configuration/DataStorePropertiesConfiguration.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/properties/datastore/configuration/DataStorePropertiesConfiguration.java
@@ -66,7 +66,7 @@ public class DataStorePropertiesConfiguration {
           supportedFeatures.getSai(),
           supportedFeatures.getLoggedBatches());
     } catch (Exception e) {
-      if (dataStoreConfig.useFallbacksIfCallFails()) {
+      if (dataStoreConfig.bridgeFallbackEnabled()) {
         LOG.warn(
             "Failed to fetch the data store metadata, 'useFallbacksIfCallFails' == true, will return fallback data store metadata",
             e);
@@ -93,7 +93,8 @@ public class DataStorePropertiesConfiguration {
     try {
       return bridge.getSupportedFeatures(Schema.SupportedFeaturesRequest.newBuilder().build());
     } catch (Exception e) {
-      LOG.warn("Data store metadata fetch using Bridge failed, problem: {}", e.getMessage());
+      // only log at info() level here; warn()/error() if all retries exhausted
+      LOG.info("Data store metadata fetch using Bridge failed, problem: {}", e.getMessage());
       throw e;
     }
   }

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/properties/datastore/configuration/BridgeDataStorePropertiesRetryTest.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/properties/datastore/configuration/BridgeDataStorePropertiesRetryTest.java
@@ -1,0 +1,91 @@
+package io.stargate.sgv2.api.common.properties.datastore.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.test.junit.QuarkusTest;
+import io.stargate.bridge.proto.Schema;
+import io.stargate.bridge.proto.StargateBridgeGrpc;
+import io.stargate.sgv2.api.common.BridgeTest;
+import io.stargate.sgv2.api.common.config.DataStoreConfig;
+import io.stargate.sgv2.api.common.properties.datastore.DataStoreProperties;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+@QuarkusTest
+public class BridgeDataStorePropertiesRetryTest extends BridgeTest {
+  @GrpcClient("bridge")
+  StargateBridgeGrpc.StargateBridgeBlockingStub bridge;
+
+  @Inject DataStorePropertiesConfiguration dataStorePropertiesConfiguration;
+
+  protected AtomicInteger mockGetSupportedFeaturesCall(final int succeedOn) {
+    Schema.SupportedFeaturesResponse response =
+        Schema.SupportedFeaturesResponse.newBuilder()
+            .setSecondaryIndexes(false)
+            .setSai(false)
+            .setLoggedBatches(true)
+            .build();
+
+    final AtomicInteger callCounter = new AtomicInteger(0);
+    // Fail first call, succeed Nth call (and fail afterwards)
+    doAnswer(
+            new Answer() {
+              private int count = 0;
+
+              public Object answer(InvocationOnMock invocation) {
+                int callNr = callCounter.incrementAndGet();
+                final StreamObserver<Schema.SupportedFeaturesResponse> observer =
+                    invocation.getArgument(1);
+                if (callNr == succeedOn) {
+                  observer.onNext(response);
+                  observer.onCompleted();
+                } else {
+                  observer.onError(new StatusRuntimeException(Status.UNAVAILABLE));
+                }
+                return null;
+              }
+            })
+        .when(bridgeService)
+        .getSupportedFeatures(any(), any());
+    return callCounter;
+  }
+
+  @Test
+  public void dataStoreWithNoRetriesOk() {
+    dataStoreWithNCalls(1);
+  }
+
+  @Test
+  public void dataStoreWithOneRetryOk() {
+    dataStoreWithNCalls(2);
+  }
+
+  @Test
+  public void dataStoreWithTwoRetriesOk() {
+    dataStoreWithNCalls(3);
+  }
+
+  private void dataStoreWithNCalls(int callsToSucceed) {
+    DataStoreConfig config = mock(DataStoreConfig.class);
+    when(config.ignoreBridge()).thenReturn(false);
+    final AtomicInteger callCounter = mockGetSupportedFeaturesCall(callsToSucceed);
+
+    DataStoreProperties props = dataStorePropertiesConfiguration.configuration(bridge, config);
+    assertThat(props.secondaryIndexesEnabled()).isFalse();
+    assertThat(props.saiEnabled()).isFalse();
+    assertThat(props.loggedBatchesEnabled()).isTrue();
+
+    assertThat(callCounter.get()).isEqualTo(callsToSucceed);
+  }
+}

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/properties/datastore/configuration/BridgeDataStorePropertiesRetryTest.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/properties/datastore/configuration/BridgeDataStorePropertiesRetryTest.java
@@ -49,21 +49,17 @@ public class BridgeDataStorePropertiesRetryTest extends BridgeTest {
     final AtomicInteger callCounter = new AtomicInteger(0);
     // Fail first call, succeed Nth call (and fail afterwards)
     doAnswer(
-            new Answer() {
-              private int count = 0;
-
-              public Object answer(InvocationOnMock invocation) {
-                int callNr = callCounter.incrementAndGet();
-                final StreamObserver<Schema.SupportedFeaturesResponse> observer =
-                    invocation.getArgument(1);
-                if (callNr == succeedOn) {
-                  observer.onNext(response);
-                  observer.onCompleted();
-                } else {
-                  observer.onError(new StatusRuntimeException(Status.UNAVAILABLE));
-                }
-                return null;
+            invocation -> {
+              int callNr = callCounter.incrementAndGet();
+              final StreamObserver<Schema.SupportedFeaturesResponse> observer =
+                  invocation.getArgument(1);
+              if (callNr == succeedOn) {
+                observer.onNext(response);
+                observer.onCompleted();
+              } else {
+                observer.onError(new StatusRuntimeException(Status.UNAVAILABLE));
               }
+              return null;
             })
         .when(bridgeService)
         .getSupportedFeatures(any(), any());

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/properties/datastore/configuration/BridgeDataStorePropertiesRetryTest.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/properties/datastore/configuration/BridgeDataStorePropertiesRetryTest.java
@@ -1,6 +1,7 @@
 package io.stargate.sgv2.api.common.properties.datastore.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -18,7 +19,6 @@ import io.stargate.sgv2.api.common.config.DataStoreConfig;
 import io.stargate.sgv2.api.common.properties.datastore.DataStoreProperties;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.inject.Inject;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -57,13 +57,9 @@ public class BridgeDataStorePropertiesRetryTest extends BridgeTest {
   @Test
   public void dataStoreWithTwoRetriesFail() {
     // Fails after 5 calls
-    try {
-      dataStoreWithNCalls(6);
-      Assertions.fail("Should not have succeeded (max 4 retries)");
-    } catch (Exception e) {
-      assertThat(e).isInstanceOf(StatusRuntimeException.class);
-      assertThat(e.getMessage()).contains("UNAVAILABLE");
-    }
+    Throwable e = catchThrowable(() -> dataStoreWithNCalls(6));
+    assertThat(e).isInstanceOf(StatusRuntimeException.class);
+    assertThat(e.getMessage()).contains("UNAVAILABLE");
   }
 
   // // // Helper methods for tests

--- a/apis/sgv2-quarkus-common/src/test/resources/application.yaml
+++ b/apis/sgv2-quarkus-common/src/test/resources/application.yaml
@@ -19,6 +19,5 @@ io:
           properties:
             datastore:
               configuration:
-                # Test overrides for "BridgeDataStorePropertiesRetryTest"
-                DataStorePropertiesConfiguration/fetchSupportedFeatures/Retry/maxRetries: 2
+                # Test override(s) for "BridgeDataStorePropertiesRetryTest" to speed up test
                 DataStorePropertiesConfiguration/fetchSupportedFeatures/Retry/delay: 0

--- a/apis/sgv2-quarkus-common/src/test/resources/application.yaml
+++ b/apis/sgv2-quarkus-common/src/test/resources/application.yaml
@@ -10,3 +10,15 @@ quarkus:
       bridge:
         host: localhost
         port: 8091
+
+io:
+  stargate:
+    sgv2:
+      api:
+        common:
+          properties:
+            datastore:
+              configuration:
+                # Test overrides for "BridgeDataStorePropertiesRetryTest"
+                DataStorePropertiesConfiguration/fetchSupportedFeatures/Retry/maxRetries: 2
+                DataStorePropertiesConfiguration/fetchSupportedFeatures/Retry/delay: 0


### PR DESCRIPTION
**What this PR does**:

Improves reliability of data store metadata lookup on startup; makes use of possible fallbacks configurable (defaulting to no fallbacks)

**Which issue(s) this PR fixes**:
Fixes #2075

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
