### PR TITLE
Fix "all keyspaces" test to work with CNDB backend

### DIFF
--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2Keyspace.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2Keyspace.java
@@ -53,6 +53,12 @@ public class Sgv2Keyspace {
     datacenters.add(new Datacenter(name, replicas));
   }
 
+  // Define to give more meaningful failure messages from ITs:
+  @Override
+  public String toString() {
+    return "[Keyspace '" + name + "']";
+  }
+
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public static class Datacenter {
     private String name;

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaKeyspacesIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaKeyspacesIT.java
@@ -11,11 +11,14 @@ import io.stargate.sgv2.api.common.exception.model.dto.ApiError;
 import io.stargate.sgv2.common.IntegrationTestUtils;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.restapi.service.models.Sgv2Keyspace;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
@@ -74,6 +77,7 @@ public class RestApiV2QSchemaKeyspacesIT extends RestApiV2QIntegrationTestBase {
 
   // 09-Aug-2022, tatu: Alas, Auth token seems not to be checked
   // @Ignore("Auth token handling hard-coded, won't fail as expected")
+  @Test
   public void keyspacesGetAllMissingToken() {
     String response =
         givenWithoutAuth()
@@ -86,7 +90,8 @@ public class RestApiV2QSchemaKeyspacesIT extends RestApiV2QIntegrationTestBase {
   }
 
   // 09-Aug-2022, tatu: Alas, Auth token seems not to be checked
-  @Ignore("Auth token handling hard-coded, won't fail as expected")
+  // @Ignore("Auth token handling hard-coded, won't fail as expected")
+  @Test
   public void keyspacesGetAllBadToken() {
     String response =
         givenWithAuthToken("NotAPassword")
@@ -319,14 +324,18 @@ public class RestApiV2QSchemaKeyspacesIT extends RestApiV2QIntegrationTestBase {
    */
 
   private void assertSystemKeyspaces(Sgv2Keyspace[] keyspaces) {
-    assertSimpleKeyspaces(keyspaces, "system", "system_auth", "system_schema");
+    // While C*3, C*4, DSE have "system", "system_auth", "system_schema", CNDB
+    // does not have "system_auth"
+    assertSimpleKeyspaces(keyspaces, "system", "system_schema");
   }
 
   private void assertSimpleKeyspaces(Sgv2Keyspace[] keyspaces, String... expectedKsNames) {
-    for (String ksName : expectedKsNames) {
-      assertThat(keyspaces)
-          .anySatisfy(
-              v -> assertThat(v).usingRecursiveComparison().isEqualTo(new Sgv2Keyspace(ksName)));
+    Set<String> existingNames =
+        Arrays.stream(keyspaces)
+            .map(k -> k.getName())
+            .collect(Collectors.toCollection(TreeSet::new));
+    for (String expectedName : expectedKsNames) {
+      assertThat(existingNames).contains(expectedName);
     }
   }
 }

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaKeyspacesIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaKeyspacesIT.java
@@ -22,6 +22,7 @@ import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,7 +87,8 @@ public class RestApiV2QSchemaKeyspacesIT extends RestApiV2QIntegrationTestBase {
             .asString();
   }
 
-  @Test
+  // 09-Aug-2022, tatu: Alas, Auth token seems not to be checked
+  @Ignore("Auth token handling hard-coded, won't fail as expected")
   public void keyspacesGetAllBadToken() {
     String response =
         givenWithAuthToken("NotAPassword")

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaKeyspacesIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaKeyspacesIT.java
@@ -22,7 +22,6 @@ import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
-import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,8 +74,6 @@ public class RestApiV2QSchemaKeyspacesIT extends RestApiV2QIntegrationTestBase {
     assertSystemKeyspaces(readJsonAs(response, Sgv2Keyspace[].class));
   }
 
-  // 09-Aug-2022, tatu: Alas, Auth token seems not to be checked
-  // @Ignore("Auth token handling hard-coded, won't fail as expected")
   @Test
   public void keyspacesGetAllMissingToken() {
     String response =
@@ -89,8 +86,6 @@ public class RestApiV2QSchemaKeyspacesIT extends RestApiV2QIntegrationTestBase {
             .asString();
   }
 
-  // 09-Aug-2022, tatu: Alas, Auth token seems not to be checked
-  // @Ignore("Auth token handling hard-coded, won't fail as expected")
   @Test
   public void keyspacesGetAllBadToken() {
     String response =

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/persistence/RestApiV2QIndexSASI_IT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/persistence/RestApiV2QIndexSASI_IT.java
@@ -19,19 +19,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Test(s) to verify Storage-Attached Index (SAI) creation. Separate from other Index tests since
- * SAI not available on all backends.
+ * Test(s) to verify SSTable-Attached Secondary Index (SASI) creation. Separate from other Index
+ * tests since SASI not available on all backends.
  */
 @QuarkusIntegrationTest
 @QuarkusTestResource(
     value = StargateTestResource.class,
     initArgs =
         @ResourceArg(name = StargateTestResource.Options.DISABLE_FIXED_TOKEN, value = "true"))
-public class RestApiV2QIndexSAI_IT extends RestApiV2QIntegrationTestBase {
-  private static final Logger LOG = LoggerFactory.getLogger(RestApiV2QIndexSAI_IT.class);
+public class RestApiV2QIndexSASI_IT extends RestApiV2QIntegrationTestBase {
+  private static final Logger LOG = LoggerFactory.getLogger(RestApiV2QIndexSASI_IT.class);
 
-  public RestApiV2QIndexSAI_IT() {
-    super("sai_ks_", "sai_t_");
+  public RestApiV2QIndexSASI_IT() {
+    super("sasi_ks_", "sasi_t_");
   }
 
   /*
@@ -41,11 +41,11 @@ public class RestApiV2QIndexSAI_IT extends RestApiV2QIntegrationTestBase {
    */
 
   @Test
-  public void indexCreateCustomSAI() {
+  public void indexCreateCustomSASI() {
     boolean isC4 = IntegrationTestUtils.isCassandra40();
-    LOG.info("indexCreateCustomSAI(): is backend Cassandra 4.0? {}", isC4);
+    LOG.info("indexCreateCustomSASI(): is backend Cassandra 4.0? {}", isC4);
     assumeThat(!isC4)
-        .as("Disabled because it is currently not possible to enable SAI indexes on C*4.0 backend")
+        .as("Disabled because it is currently not possible to enable SASI indexes on C*4.0 backend")
         .isTrue();
 
     final String tableName = testTableName();


### PR DESCRIPTION
**What this PR does**:

Fixes "getAllKeyspaces()" test to work with another backend.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
