### PR TITLE
conditional bump version PR on the release

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -342,8 +342,10 @@ jobs:
           cosign sign --key $COSIGN_KEY_FILE -a $AUX_KEY=$AUX_VALUE $COSIGN_IMAGE
 
   # creates a PR for bumping the versions to the next snapshot
+  # only executed if we have created the new release
   create-pr:
     name: Version upgrade PR
+    needs: [create-release]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
**What this PR does**:

Hit a situation that re-running the release V2, would overwrite any commits in the PR responsible for the bumping the versions.. Thus, a small fix to only run this if we created the release successfully. 
