### PR TITLE
fix flaky graphql v2 int tests

### DIFF
--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/MetricsIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/MetricsIntegrationTest.java
@@ -25,6 +25,8 @@ import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.CqlFirstIntegrationTest;
 import io.stargate.sgv2.graphql.integration.util.MetricsTestsHelper;
 import java.util.regex.Pattern;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -67,7 +69,10 @@ public class MetricsIntegrationTest extends CqlFirstIntegrationTest {
 
   private int getQueryCount() {
     String body = client.getMetrics();
-    return (int)
-        MetricsTestsHelper.getMetricValue(body, "graphqlapi", GRAPHQL_OPERATIONS_METRIC_REGEXP);
+    Collector<Double, ?, Double> aggregator = Collectors.summingDouble(Double::doubleValue);
+    Double value =
+        MetricsTestsHelper.getMetricValue(
+            body, "graphqlapi", GRAPHQL_OPERATIONS_METRIC_REGEXP, aggregator);
+    return value.intValue();
   }
 }

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/ScalarsIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/ScalarsIntegrationTest.java
@@ -138,7 +138,7 @@ public class ScalarsIntegrationTest extends CqlFirstIntegrationTest {
       ThreadLocal.withInitial(
           () -> {
             SimpleDateFormat parser = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-            parser.setTimeZone(TimeZone.getTimeZone(ZoneId.systemDefault()));
+            parser.setTimeZone(TimeZone.getTimeZone(ZoneId.of("UTC")));
             return parser;
           });
 }

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/DataTypesIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/DataTypesIntegrationTest.java
@@ -167,7 +167,7 @@ public class DataTypesIntegrationTest extends GraphqlFirstIntegrationTest {
 
   private static String formatToSystemTimeZone(long epochMillis) {
     SimpleDateFormat parser = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-    parser.setTimeZone(TimeZone.getTimeZone(ZoneId.systemDefault()));
+    parser.setTimeZone(TimeZone.getTimeZone(ZoneId.of("UTC")));
     return parser.format(new Date(epochMillis));
   }
 }

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/util/MetricsTestsHelper.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/util/MetricsTestsHelper.java
@@ -16,14 +16,17 @@
 package io.stargate.sgv2.graphql.integration.util;
 
 import java.util.Arrays;
-import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collector;
 
 public class MetricsTestsHelper {
 
-  public static Optional<Double> getMetricValueOptional(
-      String body, String metricName, Pattern regexpPattern) {
+  public static Double getMetricValue(
+      String body,
+      String metricName,
+      Pattern regexpPattern,
+      Collector<Double, ?, Double> aggregator) {
     return Arrays.stream(body.split("\n"))
         .filter(v -> v.contains(metricName))
         .filter(v -> regexpPattern.matcher(v).find())
@@ -37,10 +40,6 @@ public class MetricsTestsHelper {
                   String.format("Value: %s does not contain the numeric value for metric", v));
             })
         .map(Double::parseDouble)
-        .findAny();
-  }
-
-  public static double getMetricValue(String body, String metricName, Pattern regexpPattern) {
-    return getMetricValueOptional(body, metricName, regexpPattern).get();
+        .collect(aggregator);
   }
 }


### PR DESCRIPTION
**What this PR does**:
 
Fixes flaky graphql integration tests:

* writing UTC times, as comparing is generic and some storage only stores UTC times
* metrics test to add aggregator, so possibly different tags are taken into account and summed-up

**Tasks**:

* [x] rebase after #2086 is merged