### PR TITLE
relates to #2065: bump DSE version to 6.8.26 

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -54,7 +54,7 @@ RUN git clone --branch master --single-branch https://github.com/riptano/ccm.git
 # Create clusters to pre-download necessary artifacts
 RUN ccm create -v 4.0.4 stargate_40 && ccm remove stargate_40
 RUN ccm create -v 3.11.13 stargate_311 && ccm remove stargate_311
-RUN ccm create -v 6.8.25 --dse stargate_dse68 && ccm remove stargate_dse68
+RUN ccm create -v 6.8.26 --dse stargate_dse68 && ccm remove stargate_dse68
 
 # init the maven user home dir with correct permissions
 # needed for running maven wrapper

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -1,7 +1,7 @@
 HOSTNAME        := gcr.io
 PROJECT         := stargateio
 NAME            := stargate-builder
-VERSION         := v1.0.10
+VERSION         := v1.0.11
 TAG             := ${VERSION}
 IMG             := ${NAME}:${TAG}
 IMG_GCP         := ${HOSTNAME}/${PROJECT}/${IMG}

--- a/cloudbuild-3_11.yaml
+++ b/cloudbuild-3_11.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.10'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.11'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'
@@ -30,7 +30,7 @@ steps:
         name: 'm2_cache'
   - id: 'cassandra-3.11'
     waitFor: [ 'fetch_secret', 'init_cache' ]
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.9'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.11'
     entrypoint: 'bash'
     args: [ 'ci/test.sh' ]
     volumes:

--- a/cloudbuild-4_0.yaml
+++ b/cloudbuild-4_0.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.10'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.11'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'
@@ -30,7 +30,7 @@ steps:
         name: 'm2_cache'
   - id: 'cassandra-4.0'
     waitFor: [ 'fetch_secret', 'init_cache' ]
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.9'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.11'
     entrypoint: 'bash'
     args: [ 'ci/test.sh' ]
     volumes:

--- a/cloudbuild-dse.yaml
+++ b/cloudbuild-dse.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.10'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.11'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'
@@ -30,7 +30,7 @@ steps:
         name: 'm2_cache'
   - id: 'dse-6.8'
     waitFor: [ 'fetch_secret', 'init_cache' ]
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.9'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.11'
     entrypoint: 'bash'
     args: [ 'ci/test.sh' ]
     volumes:

--- a/persistence-cassandra-3.11/README.md
+++ b/persistence-cassandra-3.11/README.md
@@ -16,7 +16,7 @@ Note that transitive dependencies can be seen on [mvnrepository.com](https://mvn
 * Check if the new version has a transitive dependency to `org.apache.cassandra:cassandra-thrift`, and if it does remove that dependency from our [pom.xml](pom.xml).
 The `cassandra-thrift` was explicitly added when updating to `3.11.12` as it was not anymore in the `cassandra-all`.
 * Update the [CI Dockerfile](../ci/Dockerfile) and set the new version in the `ccm create` command related to 3.11.
-Note that this will have no effect until the docker image is rebuilt and pushed to the remote repository, thus creating an issue for that would be a good idea.* Create a separate PR for bumping the DSE version in the Quarkus-based API integration tests on the `v2.0.0` branch. Test profiles are defined in the `apis/pom.xml`.
+Note that this will have no effect until the docker image is rebuilt and pushed to the remote repository, thus creating an issue for that would be a good idea.
 * Create a separate PR for bumping the Cassandra 3 version in the Quarkus-based API integration tests on the `v2.0.0` branch. Test profiles are defined in the `apis/pom.xml`.
 * Make sure everything compiles and CI tests are green.
 * Update the [DEVGUIDE.md](../DEV_GUIDE.md) and replace the old version in the examples.

--- a/persistence-cassandra-3.11/README.md
+++ b/persistence-cassandra-3.11/README.md
@@ -16,7 +16,8 @@ Note that transitive dependencies can be seen on [mvnrepository.com](https://mvn
 * Check if the new version has a transitive dependency to `org.apache.cassandra:cassandra-thrift`, and if it does remove that dependency from our [pom.xml](pom.xml).
 The `cassandra-thrift` was explicitly added when updating to `3.11.12` as it was not anymore in the `cassandra-all`.
 * Update the [CI Dockerfile](../ci/Dockerfile) and set the new version in the `ccm create` command related to 3.11.
-Note that this will have no effect until the docker image is rebuilt and pushed to the remote repository, thus creating an issue for that would be a good idea.
+Note that this will have no effect until the docker image is rebuilt and pushed to the remote repository, thus creating an issue for that would be a good idea.* Create a separate PR for bumping the DSE version in the Quarkus-based API integration tests on the `v2.0.0` branch. Test profiles are defined in the `apis/pom.xml`.
+* Create a separate PR for bumping the Cassandra 3 version in the Quarkus-based API integration tests on the `v2.0.0` branch. Test profiles are defined in the `apis/pom.xml`.
 * Make sure everything compiles and CI tests are green.
 * Update the [DEVGUIDE.md](../DEV_GUIDE.md) and replace the old version in the examples.
 * Update this `README.md` file with the new or updated instructions.

--- a/persistence-cassandra-4.0/README.md
+++ b/persistence-cassandra-4.0/README.md
@@ -15,6 +15,7 @@ This dependency is set as optional in the `cassandra-all`, but we need it to cor
 Note that transitive dependencies can be seen on [mvnrepository.com](https://mvnrepository.com/artifact/org.apache.cassandra/cassandra-all) or by running `./mvnw dependency:tree -pl persistence-cassandra-4.0`.
 * Update the [CI Dockerfile](../ci/Dockerfile) and set the new version in the `ccm create` command related to 4.0.
 Note that this will have no effect until the docker image is rebuilt and pushed to the remote repository, thus creating an issue for that would be a good idea.
+* Create a separate PR for bumping the Cassandra 4 version in the Quarkus-based API integration tests on the `v2.0.0` branch. Test profiles are defined in the `apis/pom.xml`.
 * Make sure everything compiles and CI tests are green.
 * Update this `README.md` file with the new or updated instructions.
 

--- a/persistence-dse-6.8/README.md
+++ b/persistence-dse-6.8/README.md
@@ -5,13 +5,14 @@ the DSE (DataStax Enterprise cassandra) `6.8.x` version.
 
 ## Cassandra version update
 
-The current Cassandra version this module depends on is `6.8.25`.
+The current Cassandra version this module depends on is `6.8.26`.
 In order to update to a newer patch version, please follow the guidelines below:
 
 * Update the `dse.version` property in the [pom.xml](pom.xml).
-* Update the `ccm.version` property (`it-dse-6.8` profile section) in [testing/pom.xml](testing/pom.xml)
+* Update the `ccm.version` property (`it-dse-6.8` profile section) in [testing/pom.xml](../testing/pom.xml)
 * Update the [CI Dockerfile](../ci/Dockerfile) and set the new version in the `ccm create` command related to DSE 6.8.
 Note that this will have no effect until the docker image is rebuilt and pushed to the remote repository, thus creating an issue for that would be a good idea (see below for one such PR)
+* Create a separate PR for bumping the DSE version in the Quarkus-based API integration tests on the `v2.0.0` branch. Test profiles are defined in the `apis/pom.xml`.
 * Make sure everything compiles and CI tests are green.
 * Update this `README.md` file with the new or updated instructions.
 

--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -10,7 +10,7 @@
   <groupId>io.stargate.db.dse</groupId>
   <artifactId>persistence-dse-6.8</artifactId>
   <properties>
-    <dse.version>6.8.25</dse.version>
+    <dse.version>6.8.26</dse.version>
   </properties>
   <repositories>
     <repository>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -437,7 +437,7 @@
                 <configuration>
                   <systemPropertyVariables>
                     <ccm.dse>true</ccm.dse>
-                    <ccm.version>6.8.25</ccm.version>
+                    <ccm.version>6.8.26</ccm.version>
                     <stargate.test.nodes>1</stargate.test.nodes>
                   </systemPropertyVariables>
                   <failIfNoTests>true</failIfNoTests>


### PR DESCRIPTION
**What this PR does**:

Bumps DSE to `6.8.26`. New CI image already used in this PR..

A `v2.0.0` PR to follow..
