### PR TITLE
closes #2065: bump DSE to 6.8.26 in v2 int tests

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -154,7 +154,7 @@
       <id>dse-68</id>
       <properties>
         <stargate.int-test.cassandra.image>datastax/dse-server</stargate.int-test.cassandra.image>
-        <stargate.int-test.cassandra.image-tag>6.8.25</stargate.int-test.cassandra.image-tag>
+        <stargate.int-test.cassandra.image-tag>6.8.26</stargate.int-test.cassandra.image-tag>
         <stargate.int-test.coordinator.image>stargateio/coordinator-dse-68</stargate.int-test.coordinator.image>
         <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
         <stargate.int-test.cluster.name>dse-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>


### PR DESCRIPTION
**What this PR does**:

Bumps DSE in the V2 integration tests to the `6.8.26`.. Depends on #2094..

**Which issue(s) this PR fixes**:
Fixes #2056

**Checklist**
- [x] needs #2094 merged
- [ ] needs merging `v2.0.0` with master
