### PR TITLE
closes #2085: publish v2 quarkus-common jar to the maven repository

### DIFF
--- a/.github/workflows/apis-v2.yaml
+++ b/.github/workflows/apis-v2.yaml
@@ -191,7 +191,7 @@ jobs:
       - name: Build & Test Stargate v2 Quarkus-based APIs
         run: |
           cd apis/
-          ./mvnw -B test
+          ./mvnw -B clean test
 
   # runs int tests for the sgv2-docsapi
   # supports downloading and importing the built docker image

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -128,12 +128,22 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # install both Java 8 & Java 17, keep paths in vars
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '8'
           cache: maven
+      - run: echo "JAVA_8=$JAVA_HOME" >> $GITHUB_ENV
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: maven
+      - run: echo "JAVA_17=$JAVA_HOME" >> $GITHUB_ENV
 
       - name: Setup Maven
         env:
@@ -168,11 +178,18 @@ jobs:
         run: |
           cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
 
-      - name: Publish package
+      - name: Publish coordinator JARs
         if: ${{ !inputs.skipPublish }}
         run: |
-          ./mvnw versions:set -DremoveSnapshot versions:commit
-          ./mvnw -B -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy,dse
+          JAVA_HOME=$JAVA_8 ./mvnw versions:set -DremoveSnapshot versions:commit
+          JAVA_HOME=$JAVA_8 ./mvnw -B -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy,dse
+
+      - name: Publish Quarkus Common JAR
+        if: ${{ !inputs.skipPublish }}
+        run: |
+          cd apis/
+          JAVA_HOME=$JAVA_17 ./mvnw versions:set -DremoveSnapshot versions:commit
+          JAVA_HOME=$JAVA_17 ./mvnw -B -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy
 
   # publishes the docker images for the coordinator and the APIs
   publish-docker:

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -184,12 +184,13 @@ jobs:
           JAVA_HOME=$JAVA_8 ./mvnw versions:set -DremoveSnapshot versions:commit
           JAVA_HOME=$JAVA_8 ./mvnw -B -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy,dse
 
+      # explicitly only -pl sgv2-quarkus-common
       - name: Publish Quarkus Common JAR
         if: ${{ !inputs.skipPublish }}
         run: |
           cd apis/
           JAVA_HOME=$JAVA_17 ./mvnw versions:set -DremoveSnapshot versions:commit
-          JAVA_HOME=$JAVA_17 ./mvnw -B -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy
+          JAVA_HOME=$JAVA_17 ./mvnw -B -pl sgv2-quarkus-common -am -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy
 
   # publishes the docker images for the coordinator and the APIs
   publish-docker:

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.stargate</groupId>
   <artifactId>sgv2-api-parent</artifactId>
@@ -133,7 +134,8 @@
         <stargate.int-test.cassandra.image-tag>4.0.4</stargate.int-test.cassandra.image-tag>
         <stargate.int-test.coordinator.image>stargateio/coordinator-4_0</stargate.int-test.coordinator.image>
         <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
-        <stargate.int-test.cluster.name>cass-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
+        <stargate.int-test.cluster.name>cass-${stargate.int-test.cassandra.image-tag}-cluster
+        </stargate.int-test.cluster.name>
         <stargate.int-test.cluster.version>4.0</stargate.int-test.cluster.version>
         <stargate.int-test.cluster.dse>false</stargate.int-test.cluster.dse>
       </properties>
@@ -151,7 +153,8 @@
         <stargate.int-test.cassandra.image-tag>3.11.13</stargate.int-test.cassandra.image-tag>
         <stargate.int-test.coordinator.image>stargateio/coordinator-3_11</stargate.int-test.coordinator.image>
         <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
-        <stargate.int-test.cluster.name>cass-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
+        <stargate.int-test.cluster.name>cass-${stargate.int-test.cassandra.image-tag}-cluster
+        </stargate.int-test.cluster.name>
         <stargate.int-test.cluster.version>3.11</stargate.int-test.cluster.version>
         <stargate.int-test.cluster.dse>false</stargate.int-test.cluster.dse>
       </properties>
@@ -169,7 +172,8 @@
         <stargate.int-test.cassandra.image-tag>6.8.26</stargate.int-test.cassandra.image-tag>
         <stargate.int-test.coordinator.image>stargateio/coordinator-dse-68</stargate.int-test.coordinator.image>
         <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
-        <stargate.int-test.cluster.name>dse-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
+        <stargate.int-test.cluster.name>dse-${stargate.int-test.cassandra.image-tag}-cluster
+        </stargate.int-test.cluster.name>
         <stargate.int-test.cluster.version>6.8</stargate.int-test.cluster.version>
         <stargate.int-test.cluster.dse>true</stargate.int-test.cluster.dse>
       </properties>
@@ -263,4 +267,22 @@
       </build>
     </profile>
   </profiles>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+  <scm>
+    <connection>scm:git:git://github.com/stargate/stargate.git</connection>
+    <developerConnection>scm:git:git@github.com:stargate/stargate.git</developerConnection>
+    <url>http://github.com/stargate/stargate/tree/v2.0.0</url>
+  </scm>
+  <developers>
+    <developer>
+      <name>The Stargate Authors</name>
+      <email>maintainers@stargate.io</email>
+      <organization>Stargate</organization>
+    </developer>
+  </developers>
 </project>

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -5,6 +5,12 @@
   <artifactId>sgv2-api-parent</artifactId>
   <version>2.0.0-BETA-3-SNAPSHOT</version>
   <packaging>pom</packaging>
+  <modules>
+    <module>sgv2-quarkus-common</module>
+    <module>sgv2-docsapi</module>
+    <module>sgv2-graphqlapi</module>
+    <module>sgv2-restapi</module>
+  </modules>
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.source>17</maven.compiler.source>
@@ -118,12 +124,6 @@
   <profiles>
     <profile>
       <id>cassandra-40</id>
-      <modules>
-        <module>sgv2-quarkus-common</module>
-        <module>sgv2-docsapi</module>
-        <module>sgv2-graphqlapi</module>
-        <module>sgv2-restapi</module>
-      </modules>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
@@ -140,12 +140,6 @@
     </profile>
     <profile>
       <id>cassandra-311</id>
-      <modules>
-        <module>sgv2-quarkus-common</module>
-        <module>sgv2-docsapi</module>
-        <module>sgv2-graphqlapi</module>
-        <module>sgv2-restapi</module>
-      </modules>
       <properties>
         <stargate.int-test.cassandra.image>cassandra</stargate.int-test.cassandra.image>
         <stargate.int-test.cassandra.image-tag>3.11.13</stargate.int-test.cassandra.image-tag>
@@ -158,12 +152,6 @@
     </profile>
     <profile>
       <id>dse-68</id>
-      <modules>
-        <module>sgv2-quarkus-common</module>
-        <module>sgv2-docsapi</module>
-        <module>sgv2-graphqlapi</module>
-        <module>sgv2-restapi</module>
-      </modules>
       <properties>
         <stargate.int-test.cassandra.image>datastax/dse-server</stargate.int-test.cassandra.image>
         <stargate.int-test.cassandra.image-tag>6.8.26</stargate.int-test.cassandra.image-tag>
@@ -177,9 +165,6 @@
     <!-- The deployment profile must be used only with the sgv2-quarkus-common   -->
     <profile>
       <id>deploy</id>
-      <modules>
-        <module>sgv2-quarkus-common</module>
-      </modules>
       <distributionManagement>
         <repository>
           <id>ossrh</id>

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -199,6 +199,14 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <version>3.4.1</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
             <configuration>
               <additionalOptions>-Xdoclint:none</additionalOptions>
               <verbose>false</verbose>
@@ -211,14 +219,28 @@
                 </tag>
               </tags>
             </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.0.1</version>
             <executions>
               <execution>
-                <id>attach-javadocs</id>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
                 <goals>
-                  <goal>jar</goal>
+                  <goal>sign</goal>
                 </goals>
               </execution>
             </executions>
+            <!-- Copied the config from the base Stargate pom -->
+            <configuration>
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+              <outputDirectory>${project.basedir}/target</outputDirectory>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -5,12 +5,6 @@
   <artifactId>sgv2-api-parent</artifactId>
   <version>2.0.0-BETA-3-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <modules>
-    <module>sgv2-quarkus-common</module>
-    <module>sgv2-docsapi</module>
-    <module>sgv2-graphqlapi</module>
-    <module>sgv2-restapi</module>
-  </modules>
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.source>17</maven.compiler.source>
@@ -124,6 +118,12 @@
   <profiles>
     <profile>
       <id>cassandra-40</id>
+      <modules>
+        <module>sgv2-quarkus-common</module>
+        <module>sgv2-docsapi</module>
+        <module>sgv2-graphqlapi</module>
+        <module>sgv2-restapi</module>
+      </modules>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
@@ -140,6 +140,12 @@
     </profile>
     <profile>
       <id>cassandra-311</id>
+      <modules>
+        <module>sgv2-quarkus-common</module>
+        <module>sgv2-docsapi</module>
+        <module>sgv2-graphqlapi</module>
+        <module>sgv2-restapi</module>
+      </modules>
       <properties>
         <stargate.int-test.cassandra.image>cassandra</stargate.int-test.cassandra.image>
         <stargate.int-test.cassandra.image-tag>3.11.13</stargate.int-test.cassandra.image-tag>
@@ -152,6 +158,12 @@
     </profile>
     <profile>
       <id>dse-68</id>
+      <modules>
+        <module>sgv2-quarkus-common</module>
+        <module>sgv2-docsapi</module>
+        <module>sgv2-graphqlapi</module>
+        <module>sgv2-restapi</module>
+      </modules>
       <properties>
         <stargate.int-test.cassandra.image>datastax/dse-server</stargate.int-test.cassandra.image>
         <stargate.int-test.cassandra.image-tag>6.8.26</stargate.int-test.cassandra.image-tag>
@@ -161,6 +173,55 @@
         <stargate.int-test.cluster.version>6.8</stargate.int-test.cluster.version>
         <stargate.int-test.cluster.dse>true</stargate.int-test.cluster.dse>
       </properties>
+    </profile>
+    <!-- The deployment profile must be used only with the sgv2-quarkus-common   -->
+    <profile>
+      <id>deploy</id>
+      <modules>
+        <module>sgv2-quarkus-common</module>
+      </modules>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.2.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.4.1</version>
+            <configuration>
+              <additionalOptions>-Xdoclint:none</additionalOptions>
+              <verbose>false</verbose>
+              <quiet>true</quiet>
+              <tags>
+                <tag>
+                  <name>apiNote</name>
+                  <placement>a</placement>
+                  <head>API note:</head>
+                </tag>
+              </tags>
+            </configuration>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -180,6 +180,12 @@
       <modules>
         <module>sgv2-quarkus-common</module>
       </modules>
+      <distributionManagement>
+        <repository>
+          <id>ossrh</id>
+          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+      </distributionManagement>
       <build>
         <plugins>
           <plugin>
@@ -240,6 +246,17 @@
                 <arg>loopback</arg>
               </gpgArguments>
               <outputDirectory>${project.basedir}/target</outputDirectory>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.13</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>true</autoReleaseAfterClose>
             </configuration>
           </plugin>
         </plugins>

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.stargate</groupId>
   <artifactId>sgv2-api-parent</artifactId>
@@ -134,8 +133,7 @@
         <stargate.int-test.cassandra.image-tag>4.0.4</stargate.int-test.cassandra.image-tag>
         <stargate.int-test.coordinator.image>stargateio/coordinator-4_0</stargate.int-test.coordinator.image>
         <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
-        <stargate.int-test.cluster.name>cass-${stargate.int-test.cassandra.image-tag}-cluster
-        </stargate.int-test.cluster.name>
+        <stargate.int-test.cluster.name>cass-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
         <stargate.int-test.cluster.version>4.0</stargate.int-test.cluster.version>
         <stargate.int-test.cluster.dse>false</stargate.int-test.cluster.dse>
       </properties>
@@ -153,8 +151,7 @@
         <stargate.int-test.cassandra.image-tag>3.11.13</stargate.int-test.cassandra.image-tag>
         <stargate.int-test.coordinator.image>stargateio/coordinator-3_11</stargate.int-test.coordinator.image>
         <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
-        <stargate.int-test.cluster.name>cass-${stargate.int-test.cassandra.image-tag}-cluster
-        </stargate.int-test.cluster.name>
+        <stargate.int-test.cluster.name>cass-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
         <stargate.int-test.cluster.version>3.11</stargate.int-test.cluster.version>
         <stargate.int-test.cluster.dse>false</stargate.int-test.cluster.dse>
       </properties>
@@ -172,8 +169,7 @@
         <stargate.int-test.cassandra.image-tag>6.8.26</stargate.int-test.cassandra.image-tag>
         <stargate.int-test.coordinator.image>stargateio/coordinator-dse-68</stargate.int-test.coordinator.image>
         <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
-        <stargate.int-test.cluster.name>dse-${stargate.int-test.cassandra.image-tag}-cluster
-        </stargate.int-test.cluster.name>
+        <stargate.int-test.cluster.name>dse-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
         <stargate.int-test.cluster.version>6.8</stargate.int-test.cluster.version>
         <stargate.int-test.cluster.dse>true</stargate.int-test.cluster.dse>
       </properties>

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/proto/Rows.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/proto/Rows.java
@@ -71,7 +71,7 @@ public class Rows {
     return getBasic(row, name, columns, Values::bool);
   }
 
-  /** @return the index, or <0 if the column does not exist. */
+  /** @return the index, or a negative value if the column does not exist. */
   public static int firstIndexOf(String name, List<ColumnSpec> columns) {
     for (int i = 0; i < columns.size(); i++) {
       ColumnSpec column = columns.get(i);

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/tenant/TenantResolver.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/tenant/TenantResolver.java
@@ -26,7 +26,7 @@ import javax.ws.rs.core.SecurityContext;
 public interface TenantResolver {
 
   /**
-   * Returns a tenant identifier given a RoutingContext & SecurityContext.
+   * Returns a tenant identifier given a {@link RoutingContext} and a {@link SecurityContext}.
    *
    * @param context the routing context
    * @param securityContext the security context

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/token/CassandraTokenResolver.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/token/CassandraTokenResolver.java
@@ -31,7 +31,7 @@ import javax.ws.rs.core.SecurityContext;
 public interface CassandraTokenResolver {
 
   /**
-   * Returns a Cassandra token given a RoutingContext & SecurityContext.
+   * Returns a Cassandra token given a {@link RoutingContext} and a {@link SecurityContext}.
    *
    * @param context the routing context
    * @param securityContext the security context


### PR DESCRIPTION
**What this PR does**:
Publishes `svg2-quarkus-common` to the Maven repository:

* uses similar setup as the base pom
* however, with the newest plugin versions
* I had to do some gymnastics to enable only `svg2-quarkus-common` in the deploy profile

**Which issue(s) this PR fixes**:
Fixes #2085
