### PR TITLE
Fix docker compose ports

### DIFF
--- a/docker-compose/cassandra-3.11/README.md
+++ b/docker-compose/cassandra-3.11/README.md
@@ -42,3 +42,4 @@ ERROR: manifest for stargateio/coordinator-3_11:2.0.0-BETA-4-SNAPSHOT not found:
 
 you are trying to deploy a version that is neither publicly available (official release) nor built locally.
 You will either want to specify a non-snapshot image tag (version) using `-t [VERSION]`, or build the snapshot version locally.
+Consult [Docker Hub](https://hub.docker.com/r/stargateio/coordinator-3_11/tags) for a list of available tags.

--- a/docker-compose/cassandra-3.11/docker-compose-dev-mode.yml
+++ b/docker-compose/cassandra-3.11/docker-compose-dev-mode.yml
@@ -6,12 +6,11 @@ services:
     networks:
       - stargate
     ports:
-      - 9042:9042
-      - 8080:8080
-      - 8081:8081
-      - 8083:8083
-      - 8084:8084
-      - 8091:8091
+      - "9042:9042"
+      - "8080:8080"
+      - "8081:8081"
+      - "8084:8084"
+      - "8090:8090"
     mem_limit: 2G
     environment:
       - JAVA_OPTS="-Xmx2G"
@@ -28,7 +27,7 @@ services:
     networks:
       - stargate
     ports:
-      - 8082:8082
+      - "8082:8082"
     mem_limit: 2G
     environment:
       - QUARKUS_GRPC_CLIENTS_BRIDGE_HOST=coordinator
@@ -40,7 +39,7 @@ services:
     networks:
       - stargate
     ports:
-      - 8085:8080
+      - "8080:8080"
     mem_limit: 2G
     environment:
       - QUARKUS_GRPC_CLIENTS_BRIDGE_HOST=coordinator
@@ -52,7 +51,7 @@ services:
     networks:
       - stargate
     ports:
-      - 8180:8180
+      - "8180:8180"
     mem_limit: 2G
     environment:
       - QUARKUS_GRPC_CLIENTS_BRIDGE_HOST=coordinator

--- a/docker-compose/cassandra-3.11/docker-compose.yml
+++ b/docker-compose/cassandra-3.11/docker-compose.yml
@@ -41,12 +41,11 @@ services:
     networks:
       - stargate
     ports:
-      - 9042:9042
-      - 8080:8080
-      - 8081:8081
-      - 8083:8083
-      - 8084:8084
-      - 8091:8091
+      - "9042:9042"
+      - "8080:8080"
+      - "8081:8081"
+      - "8084:8084"
+      - "8090:8090"
     mem_limit: 2G
     environment:
       - JAVA_OPTS="-Xmx2G"
@@ -63,7 +62,7 @@ services:
     networks:
       - stargate
     ports:
-      - 8082:8082
+      - "8082:8082"
     mem_limit: 2G
     environment:
       - QUARKUS_GRPC_CLIENTS_BRIDGE_HOST=coordinator
@@ -75,7 +74,7 @@ services:
     networks:
       - stargate
     ports:
-      - 8085:8080
+      - "8080:8080"
     mem_limit: 2G
     environment:
       - QUARKUS_GRPC_CLIENTS_BRIDGE_HOST=coordinator
@@ -87,7 +86,7 @@ services:
     networks:
       - stargate
     ports:
-      - 8180:8180
+      - "8180:8180"
     mem_limit: 2G
     environment:
       - QUARKUS_GRPC_CLIENTS_BRIDGE_HOST=coordinator

--- a/docker-compose/cassandra-4.0/README.md
+++ b/docker-compose/cassandra-4.0/README.md
@@ -42,3 +42,4 @@ ERROR: manifest for stargateio/coordinator-4_0:2.0.0-BETA-4-SNAPSHOT not found: 
 
 you are trying to deploy a version that is neither publicly available (official release) nor built locally.
 You will either want to specify a non-snapshot image tag (version) using `-t [VERSION]`, or build the snapshot version locally.
+Consult [Docker Hub](https://hub.docker.com/r/stargateio/coordinator-4_0/tags) for a list of available tags.

--- a/docker-compose/cassandra-4.0/docker-compose-dev-mode.yml
+++ b/docker-compose/cassandra-4.0/docker-compose-dev-mode.yml
@@ -6,12 +6,11 @@ services:
     networks:
       - stargate
     ports:
-      - 9042:9042
-      - 8080:8080
-      - 8081:8081
-      - 8083:8083
-      - 8084:8084
-      - 8091:8091
+      - "9042:9042"
+      - "8080:8080"
+      - "8081:8081"
+      - "8084:8084"
+      - "8090:8090"
     mem_limit: 2G
     environment:
       - JAVA_OPTS="-Xmx2G"
@@ -28,7 +27,7 @@ services:
     networks:
       - stargate
     ports:
-      - 8082:8082
+      - "8082:8082"
     mem_limit: 2G
     environment:
       - QUARKUS_GRPC_CLIENTS_BRIDGE_HOST=coordinator
@@ -40,7 +39,7 @@ services:
     networks:
       - stargate
     ports:
-      - 8085:8080
+      - "8080:8080"
     mem_limit: 2G
     environment:
       - QUARKUS_GRPC_CLIENTS_BRIDGE_HOST=coordinator
@@ -52,7 +51,7 @@ services:
     networks:
       - stargate
     ports:
-      - 8180:8180
+      - "8180:8180"
     mem_limit: 2G
     environment:
       - QUARKUS_GRPC_CLIENTS_BRIDGE_HOST=coordinator

--- a/docker-compose/cassandra-4.0/docker-compose.yml
+++ b/docker-compose/cassandra-4.0/docker-compose.yml
@@ -41,12 +41,11 @@ services:
     networks:
       - stargate
     ports:
-      - 9042:9042
-      - 8080:8080
-      - 8081:8081
-      - 8083:8083
-      - 8084:8084
-      - 8091:8091
+      - "9042:9042"
+      - "8080:8080"
+      - "8081:8081"
+      - "8084:8084"
+      - "8090:8090"
     mem_limit: 2G
     environment:
       - JAVA_OPTS="-Xmx2G"
@@ -63,7 +62,7 @@ services:
     networks:
       - stargate
     ports:
-      - 8082:8082
+      - "8082:8082"
     mem_limit: 2G
     environment:
       - QUARKUS_GRPC_CLIENTS_BRIDGE_HOST=coordinator
@@ -75,7 +74,7 @@ services:
     networks:
       - stargate
     ports:
-      - 8085:8080
+      - "8080:8080"
     mem_limit: 2G
     environment:
       - QUARKUS_GRPC_CLIENTS_BRIDGE_HOST=coordinator
@@ -87,7 +86,7 @@ services:
     networks:
       - stargate
     ports:
-      - 8180:8180
+      - "8180:8180"
     mem_limit: 2G
     environment:
       - QUARKUS_GRPC_CLIENTS_BRIDGE_HOST=coordinator

--- a/docker-compose/dse-6.8/README.md
+++ b/docker-compose/dse-6.8/README.md
@@ -42,3 +42,4 @@ ERROR: manifest for stargateio/coordinator-dse-68:2.0.0-BETA-4-SNAPSHOT not foun
 
 you are trying to deploy a version that is neither publicly available (official release) nor built locally.
 You will either want to specify a non-snapshot image tag (version) using `-t [VERSION]`, or build the snapshot version locally.
+Consult [Docker Hub](https://hub.docker.com/r/stargateio/coordinator-dse-68/tags) for a list of available tags.

--- a/docker-compose/dse-6.8/docker-compose-dev-mode.yml
+++ b/docker-compose/dse-6.8/docker-compose-dev-mode.yml
@@ -6,12 +6,11 @@ services:
     networks:
       - stargate
     ports:
-      - 9042:9042
-      - 8080:8080
-      - 8081:8081
-      - 8083:8083
-      - 8084:8084
-      - 8091:8091
+      - "9042:9042"
+      - "8080:8080"
+      - "8081:8081"
+      - "8084:8084"
+      - "8090:8090"
     mem_limit: 2G
     environment:
       - JAVA_OPTS="-Xmx2G"
@@ -29,7 +28,7 @@ services:
     networks:
       - stargate
     ports:
-      - 8082:8082
+      - "8082:8082"
     mem_limit: 2G
     environment:
       - QUARKUS_GRPC_CLIENTS_BRIDGE_HOST=coordinator
@@ -41,7 +40,7 @@ services:
     networks:
       - stargate
     ports:
-      - 8085:8080
+      - "8080:8080"
     mem_limit: 2G
     environment:
       - QUARKUS_GRPC_CLIENTS_BRIDGE_HOST=coordinator
@@ -53,7 +52,7 @@ services:
     networks:
       - stargate
     ports:
-      - 8180:8180
+      - "8180:8180"
     mem_limit: 2G
     environment:
       - QUARKUS_GRPC_CLIENTS_BRIDGE_HOST=coordinator

--- a/docker-compose/dse-6.8/docker-compose.yml
+++ b/docker-compose/dse-6.8/docker-compose.yml
@@ -49,12 +49,11 @@ services:
     networks:
       - stargate
     ports:
-      - 9042:9042
-      - 8080:8080
-      - 8081:8081
-      - 8083:8083
-      - 8084:8084
-      - 8091:8091
+      - "9042:9042"
+      - "8080:8080"
+      - "8081:8081"
+      - "8084:8084"
+      - "8090:8090"
     mem_limit: 2G
     environment:
       - JAVA_OPTS="-Xmx2G"
@@ -72,7 +71,7 @@ services:
     networks:
       - stargate
     ports:
-      - 8082:8082
+      - "8082:8082"
     mem_limit: 2G
     environment:
       - QUARKUS_GRPC_CLIENTS_BRIDGE_HOST=coordinator
@@ -84,7 +83,7 @@ services:
     networks:
       - stargate
     ports:
-      - 8085:8080
+      - "8080:8080"
     mem_limit: 2G
     environment:
       - QUARKUS_GRPC_CLIENTS_BRIDGE_HOST=coordinator
@@ -96,7 +95,7 @@ services:
     networks:
       - stargate
     ports:
-      - 8180:8180
+      - "8180:8180"
     mem_limit: 2G
     environment:
       - QUARKUS_GRPC_CLIENTS_BRIDGE_HOST=coordinator


### PR DESCRIPTION
We have some inconsistencies and errors in port mappings for the v2 docker compose scripts

* legacy GraphQL interface port `8080` is exposed on coordinator node containers, making it unavailable for use on...
* GraphQL API container has `8080` mapped to `8085,` which causes unneccessary disruption to clients such as our postman projects
* gRPC port `8090` is not exposed on coordinator and should be
* bridge port `8091` is exposed and does not need to be
* it was originally thought that the docs API port would be `8083` but is now `8180`.

