### PR TITLE
Switch port numbers for in-coordinator/extracted-drop-wizard cases

### DIFF
--- a/restapi/src/main/resources/restapi-config.yaml
+++ b/restapi/src/main/resources/restapi-config.yaml
@@ -3,9 +3,9 @@ server:
   applicationContextPath: /
   connector:
     type: http
-    # 11-Feb-2022, tatu: For Stargate V1, REST+Docs were on port 8082, but for Stargate V2
-    #    will separate the two and the "new" REST API inherits 8082, Docs moves to 8083
-    port: 8083
+    # 28-Sep-2022, tatu: Need to retain same port number for SGv2 as SGv1
+    #    for in-coordinator REST API (only for RESTv1)
+    port: 8082
   requestLog:
     type: external
 logging:

--- a/sgv2-restapi/src/main/resources/config.yaml
+++ b/sgv2-restapi/src/main/resources/config.yaml
@@ -3,9 +3,9 @@ server:
   applicationContextPath: /
   connector:
     type: http
-    # 11-Feb-2022, tatu: For Stargate V1, REST+Docs were both on port 8082, but for Stargate V2
-    #    will separate the two and the "new" REST API inherits 8082
-    port: 8082
+    # 11-Feb-2022, tatu: This implementation will be removed soon, but until then
+    #    has to expose port OTHER than 8082 for ITs to work
+    port: 8083
   requestLog:
     type: external
 stargate:

--- a/testing/src/main/java/io/stargate/it/http/BaseRestApiTest.java
+++ b/testing/src/main/java/io/stargate/it/http/BaseRestApiTest.java
@@ -14,9 +14,9 @@ public class BaseRestApiTest extends BaseIntegrationTest {
    */
   public static void buildApiServiceParameters(ApiServiceParameters.Builder builder) {
     builder.serviceName("rest-api");
-    builder.servicePort(8082);
+    builder.servicePort(8083);
     builder.servicePortPropertyName("dw.server.connector.port");
-    builder.metricsPort(8082);
+    builder.metricsPort(8083);
     builder.serviceStartedMessage("Started RestServiceServer");
     builder.serviceLibDirProperty("stargate.rest.libdir");
     builder.serviceJarBase("sgv2-restapi");


### PR DESCRIPTION
**What this PR does**:

Fixes port number of in-coordinator REST API for SGv2 to be same as in SGv1 (8082); switches now-obsolete DropWizard-based "new" REST API to 8083 until it can be safely removed. And modifies test base class to use that port number.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
