### PR TITLE
Fix #2124: add `-ntp` flag for CI Maven invocations to avoid printing progress msgs

### DIFF
--- a/.github/workflows/apis-v2.yaml
+++ b/.github/workflows/apis-v2.yaml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Build
         if: steps.cache-coordinator-snapshots.outputs.cache-hit != 'true'
-        run: MAVEN_OPTS="-Xmx4g" ./mvnw install -P dse -DskipTests
+        run: MAVEN_OPTS="-Xmx4g" ./mvnw -B -ntp install -P dse -DskipTests
 
   # Builds C*3, C*4 and DSE coordinator images using matrix
   # Exports image to a file and then uploads it using action artifacts
@@ -191,7 +191,7 @@ jobs:
       - name: Build & Test Stargate v2 Quarkus-based APIs
         run: |
           cd apis/
-          ./mvnw -B test
+          ./mvnw -B -ntp test
 
   # runs int tests for the sgv2-docsapi
   # supports downloading and importing the built docker image
@@ -297,7 +297,7 @@ jobs:
       - name: Integration Test
         run: |
           cd apis/
-          ./mvnw -B verify -DskipUnitTests -pl ${{ matrix.project }} -am -P ${{ matrix.profile }} -Dtesting.containers.stargate-image=${{ matrix.image }}
+          ./mvnw -B -ntp verify -DskipUnitTests -pl ${{ matrix.project }} -am -P ${{ matrix.profile }} -Dtesting.containers.stargate-image=${{ matrix.image }}
 
   # runs always, deletes built docker image artifacts
   clean-up:

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -42,7 +42,7 @@ jobs:
           EOF
       - name: Check Maven Dependency Updates
         run: |
-          mvn -B versions:display-dependency-updates -Dversions.outputFile=target/dependency-updates-report.txt
+          mvn -B -ntp versions:display-dependency-updates -Dversions.outputFile=target/dependency-updates-report.txt
       - name: Archive dependency update results
         uses: actions/upload-artifact@v3
         with:
@@ -84,7 +84,7 @@ jobs:
           EOF
       - name: Check Maven Dependencies
         run: |
-          mvn -B dependency-check:aggregate
+          mvn -B -ntp dependency-check:aggregate
       - name: Archive vulnerability results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -103,8 +103,8 @@ jobs:
 
       - name: Build with Maven
         run: |
-          ./mvnw versions:set -DremoveSnapshot versions:commit
-          ./mvnw -P dse -q -ff clean package -DskipTests
+          ./mvnw -B -ntp versions:set -DremoveSnapshot versions:commit
+          ./mvnw -B -ntp -q -ff -P dse clean package -DskipTests
 
       - name: Zip-up `stargate-lib`
         run: |
@@ -171,8 +171,8 @@ jobs:
       - name: Publish package
         if: ${{ !inputs.skipPublish }}
         run: |
-          ./mvnw versions:set -DremoveSnapshot versions:commit
-          ./mvnw -B -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy,dse
+          ./mvnw -B -ntp versions:set -DremoveSnapshot versions:commit
+          ./mvnw -B -ntp -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy,dse
 
   # publishes the docker images for the coordinator and the APIs
   publish-docker:
@@ -221,14 +221,14 @@ jobs:
 
       - name: Install coordinator
         run: |
-          JAVA_HOME=$JAVA_8 ./mvnw versions:set -DremoveSnapshot versions:commit
-          JAVA_HOME=$JAVA_8 ./mvnw -B clean install -P dse -DskipTests 
+          JAVA_HOME=$JAVA_8 ./mvnw -B -ntp versions:set -DremoveSnapshot versions:commit
+          JAVA_HOME=$JAVA_8 ./mvnw -B -ntp clean install -P dse -DskipTests 
 
       # only set version here
       - name: Install APIs
         run: |
           cd apis/
-          JAVA_HOME=$JAVA_17 ./mvnw versions:set -DremoveSnapshot versions:commit
+          JAVA_HOME=$JAVA_17 ./mvnw -B -ntp versions:set -DremoveSnapshot versions:commit
           cd ../
 
       - name: Set up Docker QEMU
@@ -260,14 +260,14 @@ jobs:
         if: ${{ !inputs.skipPublish }}
         run: |
           cd apis/
-          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.tag=${{needs.resolve-tag.outputs.release-tag}}
+          JAVA_HOME=$JAVA_17 ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.tag=${{needs.resolve-tag.outputs.release-tag}}
           cd ../
 
       - name: Build without push (apis, DockerHub)
         if: ${{ inputs.skipPublish }}
         run: |
           cd apis/
-          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.tag=${{needs.resolve-tag.outputs.release-tag}}
+          JAVA_HOME=$JAVA_17 ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.tag=${{needs.resolve-tag.outputs.release-tag}}
           cd ../
 
       # repeat the same for the AWS ECR
@@ -291,7 +291,7 @@ jobs:
         if: ${{ !inputs.skipPublish }}
         run: |
           cd apis/
-          JAVA_HOME=$JAVA_17 ./mvnw clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{needs.resolve-tag.outputs.release-tag}}
+          JAVA_HOME=$JAVA_17 ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{needs.resolve-tag.outputs.release-tag}}
           cd ../
 
   # signs all docker images with cosign
@@ -380,14 +380,14 @@ jobs:
 
       - name: Update version numbers (coordinator)
         run: |
-          ./mvnw -B release:update-versions -DautoVersionSubmodules=true versions:commit -Pdse
-          ./mvnw xml-format:xml-format fmt:format -Pdse
+          ./mvnw -B -ntp release:update-versions -DautoVersionSubmodules=true versions:commit -Pdse
+          ./mvnw -B -ntp xml-format:xml-format fmt:format -Pdse
 
       - name: Update version numbers (apis)
         run: |
           cd apis/
-          ./mvnw -B release:update-versions -DautoVersionSubmodules=true versions:commit
-          ./mvnw xml-format:xml-format fmt:format
+          ./mvnw -B -ntp release:update-versions -DautoVersionSubmodules=true versions:commit
+          ./mvnw -B -ntp xml-format:xml-format fmt:format
           cd ../
 
       - name: Rev Version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,8 +96,8 @@ jobs:
 
       - name: Build with Maven
         run: |
-          mvn versions:set -DremoveSnapshot versions:commit
-          mvn -P dse -q -ff clean package -DskipTests
+          mvn -B -ntp versions:set -DremoveSnapshot versions:commit
+          mvn -P dse -B -ntp -q -ff clean package -DskipTests
 
       - name: Zip-up `stargate-lib`
         run: |
@@ -163,13 +163,13 @@ jobs:
       - name: Publish package
         if: ${{ !inputs.skipPublish }}
         run: |
-          ./mvnw versions:set -DremoveSnapshot versions:commit
-          ./mvnw -B -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy,dse
+          ./mvnw -B -ntp versions:set -DremoveSnapshot versions:commit
+          ./mvnw -B -ntp -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy,dse
 
       - name: Bump versions
         run: |
-          ./mvnw -B release:update-versions -DautoVersionSubmodules=true versions:commit -Pdse
-          ./mvnw xml-format:xml-format fmt:format -Pdse
+          ./mvnw -B -ntp release:update-versions -DautoVersionSubmodules=true versions:commit -Pdse
+          ./mvnw -B -ntp xml-format:xml-format fmt:format -Pdse
 
       - name: Rev Version
         if: success()


### PR DESCRIPTION
**What this PR does**:

As per #2124 reduces verbosity of CI Maven output by eliminating progress update messages: these only make sense for interactive use, not CI.

**Which issue(s) this PR fixes**:
Fixes #2124

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
