### PR TITLE
Fix DSE version upgrade changes that were not merged due to version c…

### DIFF
--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -10,7 +10,7 @@
   <groupId>io.stargate.db.dse</groupId>
   <artifactId>persistence-dse-6.8</artifactId>
   <properties>
-    <dse.version>6.8.25</dse.version>
+    <dse.version>6.8.26</dse.version>
   </properties>
   <repositories>
     <repository>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -421,7 +421,7 @@
                 <configuration>
                   <systemPropertyVariables>
                     <ccm.dse>true</ccm.dse>
-                    <ccm.version>6.8.25</ccm.version>
+                    <ccm.version>6.8.26</ccm.version>
                     <stargate.test.nodes>1</stargate.test.nodes>
                   </systemPropertyVariables>
                   <failIfNoTests>true</failIfNoTests>


### PR DESCRIPTION
**What this PR does**:

Fixes DSE dependence discrepancy in `v2.0.0` branch: likely due to earlier merge where merge conflicts wrt project version resulted in accidental dropping of necessary upgrade (we get dozens of version merge failures each time release is made so it is easy to miss intended changes in `pom.xml`s).

**Which issue(s) this PR fixes**:
No issue filed.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
