### PR TITLE
Try to recreate fix from PR #2074, to fix Mac M1 proto build

### DIFF
--- a/grpc-proto/pom.xml
+++ b/grpc-proto/pom.xml
@@ -65,7 +65,7 @@
         <version>0.6.1</version>
         <configuration>
           <protoSourceRoot>proto</protoSourceRoot>
-          <protocArtifact>com.google.protobuf:protoc:3.18.3.0:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:3.18.3:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
           <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
           <protocPlugins>

--- a/grpc-proto/pom.xml
+++ b/grpc-proto/pom.xml
@@ -65,9 +65,9 @@
         <version>0.6.1</version>
         <configuration>
           <protoSourceRoot>proto</protoSourceRoot>
-          <protocArtifact>com.google.protobuf:protoc:3.12.0:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:3.18.3.0:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
-          <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.35.0:exe:${os.detected.classifier}</pluginArtifact>
+          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
           <protocPlugins>
             <protocPlugin>
               <id>reactor-grpc</id>

--- a/pom.xml
+++ b/pom.xml
@@ -626,6 +626,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- 30-Sep-2022, tatu: added by [stargate#2074] needed to fix Mac M1 builds
+        -->
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna</artifactId>
+        <version>5.12.1</version>
+      </dependency>
 
       <dependency>
         <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
**What this PR does**:

As per #2074: Bumping binary dependencies to versions where there's aarch64 binary, to avoid build breakage wrt Protoc generation on Mac M1 systems.

Contributed by @tub -- unfortunately we seem to hit #2129 -- which is why this separate PR used for merging.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
