### PR TITLE
publish to OSSRH not to fail job on error

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -178,8 +178,11 @@ jobs:
         run: |
           cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
 
+      # coordinator jars
+      # continue on error as sometimes deploy works even if an error is reported and we want to try next step as well
       - name: Publish coordinator JARs
         if: ${{ !inputs.skipPublish }}
+        continue-on-error: true
         run: |
           JAVA_HOME=$JAVA_8 ./mvnw -B -ntp versions:set -DremoveSnapshot versions:commit
           JAVA_HOME=$JAVA_8 ./mvnw -B -ntp -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy,dse


### PR DESCRIPTION
**What this PR does**:

In this [release action](https://github.com/stargate/stargate/actions/runs/3161467691/jobs/5149553877), the first publish to OSSRH reported an error, but jars were pushed.. I added `continue-on-error: true` so that next step for pushing quarkus-commons jars runs regardless of the error or not..


