### PR TITLE
added health extension to the graphql v2

### DIFF
--- a/apis/sgv2-graphqlapi/pom.xml
+++ b/apis/sgv2-graphqlapi/pom.xml
@@ -32,6 +32,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-health</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
**What this PR does**:
Adding missing health extension to the graphql v2.. I really don't know how we ended up having different extensions and configuration when we had a clear example on the bootstrapping and could simply use copy-pasta..

