### PR TITLE
disabe vert.x uri validation in the v2 docker images

### DIFF
--- a/apis/sgv2-docsapi/src/main/docker/Dockerfile.jvm
+++ b/apis/sgv2-docsapi/src/main/docker/Dockerfile.jvm
@@ -88,6 +88,6 @@ COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
 USER 185
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dvertx.disableURIValidation=true"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 

--- a/apis/sgv2-docsapi/src/main/docker/Dockerfile.legacy-jar
+++ b/apis/sgv2-docsapi/src/main/docker/Dockerfile.legacy-jar
@@ -85,5 +85,5 @@ COPY target/*-runner.jar /deployments/quarkus-run.jar
 
 EXPOSE 8080
 USER 185
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dvertx.disableURIValidation=true"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/apis/sgv2-docsapi/src/main/docker/Dockerfile.native
+++ b/apis/sgv2-docsapi/src/main/docker/Dockerfile.native
@@ -24,4 +24,4 @@ COPY --chown=1001:root target/*-runner /work/application
 EXPOSE 8080
 USER 1001
 
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0", "-Dvertx.disableURIValidation=true"]

--- a/apis/sgv2-docsapi/src/main/docker/Dockerfile.native-micro
+++ b/apis/sgv2-docsapi/src/main/docker/Dockerfile.native-micro
@@ -27,4 +27,4 @@ COPY --chown=1001:root target/*-runner /work/application
 EXPOSE 8080
 USER 1001
 
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0", "-Dvertx.disableURIValidation=true"]

--- a/apis/sgv2-restapi/src/main/docker/Dockerfile.jvm
+++ b/apis/sgv2-restapi/src/main/docker/Dockerfile.jvm
@@ -88,6 +88,6 @@ COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
 USER 185
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dvertx.disableURIValidation=true"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 

--- a/apis/sgv2-restapi/src/main/docker/Dockerfile.legacy-jar
+++ b/apis/sgv2-restapi/src/main/docker/Dockerfile.legacy-jar
@@ -85,5 +85,5 @@ COPY target/*-runner.jar /deployments/quarkus-run.jar
 
 EXPOSE 8080
 USER 185
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dvertx.disableURIValidation=true"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/apis/sgv2-restapi/src/main/docker/Dockerfile.native
+++ b/apis/sgv2-restapi/src/main/docker/Dockerfile.native
@@ -24,4 +24,4 @@ COPY --chown=1001:root target/*-runner /work/application
 EXPOSE 8080
 USER 1001
 
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0", "-Dvertx.disableURIValidation=true"]

--- a/apis/sgv2-restapi/src/main/docker/Dockerfile.native-micro
+++ b/apis/sgv2-restapi/src/main/docker/Dockerfile.native-micro
@@ -27,4 +27,4 @@ COPY --chown=1001:root target/*-runner /work/application
 EXPOSE 8080
 USER 1001
 
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0", "-Dvertx.disableURIValidation=true"]


### PR DESCRIPTION
**What this PR does**:
The `-Dvertx.disableURIValidation=true` works and disables the URI validation, but can not be defined in the `application.yaml` config.. I had no other idea, then actually adding this to the docker image.. Or should we leave this as optional in the deployment?

Another thing I noticed in the docker images is `JAVA_OPTS` and `JAVA_OPTS_APPEND`. Would defining a `JAVA_OPTS` in the container during deployment actually overwrite what I added? We need to use the `JAVA_OPTS_APPEND` then..

It would be nice to have a test for this, will try to add one maybe.

**Tasks:**

* [ ] Test
* [ ] Final agreement on the option specification
