### PR TITLE
Stargate v2 Docker usability

### DIFF
--- a/apis/sgv2-docsapi/pom.xml
+++ b/apis/sgv2-docsapi/pom.xml
@@ -12,6 +12,7 @@
     <quarkus.container-image.group>stargateio</quarkus.container-image.group>
     <quarkus.container-image.name>docsapi</quarkus.container-image.name>
     <quarkus.container-image.tag>v${project.version}</quarkus.container-image.tag>
+    <quarkus.container-image.additional-tags>v2</quarkus.container-image.additional-tags>
   </properties>
   <dependencies>
     <dependency>

--- a/apis/sgv2-graphqlapi/pom.xml
+++ b/apis/sgv2-graphqlapi/pom.xml
@@ -11,6 +11,7 @@
     <quarkus.container-image.group>stargateio</quarkus.container-image.group>
     <quarkus.container-image.name>graphqlapi</quarkus.container-image.name>
     <quarkus.container-image.tag>v${project.version}</quarkus.container-image.tag>
+    <quarkus.container-image.additional-tags>v2</quarkus.container-image.additional-tags>
   </properties>
   <dependencies>
     <dependency>

--- a/apis/sgv2-restapi/pom.xml
+++ b/apis/sgv2-restapi/pom.xml
@@ -13,6 +13,7 @@
     <quarkus.container-image.group>stargateio</quarkus.container-image.group>
     <quarkus.container-image.name>restapi</quarkus.container-image.name>
     <quarkus.container-image.tag>v${project.version}</quarkus.container-image.tag>
+    <quarkus.container-image.additional-tags>v2</quarkus.container-image.additional-tags>
   </properties>
   <dependencies>
     <dependency>

--- a/build_docker_images.sh
+++ b/build_docker_images.sh
@@ -72,9 +72,9 @@ cp ./stargate-lib/logback.xml $LIBDIR
 rm ${LIBDIR}/persistence*.jar
 
 if [ -z $API_ONLY ]; then
-  docker buildx build --target coordinator-4_0 --build-arg LIBDIR="$LIBDIR" -t $REPO/coordinator-4_0:$SGTAG $DOCKER_FLAGS .
-  docker buildx build --target coordinator-3_11 --build-arg LIBDIR="$LIBDIR" -t $REPO/coordinator-3_11:$SGTAG $DOCKER_FLAGS .
-  docker buildx build --target coordinator-dse-68 --build-arg LIBDIR="$LIBDIR" -t $REPO/coordinator-dse-68:$SGTAG $DOCKER_FLAGS .
+  docker buildx build --target coordinator-4_0 --build-arg LIBDIR="$LIBDIR" -t $REPO/coordinator-4_0:$SGTAG -t $REPO/coordinator-4_0:v2 $DOCKER_FLAGS .
+  docker buildx build --target coordinator-3_11 --build-arg LIBDIR="$LIBDIR" -t $REPO/coordinator-3_11:$SGTAG -t $REPO/coordinator-3_11:v2 $DOCKER_FLAGS .
+  docker buildx build --target coordinator-dse-68 --build-arg LIBDIR="$LIBDIR" -t $REPO/coordinator-dse-68:$SGTAG -t $REPO/coordinator-dse-68:v2 $DOCKER_FLAGS .
 fi
 
 rm -rf ${LIBDIR}

--- a/docker-compose/cassandra-3.11/README.md
+++ b/docker-compose/cassandra-3.11/README.md
@@ -19,6 +19,14 @@ separate Cassandra cluster is required. This can be run with the command:
 
 You can stop execution of this script with `Ctrl-C` and the stack will be torn down.
 
+# Script options
+
+Both scripts support the following options: 
+
+* You can specify a released image tag (version) using `-t [VERSION]`. Consult [Docker Hub](https://hub.docker.com/r/stargateio/coordinator-3_11/tags) for a list of available tags.
+
+* Alternatively, build the snapshot version locally using instructions in the [developer guide](../../DEV_GUIDE.md) and run the script using the `-l` option.
+
 # Notes
 
 * The `.env` file defines variables for the docker compose project name (`COMPOSE_PROJECT_NAME`),
@@ -41,5 +49,4 @@ ERROR: manifest for stargateio/coordinator-3_11:2.0.0-BETA-4-SNAPSHOT not found:
 ```
 
 you are trying to deploy a version that is neither publicly available (official release) nor built locally.
-You will either want to specify a non-snapshot image tag (version) using `-t [VERSION]`, or build the snapshot version locally.
-Consult [Docker Hub](https://hub.docker.com/r/stargateio/coordinator-3_11/tags) for a list of available tags.
+

--- a/docker-compose/cassandra-3.11/start_cass_311.sh
+++ b/docker-compose/cassandra-3.11/start_cass_311.sh
@@ -1,16 +1,20 @@
 #!/bin/sh
 
-# Set variable SGTAG
+# Default to using images tagged "v2"
+SGTAG=v2
 
-SGTAG="v$(../../mvnw -f ../.. help:evaluate -Dexpression=project.version -q -DforceStdout)"
-
-while getopts ":pt:" opt; do
+while getopts "lt:" opt; do
   case $opt in
     t)
       SGTAG=$OPTARG
       ;;
+    l)
+      SGTAG="v$(../../mvnw -f ../.. help:evaluate -Dexpression=project.version -q -DforceStdout)"
+      ;;
     \?)
-      echo "Invalid option: -$OPTARG" >&2
+      echo "Valid options:"
+      echo "  -t <tag> - use Docker images tagged with specified Stargate version (will pull images from Docker Hub if needed)"
+      echo "  -l - use Docker images from local build (see project README for build instructions)"
       exit 1
       ;;
   esac

--- a/docker-compose/cassandra-3.11/start_cass_311_dev_mode.sh
+++ b/docker-compose/cassandra-3.11/start_cass_311_dev_mode.sh
@@ -1,16 +1,20 @@
 #!/bin/sh
 
-# Set variable SGTAG
+# Default to using images tagged "v2"
+SGTAG=v2
 
-SGTAG="v$(../../mvnw -f ../.. help:evaluate -Dexpression=project.version -q -DforceStdout)"
-
-while getopts ":pt:" opt; do
+while getopts "lt:" opt; do
   case $opt in
     t)
       SGTAG=$OPTARG
       ;;
+    l)
+      SGTAG="v$(../../mvnw -f ../.. help:evaluate -Dexpression=project.version -q -DforceStdout)"
+      ;;
     \?)
-      echo "Invalid option: -$OPTARG" >&2
+      echo "Valid options:"
+      echo "  -t <tag> - use Docker images tagged with specified Stargate version (will pull images from Docker Hub if needed)"
+      echo "  -l - use Docker images from local build (see project README for build instructions)"
       exit 1
       ;;
   esac

--- a/docker-compose/cassandra-4.0/README.md
+++ b/docker-compose/cassandra-4.0/README.md
@@ -19,6 +19,14 @@ separate Cassandra cluster is required. This can be run with the command:
 
 You can stop execution of this script with `Ctrl-C` and the stack will be torn down.
 
+# Script options
+
+Both scripts support the following options:
+
+* You can specify a released image tag (version) using `-t [VERSION]`. Consult [Docker Hub](https://hub.docker.com/r/stargateio/coordinator-4_0/tags) for a list of available tags.
+
+* Alternatively, build the snapshot version locally using instructions in the [developer guide](../../DEV_GUIDE.md) and run the script using the `-l` option.
+
 # Notes
 
 * The `.env` file defines variables for the docker compose project name (`COMPOSE_PROJECT_NAME`),
@@ -41,5 +49,4 @@ ERROR: manifest for stargateio/coordinator-4_0:2.0.0-BETA-4-SNAPSHOT not found: 
 ```
 
 you are trying to deploy a version that is neither publicly available (official release) nor built locally.
-You will either want to specify a non-snapshot image tag (version) using `-t [VERSION]`, or build the snapshot version locally.
-Consult [Docker Hub](https://hub.docker.com/r/stargateio/coordinator-4_0/tags) for a list of available tags.
+

--- a/docker-compose/cassandra-4.0/start_cass_40.sh
+++ b/docker-compose/cassandra-4.0/start_cass_40.sh
@@ -1,16 +1,20 @@
 #!/bin/sh
 
-# Set variable SGTAG
+# Default to using images tagged "v2"
+SGTAG=v2
 
-SGTAG="v$(../../mvnw -f ../.. help:evaluate -Dexpression=project.version -q -DforceStdout)"
-
-while getopts ":pt:" opt; do
+while getopts "lt:" opt; do
   case $opt in
     t)
       SGTAG=$OPTARG
       ;;
+    l)
+      SGTAG="v$(../../mvnw -f ../.. help:evaluate -Dexpression=project.version -q -DforceStdout)"
+      ;;
     \?)
-      echo "Invalid option: -$OPTARG" >&2
+      echo "Valid options:"
+      echo "  -t <tag> - use Docker images tagged with specified Stargate version (will pull images from Docker Hub if needed)"
+      echo "  -l - use Docker images from local build (see project README for build instructions)"
       exit 1
       ;;
   esac

--- a/docker-compose/cassandra-4.0/start_cass_40_dev_mode.sh
+++ b/docker-compose/cassandra-4.0/start_cass_40_dev_mode.sh
@@ -1,16 +1,20 @@
 #!/bin/sh
 
-# Set variable SGTAG
+# Default to using images tagged "v2"
+SGTAG=v2
 
-SGTAG="v$(../../mvnw -f ../.. help:evaluate -Dexpression=project.version -q -DforceStdout)"
-
-while getopts ":pt:" opt; do
+while getopts "lt:" opt; do
   case $opt in
     t)
       SGTAG=$OPTARG
       ;;
+    l)
+      SGTAG="v$(../../mvnw -f ../.. help:evaluate -Dexpression=project.version -q -DforceStdout)"
+      ;;
     \?)
-      echo "Invalid option: -$OPTARG" >&2
+      echo "Valid options:"
+      echo "  -t <tag> - use Docker images tagged with specified Stargate version (will pull images from Docker Hub if needed)"
+      echo "  -l - use Docker images from local build (see project README for build instructions)"
       exit 1
       ;;
   esac

--- a/docker-compose/dse-6.8/README.md
+++ b/docker-compose/dse-6.8/README.md
@@ -19,6 +19,14 @@ separate Cassandra cluster is required. This can be run directly with the comman
 
 You can stop execution of this script with `Ctrl-C` and the stack will be torn down.
 
+# Script options
+
+Both scripts support the following options:
+
+* You can specify a released image tag (version) using `-t [VERSION]`. Consult [Docker Hub](https://hub.docker.com/r/stargateio/coordinator-dse-68/tags) for a list of available tags.
+
+* Alternatively, build the snapshot version locally using instructions in the [developer guide](../../DEV_GUIDE.md) and run the script using the `-l` option.
+
 # Notes
 
 * The `.env` file defines variables for the docker compose project name (`COMPOSE_PROJECT_NAME`),
@@ -41,5 +49,4 @@ ERROR: manifest for stargateio/coordinator-dse-68:2.0.0-BETA-4-SNAPSHOT not foun
 ```
 
 you are trying to deploy a version that is neither publicly available (official release) nor built locally.
-You will either want to specify a non-snapshot image tag (version) using `-t [VERSION]`, or build the snapshot version locally.
-Consult [Docker Hub](https://hub.docker.com/r/stargateio/coordinator-dse-68/tags) for a list of available tags.
+

--- a/docker-compose/dse-6.8/start_dse_68.sh
+++ b/docker-compose/dse-6.8/start_dse_68.sh
@@ -1,16 +1,20 @@
 #!/bin/sh
 
-# Set variable SGTAG
+# Default to using images tagged "v2"
+SGTAG=v2
 
-SGTAG="v$(../../mvnw -f ../.. help:evaluate -Dexpression=project.version -q -DforceStdout)"
-
-while getopts ":pt:" opt; do
+while getopts "lt:" opt; do
   case $opt in
     t)
       SGTAG=$OPTARG
       ;;
+    l)
+      SGTAG="v$(../../mvnw -f ../.. help:evaluate -Dexpression=project.version -q -DforceStdout)"
+      ;;
     \?)
-      echo "Invalid option: -$OPTARG" >&2
+      echo "Valid options:"
+      echo "  -t <tag> - use Docker images tagged with specified Stargate version (will pull images from Docker Hub if needed)"
+      echo "  -l - use Docker images from local build (see project README for build instructions)"
       exit 1
       ;;
   esac

--- a/docker-compose/dse-6.8/start_dse_68_dev_mode.sh
+++ b/docker-compose/dse-6.8/start_dse_68_dev_mode.sh
@@ -1,16 +1,20 @@
 #!/bin/sh
 
-# Set variable SGTAG
+# Default to using images tagged "v2"
+SGTAG=v2
 
-SGTAG="v$(../../mvnw -f ../.. help:evaluate -Dexpression=project.version -q -DforceStdout)"
-
-while getopts ":pt:" opt; do
+while getopts "lt:" opt; do
   case $opt in
     t)
       SGTAG=$OPTARG
       ;;
+    l)
+      SGTAG="v$(../../mvnw -f ../.. help:evaluate -Dexpression=project.version -q -DforceStdout)"
+      ;;
     \?)
-      echo "Invalid option: -$OPTARG" >&2
+      echo "Valid options:"
+      echo "  -t <tag> - use Docker images tagged with specified Stargate version (will pull images from Docker Hub if needed)"
+      echo "  -l - use Docker images from local build (see project README for build instructions)"
       exit 1
       ;;
   esac


### PR DESCRIPTION
Makes the v2 Docker images and docker-compose scripts easier to use, especially for first time users.

* tag images with `v2` on push to Docker Hub. This makes it easier to reference the latest v2 image (note we are not tagging with `latest`)
* update docker-compose wrapper scripts (`docker-compose/*/start*.sh), they now default to using the `v2` tag. The `-t' option still allows the user to specify desired version. The previous default of getting the version number from the root Maven pom is now available via the `-l` option.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
