### PR TITLE
Fix #2132 by adding missing properties to parent pom

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -3,8 +3,11 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.stargate</groupId>
   <artifactId>sgv2-api-parent</artifactId>
+  <name>Stargate V2 API parent pom</name>
   <version>2.0.0-BETA-5-SNAPSHOT</version>
+  <description>Parent POM for Stargate v2 APIs</description>
   <packaging>pom</packaging>
+  <url>http://github.com/stargate/stargate</url>
   <modules>
     <module>sgv2-quarkus-common</module>
     <module>sgv2-docsapi</module>


### PR DESCRIPTION
**What this PR does**:

Resolves an issue with  #2132 by adding `name`, `description`, `url` properties so API parent pom can be published

**Which issue(s) this PR fixes**:
Fixes #2132

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
