### PR TITLE
closes #2131: fixes swagger issues in the docs api v2

### DIFF
--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/StargateDocsApi.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/StargateDocsApi.java
@@ -166,7 +166,8 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
               @Parameter(
                   in = ParameterIn.QUERY,
                   name = OpenApiConstants.Parameters.FIELDS,
-                  description = "A JSON array representing the field names that you want to restrict the results to.",
+                  description =
+                      "A JSON array representing the field names that you want to restrict the results to.",
                   examples = {
                     @ExampleObject(name = "fields.empty", summary = "No fields", value = ""),
                     @ExampleObject(

--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/StargateDocsApi.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/StargateDocsApi.java
@@ -75,16 +75,13 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                   required = true,
                   schema = @Schema(implementation = String.class),
                   description = "The ID of the document."),
-
-              // TODO there is no correct way to handle this in Swagger
-              //  simply the multi-paths can not be defined in a single param
               @Parameter(
                   in = ParameterIn.PATH,
                   name = OpenApiConstants.Parameters.DOCUMENT_PATH,
                   required = true,
-                  schema = @Schema(implementation = String.class, type = SchemaType.ARRAY),
+                  schema = @Schema(implementation = String.class),
                   description =
-                      "The path in the JSON that you want to target. Use `\\` to escape periods, commas, and asterisks."),
+                      "The path in the JSON that you want to target. Use path delimiter `/` to target sub-paths, for example to get a JSON object under `$.account.user` use `account/user`. Use `\\` to escape periods, commas, and asterisks."),
               @Parameter(
                   in = ParameterIn.QUERY,
                   name = OpenApiConstants.Parameters.WHERE,
@@ -96,8 +93,8 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                       * allowed hints: `$selectivity` (a number between 0.0 and 1.0, less is better), defines conditions that should be search for first
                       * Use `\\` to escape periods, commas, and asterisks
                       """,
-                  schema = @Schema(type = SchemaType.OBJECT),
                   examples = {
+                    @ExampleObject(name = "where.empty", summary = "No condition", value = ""),
                     @ExampleObject(
                         name = "where.single",
                         summary = "Single condition",
@@ -169,9 +166,14 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
               @Parameter(
                   in = ParameterIn.QUERY,
                   name = OpenApiConstants.Parameters.FIELDS,
-                  description = "The field names that you want to restrict the results to.",
-                  example = "[race,location]",
-                  schema = @Schema(implementation = String.class, type = SchemaType.ARRAY)),
+                  description = "A JSON array representing the field names that you want to restrict the results to.",
+                  examples = {
+                    @ExampleObject(name = "fields.empty", summary = "No fields", value = ""),
+                    @ExampleObject(
+                        name = "fields.notEmpty",
+                        summary = "Fields example",
+                        value = "[race,location]")
+                  }),
               @Parameter(
                   in = ParameterIn.QUERY,
                   name = OpenApiConstants.Parameters.PAGE_SIZE,

--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/jsonschema/JsonSchemaResource.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/jsonschema/JsonSchemaResource.java
@@ -90,7 +90,8 @@ public class JsonSchemaResource {
             mediaType = "application/json",
             examples =
                 @ExampleObject(
-                    ref = "{\"$schema\": \"https://json-schema.org/draft/2019-09/schema\"}"))
+                    name = "Schema",
+                    value = "{\"$schema\": \"https://json-schema.org/draft/2019-09/schema\"}"))
       })
   @APIResponses(
       value = {

--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/CreateCollectionDto.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/model/dto/CreateCollectionDto.java
@@ -26,7 +26,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
  * @param name Name of the collection.
  */
 public record CreateCollectionDto(
-    @Schema(description = "The name of the collection.", pattern = "\\w+", example = "cycling")
+    @Schema(description = "The name of the collection.", pattern = "\\w+", example = "events")
         @NotNull(message = "`name` is required to create a collection")
         @NotBlank(message = "`name` is required to create a collection")
         String name) {}


### PR DESCRIPTION
**What this PR does**:
Fixes all Swagger issues in the docs API:

* `fields` and `where` passed as string (JSON), unfortunately layout in Swagger is not perfect
* `document-path` param was sent wrongly, again fallback to string
* fixed example for schema attaching
* minor documentation improvements

**Which issue(s) this PR fixes**:
Fixes #2131