### PR TITLE
closes #2163: don't delete docker imgs in failed GH workflows

### DIFF
--- a/.github/workflows/apis-v2.yaml
+++ b/.github/workflows/apis-v2.yaml
@@ -139,6 +139,7 @@ jobs:
         with:
           name: img-${{ matrix.image }}-${{ github.sha }}
           path: ${{ matrix.image }}-${{ github.sha }}.tar
+          retention-days: 3
 
   # runs unit tests for the sgv2-docsapi
   build:
@@ -305,12 +306,12 @@ jobs:
           cd apis/
           ./mvnw -B -ntp verify -DskipUnitTests -pl ${{ matrix.project }} -am -P ${{ matrix.profile }} -Dquarkus.container-image.build=$CONTAINER_TEST -Dtesting.containers.stargate-image=${{ matrix.image }}
 
-  # runs always, deletes built docker image artifacts
+  # runs only on success, deletes built docker image artifacts
+  # keep docker images for 3 days so we can re-run the workflows
   clean-up:
     name: Clean up
     runs-on: ubuntu-latest
     needs: int-tests
-    if: ${{ always() }}
 
     steps:
       - uses: geekyeggo/delete-artifact@v1


### PR DESCRIPTION
**What this PR does**:
Keep built docker images on CI failure, so we can re-run and debug locally..

**Which issue(s) this PR fixes**:
Fixes #2163
