### PR TITLE
relates to #2150: removes set-output from the V2 GH workflows

### DIFF
--- a/.github/workflows/apis-v2.yaml
+++ b/.github/workflows/apis-v2.yaml
@@ -36,7 +36,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '8'
-          cache: maven
 
       - name: Setup Maven
         env:
@@ -68,7 +67,7 @@ jobs:
         env:
           cache-name: cache-coordinator-snapshots
         with:
-          path: ~/.m2/repository/io/stargate
+          path: ~/.m2/repository
           key: snapshots-${{ github.sha }}
           restore-keys: |
             snapshots-

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -37,14 +37,14 @@ jobs:
 
       - name: Set reference
         id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
       - name: Resolve tag
         id: resolve_tag
         run: |
           TAG=${{ inputs.tag != null && inputs.tag || steps.vars.outputs.tag }}
           echo "Resolved tag for the release $TAG"
-          echo "::set-output name=tag::${TAG}"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
 
   # creates a new release if it's not existing
   # outputs the upload URL in the release-upload-url output var


### PR DESCRIPTION
**What this PR does**:

* removes usage of the `set::output` in V2 workflows
* fixes a small caching issue in the APIs V2 CI


