### PR TITLE
closes #2150: removes set-output from the V1 GH workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,14 +39,14 @@ jobs:
 
       - name: Set reference
         id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        run: echo "tag=${GITHUB_REF#refs/*/}}" >> $GITHUB_OUTPUT
 
       - name: Resolve tag
         id: resolve_tag
         run: |
           TAG=${{ inputs.tag != null && inputs.tag || steps.vars.outputs.tag }}
           echo "Resolved tag for the release $TAG"
-          echo "::set-output name=tag::${TAG}"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
 
       - name: Create release
         id: create_release


### PR DESCRIPTION
**What this PR does**:

* removes `set-output` from the V1 GH workflows