### PR TITLE
update Quarkus to `2.13.2`

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -23,7 +23,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.12.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.13.2.Final</quarkus.platform.version>
     <skipTests>false</skipTests>
     <skipUnitTests>${skipTests}</skipUnitTests>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>


### PR DESCRIPTION
**What this PR does**:

Be on track with Quarkus updates, we need some features that are coming out in the next version.. Thus, upgrade now to `2.13` to ensure easier move later on..
