### PR TITLE
Fix to skip printing the token received in the request header in the …

### DIFF
--- a/apis/sgv2-quarkus-common/src/main/resources/application.yaml
+++ b/apis/sgv2-quarkus-common/src/main/resources/application.yaml
@@ -2,3 +2,6 @@ quarkus:
   log:
     console:
       format: "%-5p [%t] %d{yyyy-MM-dd HH:mm:ss,SSS} %F:%L - %m%n"
+  http:
+    access-log:
+      pattern: "%h %l %t \"%r\" %s %b"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

When quarkus http access log is enabled (by setting quarkus.http.access-log.enabled to true), the access log is printed based on the format setting (quarkus.http.access-log.pattern) which is set to the value ‘common’ by default. 

The ‘common’ pattern implies the format of `%h %l %u %t \"%r\" %s %b` where the field %u prints the ‘Remote user that was authenticated’ (Refer: io.quarkus.vertx.http.runtime.filters.accesslog.AccessLogHandler) and token that is passed on the X-Cassandra-Token is printed in the place of this template field. 

By adjusting the access log pattern setting by excluding %u, the token will not be printed in the log any more.

**Which issue(s) this PR fixes**:
Fixes #2176 

**Checklist**
- [X] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [X] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
