### PR TITLE
enforce JDK 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -390,7 +390,8 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>1.8</version>
+                  <version>[1.8,1.9)</version>
+                  <message>Project requires JDK 8</message>
                 </requireJavaVersion>
                 <requireUpperBoundDeps>
 		  <!-- If specifying includes ONLY those are checked

--- a/pom.xml
+++ b/pom.xml
@@ -389,6 +389,9 @@
             <id>enforce</id>
             <configuration>
               <rules>
+                <requireJavaVersion>
+                  <version>1.8</version>
+                </requireJavaVersion>
                 <requireUpperBoundDeps>
 		  <!-- If specifying includes ONLY those are checked
 		       (default: all)


### PR DESCRIPTION
Use the Maven enforcer plugin to ensure usage of JDK 8 to compile.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
