### PR TITLE
closes #2181: bridge context key not to be used in another thread

### DIFF
--- a/bridge/src/main/java/io/stargate/bridge/service/BridgeService.java
+++ b/bridge/src/main/java/io/stargate/bridge/service/BridgeService.java
@@ -155,7 +155,9 @@ public class BridgeService extends StargateBridgeGrpc.StargateBridgeImplBase {
   public void describeKeyspace(
       Schema.DescribeKeyspaceQuery request,
       StreamObserver<Schema.CqlKeyspaceDescribe> responseObserver) {
-    executor.execute(() -> SchemaHandler.describeKeyspace(request, persistence, responseObserver));
+    Map<String, String> headers = HEADERS_KEY.get();
+    executor.execute(
+        () -> SchemaHandler.describeKeyspace(request, persistence, headers, responseObserver));
   }
 
   @Override

--- a/bridge/src/main/java/io/stargate/bridge/service/SchemaHandler.java
+++ b/bridge/src/main/java/io/stargate/bridge/service/SchemaHandler.java
@@ -53,14 +53,14 @@ class SchemaHandler {
   public static void describeKeyspace(
       DescribeKeyspaceQuery query,
       Persistence persistence,
+      Map<String, String> headers,
       StreamObserver<CqlKeyspaceDescribe> responseObserver) {
 
     // The name that the client asked for, e.g. "ks".
+    // If the persistence supports multi-tenancy, the decorated name contains tenant information,
+    // e.g.
     String simpleName = query.getKeyspaceName();
-    // If the persistence supports multi-tenancy, the actual name contains tenant information, e.g.
-    // "tenant1_ks".
-    String decoratedName =
-        persistence.decorateKeyspaceName(simpleName, BridgeService.HEADERS_KEY.get());
+    String decoratedName = persistence.decorateKeyspaceName(simpleName, headers);
 
     Keyspace keyspace = persistence.schema().keyspace(decoratedName);
     if (keyspace == null) {


### PR DESCRIPTION
**What this PR does**:
Fixes grpc context access in executor.. Reproduced first with the updated test, then added a fix..

Unfortunately our tests around the `Bridge` are not good enough, and we might need to revisit those asap..

**Which issue(s) this PR fixes**:
Fixes #2181

