### PR TITLE
OpenAPI schema URL context path changes

### DIFF
--- a/apis/sgv2-docsapi/src/main/resources/application.yaml
+++ b/apis/sgv2-docsapi/src/main/resources/application.yaml
@@ -134,6 +134,7 @@ quarkus:
 
   # information for the generated Open API definitions
   smallrye-openapi:
+    path: /api/docs/openapi
     info-title: ${quarkus.application.name}
     info-version: ${quarkus.application.version:}
     info-description:

--- a/apis/sgv2-graphqlapi/src/main/resources/application.yaml
+++ b/apis/sgv2-graphqlapi/src/main/resources/application.yaml
@@ -109,6 +109,9 @@ quarkus:
   swagger-ui:
     enable: false
 
+  smallrye-openapi:
+    enable: false
+
 # shared development properties
 "%dev":
 

--- a/apis/sgv2-restapi/src/main/resources/application.yaml
+++ b/apis/sgv2-restapi/src/main/resources/application.yaml
@@ -116,6 +116,7 @@ quarkus:
 
   # information for the generated Open API definitions
   smallrye-openapi:
+    path: /api/rest/openapi
     info-title: ${quarkus.application.name}
     info-version: ${quarkus.application.version:}
     info-description:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
OpenAPI schema URL context path changed in docs-api and rest-api and OpenAPI is disabled in graphql-api.

- Docs: /api/docs/openapi
- Rest: /api/rest/openapi
- GraphQL: Disabled

**Which issue(s) this PR fixes**:
Fixes #2182 

**Checklist**
- [X] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [X] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
