### PR TITLE
Fix handling of `describeKeyspace` to catch RuntimeEcxeptions too, add a test

### DIFF
--- a/bridge/src/main/java/io/stargate/bridge/service/ExceptionHandler.java
+++ b/bridge/src/main/java/io/stargate/bridge/service/ExceptionHandler.java
@@ -43,9 +43,9 @@ public class ExceptionHandler {
   static final Metadata.Key<QueryOuterClass.CasWriteUnknown> CAS_WRITE_UNKNOWN_KEY =
       ProtoUtils.keyForProto(QueryOuterClass.CasWriteUnknown.getDefaultInstance());
 
-  private final StreamObserver<QueryOuterClass.Response> responseObserver;
+  private final StreamObserver<?> responseObserver;
 
-  public ExceptionHandler(StreamObserver<QueryOuterClass.Response> responseObserver) {
+  public ExceptionHandler(StreamObserver<?> responseObserver) {
     this.responseObserver = responseObserver;
   }
 
@@ -68,8 +68,9 @@ public class ExceptionHandler {
    * StreamObserver#onError(Throwable)} method.
    */
   public void handleException(Throwable throwable) {
-    if (throwable instanceof CompletionException
-        || throwable instanceof MessageHandler.ExceptionWithIdempotencyInfo) {
+    if ((throwable instanceof CompletionException
+            || throwable instanceof MessageHandler.ExceptionWithIdempotencyInfo)
+        && (throwable.getCause() != null)) {
       handleException(throwable.getCause());
     } else if (throwable instanceof StatusException
         || throwable instanceof StatusRuntimeException) {

--- a/bridge/src/test/java/io/stargate/bridge/service/SchemaOperationsTest.java
+++ b/bridge/src/test/java/io/stargate/bridge/service/SchemaOperationsTest.java
@@ -264,9 +264,6 @@ public class SchemaOperationsTest extends BaseBridgeServiceTest {
     StargateBridgeGrpc.StargateBridgeBlockingStub stub = makeBlockingStub();
     when(persistence.decorateKeyspaceName(any(String.class), any())).thenReturn("my_stuff");
 
-    // Only need minimal schema for bootstrapping
-    io.stargate.db.schema.Schema schema = io.stargate.db.schema.Schema.build().build();
-
     when(persistence.schema()).thenThrow(new NullPointerException("No context"));
     startServer(persistence);
 

--- a/bridge/src/test/java/io/stargate/bridge/service/SchemaOperationsTest.java
+++ b/bridge/src/test/java/io/stargate/bridge/service/SchemaOperationsTest.java
@@ -21,6 +21,7 @@ import static io.stargate.db.schema.Column.Kind.PartitionKey;
 import static io.stargate.db.schema.Column.Kind.Static;
 import static io.stargate.db.schema.Column.Order.DESC;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -28,6 +29,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.stargate.auth.AuthenticationService;
 import io.stargate.auth.AuthenticationSubject;
 import io.stargate.bridge.grpc.StargateBearerToken;
@@ -252,5 +255,31 @@ public class SchemaOperationsTest extends BaseBridgeServiceTest {
         .isTrue();
     assertThat(response.getMaterializedViews(0).getColumnsCount() == 1).isTrue();
     assertThat(response.getMaterializedViews(0).getColumns(0).getName().equals("c")).isTrue();
+  }
+
+  @Test
+  @DisplayName("Handle and propagate server-side NPE appropriately")
+  public void schemaTableWithServerSideNPE() {
+    // Given
+    StargateBridgeGrpc.StargateBridgeBlockingStub stub = makeBlockingStub();
+    when(persistence.decorateKeyspaceName(any(String.class), any())).thenReturn("my_stuff");
+
+    // Only need minimal schema for bootstrapping
+    io.stargate.db.schema.Schema schema = io.stargate.db.schema.Schema.build().build();
+
+    when(persistence.schema()).thenThrow(new NullPointerException("No context"));
+    startServer(persistence);
+
+    // When
+    assertThatThrownBy(
+            () ->
+                stub.describeKeyspace(
+                        Schema.DescribeKeyspaceQuery.newBuilder().setKeyspaceName("ks").build())
+                    .getTables(0))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("No context")
+        .extracting("status")
+        .extracting("code")
+        .isEqualTo(Status.UNKNOWN.getCode());
   }
 }


### PR DESCRIPTION
**What this PR does**:

Improves bridge handling so that:

* `describeKeyspace()` operation will catch all `Throwable`s and report them properly (not just gRPC fails)
* `queryWithSchema()` operation that fails internally will also report failure gracefully (add test(s))

**Which issue(s) this PR fixes**:
Fixes #2179

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
