### PR TITLE
Update DropWizard 2.0.32->2.0.34 to get commons-text upgraded

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,17 +20,17 @@
     <xml-format.skip>true</xml-format.skip>
 
     <!-- First DropWizard version and things it directly depends on that make sense to sync -->
-    <dropwizard.version>2.0.32</dropwizard.version>
+    <dropwizard.version>2.0.34</dropwizard.version>
     <!--
       Note that this is currently aligned with the metrics version that DropWizard transitively depends on.
       It's probably a good idea to keep the two versions in sync.
     -->
-    <dropwizard.metrics.version>4.1.32</dropwizard.metrics.version>
+    <dropwizard.metrics.version>4.1.33</dropwizard.metrics.version>
     <!--
       Note that this is currently aligned with the Jetty version that DropWizard transitively depends on.
       It's probably a good idea to keep the two versions in sync.
     -->
-    <jetty.version>9.4.48.v20220622</jetty.version>
+    <jetty.version>9.4.49.v20220914</jetty.version>
     <!-- Logging framework likewise in sync -->
     <slf4j.version>1.7.36</slf4j.version>
     <logback.version>1.2.11</logback.version>


### PR DESCRIPTION
**What this PR does**:

Upgrade DropWizard dependency from 2.0.32 to 2.0.34 to get upgraded versions of some transitive dependencies, and in particular Apache commons-text (1.9 -> 1.20)

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
