### PR TITLE
enforce JDK 17+ for building SGv2 APIs

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -128,6 +128,27 @@
           </excludes>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>17</version>
+                  <message>Project requires JDK 17 or later</message>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <profiles>


### PR DESCRIPTION
Use maven enforcer plugin to ensure APIs are compiled against JDK 17 or later.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
