### PR TITLE
Fix #2200: include auth header for OpenAPI (Swagger) by adding annota…

### DIFF
--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/Sgv2RowsResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/Sgv2RowsResourceApi.java
@@ -19,6 +19,7 @@ import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 /**
@@ -29,6 +30,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 @Path("/v2/keyspaces/{keyspaceName}/{tableName}")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
+@SecurityRequirement(name = RestOpenApiConstants.SecuritySchemes.TOKEN)
 @Tag(ref = RestOpenApiConstants.Tags.DATA)
 public interface Sgv2RowsResourceApi {
   @GET

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2ColumnsResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2ColumnsResourceApi.java
@@ -23,6 +23,7 @@ import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 /**
@@ -33,6 +34,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 @Path("/v2/schemas/keyspaces/{keyspaceName}/tables/{tableName}/columns")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
+@SecurityRequirement(name = RestOpenApiConstants.SecuritySchemes.TOKEN)
 @Tag(ref = RestOpenApiConstants.Tags.SCHEMA)
 public interface Sgv2ColumnsResourceApi {
   @GET

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2IndexesResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2IndexesResourceApi.java
@@ -37,6 +37,7 @@ import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 /**
@@ -47,6 +48,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 @Path("/v2/schemas/keyspaces/{keyspaceName}/tables/{tableName}/indexes")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
+@SecurityRequirement(name = RestOpenApiConstants.SecuritySchemes.TOKEN)
 @Tag(ref = RestOpenApiConstants.Tags.SCHEMA)
 public interface Sgv2IndexesResourceApi {
   @GET

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2KeyspacesResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2KeyspacesResourceApi.java
@@ -36,6 +36,7 @@ import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 /**
@@ -46,6 +47,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 @Path("/v2/schemas/keyspaces")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
+@SecurityRequirement(name = RestOpenApiConstants.SecuritySchemes.TOKEN)
 @Tag(ref = RestOpenApiConstants.Tags.SCHEMA)
 public interface Sgv2KeyspacesResourceApi {
   @GET

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2TablesResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2TablesResourceApi.java
@@ -24,6 +24,7 @@ import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 /**
@@ -34,6 +35,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 @Path("/v2/schemas/keyspaces/{keyspaceName}/tables")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
+@SecurityRequirement(name = RestOpenApiConstants.SecuritySchemes.TOKEN)
 @Tag(ref = RestOpenApiConstants.Tags.SCHEMA)
 public interface Sgv2TablesResourceApi {
   @GET

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2UDTsResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2UDTsResourceApi.java
@@ -24,6 +24,7 @@ import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 /**
@@ -36,6 +37,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 @Path("/v2/schemas/keyspaces/{keyspaceName}/types")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
+@SecurityRequirement(name = RestOpenApiConstants.SecuritySchemes.TOKEN)
 @Tag(ref = RestOpenApiConstants.Tags.SCHEMA)
 public interface Sgv2UDTsResourceApi {
   @GET


### PR DESCRIPTION
**What this PR does**:

Makes Swagger UI pass auth header properly, by adding relevant annotation for API endpoints.

Tested locally;  `X-Cassandra-Token` was not passed before change; is after change.

**Which issue(s) this PR fixes**:
Fixes #2200

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
