### PR TITLE
Changes to CI jobs related to #1490, first part: renaming of v2.0.0->…

### DIFF
--- a/.github/workflows/apis-v2.yaml
+++ b/.github/workflows/apis-v2.yaml
@@ -2,13 +2,13 @@
 name: Stargate APIs V2
 
 # runs on
-# * pushes and pull requests on the v2.0.0.
+# * pushes and pull requests on the "main" (Stargate v2)
 # * manual trigger
 on:
   push:
-    branches: [ "v2.0.0" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "v2.0.0" ]
+    branches: [ "main" ]
   workflow_dispatch:
 
 # Jobs structure:

--- a/.github/workflows/coordinator-test.yml
+++ b/.github/workflows/coordinator-test.yml
@@ -1,4 +1,4 @@
-name: CI IT Experiment
+name: Coordinator Tests
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -399,5 +399,5 @@ jobs:
           commit-message: "Bumping version for next v2 release"
           title: "Bumping version for next v2 release"
           branch-suffix: "short-commit-hash"
-          base: "v2.0.0"
+          base: "main"
           labels: "stargate-v2"


### PR DESCRIPTION
**What this PR does**:

Changes CI job references from "v2.0.0" to "main", as part of v1/v2 branch renaming (see #1490)

**Which issue(s) this PR fixes**:
Part of fixes for #1490

**Checklist**
- [x] Changes manually tested (via CI run)
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
