### PR TITLE
Fix #2211: change default Maven repo used to resolve deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -816,11 +816,4 @@
 
     </dependencies>
   </dependencyManagement>
-  <repositories>
-    <repository>
-      <id>artifactory</id>
-      <name>artifactory</name>
-      <url>https://repo.datastax.com/artifactory/dse/</url>
-    </repository>
-  </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -817,15 +817,4 @@
     </dependencies>
   </dependencyManagement>
  
-  <repositories>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>artifactory</id>
-      <name>artifactory</name>
-      <url>https://repo.datastax.com/artifactory/dse/</url>
-    </repository>
-  </repositories>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -818,12 +818,9 @@
   </dependencyManagement>
   <repositories>
     <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>central</id>
-      <name>bintray</name>
-      <url>https://jcenter.bintray.com</url>
+      <id>artifactory</id>
+      <name>artifactory</name>
+      <url>https://repo.datastax.com/artifactory/dse/</url>
     </repository>
   </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -816,4 +816,16 @@
 
     </dependencies>
   </dependencyManagement>
+ 
+  <repositories>
+    <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>artifactory</id>
+      <name>artifactory</name>
+      <url>https://repo.datastax.com/artifactory/dse/</url>
+    </repository>
+  </repositories>
+
 </project>


### PR DESCRIPTION
**What this PR does**:

Changes (or remove) default repo settings used for resolving 3rd party dependencies off from obsolete `jcenter.bintray.com`: either use Datastax' caching artifactory or just remove definition to use default Maven Central.

If using Datastax one, ensure that access by non-datastax-employees is fine as access to anything but DSE is ok using anonymous access (and for `dse-core` we already require credentials, there's another issue for that problem).

**Which issue(s) this PR fixes**:
Fixes #2211

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
