### PR TITLE
closes #2201: playground to auto-inject token from headers

### DIFF
--- a/apis/sgv2-graphqlapi/CONFIGURATION.md
+++ b/apis/sgv2-graphqlapi/CONFIGURATION.md
@@ -11,7 +11,7 @@
 |--------------------------------------------|-----------|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `stargate.graphql.enable-default-keyspace` | `boolean` | `true`              | Whether to default to the oldest keyspace when the user accesses `/graphql`. If this is disabled, `/graphql` throws an error, and the keyspace must be provided explicitly in the path, as in `/graphql/{keyspace_name}`. |
 | `stargate.graphql.playground.enabled`      | `boolean` | `true`              | If GraphQL Playground is enabled at `/playground`.                                                                                                                                                                        |
-| `stargate.graphql.playground.token-header` | `String`  | `X-Cassandra-Token` | Optional, the header name that caries the token that should auto-injected to the playground. Note that this is used as a fallback if `CassandraTokenResolver` can not resolve the token.                                  |
+| `stargate.graphql.playground.token-header` | `String`  | `X-Cassandra-Token` | Optional, the header name that carries the token that should auto-injected to the playground. Note that this is used as a fallback if `CassandraTokenResolver` can not resolve the token.                                 |
 
 ## Quarkus Configuration
 

--- a/apis/sgv2-graphqlapi/CONFIGURATION.md
+++ b/apis/sgv2-graphqlapi/CONFIGURATION.md
@@ -1,0 +1,23 @@
+# Configuration Guide
+
+> **IMPORTANT:** Please check the [Stargate Common Configuration](../sgv2-quarkus-common/CONFIGURATION.md) for properties shared between all Stargate V2 APIs.
+
+## Stargate GraphQL API Configuration
+
+### GraphQL configuration
+*Configuration for GraphQL, defined by [GraphQLConfig.java](src/main/java/io/stargate/sgv2/graphql/config/GraphQLConfig.java).*
+
+| Property                                   | Type      | Default             | Description                                                                                                                                                                                                               |
+|--------------------------------------------|-----------|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `stargate.graphql.enable-default-keyspace` | `boolean` | `true`              | Whether to default to the oldest keyspace when the user accesses `/graphql`. If this is disabled, `/graphql` throws an error, and the keyspace must be provided explicitly in the path, as in `/graphql/{keyspace_name}`. |
+| `stargate.graphql.playground.enabled`      | `boolean` | `true`              | If GraphQL Playground is enabled at `/playground`.                                                                                                                                                                        |
+| `stargate.graphql.playground.token-header` | `String`  | `X-Cassandra-Token` | Optional, the header name that caries the token that should auto-injected to the playground. Note that this is used as a fallback if `CassandraTokenResolver` can not resolve the token.                                  |
+
+## Quarkus Configuration
+
+The complete list of Quarkus available properties can be found on [All configuration options](https://quarkus.io/guides/all-config) page.
+
+Here are some Stargate-relevant property groups that are necessary for correct service setup:
+
+* `quarkus.grpc.clients.bridge` - property group for defining the Bridge gRPC client (see [gRPC Client configuration](https://quarkus.io/guides/grpc-service-consumption#client-configuration) for all options)
+* `quarkus.cache.caffeine.keyspace-cache` - property group  for defining the keyspace cache used by [SchemaManager](../sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/schema/SchemaManager.java) (see [Caffeine cache configuration](https://quarkus.io/guides/cache#caffeine-configuration-properties) for all options)

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/config/GraphQLConfig.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/config/GraphQLConfig.java
@@ -1,0 +1,42 @@
+package io.stargate.sgv2.graphql.config;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.stargate.sgv2.api.common.config.constants.HttpConstants;
+import io.stargate.sgv2.api.common.token.CassandraTokenResolver;
+import java.util.Optional;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+/** Configuration for the GraphQL. */
+@ConfigMapping(prefix = "stargate.graphql")
+public interface GraphQLConfig {
+
+  /**
+   * @return Whether to default to the oldest keyspace when the user accesses /graphql. If this is
+   *     disabled, /graphql throws an error, and the keyspace must be provided explicitly in the
+   *     path, as in /graphql/ksName.
+   */
+  @WithDefault("true")
+  boolean enableDefaultKeyspace();
+
+  /** @return Configuration for the GraphQL Playground. */
+  @NotNull
+  @Valid
+  PlaygroundConfig playground();
+
+  interface PlaygroundConfig {
+
+    /** @return Whether to expose the GraphQL Playground at /playground. */
+    @WithDefault("true")
+    boolean enabled();
+
+    /**
+     * @return Optional, name of the HTTP header where to extract the token in case {@link
+     *     CassandraTokenResolver} does not provide a token.
+     */
+    @WithDefault(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME)
+    Optional<@NotBlank String> tokenHeader();
+  }
+}

--- a/apis/sgv2-graphqlapi/src/main/resources/application.yaml
+++ b/apis/sgv2-graphqlapi/src/main/resources/application.yaml
@@ -6,14 +6,8 @@ stargate:
     ignore-bridge: ${stargate.multi-tenancy.enabled}
 
   # graphql config
+  # see io.stargate.sgv2.graphql.config.GraphQLConfig for all config properties and options
   graphql:
-    # Whether to default to the oldest keyspace when the user accesses /graphql.
-    # If this is disabled, /graphql throws an error, and the keyspace must be provided explicitly in
-    # the path, as in /graphql/ksName.
-    enable-default-keyspace: true
-
-    # Whether to expose the GraphQL Playground in-browser IDE at /playground.
-    enable-playground: true
 
   # metrics properties
   # see io.stargate.sgv2.api.common.config.MetricsConfig for all config properties and options

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/web/resources/PlaygroundResourceTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/web/resources/PlaygroundResourceTest.java
@@ -1,0 +1,39 @@
+package io.stargate.sgv2.graphql.web.resources;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+class PlaygroundResourceTest {
+
+  @Test
+  public void playgroundWithToken() {
+    String token = RandomStringUtils.randomAlphanumeric(16);
+
+    String body =
+        given()
+            .header("X-Cassandra-Token", token)
+            .get("/playground")
+            .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString();
+
+    assertThat(body).contains("tokenValue = \"%s\";".formatted(token));
+  }
+
+  @Test
+  public void playgroundWithoutToken() {
+    String body = given().get("/playground").then().statusCode(200).extract().body().asString();
+
+    assertThat(body).contains("tokenValue = \"\";");
+  }
+}


### PR DESCRIPTION
**What this PR does**:
Enables auto-injecting a Cassandra token to the GraphQL playground from a header, in case the token resolver can not resolve it.

* added tests
* added config class and the readme for the configuration

**Which issue(s) this PR fixes**:
Fixes #2201
