### PR TITLE
closes #2185: exclude pattern for the access log

### DIFF
--- a/apis/sgv2-quarkus-common/src/main/resources/application.yaml
+++ b/apis/sgv2-quarkus-common/src/main/resources/application.yaml
@@ -77,6 +77,7 @@ quarkus:
     # access log format, must be explicitly enabled
     access-log:
       pattern: "%h %l %t \"%r\" %s %b"
+      exclude-pattern: ${quarkus.http.non-application-root-path}.*|${quarkus.micrometer.export.prometheus.path}
 
     # non-application path to /stargate
     non-application-root-path: stargate


### PR DESCRIPTION
**What this PR does**:
Excludes `/stargate` and `/metrics` from the access log by default. When access log is activated, the logs gets filled by those as those are accessed frequently.

**Which issue(s) this PR fixes**:
Fixes #2185

**Checklist**
- [ ] Rebase after #2216 is merged
