### PR TITLE
Change 1 "master" reference to "v1" for #1490

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -13,9 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Java JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 8.0.332
+          cache: 'maven'
       - name: Setup Maven
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
@@ -53,9 +55,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Java JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 8.0.332
+          cache: 'maven'
       - name: Setup Maven
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,4 +180,4 @@ jobs:
           commit-message: "Bumping version for next release"
           title: "Bumping version for next release"
           branch-suffix: "short-commit-hash"
-          base: "master"
+          base: "v1"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
   * Rebase your fork and force push to your GitHub repository (this will update your Pull Request):
 
     ```shell
-    git rebase master -i
+    git rebase main -i
     git push -f
     ```
 

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -34,7 +34,7 @@ export PATH="$JAVA_HOME/bin:$PATH"
 
 ## Building with Maven
 
-Stargate uses Maven for builds. You can download and install Maven from this [link](https://maven.apache.org/download.cgi) or use the included [maven wrapper](https://github.com/stargate/stargate/blob/master/mvnw) script as you would ordinarily use the `mvn` command.
+Stargate uses Maven for builds. You can download and install Maven from this [link](https://maven.apache.org/download.cgi) or use the included [maven wrapper](https://github.com/stargate/stargate/blob/main/mvnw) script as you would ordinarily use the `mvn` command.
 
 To build locally run the following:
 

--- a/pom.xml
+++ b/pom.xml
@@ -529,7 +529,7 @@
   <scm>
     <connection>scm:git:git://github.com/stargate/stargate.git</connection>
     <developerConnection>scm:git:git@github.com:stargate/stargate.git</developerConnection>
-    <url>http://github.com/stargate/stargate/tree/master</url>
+    <url>http://github.com/stargate/stargate/tree/main</url>
   </scm>
   <developers>
     <developer>


### PR DESCRIPTION
**What this PR does**:

Second part of #1490: renaming of `master` as `v1` requires a change in CI.

**Which issue(s) this PR fixes**:

Part of fix for #1490; will need to be merged AFTER actual rename done.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
