### PR TITLE
Bump graphql-java from 18.1 to 18.3 in /graphqlapi on `v1`

### DIFF
--- a/graphqlapi/pom.xml
+++ b/graphqlapi/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.graphql-java</groupId>
       <artifactId>graphql-java</artifactId>
-      <version>18.1</version>
+      <version>18.3</version>
     </dependency>
     <dependency>
       <groupId>io.dropwizard</groupId>


### PR DESCRIPTION
**What this PR does**:
Backport for V1.
