### PR TITLE
Make InboundHAProxyHandler @Sharable

### DIFF
--- a/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/HAProxyProtocolDetectingDecoder.java
+++ b/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/HAProxyProtocolDetectingDecoder.java
@@ -75,6 +75,7 @@ public class HAProxyProtocolDetectingDecoder extends ByteToMessageDecoder {
     return true;
   }
 
+  @Sharable
   static class InboundHAProxyHandler extends SimpleChannelInboundHandler<HAProxyMessage> {
     public static final InboundHAProxyHandler INSTANCE = new InboundHAProxyHandler();
 


### PR DESCRIPTION
#2205 introduces a regression where multiple uses of `HAProxyProtocolDetectingDecoder::decode` will now end with Exception:
`io.netty.channel.ChannelPipelineException: org.apache.cassandra.stargate.transport.internal.HAProxyProtocolDetectingDecoder is not a @Sharable handler, so can't be added or removed multiple times.`

Since `InboundHAProxyHandler` looks reentrant and because the original idea in #2205 was to make it shared let's do just that

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #2232

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
