### PR TITLE
Update grpc.version from 1.45.1 to 1.49.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <caffeine.version>2.9.3</caffeine.version>
     <commons-io.version>2.7</commons-io.version>
-    <grpc.version>1.45.1</grpc.version>
+    <grpc.version>1.49.2</grpc.version>
     <immutables.version>2.8.8</immutables.version>
     <jackson.version>2.13.4</jackson.version>
     <javatuples.version>1.2</javatuples.version>


### PR DESCRIPTION
**What this PR does**:

Upgrades Java gRPC library version from 1.45.1 (old) to 1.49.2 (one that Quarkus uses for Stargate v2)

**Which issue(s) this PR fixes**:
Fixes #2224

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
