### PR TITLE
Fix #2245: allow numeric timestamp for CQL `timestamp` valued columns

### DIFF
--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/grpc/ToProtoValueCodecs.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/grpc/ToProtoValueCodecs.java
@@ -611,6 +611,11 @@ public class ToProtoValueCodecs {
       if (value instanceof String) {
         return protoValueFromStringified((String) value);
       }
+      // Should only accept integral numbers; Jackson will expose these as Integers and Longs
+      // (unfortunately "java.lang.Number" has no convenience methods for determining this)
+      if (value instanceof Long || value instanceof Integer) {
+        return Values.of(((Number) value).longValue());
+      }
       return cannotCoerce(value);
     }
 

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowGetIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowGetIT.java
@@ -12,6 +12,7 @@ import io.stargate.bridge.grpc.CqlDuration;
 import io.stargate.sgv2.api.common.cql.builder.CollectionIndexingType;
 import io.stargate.sgv2.api.common.exception.model.dto.ApiError;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -829,10 +830,11 @@ public class RestApiV2QRowGetIT extends RestApiV2QIntegrationTestBase {
         Arrays.asList("id"),
         Arrays.asList("created"));
     final String timestamp = "2021-04-23T18:42:22.139Z";
+    final long timestampAsMsecs = Instant.parse(timestamp).toEpochMilli();
     insertTypedRows(
         testKeyspaceName(),
         tableName,
-        // Insert with variations of timezone-offset:
+        // Insert with variations of timezone-offset as well as Long-valued numeric timestamp
         Arrays.asList(
             map("id", 1, "firstName", "John", "created", timestamp),
             map("id", 1, "firstName", "Sarah", "created", "2021-04-20T18:42:22.139+02:00"),
@@ -840,7 +842,8 @@ public class RestApiV2QRowGetIT extends RestApiV2QIntegrationTestBase {
             map("id", 3, "firstName", "Billy", "created", "2021-04-22T18:42:22.139+1000"),
             map("id", 3, "firstName", "Graham", "created", "2021-04-22T18:42:22.139-0800"),
             map("id", 4, "firstName", "Joel", "created", "2021-04-22T18:42:22.139+07"),
-            map("id", 4, "firstName", "Deborah", "created", "2021-04-22T18:42:22.139-05")));
+            map("id", 4, "firstName", "Deborah", "created", "2021-04-22T18:42:22.139-05"),
+            map("id", 5, "firstName", "Timothy", "created", timestampAsMsecs)));
 
     String whereClause =
         String.format("{\"id\":{\"$eq\":\"1\"},\"created\":{\"$in\":[\"%s\"]}}", timestamp);

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/restapi/grpc/ToProtoConverterTest.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/restapi/grpc/ToProtoConverterTest.java
@@ -64,12 +64,13 @@ public class ToProtoConverterTest {
   }
   ;
 
+  private static String DEFAULT_INSTANT_STR = "2021-04-23T18:42:22.139Z";
+  private static Instant DEFAULT_INSTANT = Instant.parse(DEFAULT_INSTANT_STR);
+
   private static Arguments[] fromExternalSamplesTimestamp() {
     return new Arguments[] {
       // First, canonical version
-      arguments(
-          "2021-04-23T18:42:22.139Z",
-          Values.of(Instant.parse("2021-04-23T18:42:22.139Z").toEpochMilli())),
+      arguments(DEFAULT_INSTANT_STR, Values.of(DEFAULT_INSTANT.toEpochMilli())),
       // same, but no milliseconds
       arguments(
           "2021-04-23T18:42:22Z", Values.of(Instant.parse("2021-04-23T18:42:22Z").toEpochMilli())),
@@ -99,6 +100,9 @@ public class ToProtoConverterTest {
       arguments(
           "2021-04-23T18:42:22-03",
           Values.of(Instant.parse("2021-04-23T21:42:22Z").toEpochMilli())),
+
+      // Also: timestamp as Long should be supported
+      arguments(DEFAULT_INSTANT.toEpochMilli(), Values.of(DEFAULT_INSTANT.toEpochMilli()))
     };
   }
 


### PR DESCRIPTION
**What this PR does**:

Allows use of JSON integral numbers for CQL `timestamp` valued columns (same as Stargate V1 / REST)

**Which issue(s) this PR fixes**:
Fixes #2245

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
