### PR TITLE
Add prefix to Cassandra/Coordinator container log redirects

### DIFF
--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
@@ -222,7 +222,9 @@ public class StargateTestResource
                 "-Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.load_ring_state=false -Dcassandra.initial_token=1")
             .withNetworkAliases("cassandra")
             .withExposedPorts(7000, 9042)
-            .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("cassandra-docker")))
+            .withLogConsumer(
+                new Slf4jLogConsumer(LoggerFactory.getLogger("cassandra-docker"))
+                    .withPrefix("CASSANDRA"))
             .waitingFor(Wait.forLogMessage(".*Created default superuser role.*\\n", 1))
             .withStartupTimeout(getCassandraStartupTimeout())
             .withReuse(reuse);
@@ -246,7 +248,9 @@ public class StargateTestResource
             .withEnv("ENABLE_AUTH", "true")
             .withNetworkAliases("coordinator")
             .withExposedPorts(8091, 8081, 8084)
-            .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("coordinator-docker")))
+            .withLogConsumer(
+                new Slf4jLogConsumer(LoggerFactory.getLogger("coordinator-docker"))
+                    .withPrefix("COORDINATOR"))
             .waitingFor(Wait.forHttp("/checker/readiness").forPort(8084).forStatusCode(200))
             .withStartupTimeout(getCoordinatorStartupTimeout())
             .withReuse(reuse);


### PR DESCRIPTION

**What this PR does**:

Add distinct prefixes to Container logs for Cassandra (Persistence) and Coordinator, to make it easier to know which container produced which log output.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
