### PR TITLE
fixing missing netty-codec dependency for dse

### DIFF
--- a/persistence-dse-6.8/README.md
+++ b/persistence-dse-6.8/README.md
@@ -12,6 +12,9 @@ In order to update to a newer patch version, please follow the guidelines below:
 * Update the `ccm.version` property (`it-dse-6.8` profile section) in [testing/pom.xml](../testing/pom.xml)
 * Update the [CI Dockerfile](../ci/Dockerfile) and set the new version in the `ccm create` command related to DSE 6.8.
 Note that this will have no effect until the docker image is rebuilt and pushed to the remote repository, thus creating an issue for that would be a good idea (see below for one such PR)
+* Check the Netty dependencies
+  * The `<netty.version>` in the [main pom.xml](../pom.xml) should be the same version that the DSE depends to.
+  * The explicit `netty-codec` dependency in the [pom.xml](pom.xml) should be removed, if the `dse-db` declares it as transitive dep (issue in `6.8.29`).
 * Create a separate PR for bumping the DSE version in the Quarkus-based API integration tests on the `v2.0.0` branch. Test profiles are defined in the `apis/pom.xml`.
 * Make sure everything compiles and CI tests are green.
 * Update this `README.md` file with the new or updated instructions.

--- a/persistence-dse-6.8/README.md
+++ b/persistence-dse-6.8/README.md
@@ -13,7 +13,6 @@ In order to update to a newer patch version, please follow the guidelines below:
 * Update the [CI Dockerfile](../ci/Dockerfile) and set the new version in the `ccm create` command related to DSE 6.8.
 Note that this will have no effect until the docker image is rebuilt and pushed to the remote repository, thus creating an issue for that would be a good idea (see below for one such PR)
 * Check the Netty dependencies
-  * The `<netty.version>` in the [main pom.xml](../pom.xml) should be the same version that the DSE depends to.
   * The explicit `netty-codec` dependency in the [pom.xml](pom.xml) should be removed, if the `dse-db` declares it as transitive dep (issue in `6.8.29`).
 * Create a separate PR for bumping the DSE version in the Quarkus-based API integration tests on the `v2.0.0` branch. Test profiles are defined in the `apis/pom.xml`.
 * Make sure everything compiles and CI tests are green.

--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -127,6 +127,11 @@
 
     <!-- 3rd party dependencies -->
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec</artifactId>
+      <version>4.1.78.1.dse</version>
+    </dependency>
+    <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
       <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,11 @@
     <snakeyaml.version>1.32</snakeyaml.version>
     <swagger-ui.version>3.52.5</swagger-ui.version>
     <swagger-jersey2-jaxrs.version>1.6.3</swagger-jersey2-jaxrs.version>
-    <netty.version>4.1.78.Final</netty.version>
+    <!-- Netty version used by Cassandra 3.11/4.0 (DSE uses different version)
+	 NOTE: upgrading version often breaks persistence backend so make sure
+	 you know what you are doing if/when upgrading
+      -->
+    <netty.version>4.1.75.Final</netty.version>
     <netty-boringssl.version>2.0.51.Final</netty-boringssl.version>
 
     <!-- And finally test/build deps -->

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <snakeyaml.version>1.32</snakeyaml.version>
     <swagger-ui.version>3.52.5</swagger-ui.version>
     <swagger-jersey2-jaxrs.version>1.6.3</swagger-jersey2-jaxrs.version>
-    <netty.version>4.1.78.Final</netty.version>
+    <netty.version>4.1.75.Final</netty.version>
     <netty-boringssl.version>2.0.51.Final</netty-boringssl.version>
 
     <!-- And finally test/build deps -->

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <snakeyaml.version>1.32</snakeyaml.version>
     <swagger-ui.version>3.52.5</swagger-ui.version>
     <swagger-jersey2-jaxrs.version>1.6.3</swagger-jersey2-jaxrs.version>
-    <netty.version>4.1.75.Final</netty.version>
+    <netty.version>4.1.78.Final</netty.version>
     <netty-boringssl.version>2.0.51.Final</netty-boringssl.version>
 
     <!-- And finally test/build deps -->


### PR DESCRIPTION
**What this PR does**:
The `dse-db` in version `6.8.29` is not specifying the `netty-codec` as transitive dependency, thus ending up in the no class found exception. I added the dependency explicitly. 

Furthermore, I bumped the netty version to the same DSE is using, @tatu-at-datastax can you confirm this is OK.
