### PR TITLE
organize dependencies in the DSE

### DIFF
--- a/persistence-dse-6.8/README.md
+++ b/persistence-dse-6.8/README.md
@@ -12,8 +12,6 @@ In order to update to a newer patch version, please follow the guidelines below:
 * Update the `ccm.version` property (`it-dse-6.8` profile section) in [testing/pom.xml](../testing/pom.xml)
 * Update the [CI Dockerfile](../ci/Dockerfile) and set the new version in the `ccm create` command related to DSE 6.8.
 Note that this will have no effect until the docker image is rebuilt and pushed to the remote repository, thus creating an issue for that would be a good idea (see below for one such PR)
-* Check the Netty dependencies
-  * The explicit `netty-codec` dependency in the [pom.xml](pom.xml) should be removed, if the `dse-db` declares it as transitive dep (issue in `6.8.29`).
 * Create a separate PR for bumping the DSE version in the Quarkus-based API integration tests on the `v2.0.0` branch. Test profiles are defined in the `apis/pom.xml`.
 * Make sure everything compiles and CI tests are green.
 * Update this `README.md` file with the new or updated instructions.

--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -44,6 +44,20 @@
       <artifactId>persistence-api</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.datastax.oss</groupId>
+          <artifactId>java-driver-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.datastax.oss</groupId>
+          <artifactId>java-driver-shaded-guava</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.esri.geometry</groupId>
+          <artifactId>esri-geometry-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.stargate.core</groupId>
@@ -81,10 +95,6 @@
           <artifactId>cassandra-log4j-appender</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>com.datastax.oss</groupId>
-          <artifactId>java-driver-core</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>dnsjava</groupId>
           <artifactId>dnsjava</artifactId>
         </exclusion>
@@ -94,15 +104,6 @@
           <artifactId>azure-storage-blob</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <!--
-      dse-java-driver-core is a transitive dependency of dse-core, but if we don't redeclare it
-      explicitly then for some reason Stargate can't gossip with peers in integration tests.
-    -->
-    <dependency>
-      <groupId>com.datastax.dse</groupId>
-      <artifactId>dse-java-driver-core</artifactId>
-      <version>1.10.0-dse+20210424</version>
     </dependency>
     <dependency>
       <groupId>com.datastax.dse</groupId>
@@ -126,11 +127,6 @@
     </dependency>
 
     <!-- 3rd party dependencies -->
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec</artifactId>
-      <version>4.1.78.1.dse</version>
-    </dependency>
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>

--- a/persistence-dse-6.8/pom.xml
+++ b/persistence-dse-6.8/pom.xml
@@ -46,16 +46,8 @@
       <scope>provided</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.datastax.oss</groupId>
-          <artifactId>java-driver-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.datastax.oss</groupId>
-          <artifactId>java-driver-shaded-guava</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.esri.geometry</groupId>
-          <artifactId>esri-geometry-api</artifactId>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-handler</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -93,6 +85,10 @@
         <exclusion>
           <groupId>com.datastax.logging</groupId>
           <artifactId>cassandra-log4j-appender</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.datastax.oss</groupId>
+          <artifactId>java-driver-core</artifactId>
         </exclusion>
         <exclusion>
           <groupId>dnsjava</groupId>


### PR DESCRIPTION
**What this PR does**:
Trying to fix the issues with the DSE dependencies.

Small info about the changes:
* netty-codec removed from explicit dependencies, will be brought in by dse-db
* the netty handler must be ignored from persistance-api, that s the only way not to override the netty-codec as the handler would be introducing it in different version
* i tried to remove the explicit dep to the dse java driver, as core would bring the right one
* I tested this against main, so that all int tests are checked as well.. but moving the base to the v1
