### PR TITLE
Fix #2244: include all columns in existence check wrt index creation

### DIFF
--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2IndexesResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2IndexesResourceImpl.java
@@ -82,7 +82,7 @@ public class Sgv2IndexesResourceImpl extends RestResourceBase implements Sgv2Ind
             tableName,
             table -> {
               if (!hasColumn(table, columnName)) {
-                new WebApplicationException(
+                throw new WebApplicationException(
                     String.format("Column '%s' not found in table '%s'", columnName, tableName),
                     Status.NOT_FOUND);
               }

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2IndexesResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2IndexesResourceImpl.java
@@ -17,6 +17,7 @@ package io.stargate.sgv2.restapi.service.resources.schemas;
 
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.bridge.proto.QueryOuterClass.Query;
 import io.stargate.bridge.proto.Schema;
 import io.stargate.sgv2.api.common.cql.builder.Predicate;
@@ -80,14 +81,11 @@ public class Sgv2IndexesResourceImpl extends RestResourceBase implements Sgv2Ind
             keyspaceName,
             tableName,
             table -> {
-              table.getColumnsList().stream()
-                  .filter(c -> columnName.equals(c.getName()))
-                  .findAny()
-                  .orElseThrow(
-                      () ->
-                          new WebApplicationException(
-                              String.format("Column '%s' not found in table.", columnName),
-                              Status.NOT_FOUND));
+              if (!hasColumn(table, columnName)) {
+                new WebApplicationException(
+                    String.format("Column '%s' not found in table '%s'", columnName, tableName),
+                    Status.NOT_FOUND);
+              }
               return new QueryBuilder()
                   .create()
                   .index(indexAdd.getName())
@@ -131,5 +129,16 @@ public class Sgv2IndexesResourceImpl extends RestResourceBase implements Sgv2Ind
                   .build();
             })
         .map(any -> RestResponse.noContent());
+  }
+
+  private boolean hasColumn(Schema.CqlTable table, String columnName) {
+    List<QueryOuterClass.ColumnSpec> s = table.getColumnsList();
+    return hasColumn(table.getColumnsList(), columnName)
+        || hasColumn(table.getPartitionKeyColumnsList(), columnName)
+        || hasColumn(table.getClusteringKeyColumnsList(), columnName);
+  }
+
+  private boolean hasColumn(List<QueryOuterClass.ColumnSpec> columns, String nameToFind) {
+    return columns.stream().anyMatch(c -> nameToFind.equals(c.getName()));
   }
 }

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaIndexesIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaIndexesIT.java
@@ -133,7 +133,7 @@ public class RestApiV2QSchemaIndexesIT extends RestApiV2QIntegrationTestBase {
     response = tryCreateIndex(testKeyspaceName(), tableName, indexAdd, HttpStatus.SC_NOT_FOUND);
     apiError = readJsonAs(response, ApiError.class);
     assertThat(apiError.code()).isEqualTo(HttpStatus.SC_NOT_FOUND);
-    assertThat(apiError.description()).isEqualTo("Column 'invalid_column' not found in table.");
+    assertThat(apiError.description()).startsWith("Column 'invalid_column' not found in table");
 
     // invalid index kind
     indexAdd.setColumn("firstName");

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaIndexesIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaIndexesIT.java
@@ -76,6 +76,37 @@ public class RestApiV2QSchemaIndexesIT extends RestApiV2QIntegrationTestBase {
     assertThat(indexes).hasSize(2);
   }
 
+  // For https://github.com/stargate/stargate/issues/2244
+  @Test
+  public void indexCreateIssue2244() {
+    final String tableName = testTableName();
+    createTestTable(
+        testKeyspaceName(),
+        tableName,
+        Arrays.asList(
+            "genre text",
+            "year int",
+            "title text",
+            "formats frozen<map<text,text>>",
+            "tuples frozen<tuple<text,text,text>>",
+            "upload timestamp",
+            "frames list<int>",
+            "tags set<text>"),
+        Arrays.asList("genre", "year", "title"),
+        Arrays.asList("year", "title"));
+
+    Sgv2IndexAddRequest indexAdd = new Sgv2IndexAddRequest("title", "test_idx_2244");
+    indexAdd.setIfNotExists(false);
+
+    String response =
+        tryCreateIndex(testKeyspaceName(), tableName, indexAdd, HttpStatus.SC_CREATED);
+    IndexResponse successResponse = readJsonAs(response, IndexResponse.class);
+    assertThat(successResponse.success).isTrue();
+
+    List<IndexDesc> indexes = findAllIndexes(testKeyspaceName(), tableName);
+    assertThat(indexes).hasSize(1);
+  }
+
   @Test
   public void indexCreateInvalid() {
     final String tableName = testTableName();


### PR DESCRIPTION
**What this PR does**:

Adds a test for #2244 to verify issue, fix by including key columns into check for existence of column for which index created (formerly only checked non-key columns)

**Which issue(s) this PR fixes**:
Fixes #2244

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
