### PR TITLE
Convert REST API to use Validation API annotations instead of explicit checks

### DIFF
--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2ColumnDefinition.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2ColumnDefinition.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
+import javax.validation.constraints.NotBlank;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 // Copied from SGv1 ColumnDefinition
@@ -28,6 +29,7 @@ public class Sgv2ColumnDefinition {
       example = "emailaddress",
       required = true,
       description = "Name for the column, which must be unique.")
+  @NotBlank(message = "columnDefinition.name must be provided")
   public String getName() {
     return name;
   }

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2IndexAddRequest.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2IndexAddRequest.java
@@ -18,6 +18,7 @@ package io.stargate.sgv2.restapi.service.models;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.stargate.sgv2.api.common.cql.builder.CollectionIndexingType;
 import java.util.Map;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
@@ -45,6 +46,7 @@ public class Sgv2IndexAddRequest {
   }
 
   @Schema(required = true, description = "Column name")
+  @NotBlank(message = "IndexAddRequest.column must be provided")
   public String getColumn() {
     return column;
   }

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2TableAddRequest.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2TableAddRequest.java
@@ -2,13 +2,14 @@ package io.stargate.sgv2.restapi.service.models;
 
 import java.util.Collections;
 import java.util.List;
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 public class Sgv2TableAddRequest {
-  @NotNull private String name;
-  @NotNull private Sgv2Table.PrimaryKey primaryKey;
-  @NotNull private List<Sgv2ColumnDefinition> columnDefinitions;
+  private String name;
+  private Sgv2Table.PrimaryKey primaryKey;
+
+  private List<Sgv2ColumnDefinition> columnDefinitions;
 
   boolean ifNotExists;
 
@@ -22,6 +23,7 @@ public class Sgv2TableAddRequest {
   }
 
   @Schema(required = true, description = "The name of the table to add.")
+  @NotBlank(message = "TableAdd.name must be provided")
   public String getName() {
     return name;
   }
@@ -53,6 +55,7 @@ public class Sgv2TableAddRequest {
     this.primaryKey = primaryKey;
   }
 
+  // Cannot enforce non-null/non-emptiness since optional for Update (but mandatory for Create)
   @Schema(
       required = true,
       description = "Definition of columns that belong to the table to be added.")

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2UDTUpdateRequest.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2UDTUpdateRequest.java
@@ -3,6 +3,7 @@ package io.stargate.sgv2.restapi.service.models;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
@@ -25,6 +26,7 @@ public class Sgv2UDTUpdateRequest {
   }
 
   @Schema(required = true, description = "User Defined Type name")
+  @NotBlank(message = "UserDefinedTypeUpdate.name must be provided")
   public String getName() {
     return name;
   }

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/RestResourceBase.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/RestResourceBase.java
@@ -242,20 +242,6 @@ public abstract class RestResourceBase {
 
   // // // Helper methods for input validation
 
-  protected static void requireNonEmptyKeyspace(String keyspaceName) {
-    if (isStringEmpty(keyspaceName)) {
-      throw new WebApplicationException(
-          "keyspaceName must be provided", Response.Status.BAD_REQUEST);
-    }
-  }
-
-  protected static void requireNonEmptyKeyspaceAndTable(String keyspaceName, String tableName) {
-    requireNonEmptyKeyspace(keyspaceName);
-    if (isStringEmpty(tableName)) {
-      throw new WebApplicationException("table name must be provided", Response.Status.BAD_REQUEST);
-    }
-  }
-
   protected static final boolean isStringEmpty(String str) {
     return (str == null) || str.isEmpty();
   }

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/Sgv2RowsResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/Sgv2RowsResourceApi.java
@@ -7,6 +7,7 @@ import io.stargate.sgv2.restapi.service.models.Sgv2RESTResponse;
 import io.stargate.sgv2.restapi.service.models.Sgv2RowsResponse;
 import java.util.List;
 import javax.enterprise.context.ApplicationScoped;
+import javax.validation.constraints.NotBlank;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.PathSegment;
@@ -54,9 +55,11 @@ public interface Sgv2RowsResourceApi {
   Uni<RestResponse<Object>> getRowWithWhere(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(name = "tableName", ref = RestOpenApiConstants.Parameters.TABLE_NAME)
           @PathParam("tableName")
+          @NotBlank(message = "tableName must be provided")
           final String tableName,
       @Parameter(
               in = ParameterIn.QUERY,
@@ -79,6 +82,7 @@ public interface Sgv2RowsResourceApi {
               schema = @Schema(type = SchemaType.OBJECT),
               required = true)
           @QueryParam("where")
+          @NotBlank(message = "'where' must be provided")
           final String where,
       @Parameter(name = "fields", ref = RestOpenApiConstants.Parameters.FIELDS)
           @QueryParam("fields")
@@ -115,9 +119,11 @@ public interface Sgv2RowsResourceApi {
   Uni<RestResponse<Object>> getRows(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(name = "tableName", ref = RestOpenApiConstants.Parameters.TABLE_NAME)
           @PathParam("tableName")
+          @NotBlank(message = "tableName must be provided")
           final String tableName,
       @Parameter(name = "primaryKey", ref = RestOpenApiConstants.Parameters.PRIMARY_KEY)
           @PathParam("primaryKey")
@@ -159,9 +165,11 @@ public interface Sgv2RowsResourceApi {
   Uni<RestResponse<Object>> getAllRows(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(name = "tableName", ref = RestOpenApiConstants.Parameters.TABLE_NAME)
           @PathParam("tableName")
+          @NotBlank(message = "tableName must be provided")
           final String tableName,
       @Parameter(name = "fields", ref = RestOpenApiConstants.Parameters.FIELDS)
           @QueryParam("fields")
@@ -196,9 +204,11 @@ public interface Sgv2RowsResourceApi {
   Uni<RestResponse<Object>> createRow(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(name = "tableName", ref = RestOpenApiConstants.Parameters.TABLE_NAME)
           @PathParam("tableName")
+          @NotBlank(message = "tableName must be provided")
           final String tableName,
       @RequestBody(description = "Fields of the Row to create as JSON", required = true)
           final String payloadAsString);
@@ -219,9 +229,11 @@ public interface Sgv2RowsResourceApi {
   Uni<RestResponse<Object>> updateRows(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(name = "tableName", ref = RestOpenApiConstants.Parameters.TABLE_NAME)
           @PathParam("tableName")
+          @NotBlank(message = "tableName must be provided")
           final String tableName,
       @Parameter(name = "primaryKey", ref = RestOpenApiConstants.Parameters.PRIMARY_KEY)
           @PathParam("primaryKey")
@@ -249,9 +261,11 @@ public interface Sgv2RowsResourceApi {
   Uni<RestResponse<Object>> patchRows(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(name = "tableName", ref = RestOpenApiConstants.Parameters.TABLE_NAME)
           @PathParam("tableName")
+          @NotBlank(message = "tableName must be provided")
           final String tableName,
       @Parameter(name = "primaryKey", ref = RestOpenApiConstants.Parameters.PRIMARY_KEY)
           @PathParam("primaryKey")
@@ -274,9 +288,11 @@ public interface Sgv2RowsResourceApi {
   Uni<RestResponse<Object>> deleteRows(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(name = "tableName", ref = RestOpenApiConstants.Parameters.TABLE_NAME)
           @PathParam("tableName")
+          @NotBlank(message = "tableName must be provided")
           final String tableName,
       @Parameter(name = "primaryKey", ref = RestOpenApiConstants.Parameters.PRIMARY_KEY)
           @PathParam("primaryKey")

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/Sgv2RowsResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/Sgv2RowsResourceImpl.java
@@ -39,11 +39,6 @@ public class Sgv2RowsResourceImpl extends RestResourceBase implements Sgv2RowsRe
       final String pageStateParam,
       final boolean raw,
       final String sortJson) {
-    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
-    if (isStringEmpty(where)) {
-      throw new WebApplicationException("Missing required 'where' parameter", Status.BAD_REQUEST);
-    }
-
     final List<Column> columns =
         isStringEmpty(fields) ? Collections.emptyList() : splitColumns(fields);
     final Map<String, Column.Order> sortOrder;
@@ -99,7 +94,6 @@ public class Sgv2RowsResourceImpl extends RestResourceBase implements Sgv2RowsRe
       final String pageStateParam,
       final boolean raw,
       final String sortJson) {
-    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     final List<Column> columns =
         isStringEmpty(fields) ? Collections.emptyList() : splitColumns(fields);
     final Map<String, Column.Order> sortOrder;
@@ -142,7 +136,6 @@ public class Sgv2RowsResourceImpl extends RestResourceBase implements Sgv2RowsRe
       final String pageStateParam,
       final boolean raw,
       final String sortJson) {
-    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     List<Column> columns = isStringEmpty(fields) ? Collections.emptyList() : splitColumns(fields);
     Map<String, Column.Order> sortOrder;
     try {
@@ -176,7 +169,6 @@ public class Sgv2RowsResourceImpl extends RestResourceBase implements Sgv2RowsRe
   @Override
   public Uni<RestResponse<Object>> createRow(
       final String keyspaceName, final String tableName, final String payloadAsString) {
-    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     Map<String, Object> payloadMap;
     try {
       payloadMap = parseJsonAsMap(payloadAsString);
@@ -224,7 +216,6 @@ public class Sgv2RowsResourceImpl extends RestResourceBase implements Sgv2RowsRe
   @Override
   public Uni<RestResponse<Object>> deleteRows(
       final String keyspaceName, final String tableName, final List<PathSegment> path) {
-    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     return queryWithTableAsync(
             keyspaceName,
             tableName,
@@ -249,7 +240,6 @@ public class Sgv2RowsResourceImpl extends RestResourceBase implements Sgv2RowsRe
       final List<PathSegment> path,
       final boolean raw,
       final String payloadAsString) {
-    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     Map<String, Object> payloadMap;
     try {
       payloadMap = parseJsonAsMap(payloadAsString);

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2ColumnsResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2ColumnsResourceApi.java
@@ -4,16 +4,10 @@ import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.restapi.config.constants.RestOpenApiConstants;
 import io.stargate.sgv2.restapi.service.models.Sgv2ColumnDefinition;
 import javax.enterprise.context.ApplicationScoped;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
@@ -58,9 +52,11 @@ public interface Sgv2ColumnsResourceApi {
   Uni<RestResponse<Object>> getAllColumns(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(name = "tableName", ref = RestOpenApiConstants.Parameters.TABLE_NAME)
           @PathParam("tableName")
+          @NotBlank(message = "tableName must be provided")
           final String tableName,
       @Parameter(name = "raw", ref = RestOpenApiConstants.Parameters.RAW) @QueryParam("raw")
           final boolean raw);
@@ -80,11 +76,13 @@ public interface Sgv2ColumnsResourceApi {
   Uni<RestResponse<Object>> createColumn(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(name = "tableName", ref = RestOpenApiConstants.Parameters.TABLE_NAME)
           @PathParam("tableName")
+          @NotBlank(message = "tableName must be provided")
           final String tableName,
-      @RequestBody(description = "Column definition as JSON", required = true) @NotNull
+      @RequestBody(description = "Column definition as JSON", required = true) @NotNull @Valid
           final Sgv2ColumnDefinition columnDefinition);
 
   @GET
@@ -105,11 +103,15 @@ public interface Sgv2ColumnsResourceApi {
   Uni<RestResponse<Object>> getOneColumn(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(name = "tableName", ref = RestOpenApiConstants.Parameters.TABLE_NAME)
           @PathParam("tableName")
+          @NotBlank(message = "tableName must be provided")
           final String tableName,
-      @Parameter(name = "columnName", required = true) @PathParam("columnName")
+      @Parameter(name = "columnName", required = true)
+          @PathParam("columnName")
+          @NotBlank(message = "columnName must be provided")
           final String columnName,
       @Parameter(name = "raw", ref = RestOpenApiConstants.Parameters.RAW) @QueryParam("raw")
           final boolean raw);
@@ -133,12 +135,15 @@ public interface Sgv2ColumnsResourceApi {
   Uni<RestResponse<Object>> updateColumn(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(name = "tableName", ref = RestOpenApiConstants.Parameters.TABLE_NAME)
           @PathParam("tableName")
+          @NotBlank(message = "tableName must be provided")
           final String tableName,
-      @PathParam("columnName") final String columnName,
-      @NotNull final Sgv2ColumnDefinition columnUpdate);
+      @PathParam("columnName") @NotBlank(message = "columnName must be provided")
+          final String columnName,
+      @NotNull @Valid final Sgv2ColumnDefinition columnUpdate);
 
   @DELETE
   @Operation(
@@ -154,10 +159,14 @@ public interface Sgv2ColumnsResourceApi {
   public Uni<RestResponse<Object>> deleteColumn(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(name = "tableName", ref = RestOpenApiConstants.Parameters.TABLE_NAME)
           @PathParam("tableName")
+          @NotBlank(message = "tableName must be provided")
           final String tableName,
-      @Parameter(name = "column name", required = true) @PathParam("columnName")
+      @Parameter(name = "column name", required = true)
+          @PathParam("columnName")
+          @NotBlank(message = "columnName must be provided")
           final String columnName);
 }

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2ColumnsResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2ColumnsResourceImpl.java
@@ -20,8 +20,6 @@ public class Sgv2ColumnsResourceImpl extends RestResourceBase implements Sgv2Col
   @Override
   public Uni<RestResponse<Object>> getAllColumns(
       String keyspaceName, String tableName, boolean raw) {
-    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
-
     return getTableAsyncCheckExistence(keyspaceName, tableName, true, Response.Status.BAD_REQUEST)
         .map(t -> table2columns(t))
         // map to wrapper if needed
@@ -32,11 +30,7 @@ public class Sgv2ColumnsResourceImpl extends RestResourceBase implements Sgv2Col
   @Override
   public Uni<RestResponse<Object>> createColumn(
       String keyspaceName, String tableName, Sgv2ColumnDefinition columnDefinition) {
-    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     final String columnName = columnDefinition.getName();
-    if (isStringEmpty(tableName)) {
-      throw new WebApplicationException("columnName must be provided", Response.Status.BAD_REQUEST);
-    }
     return queryWithTableAsync(
             keyspaceName,
             tableName,
@@ -62,10 +56,6 @@ public class Sgv2ColumnsResourceImpl extends RestResourceBase implements Sgv2Col
   @Override
   public Uni<RestResponse<Object>> getOneColumn(
       String keyspaceName, String tableName, String columnName, boolean raw) {
-    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
-    if (isStringEmpty(columnName)) {
-      throw new WebApplicationException("columnName must be provided", Response.Status.BAD_REQUEST);
-    }
     return getTableAsyncCheckExistence(keyspaceName, tableName, true, Response.Status.BAD_REQUEST)
         .map(
             tableDef -> {
@@ -84,10 +74,6 @@ public class Sgv2ColumnsResourceImpl extends RestResourceBase implements Sgv2Col
   @Override
   public Uni<RestResponse<Object>> updateColumn(
       String keyspaceName, String tableName, String columnName, Sgv2ColumnDefinition columnUpdate) {
-    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
-    if (isStringEmpty(columnName)) {
-      throw new WebApplicationException("columnName must be provided", Response.Status.BAD_REQUEST);
-    }
     final String newName = columnUpdate.getName();
     // Avoid call if there is no need to rename
     if (columnName.equals(newName)) {
@@ -117,9 +103,6 @@ public class Sgv2ColumnsResourceImpl extends RestResourceBase implements Sgv2Col
   public Uni<RestResponse<Object>> deleteColumn(
       String keyspaceName, String tableName, String columnName) {
     requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
-    if (isStringEmpty(columnName)) {
-      throw new WebApplicationException("columnName must be provided", Response.Status.BAD_REQUEST);
-    }
     return queryWithTableAsync(
             keyspaceName,
             tableName,

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2ColumnsResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2ColumnsResourceImpl.java
@@ -102,7 +102,6 @@ public class Sgv2ColumnsResourceImpl extends RestResourceBase implements Sgv2Col
   @Override
   public Uni<RestResponse<Object>> deleteColumn(
       String keyspaceName, String tableName, String columnName) {
-    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     return queryWithTableAsync(
             keyspaceName,
             tableName,

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2IndexesResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2IndexesResourceApi.java
@@ -19,6 +19,8 @@ import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.restapi.config.constants.RestOpenApiConstants;
 import io.stargate.sgv2.restapi.service.models.Sgv2IndexAddRequest;
 import javax.enterprise.context.ApplicationScoped;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -69,9 +71,11 @@ public interface Sgv2IndexesResourceApi {
   Uni<RestResponse<Object>> getAllIndexes(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(name = "tableName", ref = RestOpenApiConstants.Parameters.TABLE_NAME)
           @PathParam("tableName")
+          @NotBlank(message = "tableName must be provided")
           final String tableName);
 
   @POST
@@ -91,11 +95,13 @@ public interface Sgv2IndexesResourceApi {
   Uni<RestResponse<Object>> addIndex(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(name = "tableName", ref = RestOpenApiConstants.Parameters.TABLE_NAME)
           @PathParam("tableName")
+          @NotBlank(message = "tableName must be provided")
           final String tableName,
-      @RequestBody(description = "Index definition as JSON", required = true) @NotNull
+      @RequestBody(description = "Index definition as JSON", required = true) @NotNull @Valid
           final Sgv2IndexAddRequest indexAdd);
 
   @DELETE
@@ -111,15 +117,18 @@ public interface Sgv2IndexesResourceApi {
   Uni<RestResponse<Object>> deleteIndex(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(name = "tableName", ref = RestOpenApiConstants.Parameters.TABLE_NAME)
           @PathParam("tableName")
+          @NotBlank(message = "tableName must be provided")
           final String tableName,
       @Parameter(
               name = "Name of the index to use for the request",
               required = true,
               schema = @Schema(type = SchemaType.STRING))
           @PathParam("indexName")
+          @NotBlank(message = "indexName must be provided")
           final String indexName,
       @Parameter(
               name =

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2IndexesResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2IndexesResourceImpl.java
@@ -36,13 +36,6 @@ public class Sgv2IndexesResourceImpl extends RestResourceBase implements Sgv2Ind
 
   @Override
   public Uni<RestResponse<Object>> getAllIndexes(String keyspaceName, String tableName) {
-    if (isStringEmpty(keyspaceName)) {
-      throw new WebApplicationException("keyspaceName must be provided", Status.BAD_REQUEST);
-    }
-    if (isStringEmpty(tableName)) {
-      throw new WebApplicationException("tableName must be provided", Status.BAD_REQUEST);
-    }
-
     // check that we're authorized for the table
     Uni<List<Boolean>> uni =
         authorizeSchemaReadsAsync(
@@ -64,18 +57,7 @@ public class Sgv2IndexesResourceImpl extends RestResourceBase implements Sgv2Ind
   @Override
   public Uni<RestResponse<Object>> addIndex(
       final String keyspaceName, final String tableName, final Sgv2IndexAddRequest indexAdd) {
-    if (isStringEmpty(keyspaceName)) {
-      throw new WebApplicationException("keyspaceName must be provided", Status.BAD_REQUEST);
-    }
-    if (isStringEmpty(tableName)) {
-      throw new WebApplicationException("tableName must be provided", Status.BAD_REQUEST);
-    }
-
     String columnName = indexAdd.getColumn();
-    if (isStringEmpty(columnName)) {
-      throw new WebApplicationException("columnName must be provided", Status.BAD_REQUEST);
-    }
-
     return queryWithTableAsync(
             keyspaceName,
             tableName,
@@ -104,16 +86,6 @@ public class Sgv2IndexesResourceImpl extends RestResourceBase implements Sgv2Ind
   @Override
   public Uni<RestResponse<Object>> deleteIndex(
       String keyspaceName, String tableName, String indexName, boolean ifExists) {
-    if (isStringEmpty(keyspaceName)) {
-      throw new WebApplicationException("keyspaceName must be provided", Status.BAD_REQUEST);
-    }
-    if (isStringEmpty(tableName)) {
-      throw new WebApplicationException("tableName must be provided", Status.BAD_REQUEST);
-    }
-    if (isStringEmpty(indexName)) {
-      throw new WebApplicationException("columnName must be provided", Status.BAD_REQUEST);
-    }
-
     return queryWithTableAsync(
             keyspaceName,
             tableName,

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2KeyspacesResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2KeyspacesResourceApi.java
@@ -19,6 +19,7 @@ import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.restapi.config.constants.RestOpenApiConstants;
 import io.stargate.sgv2.restapi.service.models.Sgv2Keyspace;
 import javax.enterprise.context.ApplicationScoped;
+import javax.validation.constraints.NotBlank;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -86,6 +87,7 @@ public interface Sgv2KeyspacesResourceApi {
   Uni<RestResponse<Object>> getOneKeyspace(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(name = "raw", ref = RestOpenApiConstants.Parameters.RAW) @QueryParam("raw")
           final boolean raw);
@@ -120,6 +122,7 @@ public interface Sgv2KeyspacesResourceApi {
                       + "      ],\n"
                       + "}\n"
                       + "```")
+          @NotBlank
           String payload);
 
   @DELETE
@@ -134,5 +137,6 @@ public interface Sgv2KeyspacesResourceApi {
   Uni<RestResponse<Object>> deleteKeyspace(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName);
 }

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2TablesResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2TablesResourceApi.java
@@ -5,6 +5,8 @@ import io.stargate.sgv2.restapi.config.constants.RestOpenApiConstants;
 import io.stargate.sgv2.restapi.service.models.Sgv2Table;
 import io.stargate.sgv2.restapi.service.models.Sgv2TableAddRequest;
 import javax.enterprise.context.ApplicationScoped;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -58,6 +60,7 @@ public interface Sgv2TablesResourceApi {
   Uni<RestResponse<Object>> getAllTables(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(name = "raw", ref = RestOpenApiConstants.Parameters.RAW) @QueryParam("raw")
           final boolean raw);
@@ -80,9 +83,11 @@ public interface Sgv2TablesResourceApi {
   Uni<RestResponse<Object>> getOneTable(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(name = "tableName", ref = RestOpenApiConstants.Parameters.TABLE_NAME)
           @PathParam("tableName")
+          @NotBlank(message = "tableName must be provided")
           final String tableName,
       @Parameter(name = "raw", ref = RestOpenApiConstants.Parameters.RAW) @QueryParam("raw")
           final boolean raw);
@@ -102,8 +107,9 @@ public interface Sgv2TablesResourceApi {
   Uni<RestResponse<Object>> createTable(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
-      @RequestBody(description = "Table definition as JSON", required = true) @NotNull
+      @RequestBody(description = "Table definition as JSON", required = true) @NotNull @Valid
           final Sgv2TableAddRequest tableAdd);
 
   @PUT
@@ -125,11 +131,13 @@ public interface Sgv2TablesResourceApi {
   Uni<RestResponse<Object>> updateTable(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(name = "tableName", ref = RestOpenApiConstants.Parameters.TABLE_NAME)
           @PathParam("tableName")
+          @NotBlank(message = "tableName must be provided")
           final String tableName,
-      @RequestBody(description = "Table update definition as JSON", required = true) @NotNull
+      @RequestBody(description = "Table update definition as JSON", required = true) @NotNull @Valid
           final Sgv2TableAddRequest tableUpdate);
 
   @DELETE
@@ -146,8 +154,10 @@ public interface Sgv2TablesResourceApi {
   Uni<RestResponse<Object>> deleteTable(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(name = "tableName", ref = RestOpenApiConstants.Parameters.TABLE_NAME)
           @PathParam("tableName")
+          @NotBlank(message = "tableName must be provided")
           final String tableName);
 }

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2TablesResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2TablesResourceImpl.java
@@ -30,8 +30,6 @@ public class Sgv2TablesResourceImpl extends RestResourceBase implements Sgv2Tabl
 
   @Override
   public Uni<RestResponse<Object>> getAllTables(final String keyspaceName, final boolean raw) {
-    requireNonEmptyKeyspace(keyspaceName);
-
     return getTablesAsync(keyspaceName)
         .map(t -> table2table(t, keyspaceName))
         .collect()
@@ -44,8 +42,6 @@ public class Sgv2TablesResourceImpl extends RestResourceBase implements Sgv2Tabl
   @Override
   public Uni<RestResponse<Object>> getOneTable(
       final String keyspaceName, final String tableName, final boolean raw) {
-    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
-
     return getTableAsyncCheckExistence(keyspaceName, tableName, true, Response.Status.NOT_FOUND)
         .map(t -> table2table(t, keyspaceName))
         // map to wrapper if needed
@@ -57,14 +53,22 @@ public class Sgv2TablesResourceImpl extends RestResourceBase implements Sgv2Tabl
   public Uni<RestResponse<Object>> createTable(
       final String keyspaceName, final Sgv2TableAddRequest tableAdd) {
     final String tableName = tableAdd.getName();
-    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
 
     // Need to create name-accessible Map of column objects to make
     // it easier to sort PK columns
     Map<String, Column> columnsByName = new LinkedHashMap<>();
     final Sgv2Table.PrimaryKey primaryKeys = tableAdd.getPrimaryKey();
     final List<Sgv2Table.ClusteringExpression> clusterings = tableAdd.findClusteringExpressions();
-    for (Sgv2ColumnDefinition columnDef : tableAdd.getColumnDefinitions()) {
+    final List<Sgv2ColumnDefinition> columnDefs = tableAdd.getColumnDefinitions();
+
+    // Cannot use Bean Validation annotations because columns are optional for Update, only
+    // mandatory here:
+    if (columnDefs == null || columnDefs.isEmpty()) {
+      throw new WebApplicationException(
+          "TableAdd.columnDefinitions must be provided", Status.BAD_REQUEST);
+    }
+
+    for (Sgv2ColumnDefinition columnDef : columnDefs) {
       final String columnName = columnDef.getName();
       ImmutableColumn.Builder column =
           ImmutableColumn.builder().name(columnName).type(columnDef.getTypeDefinition());
@@ -118,7 +122,6 @@ public class Sgv2TablesResourceImpl extends RestResourceBase implements Sgv2Tabl
   @Override
   public Uni<RestResponse<Object>> updateTable(
       final String keyspaceName, final String tableName, final Sgv2TableAddRequest tableUpdate) {
-    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     return queryWithTableAsync(
             keyspaceName,
             tableName,
@@ -148,7 +151,6 @@ public class Sgv2TablesResourceImpl extends RestResourceBase implements Sgv2Tabl
 
   @Override
   public Uni<RestResponse<Object>> deleteTable(final String keyspaceName, final String tableName) {
-    requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     return executeQueryAsync(
             new QueryBuilder().drop().table(keyspaceName, tableName).ifExists().build())
         .map(any -> RestResponse.noContent());

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2UDTsResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2UDTsResourceApi.java
@@ -5,6 +5,8 @@ import io.stargate.sgv2.restapi.config.constants.RestOpenApiConstants;
 import io.stargate.sgv2.restapi.service.models.Sgv2UDT;
 import io.stargate.sgv2.restapi.service.models.Sgv2UDTUpdateRequest;
 import javax.enterprise.context.ApplicationScoped;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -60,6 +62,7 @@ public interface Sgv2UDTsResourceApi {
   Uni<RestResponse<Object>> findAllTypes(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(name = "raw", ref = RestOpenApiConstants.Parameters.RAW) @QueryParam("raw")
           final boolean raw);
@@ -82,6 +85,7 @@ public interface Sgv2UDTsResourceApi {
   Uni<RestResponse<Object>> findTypeById(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(
               name = "typeName",
@@ -89,6 +93,7 @@ public interface Sgv2UDTsResourceApi {
               required = true,
               schema = @Schema(type = SchemaType.STRING))
           @PathParam("typeName")
+          @NotBlank(message = "typeName must be provided")
           final String typeName,
       @Parameter(name = "raw", ref = RestOpenApiConstants.Parameters.RAW) @QueryParam("raw")
           final boolean raw);
@@ -110,6 +115,7 @@ public interface Sgv2UDTsResourceApi {
   Uni<RestResponse<Object>> createType(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @RequestBody(description = "Type definition as JSON", required = true) @NotNull
           final String udtAddPayload);
@@ -127,8 +133,9 @@ public interface Sgv2UDTsResourceApi {
   Uni<RestResponse<Object>> updateType(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
-      @RequestBody(description = "Type definition as JSON", required = true) @NotNull
+      @RequestBody(description = "Type definition as JSON", required = true) @NotNull @Valid
           final Sgv2UDTUpdateRequest udtUpdate);
 
   @DELETE
@@ -145,6 +152,7 @@ public interface Sgv2UDTsResourceApi {
   Uni<RestResponse<Object>> deleteType(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
+          @NotBlank(message = "keyspaceName must be provided")
           final String keyspaceName,
       @Parameter(
               name = "typeName",
@@ -152,5 +160,6 @@ public interface Sgv2UDTsResourceApi {
               required = true,
               schema = @Schema(type = SchemaType.STRING))
           @PathParam("typeName")
+          @NotBlank(message = "typeName must be provided")
           final String typeName);
 }

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaColumnsIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaColumnsIT.java
@@ -27,21 +27,6 @@ public class RestApiV2QSchemaColumnsIT extends RestApiV2QIntegrationTestBase {
    */
 
   @Test
-  public void columnAddBadType() {
-    final String tableName = testTableName();
-    createSimpleTestTable(testKeyspaceName(), tableName);
-
-    final String columnToAdd = "name";
-    Sgv2ColumnDefinition columnDef = new Sgv2ColumnDefinition(columnToAdd, "badType", false);
-    String response =
-        tryAddColumn(testKeyspaceName(), tableName, columnDef, HttpStatus.SC_BAD_REQUEST);
-    ApiError apiError = readJsonAs(response, ApiError.class);
-    assertThat(apiError.code()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
-    // Sub-optimal failure message, should improve:
-    assertThat(apiError.description()).matches("Invalid argument.*Unknown type.*badType.*");
-  }
-
-  @Test
   public void columnAddBasic() {
     final String tableName = testTableName();
     createSimpleTestTable(testKeyspaceName(), tableName);
@@ -73,6 +58,35 @@ public class RestApiV2QSchemaColumnsIT extends RestApiV2QIntegrationTestBase {
     Sgv2ColumnDefinition columnFound =
         findOneColumn(testKeyspaceName(), tableName, columnToAdd, true);
     assertThat(columnFound).isEqualTo(columnDef);
+  }
+
+  @Test
+  public void columnAddBadType() {
+    final String tableName = testTableName();
+    createSimpleTestTable(testKeyspaceName(), tableName);
+
+    final String columnToAdd = "name";
+    Sgv2ColumnDefinition columnDef = new Sgv2ColumnDefinition(columnToAdd, "badType", false);
+    String response =
+        tryAddColumn(testKeyspaceName(), tableName, columnDef, HttpStatus.SC_BAD_REQUEST);
+    ApiError apiError = readJsonAs(response, ApiError.class);
+    assertThat(apiError.code()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+    // Sub-optimal failure message, should improve:
+    assertThat(apiError.description()).matches("Invalid argument.*Unknown type.*badType.*");
+  }
+
+  @Test
+  public void columnAddMissingName() {
+    final String tableName = testTableName();
+    createSimpleTestTable(testKeyspaceName(), tableName);
+
+    Sgv2ColumnDefinition columnDef = new Sgv2ColumnDefinition(null, "badType", false);
+    String response =
+        tryAddColumn(testKeyspaceName(), tableName, columnDef, HttpStatus.SC_BAD_REQUEST);
+    ApiError apiError = readJsonAs(response, ApiError.class);
+    assertThat(apiError.code()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+    assertThat(apiError.description())
+        .startsWith("Request invalid: columnDefinition.name must be provided");
   }
 
   /*


### PR DESCRIPTION
**What this PR does**:

Implements #2263:  convert REST API endpoints to use Java Bean Validation API annotations instead of explicit checks

**Which issue(s) this PR fixes**:
Fixes #2263

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
