### PR TITLE
Fix #2262: use typed responses for REST/Async endpoints where possible

### DIFF
--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2ColumnDefinition.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2ColumnDefinition.java
@@ -3,9 +3,8 @@ package io.stargate.sgv2.restapi.service.models;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Objects;
-
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import java.util.Objects;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 // Copied from SGv1 ColumnDefinition

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2ColumnDefinition.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2ColumnDefinition.java
@@ -4,11 +4,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 // Copied from SGv1 ColumnDefinition
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(name = "ColumnDefinition")
+@RegisterForReflection
 public class Sgv2ColumnDefinition {
   private String name;
   private String typeDefinition;

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2GetResponse.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2GetResponse.java
@@ -18,10 +18,12 @@ package io.stargate.sgv2.restapi.service.models;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 // Copy of "GetResponseWrapper" of StargateV1
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@RegisterForReflection
 public class Sgv2GetResponse<T> {
   @JsonProperty("count")
   protected final int count;

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2Keyspace.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2Keyspace.java
@@ -18,10 +18,9 @@ package io.stargate.sgv2.restapi.service.models;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.util.ArrayList;
 import java.util.List;
-
-import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2Keyspace.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2Keyspace.java
@@ -20,9 +20,12 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@RegisterForReflection
 public class Sgv2Keyspace {
   protected String name;
 

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2NameResponse.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2NameResponse.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.restapi.service.models;
+
+/**
+ * Simple response type used as the success result for Create and Update operations.
+ *
+ * @param name Name to return
+ */
+public record Sgv2NameResponse(String name) {}

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2RESTResponse.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2RESTResponse.java
@@ -18,10 +18,12 @@ package io.stargate.sgv2.restapi.service.models;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 // Copy of "RESTResponseWrapper" of StargateV1
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@RegisterForReflection
 public class Sgv2RESTResponse<T> {
   @JsonProperty("data")
   private T data;

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2RowsResponse.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2RowsResponse.java
@@ -19,8 +19,11 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import java.util.Map;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@RegisterForReflection
 public class Sgv2RowsResponse extends Sgv2GetResponse<List<Map<String, Object>>> {
   // Override to add better description
   @Schema(description = "The rows returned by the request.")

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2RowsResponse.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2RowsResponse.java
@@ -17,10 +17,9 @@ package io.stargate.sgv2.restapi.service.models;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.util.List;
 import java.util.Map;
-
-import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @RegisterForReflection

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2Table.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2Table.java
@@ -3,11 +3,10 @@ package io.stargate.sgv2.restapi.service.models;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 // Note: copy from SGv1 TableResponse

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2Table.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2Table.java
@@ -6,11 +6,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 // Note: copy from SGv1 TableResponse
 @Schema(name = "TableResponse", description = "A description of a Table")
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@RegisterForReflection
 public class Sgv2Table {
   private final String name;
   private final String keyspace;

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2UDT.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2UDT.java
@@ -3,9 +3,8 @@ package io.stargate.sgv2.restapi.service.models;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.List;
-
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import java.util.List;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema(name = "UserDefinedType")

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2UDT.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/models/Sgv2UDT.java
@@ -4,10 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema(name = "UserDefinedType")
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@RegisterForReflection
 public class Sgv2UDT {
   private final String name;
   private final String keyspace;

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/RestResourceBase.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/RestResourceBase.java
@@ -266,12 +266,13 @@ public abstract class RestResourceBase {
 
   // // // Helper methods for JAX-RS response construction
 
-  protected static RestResponse<Object> restResponseCreatedWithName(String createdName) {
+  protected static RestResponse<Map<String, String>> restResponseCreatedWithName(
+      String createdName) {
     return RestResponse.status(
         Response.Status.CREATED, Collections.singletonMap("name", createdName));
   }
 
-  protected static RestResponse<Object> restResponseOkWithName(String name) {
+  protected static RestResponse<Map<String, String>> restResponseOkWithName(String name) {
     return RestResponse.status(Response.Status.OK, Collections.singletonMap("name", name));
   }
 }

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/RestResourceBase.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/RestResourceBase.java
@@ -17,11 +17,11 @@ import io.stargate.sgv2.api.common.schema.SchemaManager;
 import io.stargate.sgv2.restapi.grpc.BridgeProtoValueConverters;
 import io.stargate.sgv2.restapi.grpc.FromProtoConverter;
 import io.stargate.sgv2.restapi.grpc.ToProtoConverter;
+import io.stargate.sgv2.restapi.service.models.Sgv2NameResponse;
 import io.stargate.sgv2.restapi.service.models.Sgv2RowsResponse;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -252,13 +252,11 @@ public abstract class RestResourceBase {
 
   // // // Helper methods for JAX-RS response construction
 
-  protected static RestResponse<Map<String, String>> restResponseCreatedWithName(
-      String createdName) {
-    return RestResponse.status(
-        Response.Status.CREATED, Collections.singletonMap("name", createdName));
+  protected static RestResponse<Sgv2NameResponse> restResponseCreatedWithName(String createdName) {
+    return RestResponse.status(Response.Status.CREATED, new Sgv2NameResponse(createdName));
   }
 
-  protected static RestResponse<Map<String, String>> restResponseOkWithName(String name) {
-    return RestResponse.status(Response.Status.OK, Collections.singletonMap("name", name));
+  protected static RestResponse<Sgv2NameResponse> restResponseOkWithName(String name) {
+    return RestResponse.status(Response.Status.OK, new Sgv2NameResponse(name));
   }
 }

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/RestResourceBase.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/RestResourceBase.java
@@ -13,7 +13,6 @@ import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.bridge.proto.Schema;
 import io.stargate.sgv2.api.common.StargateRequestInfo;
-import io.stargate.sgv2.api.common.exception.model.dto.ApiError;
 import io.stargate.sgv2.api.common.schema.SchemaManager;
 import io.stargate.sgv2.restapi.grpc.BridgeProtoValueConverters;
 import io.stargate.sgv2.restapi.grpc.FromProtoConverter;
@@ -266,16 +265,6 @@ public abstract class RestResourceBase {
   }
 
   // // // Helper methods for JAX-RS response construction
-
-  protected static Uni<RestResponse<Object>> apiErrorResponseUni(
-      Response.Status httpStatus, String failMessage) {
-    return Uni.createFrom().item(apiErrorResponse(httpStatus, failMessage));
-  }
-
-  protected static RestResponse<Object> apiErrorResponse(
-      Response.Status httpStatus, String failMessage) {
-    return RestResponse.status(httpStatus, new ApiError(failMessage, httpStatus.getStatusCode()));
-  }
 
   protected static RestResponse<Object> restResponseCreatedWithName(String createdName) {
     return RestResponse.status(

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2ColumnsResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2ColumnsResourceApi.java
@@ -3,6 +3,7 @@ package io.stargate.sgv2.restapi.service.resources.schemas;
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.restapi.config.constants.RestOpenApiConstants;
 import io.stargate.sgv2.restapi.service.models.Sgv2ColumnDefinition;
+import java.util.Map;
 import javax.enterprise.context.ApplicationScoped;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -77,7 +78,7 @@ public interface Sgv2ColumnsResourceApi {
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_401),
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_500)
       })
-  Uni<RestResponse<Object>> createColumn(
+  Uni<RestResponse<Map<String, String>>> createColumn(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
           final String keyspaceName,
@@ -130,7 +131,7 @@ public interface Sgv2ColumnsResourceApi {
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_500)
       })
   @Path("/{columnName}")
-  Uni<RestResponse<Object>> updateColumn(
+  Uni<RestResponse<Map<String, String>>> updateColumn(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
           final String keyspaceName,
@@ -151,7 +152,7 @@ public interface Sgv2ColumnsResourceApi {
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_500)
       })
   @Path("/{columnName}")
-  public Uni<RestResponse<Object>> deleteColumn(
+  public Uni<RestResponse<Void>> deleteColumn(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
           final String keyspaceName,

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2ColumnsResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2ColumnsResourceApi.java
@@ -3,7 +3,7 @@ package io.stargate.sgv2.restapi.service.resources.schemas;
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.restapi.config.constants.RestOpenApiConstants;
 import io.stargate.sgv2.restapi.service.models.Sgv2ColumnDefinition;
-import java.util.Map;
+import io.stargate.sgv2.restapi.service.models.Sgv2NameResponse;
 import javax.enterprise.context.ApplicationScoped;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
@@ -74,7 +74,7 @@ public interface Sgv2ColumnsResourceApi {
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_401),
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_500)
       })
-  Uni<RestResponse<Map<String, String>>> createColumn(
+  Uni<RestResponse<Sgv2NameResponse>> createColumn(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
           @NotBlank(message = "keyspaceName must be provided")
@@ -133,7 +133,7 @@ public interface Sgv2ColumnsResourceApi {
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_500)
       })
   @Path("/{columnName}")
-  Uni<RestResponse<Map<String, String>>> updateColumn(
+  Uni<RestResponse<Sgv2NameResponse>> updateColumn(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
           @NotBlank(message = "keyspaceName must be provided")

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2ColumnsResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2ColumnsResourceImpl.java
@@ -8,11 +8,11 @@ import io.stargate.sgv2.api.common.cql.builder.ImmutableColumn;
 import io.stargate.sgv2.api.common.cql.builder.QueryBuilder;
 import io.stargate.sgv2.restapi.grpc.BridgeProtoTypeTranslator;
 import io.stargate.sgv2.restapi.service.models.Sgv2ColumnDefinition;
+import io.stargate.sgv2.restapi.service.models.Sgv2NameResponse;
 import io.stargate.sgv2.restapi.service.models.Sgv2RESTResponse;
 import io.stargate.sgv2.restapi.service.resources.RestResourceBase;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import org.jboss.resteasy.reactive.RestResponse;
@@ -29,7 +29,7 @@ public class Sgv2ColumnsResourceImpl extends RestResourceBase implements Sgv2Col
   }
 
   @Override
-  public Uni<RestResponse<Map<String, String>>> createColumn(
+  public Uni<RestResponse<Sgv2NameResponse>> createColumn(
       String keyspaceName, String tableName, Sgv2ColumnDefinition columnDefinition) {
     final String columnName = columnDefinition.getName();
     return queryWithTableAsync(
@@ -73,7 +73,7 @@ public class Sgv2ColumnsResourceImpl extends RestResourceBase implements Sgv2Col
   }
 
   @Override
-  public Uni<RestResponse<Map<String, String>>> updateColumn(
+  public Uni<RestResponse<Sgv2NameResponse>> updateColumn(
       String keyspaceName, String tableName, String columnName, Sgv2ColumnDefinition columnUpdate) {
     final String newName = columnUpdate.getName();
     // Avoid call if there is no need to rename

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2ColumnsResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2ColumnsResourceImpl.java
@@ -12,6 +12,7 @@ import io.stargate.sgv2.restapi.service.models.Sgv2RESTResponse;
 import io.stargate.sgv2.restapi.service.resources.RestResourceBase;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import org.jboss.resteasy.reactive.RestResponse;
@@ -30,7 +31,7 @@ public class Sgv2ColumnsResourceImpl extends RestResourceBase implements Sgv2Col
   }
 
   @Override
-  public Uni<RestResponse<Object>> createColumn(
+  public Uni<RestResponse<Map<String, String>>> createColumn(
       String keyspaceName, String tableName, Sgv2ColumnDefinition columnDefinition) {
     requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     final String columnName = columnDefinition.getName();
@@ -82,7 +83,7 @@ public class Sgv2ColumnsResourceImpl extends RestResourceBase implements Sgv2Col
   }
 
   @Override
-  public Uni<RestResponse<Object>> updateColumn(
+  public Uni<RestResponse<Map<String, String>>> updateColumn(
       String keyspaceName, String tableName, String columnName, Sgv2ColumnDefinition columnUpdate) {
     requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     if (isStringEmpty(columnName)) {
@@ -114,7 +115,7 @@ public class Sgv2ColumnsResourceImpl extends RestResourceBase implements Sgv2Col
   }
 
   @Override
-  public Uni<RestResponse<Object>> deleteColumn(
+  public Uni<RestResponse<Void>> deleteColumn(
       String keyspaceName, String tableName, String columnName) {
     requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     if (isStringEmpty(columnName)) {

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2IndexesResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2IndexesResourceApi.java
@@ -18,6 +18,7 @@ package io.stargate.sgv2.restapi.service.resources.schemas;
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.restapi.config.constants.RestOpenApiConstants;
 import io.stargate.sgv2.restapi.service.models.Sgv2IndexAddRequest;
+import java.util.Map;
 import javax.enterprise.context.ApplicationScoped;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -88,7 +89,7 @@ public interface Sgv2IndexesResourceApi {
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_401),
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_500)
       })
-  Uni<RestResponse<Object>> addIndex(
+  Uni<RestResponse<Map<String, Object>>> addIndex(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
           final String keyspaceName,
@@ -108,7 +109,7 @@ public interface Sgv2IndexesResourceApi {
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_500)
       })
   @Path("/{indexName}")
-  Uni<RestResponse<Object>> deleteIndex(
+  Uni<RestResponse<Void>> deleteIndex(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
           final String keyspaceName,

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2IndexesResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2IndexesResourceImpl.java
@@ -29,6 +29,7 @@ import io.stargate.sgv2.restapi.service.resources.RestResourceBase;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 import org.jboss.resteasy.reactive.RestResponse;
@@ -63,7 +64,7 @@ public class Sgv2IndexesResourceImpl extends RestResourceBase implements Sgv2Ind
   }
 
   @Override
-  public Uni<RestResponse<Object>> addIndex(
+  public Uni<RestResponse<Map<String, Object>>> addIndex(
       final String keyspaceName, final String tableName, final Sgv2IndexAddRequest indexAdd) {
     if (isStringEmpty(keyspaceName)) {
       throw new WebApplicationException("keyspaceName must be provided", Status.BAD_REQUEST);
@@ -100,7 +101,7 @@ public class Sgv2IndexesResourceImpl extends RestResourceBase implements Sgv2Ind
   }
 
   @Override
-  public Uni<RestResponse<Object>> deleteIndex(
+  public Uni<RestResponse<Void>> deleteIndex(
       String keyspaceName, String tableName, String indexName, boolean ifExists) {
     if (isStringEmpty(keyspaceName)) {
       throw new WebApplicationException("keyspaceName must be provided", Status.BAD_REQUEST);

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2KeyspacesResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2KeyspacesResourceApi.java
@@ -18,6 +18,7 @@ package io.stargate.sgv2.restapi.service.resources.schemas;
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.restapi.config.constants.RestOpenApiConstants;
 import io.stargate.sgv2.restapi.service.models.Sgv2Keyspace;
+import java.util.Map;
 import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -101,7 +102,7 @@ public interface Sgv2KeyspacesResourceApi {
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_401),
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_500)
       })
-  Uni<RestResponse<Object>> createKeyspace(
+  Uni<RestResponse<Map<String, String>>> createKeyspace(
       @RequestBody(
               description =
                   "A map representing a keyspace with SimpleStrategy or NetworkTopologyStrategy with default replicas of 1 and 3 respectively \n"
@@ -131,7 +132,7 @@ public interface Sgv2KeyspacesResourceApi {
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_500),
       })
   @Path("/{keyspaceName}")
-  Uni<RestResponse<Object>> deleteKeyspace(
+  Uni<RestResponse<Void>> deleteKeyspace(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
           final String keyspaceName);

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2KeyspacesResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2KeyspacesResourceApi.java
@@ -18,7 +18,7 @@ package io.stargate.sgv2.restapi.service.resources.schemas;
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.restapi.config.constants.RestOpenApiConstants;
 import io.stargate.sgv2.restapi.service.models.Sgv2Keyspace;
-import java.util.Map;
+import io.stargate.sgv2.restapi.service.models.Sgv2NameResponse;
 import javax.enterprise.context.ApplicationScoped;
 import javax.validation.constraints.NotBlank;
 import javax.ws.rs.Consumes;
@@ -104,7 +104,7 @@ public interface Sgv2KeyspacesResourceApi {
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_401),
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_500)
       })
-  Uni<RestResponse<Map<String, String>>> createKeyspace(
+  Uni<RestResponse<Sgv2NameResponse>> createKeyspace(
       @RequestBody(
               description =
                   "A map representing a keyspace with SimpleStrategy or NetworkTopologyStrategy with default replicas of 1 and 3 respectively \n"

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2KeyspacesResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2KeyspacesResourceImpl.java
@@ -26,6 +26,7 @@ import io.stargate.bridge.proto.Schema.CqlKeyspaceDescribe;
 import io.stargate.sgv2.api.common.cql.builder.QueryBuilder;
 import io.stargate.sgv2.api.common.cql.builder.Replication;
 import io.stargate.sgv2.restapi.service.models.Sgv2Keyspace;
+import io.stargate.sgv2.restapi.service.models.Sgv2NameResponse;
 import io.stargate.sgv2.restapi.service.models.Sgv2RESTResponse;
 import io.stargate.sgv2.restapi.service.resources.RestResourceBase;
 import java.io.IOException;
@@ -77,7 +78,7 @@ public class Sgv2KeyspacesResourceImpl extends RestResourceBase
   }
 
   @Override
-  public Uni<RestResponse<Map<String, String>>> createKeyspace(final String payloadString) {
+  public Uni<RestResponse<Sgv2NameResponse>> createKeyspace(final String payloadString) {
     SchemaBuilderHelper.KeyspaceCreateDefinition ksCreateDef;
     try {
       JsonNode payload = JSON_MAPPER.readTree(payloadString);

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2KeyspacesResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2KeyspacesResourceImpl.java
@@ -77,7 +77,7 @@ public class Sgv2KeyspacesResourceImpl extends RestResourceBase
   }
 
   @Override
-  public Uni<RestResponse<Object>> createKeyspace(final String payloadString) {
+  public Uni<RestResponse<Map<String, String>>> createKeyspace(final String payloadString) {
     SchemaBuilderHelper.KeyspaceCreateDefinition ksCreateDef;
     try {
       JsonNode payload = JSON_MAPPER.readTree(payloadString);
@@ -116,7 +116,7 @@ public class Sgv2KeyspacesResourceImpl extends RestResourceBase
   }
 
   @Override
-  public Uni<RestResponse<Object>> deleteKeyspace(final String keyspaceName) {
+  public Uni<RestResponse<Void>> deleteKeyspace(final String keyspaceName) {
     return executeQueryAsync(new QueryBuilder().drop().keyspace(keyspaceName).ifExists().build())
         .map(any -> RestResponse.noContent());
   }

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2TablesResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2TablesResourceApi.java
@@ -2,9 +2,9 @@ package io.stargate.sgv2.restapi.service.resources.schemas;
 
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.restapi.config.constants.RestOpenApiConstants;
+import io.stargate.sgv2.restapi.service.models.Sgv2NameResponse;
 import io.stargate.sgv2.restapi.service.models.Sgv2Table;
 import io.stargate.sgv2.restapi.service.models.Sgv2TableAddRequest;
-import java.util.Map;
 import javax.enterprise.context.ApplicationScoped;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
@@ -105,7 +105,7 @@ public interface Sgv2TablesResourceApi {
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_401),
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_500),
       })
-  Uni<RestResponse<Map<String, String>>> createTable(
+  Uni<RestResponse<Sgv2NameResponse>> createTable(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
           @NotBlank(message = "keyspaceName must be provided")
@@ -129,7 +129,7 @@ public interface Sgv2TablesResourceApi {
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_500),
       })
   @Path("/{tableName}")
-  Uni<RestResponse<Map<String, String>>> updateTable(
+  Uni<RestResponse<Sgv2NameResponse>> updateTable(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
           @NotBlank(message = "keyspaceName must be provided")

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2TablesResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2TablesResourceApi.java
@@ -4,6 +4,7 @@ import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.restapi.config.constants.RestOpenApiConstants;
 import io.stargate.sgv2.restapi.service.models.Sgv2Table;
 import io.stargate.sgv2.restapi.service.models.Sgv2TableAddRequest;
+import java.util.Map;
 import javax.enterprise.context.ApplicationScoped;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -99,7 +100,7 @@ public interface Sgv2TablesResourceApi {
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_401),
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_500),
       })
-  Uni<RestResponse<Object>> createTable(
+  Uni<RestResponse<Map<String, String>>> createTable(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
           final String keyspaceName,
@@ -122,7 +123,7 @@ public interface Sgv2TablesResourceApi {
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_500),
       })
   @Path("/{tableName}")
-  Uni<RestResponse<Object>> updateTable(
+  Uni<RestResponse<Map<String, String>>> updateTable(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
           final String keyspaceName,
@@ -143,7 +144,7 @@ public interface Sgv2TablesResourceApi {
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_500),
       })
   @Path("/{tableName}")
-  Uni<RestResponse<Object>> deleteTable(
+  Uni<RestResponse<Void>> deleteTable(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
           final String keyspaceName,

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2TablesResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2TablesResourceImpl.java
@@ -54,7 +54,7 @@ public class Sgv2TablesResourceImpl extends RestResourceBase implements Sgv2Tabl
   }
 
   @Override
-  public Uni<RestResponse<Object>> createTable(
+  public Uni<RestResponse<Map<String, String>>> createTable(
       final String keyspaceName, final Sgv2TableAddRequest tableAdd) {
     final String tableName = tableAdd.getName();
     requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
@@ -116,7 +116,7 @@ public class Sgv2TablesResourceImpl extends RestResourceBase implements Sgv2Tabl
   }
 
   @Override
-  public Uni<RestResponse<Object>> updateTable(
+  public Uni<RestResponse<Map<String, String>>> updateTable(
       final String keyspaceName, final String tableName, final Sgv2TableAddRequest tableUpdate) {
     requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     return queryWithTableAsync(
@@ -147,7 +147,7 @@ public class Sgv2TablesResourceImpl extends RestResourceBase implements Sgv2Tabl
   }
 
   @Override
-  public Uni<RestResponse<Object>> deleteTable(final String keyspaceName, final String tableName) {
+  public Uni<RestResponse<Void>> deleteTable(final String keyspaceName, final String tableName) {
     requireNonEmptyKeyspaceAndTable(keyspaceName, tableName);
     return executeQueryAsync(
             new QueryBuilder().drop().table(keyspaceName, tableName).ifExists().build())

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2TablesResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2TablesResourceImpl.java
@@ -8,6 +8,7 @@ import io.stargate.sgv2.api.common.cql.builder.ImmutableColumn;
 import io.stargate.sgv2.api.common.cql.builder.QueryBuilder;
 import io.stargate.sgv2.restapi.grpc.BridgeProtoTypeTranslator;
 import io.stargate.sgv2.restapi.service.models.Sgv2ColumnDefinition;
+import io.stargate.sgv2.restapi.service.models.Sgv2NameResponse;
 import io.stargate.sgv2.restapi.service.models.Sgv2RESTResponse;
 import io.stargate.sgv2.restapi.service.models.Sgv2Table;
 import io.stargate.sgv2.restapi.service.models.Sgv2TableAddRequest;
@@ -50,7 +51,7 @@ public class Sgv2TablesResourceImpl extends RestResourceBase implements Sgv2Tabl
   }
 
   @Override
-  public Uni<RestResponse<Map<String, String>>> createTable(
+  public Uni<RestResponse<Sgv2NameResponse>> createTable(
       final String keyspaceName, final Sgv2TableAddRequest tableAdd) {
     final String tableName = tableAdd.getName();
 
@@ -120,7 +121,7 @@ public class Sgv2TablesResourceImpl extends RestResourceBase implements Sgv2Tabl
   }
 
   @Override
-  public Uni<RestResponse<Map<String, String>>> updateTable(
+  public Uni<RestResponse<Sgv2NameResponse>> updateTable(
       final String keyspaceName, final String tableName, final Sgv2TableAddRequest tableUpdate) {
     return queryWithTableAsync(
             keyspaceName,

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2UDTsResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2UDTsResourceApi.java
@@ -4,6 +4,7 @@ import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.restapi.config.constants.RestOpenApiConstants;
 import io.stargate.sgv2.restapi.service.models.Sgv2UDT;
 import io.stargate.sgv2.restapi.service.models.Sgv2UDTUpdateRequest;
+import java.util.Map;
 import javax.enterprise.context.ApplicationScoped;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -107,7 +108,7 @@ public interface Sgv2UDTsResourceApi {
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_401),
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_500)
       })
-  Uni<RestResponse<Object>> createType(
+  Uni<RestResponse<Map<String, String>>> createType(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
           final String keyspaceName,
@@ -124,7 +125,7 @@ public interface Sgv2UDTsResourceApi {
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_401),
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_500),
       })
-  Uni<RestResponse<Object>> updateType(
+  Uni<RestResponse<Void>> updateType(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
           final String keyspaceName,
@@ -142,7 +143,7 @@ public interface Sgv2UDTsResourceApi {
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_500)
       })
   @Path("/{typeName}")
-  Uni<RestResponse<Object>> deleteType(
+  Uni<RestResponse<Void>> deleteType(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
           final String keyspaceName,

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2UDTsResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2UDTsResourceApi.java
@@ -2,9 +2,9 @@ package io.stargate.sgv2.restapi.service.resources.schemas;
 
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.restapi.config.constants.RestOpenApiConstants;
+import io.stargate.sgv2.restapi.service.models.Sgv2NameResponse;
 import io.stargate.sgv2.restapi.service.models.Sgv2UDT;
 import io.stargate.sgv2.restapi.service.models.Sgv2UDTUpdateRequest;
-import java.util.Map;
 import javax.enterprise.context.ApplicationScoped;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
@@ -113,7 +113,7 @@ public interface Sgv2UDTsResourceApi {
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_401),
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_500)
       })
-  Uni<RestResponse<Map<String, String>>> createType(
+  Uni<RestResponse<Sgv2NameResponse>> createType(
       @Parameter(name = "keyspaceName", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
           @PathParam("keyspaceName")
           @NotBlank(message = "keyspaceName must be provided")

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2UDTsResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2UDTsResourceImpl.java
@@ -10,6 +10,7 @@ import io.stargate.sgv2.api.common.cql.builder.Column;
 import io.stargate.sgv2.api.common.cql.builder.ImmutableColumn;
 import io.stargate.sgv2.api.common.cql.builder.Predicate;
 import io.stargate.sgv2.api.common.cql.builder.QueryBuilder;
+import io.stargate.sgv2.restapi.service.models.Sgv2NameResponse;
 import io.stargate.sgv2.restapi.service.models.Sgv2RESTResponse;
 import io.stargate.sgv2.restapi.service.models.Sgv2UDT;
 import io.stargate.sgv2.restapi.service.models.Sgv2UDTAddRequest;
@@ -92,7 +93,7 @@ public class Sgv2UDTsResourceImpl extends RestResourceBase implements Sgv2UDTsRe
   }
 
   @Override
-  public Uni<RestResponse<Map<String, String>>> createType(
+  public Uni<RestResponse<Sgv2NameResponse>> createType(
       final String keyspaceName, final String udtAddPayload) {
     Sgv2UDTAddRequest udtAdd;
 

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2UDTsResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2UDTsResourceImpl.java
@@ -97,7 +97,7 @@ public class Sgv2UDTsResourceImpl extends RestResourceBase implements Sgv2UDTsRe
   }
 
   @Override
-  public Uni<RestResponse<Object>> createType(
+  public Uni<RestResponse<Map<String, String>>> createType(
       final String keyspaceName, final String udtAddPayload) {
     requireNonEmptyKeyspace(keyspaceName);
     Sgv2UDTAddRequest udtAdd;
@@ -141,7 +141,7 @@ public class Sgv2UDTsResourceImpl extends RestResourceBase implements Sgv2UDTsRe
   }
 
   @Override
-  public Uni<RestResponse<Object>> updateType(
+  public Uni<RestResponse<Void>> updateType(
       final String keyspaceName, final Sgv2UDTUpdateRequest udtUpdate) {
     requireNonEmptyKeyspace(keyspaceName);
     final String typeName = udtUpdate.getName();
@@ -194,7 +194,7 @@ public class Sgv2UDTsResourceImpl extends RestResourceBase implements Sgv2UDTsRe
   }
 
   @Override
-  public Uni<RestResponse<Object>> deleteType(final String keyspaceName, final String typeName) {
+  public Uni<RestResponse<Void>> deleteType(final String keyspaceName, final String typeName) {
     requireNonEmptyKeyspace(keyspaceName);
     requireNonEmptyTypename(typeName);
 

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaUserTypeIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaUserTypeIT.java
@@ -1,6 +1,8 @@
 package io.stargate.sgv2.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.matchesRegex;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
@@ -312,22 +314,18 @@ public class RestApiV2QSchemaUserTypeIT extends RestApiV2QIntegrationTestBase {
         Arrays.asList("id text", "name " + typeInUse),
         Arrays.asList("id"),
         Arrays.asList());
-    String response =
-        givenWithAuth()
-            .when()
-            .delete(endpointPathForUDT(testKeyspaceName(), typeInUse))
-            .then()
-            .statusCode(HttpStatus.SC_BAD_REQUEST)
-            .extract()
-            .asString();
-    // As with earlier fail message, could be improved
-    ApiError apiError = readJsonAs(response, ApiError.class);
-    assertThat(apiError.code()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
-    assertThat(apiError.description())
-        .matches(
-            String.format(
-                "Invalid argument.*Cannot drop user type.*%s.* as it is still used by .*",
-                typeInUse));
+    givenWithAuth()
+        .when()
+        .delete(endpointPathForUDT(testKeyspaceName(), typeInUse))
+        .then()
+        .statusCode(HttpStatus.SC_BAD_REQUEST)
+        .body("code", is(HttpStatus.SC_BAD_REQUEST))
+        .body(
+            "description",
+            matchesRegex(
+                String.format(
+                    "Invalid argument.*Cannot drop user type.*%s.* as it is still used by .*",
+                    typeInUse)));
   }
 
   /*


### PR DESCRIPTION
**What this PR does**:

Improve type-safety of REST API endpoints to help with Quarkus native bindings (and documentation, general cleanliness).

NOTE: none of GET endpoints can use common base class due to odd wrapper-or-unwrapped response type (controlled by "raw" query param). Changed CREATE/UPDATE/DELETE endpoints, however, and added annotations for other response types to help with native bindings.

**Which issue(s) this PR fixes**:
Fixes #2262

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
