### PR TITLE
closes #2280: regex validation in the subdomain tenant resolver

### DIFF
--- a/apis/sgv2-quarkus-common/CONFIGURATION.md
+++ b/apis/sgv2-quarkus-common/CONFIGURATION.md
@@ -46,12 +46,13 @@
 ### Multi-tenancy configuration
 *Configuration mapping for multi tenant operation mode, defined by [MultiTenancyConfig.java](src/main/java/io/stargate/sgv2/api/common/config/MultiTenancyConfig.java).*
 
-| Property                                                     | Type      | Default | Description                                                                                                          |
-|--------------------------------------------------------------|-----------|---------|----------------------------------------------------------------------------------------------------------------------|
-| `stargate.multi-tenancy.enabled`                             | `boolean` | `false` | If multi-tenancy operation mode is enabled.                                                                          |
-| `stargate.multi-tenancy.tenant-resolver.type`                | `String`  | unset   | Tenant identifier resolver type if multi-tenancy is enabled. Possible options are `subdomain`, `fixed`, or `custom`. |
-| `stargate.multi-tenancy.tenant-resolver.fixed.tenant-id`     | `String`  | unset   | Tenant identifier value if the `fixed` type is used.                                                                 |
-| `stargate.multi-tenancy.tenant-resolver.subdomain.max-chars` | `String`  | unset   | Optional, takes only a defined number of max characters from the resolved sub-domain as tenant id.                   |
+| Property                                                     | Type      | Default | Description                                                                                                                                        |
+|--------------------------------------------------------------|-----------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `stargate.multi-tenancy.enabled`                             | `boolean` | `false` | If multi-tenancy operation mode is enabled.                                                                                                        |
+| `stargate.multi-tenancy.tenant-resolver.type`                | `String`  | unset   | Tenant identifier resolver type if multi-tenancy is enabled. Possible options are `subdomain`, `fixed`, or `custom`.                               |
+| `stargate.multi-tenancy.tenant-resolver.fixed.tenant-id`     | `String`  | unset   | Tenant identifier value if the `fixed` type is used.                                                                                               |
+| `stargate.multi-tenancy.tenant-resolver.subdomain.max-chars` | `String`  | unset   | Optional, takes only a defined number of max characters from the resolved sub-domain as tenant id. If config value is negative, then it's ignored. |
+| `stargate.multi-tenancy.tenant-resolver.subdomain.regex`     | `String`  | unset   | Optional, validates the resolved tenant id against the provided regular expression. If not matching the regex, resolves to empty (unknown) tenant. |
 
 ### Queries configuration
 *Configuration mapping for the query properties, defined by [QueriesConfig.java](src/main/java/io/stargate/sgv2/api/common/config/QueriesConfig.java).*

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/MultiTenancyConfig.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/MultiTenancyConfig.java
@@ -76,6 +76,9 @@ public interface MultiTenancyConfig {
 
       /** @return Maximum characters to pull from the subdomain. */
       OptionalInt maxChars();
+
+      /** @return The regex to validate the resolved tenant against. */
+      Optional<String> regex();
     }
   }
 }

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/tenant/impl/SubdomainTenantResolverWithRegexTest.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/tenant/impl/SubdomainTenantResolverWithRegexTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.api.common.tenant.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.mockito.InjectMock;
+import io.stargate.sgv2.api.common.tenant.TenantResolver;
+import io.vertx.ext.web.RoutingContext;
+import java.util.Map;
+import java.util.Optional;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(SubdomainTenantResolverWithRegexTest.Profile.class)
+class SubdomainTenantResolverWithRegexTest {
+
+  public static class Profile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return ImmutableMap.<String, String>builder()
+          .put("stargate.multi-tenancy.enabled", "true")
+          .put("stargate.multi-tenancy.tenant-resolver.type", "subdomain")
+          .put("stargate.multi-tenancy.tenant-resolver.subdomain.max-chars", "36")
+          .put(
+              "stargate.multi-tenancy.tenant-resolver.subdomain.regex",
+              "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}")
+          .build();
+    }
+  }
+
+  @Inject // enabled by default
+  Instance<TenantResolver> tenantResolver;
+
+  @InjectMock(returnsDeepMocks = true)
+  RoutingContext routingContext;
+
+  @Nested
+  class Resolve {
+
+    @Test
+    public void happyPath() {
+      when(routingContext.request().host())
+          .thenReturn("09cedbf6-9086-42bb-93ac-e497682227ba-eu-west-1.domain.host");
+
+      Optional<String> result = tenantResolver.get().resolve(routingContext, null);
+
+      assertThat(result).contains("09cedbf6-9086-42bb-93ac-e497682227ba");
+    }
+
+    @Test
+    public void tooShort() {
+      when(routingContext.request().host())
+          .thenReturn("09cedbf6-9086-42bb-93ac-e497682227b.domain.host");
+
+      Optional<String> result = tenantResolver.get().resolve(routingContext, null);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void regexNotMatched() {
+      when(routingContext.request().host()).thenReturn("xyz.domain.host");
+
+      Optional<String> result = tenantResolver.get().resolve(routingContext, null);
+
+      assertThat(result).isEmpty();
+    }
+  }
+}


### PR DESCRIPTION
**What this PR does**:
Allows tenant id validation.

**Which issue(s) this PR fixes**:
Fixes #2280

