### PR TITLE
Add simple substitution for Maven project.version into "index.html"

### DIFF
--- a/apis/sgv2-restapi/pom.xml
+++ b/apis/sgv2-restapi/pom.xml
@@ -139,6 +139,30 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>com.google.code.maven-replacer-plugin</groupId>
+        <artifactId>replacer</artifactId>
+        <version>1.5.3</version>
+        <executions>
+          <execution>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>replace</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <ignoreMissingFile>false</ignoreMissingFile>
+          <file>${basedir}/src/main/resources/META-INF/resources/index.html</file>
+          <outputFile>${basedir}/target/classes/META-INF/resources/index.html</outputFile>
+          <replacements>
+            <replacement>
+              <token>%VERSION%</token>
+              <value>${project.version}</value>
+            </replacement>
+          </replacements>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/apis/sgv2-restapi/src/main/resources/META-INF/resources/index.html
+++ b/apis/sgv2-restapi/src/main/resources/META-INF/resources/index.html
@@ -206,7 +206,7 @@
                             <ul>
                                 <li>GroupId: <code>io.stargate</code></li>
                                 <li>ArtifactId: <code>sgv2-restapi</code></li>
-                                <li>Version: <code>v2</code></li>
+                                <li>Version: <code>%VERSION%</code></li>
                             </ul>
                         </div>
                     </div>


### PR DESCRIPTION
**What this PR does**:

Injects `project.versions` from Maven build into Quarkus webapp home page "index.html" so that we can easily see version of (REST) API deployed.

Note: at first only added for REST API but can easily add to other APIs if we like the idea

**Which issue(s) this PR fixes**:
Fixes #2285

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
