### PR TITLE
updating docker building script, update release workflow

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -306,7 +306,7 @@ jobs:
       - name: Build and push (coordinator, Amazon ECR)
         if: ${{ !inputs.skipPublish }}
         run: |
-          ./build_docker_images.sh -p -t ${{needs.resolve-tag.outputs.release-tag}} -r ${{ secrets.ECR_REPOSITORY }} -a
+          ./build_docker_images.sh -p -t ${{needs.resolve-tag.outputs.release-tag}} -r ${{ secrets.ECR_REPOSITORY }}
 
       # downloads and prepares datastax assets
       - name: Download branding assets

--- a/build_docker_images.sh
+++ b/build_docker_images.sh
@@ -9,7 +9,6 @@ set -euo pipefail
 # -p - causes the images to be built for all supported platform architectures and pushed to
 #   Docker Hub (assumes you are logged in to Stargate Docker Hub account).
 #   This is intended to be used as part of automated builds.
-# -a - only build/push the API images; skip building the persistence images
 # -t <version> - overrides the default tag that will be applied to the image with the one
 #   you provide. By default the tag consists of the version is obtained from the parent
 #   pom.xml file, prepended with v, i.e. v2.0.0.
@@ -28,8 +27,6 @@ SGTAG="v$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)"
 
 REPO="stargateio"
 
-API_ONLY=
-
 #
 # overrides via command line
 #
@@ -44,9 +41,6 @@ while getopts ":t:r:pa" opt; do
       ;;
     r)
       REPO="$OPTARG/stargateio"
-      ;;
-    a)
-      API_ONLY=true
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
@@ -71,10 +65,8 @@ cp ./stargate-lib/*.jar $LIBDIR
 cp ./stargate-lib/logback.xml $LIBDIR
 rm ${LIBDIR}/persistence*.jar
 
-if [ -z $API_ONLY ]; then
-  docker buildx build --target coordinator-4_0 --build-arg LIBDIR="$LIBDIR" -t $REPO/coordinator-4_0:$SGTAG -t $REPO/coordinator-4_0:v2 $DOCKER_FLAGS .
-  docker buildx build --target coordinator-3_11 --build-arg LIBDIR="$LIBDIR" -t $REPO/coordinator-3_11:$SGTAG -t $REPO/coordinator-3_11:v2 $DOCKER_FLAGS .
-  docker buildx build --target coordinator-dse-68 --build-arg LIBDIR="$LIBDIR" -t $REPO/coordinator-dse-68:$SGTAG -t $REPO/coordinator-dse-68:v2 $DOCKER_FLAGS .
-fi
+docker buildx build --target coordinator-4_0 --build-arg LIBDIR="$LIBDIR" -t $REPO/coordinator-4_0:$SGTAG -t $REPO/coordinator-4_0:v2 $DOCKER_FLAGS .
+docker buildx build --target coordinator-3_11 --build-arg LIBDIR="$LIBDIR" -t $REPO/coordinator-3_11:$SGTAG -t $REPO/coordinator-3_11:v2 $DOCKER_FLAGS .
+docker buildx build --target coordinator-dse-68 --build-arg LIBDIR="$LIBDIR" -t $REPO/coordinator-dse-68:$SGTAG -t $REPO/coordinator-dse-68:v2 $DOCKER_FLAGS .
 
 rm -rf ${LIBDIR}


### PR DESCRIPTION
**What this PR does**:
Fixes the release workflow so that coordinator images are pushed to the ECR as well.

Note that I updated the `build_docker_images.sh` script, as the `-a` option was useless.. However, maybe we should actually fix this, so that the building of the api images from the script is also possible.. Not sure.

**Which issue(s) this PR fixes**:
Internal issue.
