### PR TITLE
Merge v1.0.69 to `main`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Changelog
 
-## [Unreleased](https://github.com/stargate/stargate/tree/HEAD)
-
-[Full Changelog](https://github.com/stargate/stargate/compare/v2.0.1...HEAD)
-
-**Closed issues:**
-
-- InboundHAProxyHandler is not @Sharable [\#2232](https://github.com/stargate/stargate/issues/2232)
-
 ## [v2.0.1](https://github.com/stargate/stargate/tree/v2.0.1) (2022-11-14)
 
 [Full Changelog](https://github.com/stargate/stargate/compare/v1.0.68...v2.0.1)


### PR DESCRIPTION
**What this PR does**:

Merges `v1` after 1.0.69 release into `main`. No real changes but we have to reconcile changes to allow for merging later changes from v1 into main; part of the release process.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
