### PR TITLE
fixes  openapi example in docs v2

### DIFF
--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/StargateDocsApi.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/StargateDocsApi.java
@@ -173,7 +173,9 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                     @ExampleObject(
                         name = "fields.notEmpty",
                         summary = "Fields example",
-                        value = "[race,location]")
+                        value = """
+                                ["race", "location"]
+                                """)
                   }),
               @Parameter(
                   in = ParameterIn.QUERY,

--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/StargateDocsApi.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/StargateDocsApi.java
@@ -173,9 +173,10 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                     @ExampleObject(
                         name = "fields.notEmpty",
                         summary = "Fields example",
-                        value = """
-                                ["race", "location"]
-                                """)
+                        value =
+                            """
+                            ["race", "location"]
+                            """)
                   }),
               @Parameter(
                   in = ParameterIn.QUERY,


### PR DESCRIPTION
**What this PR does**:
Small fix to make the default value for the `fields` parameter in openapi a valid JSON array.
