### PR TITLE
updates quarkus to v2.14.3

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -23,7 +23,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.14.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.14.3.Final</quarkus.platform.version>
     <skipTests>false</skipTests>
     <skipUnitTests>${skipTests}</skipUnitTests>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>

--- a/apis/sgv2-quarkus-common/README.md
+++ b/apis/sgv2-quarkus-common/README.md
@@ -123,7 +123,7 @@ Enables out-of-the-box metrics collection and the Prometheus exporter.
 Metrics are exported at the Prometheus default `/metrics` endpoint.
 All non-application endpoints are ignored from the collection.
 
-### `quarkus-opentelemetry-exporter-otlp`
+### `quarkus-opentelemetry`
 [Related guide](https://quarkus.io/guides/opentelemetry)
 
 Enables the [OpenTelemetry](https://opentelemetry.io/) tracing support.

--- a/apis/sgv2-quarkus-common/pom.xml
+++ b/apis/sgv2-quarkus-common/pom.xml
@@ -59,7 +59,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
+      <artifactId>quarkus-opentelemetry</artifactId>
     </dependency>
     <dependency>
       <groupId>com.github.misberner.duzzt</groupId>


### PR DESCRIPTION
**What this PR does**:
Opening a PR because I saw a warning like:

```
[WARNING] The artifact io.quarkus:quarkus-opentelemetry-exporter-otlp:jar:2.14.1.Final has been relocated to io.quarkus:quarkus-opentelemetry:jar:2.14.1.Final: io.quarkus:quarkus-opentelemetry-exporter-otlp:2.14.1.Final was relocated to io.quarkus:quarkus-opentelemetry-exporter-otlp:2.14.0.Final and is not managed by io.quarkus.platform:quarkus-bom:2.14.1.Final anymore. Please, update the groupId and add the corresponding version to the dependency declaration in your project configuration. For more information about this change, please refer to https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.14
```

When I was updating to `2.14.1` I took care of this, but it might be lost in merging process. I update the dependency, but then also saw Quarkus has released `2.14.3`, so I was thinking let's do two things at once.

