### PR TITLE
Document version support and branching strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ but the short of it is below.
 - If you're not sure about it or want to chat, reach out on our [Discord](https://discord.gg/GravUqY) 
 - If you want to write some user docs 🎉 head over to the [stargate/docs](https://github.com/stargate/docs) repo, Pull Requests accepted!
 
+## Supported Versions and Branching Strategy
+
+The Stargate project maintains support for the current major version number and one major version number previous. We mark the previous major version number as deprecated in order to encourage usage of the latest version. When a new major number version number release N is created, the N-2 release is no longer supported. For example, when Stargate v3 is released, v1 will no longer be supported.
+
+Supporting a release entails making bug fixes, keeping dependencies up to date, and making sure Docker images are free from vulnerabilities.
+
+The current major version is maintained on the default `main` branch. The prior major version number is maintained on a version branch, for example, `v1`.
+
+We make bug fixes in all supported releases. The recommended approach is to commit a fix first to the previous major version branch (if applicable) and merge it forward into the current major version branch.
+
+We iterate forward rather than producing patch releases. For example, for a vulnerability found in `v2.0.3`, we'd make any required fixes and dependency updates and release `v2.0.4`. We maintain a regular release cadence of approximately twice a month but can iterate more quickly as the situation dictates. 
+
+
 ## Thanks
 
 ![YourKit Logo](https://www.yourkit.com/images/yklogo.png)

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ The current major version is maintained on the default `main` branch. The prior 
 
 We make bug fixes in all supported releases. The recommended approach is to commit a fix first to the previous major version branch (if applicable) and merge it forward into the current major version branch.
 
+We use minor version numbers to indicate any changes to the coordinator that would cause compatibility changes for Stargate APIs. For example, a breaking change to the [bridge](bridge) API in v2.0.x would cause creation of a v2.1.0 release, and any API implementations would need to explicitly update in order to be compatible. You can use any version of the coordinator and API that have same the major and minor version number without issues.
+
 We iterate forward rather than producing patch releases. For example, for a vulnerability found in `v2.0.3`, we'd make any required fixes and dependency updates and release `v2.0.4`. We maintain a regular release cadence of approximately twice a month but can iterate more quickly as the situation dictates. 
 
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ but the short of it is below.
 
 ## Supported Versions and Branching Strategy
 
-The Stargate project maintains support for the current major version number and one major version number previous. We mark the previous major version number as deprecated in order to encourage usage of the latest version. When a new major number version number release N is created, the N-2 release is no longer supported. For example, when Stargate v3 is released, v1 will no longer be supported.
+The Stargate project maintains support for the current major version number and one major version number previous. We mark the previous major version number as deprecated in order to encourage usage of the latest version. We anticipate supporting a major version number release N for one year after the subsequent major version number release (N+1), or until the major version number release (N+2), whichever comes first. For example, v1 will be supported until when Stargate v3 is released, but no later than October 2023 (1 year after release date of Stargate v2). We anticipate producing a new major version number release every 6-12 months.
 
 Supporting a release entails making bug fixes, keeping dependencies up to date, and making sure Docker images are free from vulnerabilities.
 


### PR DESCRIPTION
Adds to the project README to clarify our planned support model for major version number releases and the related branching strategy. This is written to be major version agnostic such that we could make the same change to both `v1` and `main` branches.

This addresses a portion of #2294

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
