### PR TITLE
closes #2309: update quarkus to v2.15.1

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -23,7 +23,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.14.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
     <skipTests>false</skipTests>
     <skipUnitTests>${skipTests}</skipUnitTests>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -23,7 +23,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.15.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.15.1.Final</quarkus.platform.version>
     <skipTests>false</skipTests>
     <skipUnitTests>${skipTests}</skipUnitTests>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResourceIntegrationTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.startsWith;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
@@ -166,7 +165,7 @@ public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
           .then()
           .statusCode(400)
           .body("code", is(400))
-          .body("description", startsWith("Unable to process JSON"));
+          .body("description", is("HTTP 400 Bad Request"));
     }
 
     @Test

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentUpdateResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentUpdateResourceIntegrationTest.java
@@ -23,7 +23,6 @@ import static net.javacrumbs.jsonunit.JsonMatchers.jsonPartEquals;
 import static net.javacrumbs.jsonunit.core.util.ResourceUtils.resource;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.startsWith;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 import com.google.common.io.CharStreams;
@@ -391,7 +390,7 @@ class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
           .then()
           .statusCode(400)
           .body("code", is(400))
-          .body("description", startsWith("Unable to process JSON"));
+          .body("description", is("HTTP 400 Bad Request"));
     }
 
     @Test

--- a/apis/sgv2-graphqlapi/pom.xml
+++ b/apis/sgv2-graphqlapi/pom.xml
@@ -36,6 +36,13 @@
       <artifactId>graphql-java</artifactId>
       <version>18.3</version>
     </dependency>
+    <!-- Quarkus sets it's own antlr version, keep this is sync with graphql-java deps -->
+    <dependency>
+      <groupId>org.antlr</groupId>
+      <artifactId>antlr4-runtime</artifactId>
+      <version>4.9.3</version>
+      <scope>runtime</scope>
+    </dependency>
     <dependency>
       <groupId>com.apollographql.federation</groupId>
       <artifactId>federation-graphql-java-support</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -823,7 +823,6 @@
         <artifactId>nimbus-jose-jwt</artifactId>
         <version>9.21</version>
       </dependency>
-
     </dependencies>
   </dependencyManagement>
  

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <caffeine.version>2.9.3</caffeine.version>
     <commons-io.version>2.7</commons-io.version>
-    <grpc.version>1.50.2</grpc.version>
+    <grpc.version>1.51.0</grpc.version>
     <immutables.version>2.8.8</immutables.version>
     <jackson.version>2.13.4</jackson.version>
     <javatuples.version>1.2</javatuples.version>


### PR DESCRIPTION
**What this PR does**:

Updates Quarkus to v2.15.0. Needed to unblock the work on #2248. 
