### PR TITLE
closes #2248: common exception mappers must be explicitly enabled

### DIFF
--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/exception/CommonExceptionMappers.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/api/exception/CommonExceptionMappers.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.docsapi.api.exception;
+
+import io.grpc.StatusRuntimeException;
+import io.stargate.sgv2.api.common.exception.BridgeAuthorizationExceptionMapper;
+import io.stargate.sgv2.api.common.exception.ConstraintViolationExceptionMapper;
+import io.stargate.sgv2.api.common.exception.RuntimeExceptionMapper;
+import io.stargate.sgv2.api.common.exception.StatusRuntimeExceptionMapper;
+import io.stargate.sgv2.api.common.exception.WebApplicationExceptionMapper;
+import io.stargate.sgv2.api.common.exception.model.dto.ApiError;
+import io.stargate.sgv2.api.common.grpc.BridgeAuthorizationException;
+import javax.validation.ConstraintViolationException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+
+/**
+ * A setup for activating all common exceptions mappers. We have this class in order to have any
+ * exception mapper in the commons optional. Unfortunately, this same setup exists in all three
+ * APIs.
+ */
+public class CommonExceptionMappers {
+
+  private final BridgeAuthorizationExceptionMapper bridgeAuthorizationExceptionMapper =
+      new BridgeAuthorizationExceptionMapper();
+
+  private final ConstraintViolationExceptionMapper constraintViolationExceptionMapper =
+      new ConstraintViolationExceptionMapper();
+
+  private final RuntimeExceptionMapper runtimeExceptionMapper = new RuntimeExceptionMapper();
+
+  private final StatusRuntimeExceptionMapper statusRuntimeExceptionMapper =
+      new StatusRuntimeExceptionMapper();
+
+  private final WebApplicationExceptionMapper webApplicationExceptionMapper =
+      new WebApplicationExceptionMapper();
+
+  @ServerExceptionMapper
+  public RestResponse<ApiError> bridgeAuthorizationException(
+      BridgeAuthorizationException exception) {
+    return bridgeAuthorizationExceptionMapper.bridgeAuthorizationException(exception);
+  }
+
+  @ServerExceptionMapper
+  public RestResponse<ApiError> constraintViolationException(
+      ConstraintViolationException exception) {
+    return constraintViolationExceptionMapper.constraintViolationException(exception);
+  }
+
+  @ServerExceptionMapper
+  public RestResponse<ApiError> runtimeException(RuntimeException exception) {
+    return runtimeExceptionMapper.runtimeException(exception);
+  }
+
+  @ServerExceptionMapper
+  public RestResponse<ApiError> statusRuntimeException(StatusRuntimeException exception) {
+    return statusRuntimeExceptionMapper.statusRuntimeException(exception);
+  }
+
+  @ServerExceptionMapper
+  public Response webApplicationException(WebApplicationException exception) {
+    return webApplicationExceptionMapper.webApplicationException(exception);
+  }
+}

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/exception/CommonExceptionMappers.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/exception/CommonExceptionMappers.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.graphql.web.exception;
+
+import io.grpc.StatusRuntimeException;
+import io.stargate.sgv2.api.common.exception.BridgeAuthorizationExceptionMapper;
+import io.stargate.sgv2.api.common.exception.ConstraintViolationExceptionMapper;
+import io.stargate.sgv2.api.common.exception.RuntimeExceptionMapper;
+import io.stargate.sgv2.api.common.exception.StatusRuntimeExceptionMapper;
+import io.stargate.sgv2.api.common.exception.WebApplicationExceptionMapper;
+import io.stargate.sgv2.api.common.exception.model.dto.ApiError;
+import io.stargate.sgv2.api.common.grpc.BridgeAuthorizationException;
+import javax.validation.ConstraintViolationException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+
+/**
+ * A setup for activating all common exceptions mappers. We have this class in order to have any
+ * exception mapper in the commons optional. Unfortunately, this same setup exists in all three
+ * APIs.
+ */
+public class CommonExceptionMappers {
+
+  private final BridgeAuthorizationExceptionMapper bridgeAuthorizationExceptionMapper =
+      new BridgeAuthorizationExceptionMapper();
+
+  private final ConstraintViolationExceptionMapper constraintViolationExceptionMapper =
+      new ConstraintViolationExceptionMapper();
+
+  private final RuntimeExceptionMapper runtimeExceptionMapper = new RuntimeExceptionMapper();
+
+  private final StatusRuntimeExceptionMapper statusRuntimeExceptionMapper =
+      new StatusRuntimeExceptionMapper();
+
+  private final WebApplicationExceptionMapper webApplicationExceptionMapper =
+      new WebApplicationExceptionMapper();
+
+  @ServerExceptionMapper
+  public RestResponse<ApiError> bridgeAuthorizationException(
+      BridgeAuthorizationException exception) {
+    return bridgeAuthorizationExceptionMapper.bridgeAuthorizationException(exception);
+  }
+
+  @ServerExceptionMapper
+  public RestResponse<ApiError> constraintViolationException(
+      ConstraintViolationException exception) {
+    return constraintViolationExceptionMapper.constraintViolationException(exception);
+  }
+
+  @ServerExceptionMapper
+  public RestResponse<ApiError> runtimeException(RuntimeException exception) {
+    return runtimeExceptionMapper.runtimeException(exception);
+  }
+
+  @ServerExceptionMapper
+  public RestResponse<ApiError> statusRuntimeException(StatusRuntimeException exception) {
+    return statusRuntimeExceptionMapper.statusRuntimeException(exception);
+  }
+
+  @ServerExceptionMapper
+  public Response webApplicationException(WebApplicationException exception) {
+    return webApplicationExceptionMapper.webApplicationException(exception);
+  }
+}

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/exception/BridgeAuthorizationExceptionMapper.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/exception/BridgeAuthorizationExceptionMapper.java
@@ -21,12 +21,10 @@ import io.stargate.sgv2.api.common.exception.model.dto.ApiError;
 import io.stargate.sgv2.api.common.grpc.BridgeAuthorizationException;
 import javax.ws.rs.core.Response;
 import org.jboss.resteasy.reactive.RestResponse;
-import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 
 /** Simple exception mapper for the {@link BridgeAuthorizationException}. */
 public class BridgeAuthorizationExceptionMapper {
 
-  @ServerExceptionMapper
   public RestResponse<ApiError> bridgeAuthorizationException(
       BridgeAuthorizationException exception) {
     int code = Response.Status.UNAUTHORIZED.getStatusCode();

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/exception/ConstraintViolationExceptionMapper.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/exception/ConstraintViolationExceptionMapper.java
@@ -25,12 +25,10 @@ import javax.validation.ConstraintViolationException;
 import javax.ws.rs.core.Response;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.RestResponse.ResponseBuilder;
-import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 
 /** Simple exception mapper for the {@link ConstraintViolationException}. */
 public class ConstraintViolationExceptionMapper {
 
-  @ServerExceptionMapper
   public RestResponse<ApiError> constraintViolationException(
       ConstraintViolationException exception) {
     // figure out the message in the same way as V1

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/exception/RuntimeExceptionMapper.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/exception/RuntimeExceptionMapper.java
@@ -21,7 +21,6 @@ import io.stargate.sgv2.api.common.exception.model.dto.ApiError;
 import javax.ws.rs.core.Response;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.RestResponse.ResponseBuilder;
-import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +29,6 @@ public class RuntimeExceptionMapper {
 
   private static final Logger log = LoggerFactory.getLogger(RuntimeExceptionMapper.class);
 
-  @ServerExceptionMapper
   public RestResponse<ApiError> runtimeException(RuntimeException exception) {
     log.error("Unexpected runtime exception occurred.", exception);
 

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/exception/StatusRuntimeExceptionMapper.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/exception/StatusRuntimeExceptionMapper.java
@@ -23,7 +23,6 @@ import io.stargate.sgv2.api.common.exception.model.dto.ApiError;
 import javax.ws.rs.core.Response;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.RestResponse.ResponseBuilder;
-import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +31,6 @@ public class StatusRuntimeExceptionMapper {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(StatusRuntimeExceptionMapper.class);
 
-  @ServerExceptionMapper
   public RestResponse<ApiError> statusRuntimeException(StatusRuntimeException exception) {
     Status.Code sc = exception.getStatus().getCode();
     String msg = exception.getMessage();

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/exception/WebApplicationExceptionMapper.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/exception/WebApplicationExceptionMapper.java
@@ -20,7 +20,6 @@ package io.stargate.sgv2.api.common.exception;
 import io.stargate.sgv2.api.common.exception.model.dto.ApiError;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
-import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 
 /**
  * Simple exception mapper for the {@link WebApplicationException}. Needed due to the existence of
@@ -28,7 +27,6 @@ import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
  */
 public class WebApplicationExceptionMapper {
 
-  @ServerExceptionMapper
   public Response webApplicationException(WebApplicationException exception) {
     Response response = exception.getResponse();
     ApiError error = new ApiError(exception.getMessage(), response.getStatus());

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/exception/WebApplicationExceptionMapperTest.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/exception/WebApplicationExceptionMapperTest.java
@@ -24,10 +24,20 @@ import io.quarkus.test.junit.QuarkusTest;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 public class WebApplicationExceptionMapperTest {
+
+  private final WebApplicationExceptionMapper mapper = new WebApplicationExceptionMapper();
+
+  @ServerExceptionMapper
+  public Response webApplicationException(WebApplicationException exception) {
+    return mapper.webApplicationException(exception);
+  }
 
   @Path("web-application-exception-mapper-test")
   public static class TestingResource {

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/exception/CommonExceptionMappers.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/exception/CommonExceptionMappers.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.restapi.service.exception;
+
+import io.grpc.StatusRuntimeException;
+import io.stargate.sgv2.api.common.exception.BridgeAuthorizationExceptionMapper;
+import io.stargate.sgv2.api.common.exception.ConstraintViolationExceptionMapper;
+import io.stargate.sgv2.api.common.exception.RuntimeExceptionMapper;
+import io.stargate.sgv2.api.common.exception.StatusRuntimeExceptionMapper;
+import io.stargate.sgv2.api.common.exception.WebApplicationExceptionMapper;
+import io.stargate.sgv2.api.common.exception.model.dto.ApiError;
+import io.stargate.sgv2.api.common.grpc.BridgeAuthorizationException;
+import javax.validation.ConstraintViolationException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+
+/**
+ * A setup for activating all common exceptions mappers. We have this class in order to have any
+ * exception mapper in the commons optional. Unfortunately, this same setup exists in all three
+ * APIs.
+ */
+public class CommonExceptionMappers {
+
+  private final BridgeAuthorizationExceptionMapper bridgeAuthorizationExceptionMapper =
+      new BridgeAuthorizationExceptionMapper();
+
+  private final ConstraintViolationExceptionMapper constraintViolationExceptionMapper =
+      new ConstraintViolationExceptionMapper();
+
+  private final RuntimeExceptionMapper runtimeExceptionMapper = new RuntimeExceptionMapper();
+
+  private final StatusRuntimeExceptionMapper statusRuntimeExceptionMapper =
+      new StatusRuntimeExceptionMapper();
+
+  private final WebApplicationExceptionMapper webApplicationExceptionMapper =
+      new WebApplicationExceptionMapper();
+
+  @ServerExceptionMapper
+  public RestResponse<ApiError> bridgeAuthorizationException(
+      BridgeAuthorizationException exception) {
+    return bridgeAuthorizationExceptionMapper.bridgeAuthorizationException(exception);
+  }
+
+  @ServerExceptionMapper
+  public RestResponse<ApiError> constraintViolationException(
+      ConstraintViolationException exception) {
+    return constraintViolationExceptionMapper.constraintViolationException(exception);
+  }
+
+  @ServerExceptionMapper
+  public RestResponse<ApiError> runtimeException(RuntimeException exception) {
+    return runtimeExceptionMapper.runtimeException(exception);
+  }
+
+  @ServerExceptionMapper
+  public RestResponse<ApiError> statusRuntimeException(StatusRuntimeException exception) {
+    return statusRuntimeExceptionMapper.statusRuntimeException(exception);
+  }
+
+  @ServerExceptionMapper
+  public Response webApplicationException(WebApplicationException exception) {
+    return webApplicationExceptionMapper.webApplicationException(exception);
+  }
+}


### PR DESCRIPTION
**IMPORTANT: Seems that Quarkus v2.15.0 does provide an easy way to disable them with a property, so holding up until we do manage to upgrade to v2.15.0. #2309**

**What this PR does**:
Unfortunately Quarkus was not providing support for conditional exception mappers as expecting in v2.15.0. The solution I created is very simple:

* keep code in commons, but remove ` @ServerExceptionMapper` annotations so they are not auto-registered
* each api can explicitly register them now :)

We need this asap for multiple projects. 

**Which issue(s) this PR fixes**:
Fixes #2248
