### PR TITLE
no default int test profile in the sgv2 apis

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -27,6 +27,17 @@
     <skipTests>false</skipTests>
     <skipUnitTests>${skipTests}</skipUnitTests>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
+    <!--
+      Integration test properties, defaults to cassandra-40
+      Please maintain default values for int-test in sync with io.stargate.sgv2.docsapi.testresource.StargateTestResource.Defaults
+     -->
+    <stargate.int-test.cassandra.image>cassandra</stargate.int-test.cassandra.image>
+    <stargate.int-test.cassandra.image-tag>4.0.4</stargate.int-test.cassandra.image-tag>
+    <stargate.int-test.coordinator.image>stargateio/coordinator-4_0</stargate.int-test.coordinator.image>
+    <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
+    <stargate.int-test.cluster.name>cass-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
+    <stargate.int-test.cluster.version>4.0</stargate.int-test.cluster.version>
+    <stargate.int-test.cluster.dse>false</stargate.int-test.cluster.dse>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -193,19 +204,6 @@
   <profiles>
     <profile>
       <id>cassandra-40</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <properties>
-        <!-- Please maintain default values for int-test in sync with io.stargate.sgv2.docsapi.testresource.StargateTestResource.Defaults -->
-        <stargate.int-test.cassandra.image>cassandra</stargate.int-test.cassandra.image>
-        <stargate.int-test.cassandra.image-tag>4.0.4</stargate.int-test.cassandra.image-tag>
-        <stargate.int-test.coordinator.image>stargateio/coordinator-4_0</stargate.int-test.coordinator.image>
-        <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
-        <stargate.int-test.cluster.name>cass-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
-        <stargate.int-test.cluster.version>4.0</stargate.int-test.cluster.version>
-        <stargate.int-test.cluster.dse>false</stargate.int-test.cluster.dse>
-      </properties>
     </profile>
     <profile>
       <id>cassandra-311</id>

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -202,6 +202,7 @@
     </plugins>
   </build>
   <profiles>
+    <!-- cassandra-40 used to be active by default, keeping for bw compatibility -->
     <profile>
       <id>cassandra-40</id>
     </profile>


### PR DESCRIPTION
**What this PR does**:
We realized that having a maven profile `cassandra-40` activated by default, bounds any child module also to have this profile as a default one. There are situations where child modules are made for only a specific backend and thus we need to relax this a bit. Unfortunately making a profile not default in a child module is not work. Thus, a solution:

* `cassandra-40` is not marked as default anymore
* properties from `cassandra-40` are now set directly in the pom and can be overwritten by any child module in what ever fashion wanted (profile, props, etc)
