### PR TITLE
closes #2318: grpc deadline exceeded to be reported as HTTP 504

### DIFF
--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/exception/StatusRuntimeExceptionMapper.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/exception/StatusRuntimeExceptionMapper.java
@@ -67,12 +67,14 @@ public class StatusRuntimeExceptionMapper {
       case UNIMPLEMENTED:
         return grpcResponseAndLogAsError(
             sc, Response.Status.NOT_IMPLEMENTED, "Unimplemented gRPC operation", msg);
+      case DEADLINE_EXCEEDED:
+        return grpcResponseAndLogAsError(
+            sc, Response.Status.GATEWAY_TIMEOUT, "gRPC service timeout", msg);
 
         // and then all codes we consider as not expected
       case OK:
       case CANCELLED:
       case UNKNOWN:
-      case DEADLINE_EXCEEDED:
       case ALREADY_EXISTS:
       case RESOURCE_EXHAUSTED:
       case ABORTED:

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/exception/StatusRuntimeExceptionMapperTest.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/exception/StatusRuntimeExceptionMapperTest.java
@@ -74,7 +74,7 @@ public class StatusRuntimeExceptionMapperTest {
     assertThat(response.getEntity().description().endsWith(error.getMessage())).isTrue();
     assertThat(response.getEntity().grpcStatus())
         .isEqualTo(Status.Code.DEADLINE_EXCEEDED.toString());
-    assertThat(response.getEntity().code()).isEqualTo(500);
+    assertThat(response.getEntity().code()).isEqualTo(504);
   }
 
   @Test


### PR DESCRIPTION
**What this PR does**:
gRPC deadlines to be reported back as `HTTP 504 Gateway Timeout` :)

**Which issue(s) this PR fixes**:
Fixes #2318

