### PR TITLE
closes #2321: delete keyspaces on the integration test end

### DIFF
--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/DocsApiIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/DocsApiIntegrationTest.java
@@ -117,4 +117,24 @@ public abstract class DocsApiIntegrationTest {
               });
     }
   }
+
+  @Nested
+  @Order(Integer.MAX_VALUE)
+  class CleanUp {
+
+    @Test
+    public void deleteNamespace() {
+      createNamespace()
+          .ifPresent(
+              namespace -> {
+                // delete
+                given()
+                    .contentType(ContentType.JSON)
+                    .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+                    .delete(NamespacesResource.BASE_PATH + "/{namespace}", namespace)
+                    .then()
+                    .statusCode(204);
+              });
+    }
+  }
 }

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/CqlEnabledIntegrationTestBase.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/CqlEnabledIntegrationTestBase.java
@@ -77,7 +77,9 @@ public abstract class CqlEnabledIntegrationTestBase {
   }
 
   @AfterAll
-  public final void closeSession() {
+  public final void cleanUp() {
+    session.execute("DROP KEYSPACE IF EXISTS %s".formatted(keyspaceId.asCql(false)));
+
     if (session != null) {
       session.close();
     }


### PR DESCRIPTION
**What this PR does**:
Running all tests on a single env creates a lot of keyspaces, thus delete after each test. CI times should remain more or less the same.

**Which issue(s) this PR fixes**:
Fixes #2321
