### PR TITLE
closes #2314: added test to test gql invalid json response

### DIFF
--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/InvalidQueriesIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/InvalidQueriesIntegrationTest.java
@@ -77,6 +77,9 @@ public class InvalidQueriesIntegrationTest extends CqlFirstIntegrationTest {
           "query { keyspace (name: 1) { name } }",
           "Validation error of type WrongType: argument 'name' with value 'IntValue{value=1}' is not a valid 'String'"),
       arguments(
+          "query { keyspace (name: \"json_wrong) { name } }",
+          "Invalid Syntax : token recognition error at: '\"json_wrong) { name } }' at line 1 column 25"),
+      arguments(
           "query { keyspaces { name, nameInvalid } }",
           "Validation error of type FieldUndefined: Field 'nameInvalid' in type 'Keyspace' is undefined"),
     };


### PR DESCRIPTION
**What this PR does**:
Add a small test to check the response when JSON parsing exception occurs in graphql. The issue seems to be fixed by updating to Quarkus `2.15.1`, so this is just to confirm.

**Which issue(s) this PR fixes**:
Fixes #2314 
