### PR TITLE
remove async reponse from graphql

### DIFF
--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/AdminResource.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/AdminResource.java
@@ -17,9 +17,8 @@ package io.stargate.sgv2.graphql.web.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.GraphQL;
-import io.quarkus.grpc.GrpcClient;
 import io.smallrye.mutiny.Uni;
-import io.stargate.bridge.proto.StargateBridge;
+import io.stargate.sgv2.api.common.StargateRequestInfo;
 import io.stargate.sgv2.api.common.grpc.StargateBridgeClient;
 import io.stargate.sgv2.graphql.web.models.GraphqlFormData;
 import io.stargate.sgv2.graphql.web.models.GraphqlJsonBody;
@@ -48,11 +47,11 @@ public class AdminResource extends StargateGraphqlResourceBase {
 
   @Inject
   public AdminResource(
-      @GrpcClient("bridge") StargateBridge stargateBridge,
+      StargateRequestInfo requestInfo,
       ObjectMapper objectMapper,
       StargateBridgeClient bridgeClient,
       GraphqlCache graphqlCache) {
-    super(stargateBridge, objectMapper, bridgeClient, graphqlCache);
+    super(requestInfo, objectMapper, bridgeClient, graphqlCache);
     this.graphql = graphqlCache.getSchemaFirstAdminGraphql();
   }
 

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/AdminResource.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/AdminResource.java
@@ -17,6 +17,7 @@ package io.stargate.sgv2.graphql.web.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.GraphQL;
+import io.quarkus.grpc.GrpcClient;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.proto.StargateBridge;
 import io.stargate.sgv2.api.common.grpc.StargateBridgeClient;
@@ -47,11 +48,11 @@ public class AdminResource extends StargateGraphqlResourceBase {
 
   @Inject
   public AdminResource(
+      @GrpcClient("bridge") StargateBridge stargateBridge,
       ObjectMapper objectMapper,
-      StargateBridge stargateBridge,
       StargateBridgeClient bridgeClient,
       GraphqlCache graphqlCache) {
-    super(objectMapper, stargateBridge, bridgeClient, graphqlCache);
+    super(stargateBridge, objectMapper, bridgeClient, graphqlCache);
     this.graphql = graphqlCache.getSchemaFirstAdminGraphql();
   }
 

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/AdminResource.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/AdminResource.java
@@ -18,6 +18,7 @@ package io.stargate.sgv2.graphql.web.resources;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.GraphQL;
 import io.smallrye.mutiny.Uni;
+import io.stargate.bridge.proto.StargateBridge;
 import io.stargate.sgv2.api.common.grpc.StargateBridgeClient;
 import io.stargate.sgv2.graphql.web.models.GraphqlFormData;
 import io.stargate.sgv2.graphql.web.models.GraphqlJsonBody;
@@ -46,8 +47,11 @@ public class AdminResource extends StargateGraphqlResourceBase {
 
   @Inject
   public AdminResource(
-      ObjectMapper objectMapper, StargateBridgeClient bridge, GraphqlCache graphqlCache) {
-    super(objectMapper, bridge, graphqlCache);
+      ObjectMapper objectMapper,
+      StargateBridge stargateBridge,
+      StargateBridgeClient bridgeClient,
+      GraphqlCache graphqlCache) {
+    super(objectMapper, stargateBridge, bridgeClient, graphqlCache);
     this.graphql = graphqlCache.getSchemaFirstAdminGraphql();
   }
 

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/AdminResource.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/AdminResource.java
@@ -16,6 +16,7 @@
 package io.stargate.sgv2.graphql.web.resources;
 
 import graphql.GraphQL;
+import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.graphql.web.models.GraphqlFormData;
 import io.stargate.sgv2.graphql.web.models.GraphqlJsonBody;
 import javax.inject.Inject;
@@ -27,9 +28,8 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.container.AsyncResponse;
-import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
+import org.jboss.resteasy.reactive.RestResponse;
 
 /**
  * A GraphQL service that allows users to deploy and manage custom GraphQL schemas for their
@@ -48,36 +48,31 @@ public class AdminResource extends StargateGraphqlResourceBase {
   }
 
   @GET
-  public void get(
+  public Uni<RestResponse<?>> get(
       @QueryParam("query") String query,
       @QueryParam("operationName") String operationName,
-      @QueryParam("variables") String variables,
-      @Suspended AsyncResponse asyncResponse) {
+      @QueryParam("variables") String variables) {
 
-    get(query, operationName, variables, graphql, newContext(), asyncResponse);
+    return get(query, operationName, variables, graphql, newContext());
   }
 
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
-  public void postJson(
-      GraphqlJsonBody jsonBody,
-      @QueryParam("query") String queryFromUrl,
-      @Suspended AsyncResponse asyncResponse) {
+  public Uni<RestResponse<?>> postJson(
+      GraphqlJsonBody jsonBody, @QueryParam("query") String queryFromUrl) {
 
-    postJson(jsonBody, queryFromUrl, graphql, newContext(), asyncResponse);
+    return postJson(jsonBody, queryFromUrl, graphql, newContext());
   }
 
   @POST
   @Consumes(MediaType.MULTIPART_FORM_DATA)
-  public void postMultipartJson(
-      @BeanParam GraphqlFormData formData, @Suspended AsyncResponse asyncResponse) {
-    postMultipartJson(formData, graphql, newContext(), asyncResponse);
+  public Uni<RestResponse<?>> postMultipartJson(@BeanParam GraphqlFormData formData) {
+    return postMultipartJson(formData, graphql, newContext());
   }
 
   @POST
   @Consumes(APPLICATION_GRAPHQL)
-  public void postGraphql(String query, @Suspended AsyncResponse asyncResponse) {
-
-    postGraphql(query, graphql, newContext(), asyncResponse);
+  public Uni<RestResponse<?>> postGraphql(String query) {
+    return postGraphql(query, graphql, newContext());
   }
 }

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/AdminResource.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/AdminResource.java
@@ -15,8 +15,10 @@
  */
 package io.stargate.sgv2.graphql.web.resources;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.GraphQL;
 import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.api.common.grpc.StargateBridgeClient;
 import io.stargate.sgv2.graphql.web.models.GraphqlFormData;
 import io.stargate.sgv2.graphql.web.models.GraphqlJsonBody;
 import javax.inject.Inject;
@@ -43,7 +45,9 @@ public class AdminResource extends StargateGraphqlResourceBase {
   private final GraphQL graphql;
 
   @Inject
-  public AdminResource(GraphqlCache graphqlCache) {
+  public AdminResource(
+      ObjectMapper objectMapper, StargateBridgeClient bridge, GraphqlCache graphqlCache) {
+    super(objectMapper, bridge, graphqlCache);
     this.graphql = graphqlCache.getSchemaFirstAdminGraphql();
   }
 

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DdlResource.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DdlResource.java
@@ -18,6 +18,7 @@ package io.stargate.sgv2.graphql.web.resources;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.GraphQL;
 import io.smallrye.mutiny.Uni;
+import io.stargate.bridge.proto.StargateBridge;
 import io.stargate.sgv2.api.common.grpc.StargateBridgeClient;
 import io.stargate.sgv2.graphql.web.models.GraphqlJsonBody;
 import javax.inject.Inject;
@@ -42,8 +43,11 @@ public class DdlResource extends StargateGraphqlResourceBase {
 
   @Inject
   public DdlResource(
-      ObjectMapper objectMapper, StargateBridgeClient bridge, GraphqlCache graphqlCache) {
-    super(objectMapper, bridge, graphqlCache);
+      ObjectMapper objectMapper,
+      StargateBridge stargateBridge,
+      StargateBridgeClient bridgeClient,
+      GraphqlCache graphqlCache) {
+    super(objectMapper, stargateBridge, bridgeClient, graphqlCache);
     this.graphql = graphqlCache.getDdl();
   }
 

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DdlResource.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DdlResource.java
@@ -16,6 +16,7 @@
 package io.stargate.sgv2.graphql.web.resources;
 
 import graphql.GraphQL;
+import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.graphql.web.models.GraphqlJsonBody;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -24,9 +25,8 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.container.AsyncResponse;
-import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
+import org.jboss.resteasy.reactive.RestResponse;
 
 /**
  * A GraphQL service that allows users to execute CQL DDL queries directly (e.g. create a keyspace,
@@ -44,29 +44,26 @@ public class DdlResource extends StargateGraphqlResourceBase {
   }
 
   @GET
-  public void get(
+  public Uni<RestResponse<?>> get(
       @QueryParam("query") String query,
       @QueryParam("operationName") String operationName,
-      @QueryParam("variables") String variables,
-      @Suspended AsyncResponse asyncResponse) {
+      @QueryParam("variables") String variables) {
 
-    get(query, operationName, variables, graphql, newContext(), asyncResponse);
+    return get(query, operationName, variables, graphql, newContext());
   }
 
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
-  public void postJson(
-      GraphqlJsonBody jsonBody,
-      @QueryParam("query") String queryFromUrl,
-      @Suspended AsyncResponse asyncResponse) {
+  public Uni<RestResponse<?>> postJson(
+      GraphqlJsonBody jsonBody, @QueryParam("query") String queryFromUrl) {
 
-    postJson(jsonBody, queryFromUrl, graphql, newContext(), asyncResponse);
+    return postJson(jsonBody, queryFromUrl, graphql, newContext());
   }
 
   @POST
   @Consumes(APPLICATION_GRAPHQL)
-  public void postGraphql(String query, @Suspended AsyncResponse asyncResponse) {
+  public Uni<RestResponse<?>> postGraphql(String query) {
 
-    postGraphql(query, graphql, newContext(), asyncResponse);
+    return postGraphql(query, graphql, newContext());
   }
 }

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DdlResource.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DdlResource.java
@@ -17,6 +17,7 @@ package io.stargate.sgv2.graphql.web.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.GraphQL;
+import io.quarkus.grpc.GrpcClient;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.proto.StargateBridge;
 import io.stargate.sgv2.api.common.grpc.StargateBridgeClient;
@@ -43,11 +44,11 @@ public class DdlResource extends StargateGraphqlResourceBase {
 
   @Inject
   public DdlResource(
+      @GrpcClient("bridge") StargateBridge stargateBridge,
       ObjectMapper objectMapper,
-      StargateBridge stargateBridge,
       StargateBridgeClient bridgeClient,
       GraphqlCache graphqlCache) {
-    super(objectMapper, stargateBridge, bridgeClient, graphqlCache);
+    super(stargateBridge, objectMapper, bridgeClient, graphqlCache);
     this.graphql = graphqlCache.getDdl();
   }
 

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DdlResource.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DdlResource.java
@@ -15,8 +15,10 @@
  */
 package io.stargate.sgv2.graphql.web.resources;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.GraphQL;
 import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.api.common.grpc.StargateBridgeClient;
 import io.stargate.sgv2.graphql.web.models.GraphqlJsonBody;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -39,7 +41,9 @@ public class DdlResource extends StargateGraphqlResourceBase {
   private final GraphQL graphql;
 
   @Inject
-  public DdlResource(GraphqlCache graphqlCache) {
+  public DdlResource(
+      ObjectMapper objectMapper, StargateBridgeClient bridge, GraphqlCache graphqlCache) {
+    super(objectMapper, bridge, graphqlCache);
     this.graphql = graphqlCache.getDdl();
   }
 

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DdlResource.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DdlResource.java
@@ -17,9 +17,8 @@ package io.stargate.sgv2.graphql.web.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.GraphQL;
-import io.quarkus.grpc.GrpcClient;
 import io.smallrye.mutiny.Uni;
-import io.stargate.bridge.proto.StargateBridge;
+import io.stargate.sgv2.api.common.StargateRequestInfo;
 import io.stargate.sgv2.api.common.grpc.StargateBridgeClient;
 import io.stargate.sgv2.graphql.web.models.GraphqlJsonBody;
 import javax.inject.Inject;
@@ -44,11 +43,11 @@ public class DdlResource extends StargateGraphqlResourceBase {
 
   @Inject
   public DdlResource(
-      @GrpcClient("bridge") StargateBridge stargateBridge,
+      StargateRequestInfo requestInfo,
       ObjectMapper objectMapper,
       StargateBridgeClient bridgeClient,
       GraphqlCache graphqlCache) {
-    super(stargateBridge, objectMapper, bridgeClient, graphqlCache);
+    super(requestInfo, objectMapper, bridgeClient, graphqlCache);
     this.graphql = graphqlCache.getDdl();
   }
 

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DefaultKeyspaceHelper.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DefaultKeyspaceHelper.java
@@ -24,6 +24,7 @@ import io.stargate.bridge.proto.QueryOuterClass.Row;
 import io.stargate.bridge.proto.QueryOuterClass.Value;
 import io.stargate.sgv2.api.common.cql.builder.QueryBuilder;
 import io.stargate.sgv2.api.common.grpc.StargateBridgeClient;
+import io.stargate.sgv2.graphql.web.models.GraphqlJsonBody;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -37,12 +38,9 @@ import org.slf4j.LoggerFactory;
  * Finds the oldest, non-system keyspace in the database. It is used as a default when no keyspace
  * name is provided in the URL path.
  *
- * @see DmlResource#get(String, String, String, javax.ws.rs.container.AsyncResponse,
- *     StargateBridgeClient)
- * @see DmlResource#postJson(io.stargate.sgv2.graphql.web.models.GraphqlJsonBody, String,
- *     javax.ws.rs.container.AsyncResponse, StargateBridgeClient)
- * @see DmlResource#postGraphql(String, String, javax.ws.rs.container.AsyncResponse,
- *     StargateBridgeClient)
+ * @see DmlResource#get(String, String, String)
+ * @see DmlResource#postJson(GraphqlJsonBody, String)
+ * @see DmlResource#postGraphql(String, String)
  */
 class DefaultKeyspaceHelper {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultKeyspaceHelper.class);

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DmlResource.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DmlResource.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.GraphQL;
 import graphql.GraphqlErrorException;
 import io.smallrye.mutiny.Uni;
+import io.stargate.bridge.proto.StargateBridge;
 import io.stargate.sgv2.api.common.grpc.StargateBridgeClient;
 import io.stargate.sgv2.graphql.web.models.GraphqlJsonBody;
 import java.util.Optional;
@@ -58,8 +59,11 @@ public class DmlResource extends StargateGraphqlResourceBase {
 
   @Inject
   public DmlResource(
-      ObjectMapper objectMapper, StargateBridgeClient bridge, GraphqlCache graphqlCache) {
-    super(objectMapper, bridge, graphqlCache);
+      ObjectMapper objectMapper,
+      StargateBridge stargateBridge,
+      StargateBridgeClient bridgeClient,
+      GraphqlCache graphqlCache) {
+    super(objectMapper, stargateBridge, bridgeClient, graphqlCache);
   }
 
   @GET
@@ -147,8 +151,9 @@ public class DmlResource extends StargateGraphqlResourceBase {
                         }
 
                         try {
-                          bridge.decorateKeyspaceName(keyspaceName);
-                          Optional<GraphQL> graphql = graphqlCache.getDml(bridge, keyspaceName);
+                          bridgeClient.decorateKeyspaceName(keyspaceName);
+                          Optional<GraphQL> graphql =
+                              graphqlCache.getDml(bridgeClient, keyspaceName);
 
                           return Uni.createFrom()
                               .optional(graphql)
@@ -179,7 +184,8 @@ public class DmlResource extends StargateGraphqlResourceBase {
   }
 
   private Uni<GraphQL> getDefaultGraphql() {
-    CompletionStage<Optional<String>> result = graphqlCache.getDefaultKeyspaceNameAsync(bridge);
+    CompletionStage<Optional<String>> result =
+        graphqlCache.getDefaultKeyspaceNameAsync(bridgeClient);
 
     // create from future
     return Uni.createFrom()

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DmlResource.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DmlResource.java
@@ -17,6 +17,7 @@ package io.stargate.sgv2.graphql.web.resources;
 
 import graphql.GraphQL;
 import graphql.GraphqlErrorException;
+import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.graphql.web.models.GraphqlJsonBody;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -28,10 +29,9 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.container.AsyncResponse;
-import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response.Status;
+import org.jboss.resteasy.reactive.RestResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,75 +53,67 @@ public class DmlResource extends StargateGraphqlResourceBase {
   static final Pattern KEYSPACE_NAME_PATTERN = Pattern.compile("\\w+");
 
   @GET
-  public void get(
+  public Uni<RestResponse<?>> get(
       @QueryParam("query") String query,
       @QueryParam("operationName") String operationName,
-      @QueryParam("variables") String variables,
-      @Suspended AsyncResponse asyncResponse) {
+      @QueryParam("variables") String variables) {
 
     GraphQL graphql = getDefaultGraphql();
-    get(query, operationName, variables, graphql, newContext(), asyncResponse);
+    return get(query, operationName, variables, graphql, newContext());
   }
 
   @GET
   @Path("/{keyspaceName}")
-  public void get(
+  public Uni<RestResponse<?>> get(
       @PathParam("keyspaceName") String keyspaceName,
       @QueryParam("query") String query,
       @QueryParam("operationName") String operationName,
-      @QueryParam("variables") String variables,
-      @Suspended AsyncResponse asyncResponse) {
+      @QueryParam("variables") String variables) {
 
     GraphQL graphql = getGraphql(keyspaceName);
-    get(query, operationName, variables, graphql, newContext(), asyncResponse);
+    return get(query, operationName, variables, graphql, newContext());
   }
 
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
-  public void postJson(
-      GraphqlJsonBody jsonBody,
-      @QueryParam("query") String queryFromUrl,
-      @Suspended AsyncResponse asyncResponse) {
+  public Uni<RestResponse<?>> postJson(
+      GraphqlJsonBody jsonBody, @QueryParam("query") String queryFromUrl) {
 
     GraphQL graphql = getDefaultGraphql();
-    postJson(jsonBody, queryFromUrl, graphql, newContext(), asyncResponse);
+    return postJson(jsonBody, queryFromUrl, graphql, newContext());
   }
 
   @POST
   @Path("/{keyspaceName}")
   @Consumes(MediaType.APPLICATION_JSON)
-  public void postJson(
+  public Uni<RestResponse<?>> postJson(
       @PathParam("keyspaceName") String keyspaceName,
       GraphqlJsonBody jsonBody,
-      @QueryParam("query") String queryFromUrl,
-      @Suspended AsyncResponse asyncResponse) {
+      @QueryParam("query") String queryFromUrl) {
 
     GraphQL graphql = getGraphql(keyspaceName);
-    postJson(jsonBody, queryFromUrl, graphql, newContext(), asyncResponse);
+    return postJson(jsonBody, queryFromUrl, graphql, newContext());
   }
 
   @POST
   @Consumes(APPLICATION_GRAPHQL)
-  public void postGraphql(
-      String query,
-      @HeaderParam("X-Cassandra-Token") String token,
-      @Suspended AsyncResponse asyncResponse) {
+  public Uni<RestResponse<?>> postGraphql(
+      String query, @HeaderParam("X-Cassandra-Token") String token) {
 
     GraphQL graphql = getDefaultGraphql();
-    postGraphql(query, graphql, newContext(), asyncResponse);
+    return postGraphql(query, graphql, newContext());
   }
 
   @POST
   @Path("/{keyspaceName}")
   @Consumes(APPLICATION_GRAPHQL)
-  public void postGraphql(
+  public Uni<RestResponse<?>> postGraphql(
       @PathParam("keyspaceName") String keyspaceName,
       String query,
-      @HeaderParam("X-Cassandra-Token") String token,
-      @Suspended AsyncResponse asyncResponse) {
+      @HeaderParam("X-Cassandra-Token") String token) {
 
     GraphQL graphql = getGraphql(keyspaceName);
-    postGraphql(query, graphql, newContext(), asyncResponse);
+    return postGraphql(query, graphql, newContext());
   }
 
   private GraphQL getGraphql(String keyspaceName) {

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DmlResource.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DmlResource.java
@@ -18,10 +18,9 @@ package io.stargate.sgv2.graphql.web.resources;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.GraphQL;
 import graphql.GraphqlErrorException;
-import io.quarkus.grpc.GrpcClient;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
-import io.stargate.bridge.proto.StargateBridge;
+import io.stargate.sgv2.api.common.StargateRequestInfo;
 import io.stargate.sgv2.api.common.grpc.StargateBridgeClient;
 import io.stargate.sgv2.graphql.web.models.GraphqlJsonBody;
 import java.util.Optional;
@@ -61,11 +60,11 @@ public class DmlResource extends StargateGraphqlResourceBase {
 
   @Inject
   public DmlResource(
-      @GrpcClient("bridge") StargateBridge stargateBridge,
+      StargateRequestInfo requestInfo,
       ObjectMapper objectMapper,
       StargateBridgeClient bridgeClient,
       GraphqlCache graphqlCache) {
-    super(stargateBridge, objectMapper, bridgeClient, graphqlCache);
+    super(requestInfo, objectMapper, bridgeClient, graphqlCache);
   }
 
   @GET

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DmlResource.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DmlResource.java
@@ -15,13 +15,16 @@
  */
 package io.stargate.sgv2.graphql.web.resources;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.GraphQL;
 import graphql.GraphqlErrorException;
 import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.api.common.grpc.StargateBridgeClient;
 import io.stargate.sgv2.graphql.web.models.GraphqlJsonBody;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.regex.Pattern;
+import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -52,6 +55,12 @@ public class DmlResource extends StargateGraphqlResourceBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(DmlResource.class);
   static final Pattern KEYSPACE_NAME_PATTERN = Pattern.compile("\\w+");
+
+  @Inject
+  public DmlResource(
+      ObjectMapper objectMapper, StargateBridgeClient bridge, GraphqlCache graphqlCache) {
+    super(objectMapper, bridge, graphqlCache);
+  }
 
   @GET
   public Uni<RestResponse<?>> get(

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DmlResource.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/DmlResource.java
@@ -18,6 +18,7 @@ package io.stargate.sgv2.graphql.web.resources;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.GraphQL;
 import graphql.GraphqlErrorException;
+import io.quarkus.grpc.GrpcClient;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.stargate.bridge.proto.StargateBridge;
@@ -60,11 +61,11 @@ public class DmlResource extends StargateGraphqlResourceBase {
 
   @Inject
   public DmlResource(
+      @GrpcClient("bridge") StargateBridge stargateBridge,
       ObjectMapper objectMapper,
-      StargateBridge stargateBridge,
       StargateBridgeClient bridgeClient,
       GraphqlCache graphqlCache) {
-    super(objectMapper, stargateBridge, bridgeClient, graphqlCache);
+    super(stargateBridge, objectMapper, bridgeClient, graphqlCache);
   }
 
   @GET

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/GraphqlResourceBase.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/GraphqlResourceBase.java
@@ -46,11 +46,17 @@ import org.slf4j.LoggerFactory;
 @Produces(MediaType.APPLICATION_JSON)
 public abstract class GraphqlResourceBase {
 
+  private static final Logger LOG = LoggerFactory.getLogger(GraphqlResourceBase.class);
+
   public static final String APPLICATION_GRAPHQL = "application/graphql";
 
-  private static final Logger LOG = LoggerFactory.getLogger(GraphqlResourceBase.class);
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final Splitter PATH_SPLITTER = Splitter.on(".");
+
+  private final ObjectMapper objectMapper;
+
+  protected GraphqlResourceBase(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
 
   /**
    * Handles a GraphQL GET request.
@@ -78,7 +84,7 @@ public abstract class GraphqlResourceBase {
                 if (!Strings.isNullOrEmpty(variables)) {
                   @SuppressWarnings("unchecked")
                   Map<String, Object> parsedVariables =
-                      OBJECT_MAPPER.readValue(variables, Map.class);
+                      objectMapper.readValue(variables, Map.class);
                   input = input.context(context).variables(parsedVariables);
                 }
 

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/GraphqlResourceBase.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/GraphqlResourceBase.java
@@ -17,6 +17,7 @@ package io.stargate.sgv2.graphql.web.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.ExecutionInput;
+import graphql.ExecutionResult;
 import graphql.GraphQL;
 import graphql.GraphqlErrorException;
 import graphql.com.google.common.base.MoreObjects;
@@ -24,6 +25,7 @@ import graphql.com.google.common.base.Splitter;
 import graphql.com.google.common.base.Strings;
 import graphql.com.google.common.collect.ImmutableList;
 import graphql.com.google.common.collect.ImmutableMap;
+import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.graphql.web.models.GraphqlFormData;
 import io.stargate.sgv2.graphql.web.models.GraphqlJsonBody;
 import java.io.IOException;
@@ -31,12 +33,12 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.container.AsyncResponse;
-import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.multipart.FileUpload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,75 +57,94 @@ public abstract class GraphqlResourceBase {
    *
    * <p>The payload is provided via URL parameters.
    */
-  protected void get(
-      String query,
-      String operationName,
-      String variables,
-      GraphQL graphql,
-      Object context,
-      AsyncResponse asyncResponse) {
+  protected Uni<RestResponse<?>> get(
+      String query, String operationName, String variables, GraphQL graphql, Object context) {
 
-    if (Strings.isNullOrEmpty(query)) {
-      throw graphqlError(
-          Response.Status.BAD_REQUEST, "You must provide a GraphQL query as a URL parameter");
-    }
+    return Uni.createFrom()
+        .deferred(
+            () -> {
+              if (Strings.isNullOrEmpty(query)) {
+                return Uni.createFrom()
+                    .failure(
+                        graphqlError(
+                            Response.Status.BAD_REQUEST,
+                            "You must provide a GraphQL query as a URL parameter"));
+              }
 
-    try {
-      ExecutionInput.Builder input =
-          ExecutionInput.newExecutionInput(query).operationName(operationName);
+              try {
+                ExecutionInput.Builder input =
+                    ExecutionInput.newExecutionInput(query).operationName(operationName);
 
-      if (!Strings.isNullOrEmpty(variables)) {
-        @SuppressWarnings("unchecked")
-        Map<String, Object> parsedVariables = OBJECT_MAPPER.readValue(variables, Map.class);
-        input = input.context(context).variables(parsedVariables);
-      }
+                if (!Strings.isNullOrEmpty(variables)) {
+                  @SuppressWarnings("unchecked")
+                  Map<String, Object> parsedVariables =
+                      OBJECT_MAPPER.readValue(variables, Map.class);
+                  input = input.context(context).variables(parsedVariables);
+                }
 
-      executeAsync(input.build(), graphql, asyncResponse);
-    } catch (IOException e) {
-      throw graphqlError(
-          Response.Status.BAD_REQUEST, "Could not parse variables: " + e.getMessage());
-    }
+                return execute(input.build(), graphql);
+              } catch (IOException e) {
+                return Uni.createFrom()
+                    .failure(
+                        graphqlError(
+                            Response.Status.BAD_REQUEST,
+                            "Could not parse variables: " + e.getMessage()));
+              }
+            })
+        // map to rest response
+        .map(RestResponse::ok);
   }
+
   /**
    * Handles a GraphQL POST request that uses the {@link MediaType#APPLICATION_JSON} content type.
    *
    * <p>Such a request normally comprises a JSON-encoded body, but the spec also allows the query to
    * be passed as a URL parameter.
    */
-  protected void postJson(
-      GraphqlJsonBody jsonBody,
-      String queryFromUrl,
-      GraphQL graphql,
-      Object context,
-      AsyncResponse asyncResponse) {
+  protected Uni<RestResponse<?>> postJson(
+      GraphqlJsonBody jsonBody, String queryFromUrl, GraphQL graphql, Object context) {
 
-    queryFromUrl = Strings.emptyToNull(queryFromUrl);
-    String queryFromBody = (jsonBody == null) ? null : Strings.emptyToNull(jsonBody.getQuery());
-    String operationName =
-        (jsonBody == null) ? null : Strings.emptyToNull(jsonBody.getOperationName());
-    Map<String, Object> variables = (jsonBody == null) ? null : jsonBody.getVariables();
+    return Uni.createFrom()
+        .deferred(
+            () -> {
+              String queryFromUrlSafe = Strings.emptyToNull(queryFromUrl);
+              String queryFromBody =
+                  (jsonBody == null) ? null : Strings.emptyToNull(jsonBody.getQuery());
+              String operationName =
+                  (jsonBody == null) ? null : Strings.emptyToNull(jsonBody.getOperationName());
+              Map<String, Object> variables = (jsonBody == null) ? null : jsonBody.getVariables();
 
-    if (queryFromBody == null && queryFromUrl == null) {
-      throw graphqlError(
-          Response.Status.BAD_REQUEST,
-          "You must provide a GraphQL query, either as a query parameter or in the request body");
-    }
+              if (queryFromBody == null && queryFromUrlSafe == null) {
+                return Uni.createFrom()
+                    .failure(
+                        graphqlError(
+                            Response.Status.BAD_REQUEST,
+                            "You must provide a GraphQL query, either as a query parameter or in the request body"));
+              }
 
-    if (queryFromBody != null && queryFromUrl != null) {
-      // The GraphQL spec doesn't specify what to do in this case, but it's probably better to error
-      // out rather than pick one arbitrarily.
-      throw graphqlError(
-          Response.Status.BAD_REQUEST,
-          "You can't provide a GraphQL query both as a query parameter and in the request body");
-    }
+              if (queryFromBody != null && queryFromUrlSafe != null) {
+                // The GraphQL spec doesn't specify what to do in this case, but it's probably
+                // better to error
+                // out rather than pick one arbitrarily.
+                return Uni.createFrom()
+                    .failure(
+                        graphqlError(
+                            Response.Status.BAD_REQUEST,
+                            "You can't provide a GraphQL query both as a query parameter and in the request body"));
+              }
 
-    String query = MoreObjects.firstNonNull(queryFromBody, queryFromUrl);
-    ExecutionInput.Builder input =
-        ExecutionInput.newExecutionInput(query).operationName(operationName).context(context);
-    if (variables != null) {
-      input = input.variables(variables);
-    }
-    executeAsync(input.build(), graphql, asyncResponse);
+              String query = MoreObjects.firstNonNull(queryFromBody, queryFromUrlSafe);
+              ExecutionInput.Builder input =
+                  ExecutionInput.newExecutionInput(query)
+                      .operationName(operationName)
+                      .context(context);
+              if (variables != null) {
+                input = input.variables(variables);
+              }
+              return execute(input.build(), graphql);
+            })
+        // map to rest response
+        .map(RestResponse::ok);
   }
 
   /**
@@ -132,27 +153,33 @@ public abstract class GraphqlResourceBase {
    *
    * @see GraphqlFormData
    */
-  protected void postMultipartJson(
-      GraphqlFormData formData, GraphQL graphql, Object context, AsyncResponse asyncResponse) {
+  protected Uni<RestResponse<?>> postMultipartJson(
+      GraphqlFormData formData, GraphQL graphql, Object context) {
 
-    if (formData.operations == null) {
-      throw graphqlError(
-          Response.Status.BAD_REQUEST,
-          "Could not find GraphQL operations object. "
-              + "Make sure your multipart request includes an 'operations' part with MIME type "
-              + MediaType.APPLICATION_JSON);
-    }
+    return Uni.createFrom()
+        .deferred(
+            () -> {
+              if (formData.operations == null) {
+                return Uni.createFrom()
+                    .failure(
+                        graphqlError(
+                            Response.Status.BAD_REQUEST,
+                            "Could not find GraphQL operations object. "
+                                + "Make sure your multipart request includes an 'operations' part with MIME type "
+                                + MediaType.APPLICATION_JSON));
+              }
 
-    bindFilesToVariables(formData);
+              bindFilesToVariables(formData);
 
-    postJson(
-        formData.operations,
-        // We don't allow passing the query as a URL param for this variant. The spec does not
-        // preclude it explicitly, but it's unlikely that someone would try to do that.
-        null,
-        graphql,
-        context,
-        asyncResponse);
+              return postJson(
+                  formData.operations,
+                  // We don't allow passing the query as a URL param for this variant. The spec does
+                  // not
+                  // preclude it explicitly, but it's unlikely that someone would try to do that.
+                  null,
+                  graphql,
+                  context);
+            });
   }
 
   /**
@@ -232,36 +259,58 @@ public abstract class GraphqlResourceBase {
    *
    * <p>The request body is the GraphQL query directly.
    */
-  protected void postGraphql(
-      String query, GraphQL graphql, Object context, AsyncResponse asyncResponse) {
+  protected Uni<RestResponse<?>> postGraphql(String query, GraphQL graphql, Object context) {
 
-    if (Strings.isNullOrEmpty(query)) {
-      throw graphqlError(
-          Response.Status.BAD_REQUEST, "You must provide a GraphQL query in the request body");
-    }
+    return Uni.createFrom()
+        .deferred(
+            () -> {
+              if (Strings.isNullOrEmpty(query)) {
+                return Uni.createFrom()
+                    .failure(
+                        graphqlError(
+                            Response.Status.BAD_REQUEST,
+                            "You must provide a GraphQL query in the request body"));
+              }
 
-    ExecutionInput input = ExecutionInput.newExecutionInput(query).context(context).build();
-    executeAsync(input, graphql, asyncResponse);
+              ExecutionInput input =
+                  ExecutionInput.newExecutionInput(query).context(context).build();
+              return execute(input, graphql);
+            })
+        // map to rest response
+        .map(RestResponse::ok);
   }
 
-  protected static void executeAsync(
-      ExecutionInput input, GraphQL graphql, @Suspended AsyncResponse asyncResponse) {
-    graphql
-        .executeAsync(input)
-        .whenComplete(
-            (result, error) -> {
-              if (error != null) {
-                LOG.error("Unexpected error while processing GraphQL request", error);
-                throw graphqlError(Response.Status.INTERNAL_SERVER_ERROR, "Internal server error");
+  protected static Uni<Map<String, Object>> execute(ExecutionInput input, GraphQL graphql) {
+    // invoke graphql
+    CompletableFuture<ExecutionResult> future = graphql.executeAsync(input);
+
+    // create uni from future
+    return Uni.createFrom()
+        .future(future)
+
+        // on item check if we are not maybe overloaded
+        .onItem()
+        .transformToUni(
+            result -> {
+              Object context = input.getContext();
+              if (context instanceof StargateGraphqlContext
+                  && ((StargateGraphqlContext) context).isOverloaded()) {
+                return Uni.createFrom()
+                    .failure(
+                        graphqlError(Response.Status.TOO_MANY_REQUESTS, "Database is overloaded"));
               } else {
-                Object context = input.getContext();
-                if (context instanceof StargateGraphqlContext
-                    && ((StargateGraphqlContext) context).isOverloaded()) {
-                  throw graphqlError(Response.Status.TOO_MANY_REQUESTS, "Database is overloaded");
-                } else {
-                  asyncResponse.resume(result.toSpecification());
-                }
+                return Uni.createFrom().item(result.toSpecification());
               }
+            })
+
+        // on failure map to web app exception
+        .onFailure()
+        .recoverWithUni(
+            error -> {
+              LOG.error("Unexpected error while processing GraphQL request", error);
+              return Uni.createFrom()
+                  .failure(
+                      graphqlError(Response.Status.INTERNAL_SERVER_ERROR, "Internal server error"));
             });
   }
 

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/StargateGraphqlResourceBase.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/StargateGraphqlResourceBase.java
@@ -19,24 +19,24 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.proto.Schema;
 import io.stargate.bridge.proto.Schema.SchemaRead;
-import io.stargate.bridge.proto.StargateBridge;
+import io.stargate.sgv2.api.common.StargateRequestInfo;
 import io.stargate.sgv2.api.common.grpc.StargateBridgeClient;
 import io.stargate.sgv2.api.common.grpc.proto.SchemaReads;
 import java.util.List;
 
 public class StargateGraphqlResourceBase extends GraphqlResourceBase {
 
-  protected final StargateBridge stargateBridge;
+  protected final StargateRequestInfo requestInfo;
   protected final StargateBridgeClient bridgeClient;
   protected final GraphqlCache graphqlCache;
 
   public StargateGraphqlResourceBase(
-      StargateBridge stargateBridge,
+      StargateRequestInfo requestInfo,
       ObjectMapper objectMapper,
       StargateBridgeClient bridgeClient,
       GraphqlCache graphqlCache) {
     super(objectMapper);
-    this.stargateBridge = stargateBridge;
+    this.requestInfo = requestInfo;
     this.bridgeClient = bridgeClient;
     this.graphqlCache = graphqlCache;
   }
@@ -50,7 +50,8 @@ public class StargateGraphqlResourceBase extends GraphqlResourceBase {
     Schema.AuthorizeSchemaReadsRequest request =
         Schema.AuthorizeSchemaReadsRequest.newBuilder().addSchemaReads(schemaRead).build();
 
-    return stargateBridge
+    return requestInfo
+        .getStargateBridge()
         .authorizeSchemaReads(request)
         .map(
             response -> {

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/StargateGraphqlResourceBase.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/StargateGraphqlResourceBase.java
@@ -15,16 +15,23 @@
  */
 package io.stargate.sgv2.graphql.web.resources;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.api.common.grpc.StargateBridgeClient;
 import io.stargate.sgv2.api.common.grpc.proto.SchemaReads;
 import java.util.concurrent.CompletionStage;
-import javax.inject.Inject;
 
 public class StargateGraphqlResourceBase extends GraphqlResourceBase {
 
-  @Inject protected StargateBridgeClient bridge;
-  @Inject protected GraphqlCache graphqlCache;
+  protected final StargateBridgeClient bridge;
+  protected final GraphqlCache graphqlCache;
+
+  public StargateGraphqlResourceBase(
+      ObjectMapper objectMapper, StargateBridgeClient bridge, GraphqlCache graphqlCache) {
+    super(objectMapper);
+    this.bridge = bridge;
+    this.graphqlCache = graphqlCache;
+  }
 
   protected StargateGraphqlContext newContext() {
     return new StargateGraphqlContext(bridge, graphqlCache);

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/StargateGraphqlResourceBase.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/StargateGraphqlResourceBase.java
@@ -15,8 +15,10 @@
  */
 package io.stargate.sgv2.graphql.web.resources;
 
+import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.api.common.grpc.StargateBridgeClient;
 import io.stargate.sgv2.api.common.grpc.proto.SchemaReads;
+import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
 
 public class StargateGraphqlResourceBase extends GraphqlResourceBase {
@@ -28,7 +30,9 @@ public class StargateGraphqlResourceBase extends GraphqlResourceBase {
     return new StargateGraphqlContext(bridge, graphqlCache);
   }
 
-  protected boolean isAuthorized(String keyspaceName) {
-    return bridge.authorizeSchemaRead(SchemaReads.keyspace(keyspaceName));
+  protected Uni<Boolean> isAuthorized(String keyspaceName) {
+    Schema.SchemaRead schemaRead = SchemaReads.keyspace(keyspaceName);
+    CompletionStage<Boolean> result = bridge.authorizeSchemaReadAsync(schemaRead);
+    return Uni.createFrom().future(result.toCompletableFuture());
   }
 }

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/StargateGraphqlResourceBase.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/StargateGraphqlResourceBase.java
@@ -15,11 +15,13 @@
  */
 package io.stargate.sgv2.graphql.web.resources;
 
+import java.util.concurrent.CompletionStage;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.smallrye.mutiny.Uni;
+import io.stargate.bridge.proto.Schema.SchemaRead;
 import io.stargate.sgv2.api.common.grpc.StargateBridgeClient;
 import io.stargate.sgv2.api.common.grpc.proto.SchemaReads;
-import java.util.concurrent.CompletionStage;
 
 public class StargateGraphqlResourceBase extends GraphqlResourceBase {
 
@@ -38,7 +40,7 @@ public class StargateGraphqlResourceBase extends GraphqlResourceBase {
   }
 
   protected Uni<Boolean> isAuthorized(String keyspaceName) {
-    Schema.SchemaRead schemaRead = SchemaReads.keyspace(keyspaceName);
+    SchemaRead schemaRead = SchemaReads.keyspace(keyspaceName);
     CompletionStage<Boolean> result = bridge.authorizeSchemaReadAsync(schemaRead);
     return Uni.createFrom().future(result.toCompletableFuture());
   }

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/StargateGraphqlResourceBase.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/StargateGraphqlResourceBase.java
@@ -31,8 +31,8 @@ public class StargateGraphqlResourceBase extends GraphqlResourceBase {
   protected final GraphqlCache graphqlCache;
 
   public StargateGraphqlResourceBase(
-      ObjectMapper objectMapper,
       StargateBridge stargateBridge,
+      ObjectMapper objectMapper,
       StargateBridgeClient bridgeClient,
       GraphqlCache graphqlCache) {
     super(objectMapper);

--- a/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/StargateGraphqlResourceBase.java
+++ b/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/StargateGraphqlResourceBase.java
@@ -15,13 +15,12 @@
  */
 package io.stargate.sgv2.graphql.web.resources;
 
-import java.util.concurrent.CompletionStage;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.proto.Schema.SchemaRead;
 import io.stargate.sgv2.api.common.grpc.StargateBridgeClient;
 import io.stargate.sgv2.api.common.grpc.proto.SchemaReads;
+import java.util.concurrent.CompletionStage;
 
 public class StargateGraphqlResourceBase extends GraphqlResourceBase {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/web/resources/TestGraphqlResource.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/web/resources/TestGraphqlResource.java
@@ -28,6 +28,7 @@ import graphql.GraphQLContext;
 import graphql.Scalars;
 import graphql.schema.DataFetcher;
 import graphql.schema.FieldCoordinates;
+import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.graphql.schema.FileSupport;
 import io.stargate.sgv2.graphql.web.models.GraphqlFormData;
 import io.stargate.sgv2.graphql.web.models.GraphqlJsonBody;
@@ -41,9 +42,8 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.container.AsyncResponse;
-import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
+import org.jboss.resteasy.reactive.RestResponse;
 
 /**
  * A test-only resource without any Stargate-specific logic, just to cover the generic functionality
@@ -93,33 +93,29 @@ public class TestGraphqlResource extends GraphqlResourceBase {
   private static final GraphQLContext CONTEXT = GraphQLContext.newContext().build();
 
   @GET
-  public void get(
+  public Uni<RestResponse<?>> get(
       @QueryParam("query") String query,
       @QueryParam("operationName") String operationName,
-      @QueryParam("variables") String variables,
-      @Suspended AsyncResponse asyncResponse) {
-    super.get(query, operationName, variables, GRAPHQL, CONTEXT, asyncResponse);
+      @QueryParam("variables") String variables) {
+    return super.get(query, operationName, variables, GRAPHQL, CONTEXT);
   }
 
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
-  public void postJson(
-      GraphqlJsonBody jsonBody,
-      @QueryParam("query") String queryFromUrl,
-      @Suspended AsyncResponse asyncResponse) {
-    super.postJson(jsonBody, queryFromUrl, GRAPHQL, CONTEXT, asyncResponse);
+  public Uni<RestResponse<?>> postJson(
+      GraphqlJsonBody jsonBody, @QueryParam("query") String queryFromUrl) {
+    return super.postJson(jsonBody, queryFromUrl, GRAPHQL, CONTEXT);
   }
 
   @POST
   @Consumes(APPLICATION_GRAPHQL)
-  public void postGraphql(String query, @Suspended AsyncResponse asyncResponse) {
-    super.postGraphql(query, GRAPHQL, CONTEXT, asyncResponse);
+  public Uni<RestResponse<?>> postGraphql(String query) {
+    return super.postGraphql(query, GRAPHQL, CONTEXT);
   }
 
   @POST
   @Consumes(MediaType.MULTIPART_FORM_DATA)
-  public void postMultipartJson(
-      @BeanParam GraphqlFormData formData, @Suspended AsyncResponse asyncResponse) {
-    super.postMultipartJson(formData, GRAPHQL, CONTEXT, asyncResponse);
+  public Uni<RestResponse<?>> postMultipartJson(@BeanParam GraphqlFormData formData) {
+    return super.postMultipartJson(formData, GRAPHQL, CONTEXT);
   }
 }

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/web/resources/TestGraphqlResource.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/web/resources/TestGraphqlResource.java
@@ -22,6 +22,7 @@ import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLObjectType.newObject;
 import static graphql.schema.GraphQLSchema.newSchema;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.CharStreams;
 import graphql.GraphQL;
 import graphql.GraphQLContext;
@@ -35,6 +36,7 @@ import io.stargate.sgv2.graphql.web.models.GraphqlJsonBody;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import javax.inject.Inject;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -91,6 +93,11 @@ public class TestGraphqlResource extends GraphqlResourceBase {
 
   // Don't need anything specific in the context
   private static final GraphQLContext CONTEXT = GraphQLContext.newContext().build();
+
+  @Inject
+  public TestGraphqlResource(ObjectMapper objectMapper) {
+    super(objectMapper);
+  }
 
   @GET
   public Uni<RestResponse<?>> get(


### PR DESCRIPTION
**What this PR does**:
This is an effort to remove rest handling in the GraphQL API using the `AsyncResponse`.. All resources are transformed to use the Mutiny. 

Note that this is still **not** making GraphQL API non-blocking. The execution of the GraphQL call, which contains blocking code if offloaded to the workers thread executor. We need significantly more changes to make everything non-blocking.

https://github.com/stargate/stargate/blob/da9b1151005b54021e5ea6cffe818c0f02351a80/apis/sgv2-graphqlapi/src/main/java/io/stargate/sgv2/graphql/web/resources/GraphqlResourceBase.java#L313-L322

**Which issue(s) this PR fixes**:
Internal issue.
