### PR TITLE
add default grpc client deadline of 10sec

### DIFF
--- a/apis/sgv2-quarkus-common/src/main/resources/application.yaml
+++ b/apis/sgv2-quarkus-common/src/main/resources/application.yaml
@@ -62,6 +62,7 @@ quarkus:
       bridge:
         host: localhost
         port: 8091
+        deadline: PT10S
         retry: true
         max-hedged-attempts: 0
 


### PR DESCRIPTION
**What this PR does**:
Checks if all INT tests are green if client deadline is used.

**Which issue(s) this PR fixes**:
Relates to #2192.