### PR TITLE
update APIs to test against C* 4.0.7

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -32,7 +32,7 @@
       Please maintain default values for int-test in sync with io.stargate.sgv2.docsapi.testresource.StargateTestResource.Defaults
      -->
     <stargate.int-test.cassandra.image>cassandra</stargate.int-test.cassandra.image>
-    <stargate.int-test.cassandra.image-tag>4.0.4</stargate.int-test.cassandra.image-tag>
+    <stargate.int-test.cassandra.image-tag>4.0.7</stargate.int-test.cassandra.image-tag>
     <stargate.int-test.coordinator.image>stargateio/coordinator-4_0</stargate.int-test.coordinator.image>
     <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
     <stargate.int-test.cluster.name>cass-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
@@ -72,7 +72,7 @@ public class StargateTestResource
   interface Defaults {
 
     String CASSANDRA_IMAGE = "cassandra";
-    String CASSANDRA_IMAGE_TAG = "4.0.4";
+    String CASSANDRA_IMAGE_TAG = "4.0.7";
 
     String STARGATE_IMAGE = "stargateio/coordinator-4_0";
     String STARGATE_IMAGE_TAG = "latest";


### PR DESCRIPTION
**What this PR does**:
Updates int test setup to use 4.0.7. Needs merging of `v1` and `main`. Followup work after #2329. 

**Checklist**
- [ ] Rebase after merge occurs..
