### PR TITLE
Update Cassandra 3.11 Persistence with Deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Stargate contains the following components:
     converts internal C* objects and ResultSets to Stargate Datastore objects.
     - persistence-cassandra-4.0: (same as above but for Cassandra 4.0)
 
+**Warning:** Support for Cassandra 3.11 is considered deprecated and will be removed in the Stargate v3 release: [details](https://github.com/stargate/stargate/discussions/2242).
+
 - **Authentication Services**: Responsible for authentication to Stargate
 
     - auth-api: REST service for generating auth tokens

--- a/persistence-cassandra-3.11/README.md
+++ b/persistence-cassandra-3.11/README.md
@@ -2,6 +2,8 @@
 
 This module represents the implementation of the [persistence-api](../persistence-api) for the Cassandra `3.11.x` version.
 
+**Warning:** Support for Cassandra 3.11 is considered deprecated and will be removed in the Stargate v3 release: [details](https://github.com/stargate/stargate/discussions/2242).
+
 ## Cassandra version update
 
 The current Cassandra version this module depends on is `3.11.13`.

--- a/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Cassandra311Persistence.java
+++ b/persistence-cassandra-3.11/src/main/java/io/stargate/db/cassandra/impl/Cassandra311Persistence.java
@@ -190,6 +190,9 @@ public class Cassandra311Persistence
 
   @Override
   protected void initializePersistence(Config config) {
+    logger.warn(
+        "Support for Cassandra 3.11 is considered deprecated and will be removed in the Stargate v3 release.");
+
     // C* picks this property during the static loading of the ClientState class. So we set it
     // early, to make sure that class is not loaded before we've set it.
     System.setProperty(


### PR DESCRIPTION
Update documentation to note deprecation of Cassandra 3.11 as a supported backend and add warning message on startup of the 3.11 persistence module

Which issue(s) this PR fixes:
Part of https://github.com/stargate/stargate/issues/2254

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
