### PR TITLE
add workflow to test postman collections against docker compose scripts

### DIFF
--- a/.github/workflows/postman-docker.yaml
+++ b/.github/workflows/postman-docker.yaml
@@ -50,7 +50,7 @@ jobs:
         # Run Stargate coordinator in developer mode to save time / resources
         run: |
           cd ${{ matrix.path }}
-          docker compose up -f docker-compose-dev-mode.yml -d
+          docker compose -f docker-compose-dev-mode.yml up -d
       - name: Run API test
         run: |
           postman collection run ${{ matrix.collection-id }} -e ${{ matrix.environment-id }}

--- a/.github/workflows/postman-docker.yaml
+++ b/.github/workflows/postman-docker.yaml
@@ -12,8 +12,6 @@ jobs:
   automated-api-tests:
     runs-on: ubuntu-latest
     strategy:
-      # temporary change for testing
-      max-parallel: 1
 
       # let all tests run, can find multiple failures in different apis
       fail-fast: false

--- a/.github/workflows/postman-docker.yaml
+++ b/.github/workflows/postman-docker.yaml
@@ -12,6 +12,8 @@ jobs:
   automated-api-tests:
     runs-on: ubuntu-latest
     strategy:
+      # temporary change for testing
+      max-parallel: 1
 
       # let all tests run, can find multiple failures in different apis
       fail-fast: false
@@ -55,7 +57,8 @@ jobs:
         run: |
           postman collection run ${{ matrix.collection-id }} -e ${{ matrix.environment-id }}
       - name: Stop Backend
-        # Not sure if strictly required?
+        if: always()
         run: |
-          docker compose down
+          cd ${{ matrix.path }}
+          docker compose -f docker-compose-dev-mode.yml down
 

--- a/.github/workflows/postman-docker.yaml
+++ b/.github/workflows/postman-docker.yaml
@@ -1,0 +1,61 @@
+# @author Jeff Carpenter
+name: Stargate Postman Collections
+
+# runs on
+# * manual trigger
+on:
+  workflow_dispatch:
+
+jobs:
+
+  # Runs Stargate Postman Collections against local Stargate instance using docker compose scripts
+  automated-api-tests:
+    runs-on: ubuntu-latest
+    strategy:
+
+      # let all tests run, can find multiple failures in different apis
+      fail-fast: false
+
+      # props:
+      # backend - cassandra backend to run
+      # collection - Postman collection to run
+
+      matrix:
+        backend: [ cassandra-40, cassandra-311, dse-68 ]
+        collection: [ docsapi-library, graphqlapi-library, restapi-users ]
+        include:
+          - backend: cassandra-40
+            path: docker-compose/cassandra-4.0
+          - backend: cassandra-311
+            path: docker-compose/cassandra-3.11
+          - backend: dse-68
+            path: docker-compose/dse-6.8
+          - collection: docsapi-library
+            collection-id: 12949543-caba2a02-6559-486a-9e4a-d5c0791fd296
+            environment-id: 17930693-2f355f7b-123d-4bca-9a9c-7d82222ca49d
+          - collection: graphqlapi-library
+            collection-id: 17930693-65da5c64-561a-449b-a0e8-0318575f6871
+            environment-id: 17930693-2f355f7b-123d-4bca-9a9c-7d82222ca49d
+          - collection: restapi-users
+            collection-id: 17930693-47ab5f0d-407e-48cf-aa11-c51d129f1eef
+            environment-id: 17930693-2f355f7b-123d-4bca-9a9c-7d82222ca49d
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Postman CLI
+        run: |
+          curl -o- "https://dl-cli.pstmn.io/install/linux64.sh" | sh
+      - name: Login to Postman CLI
+        run: postman login --with-api-key ${{ secrets.POSTMAN_API_KEY }}
+      - name: Start Backend
+        # Run Stargate coordinator in developer mode to save time / resources
+        run: |
+          cd ${{ matrix.path }}
+          docker compose up -f docker-compose-dev-mode.yml -d
+      - name: Run API test
+        run: |
+          postman collection run ${{ matrix.collection-id }} -e ${{ matrix.environment-id }}
+      - name: Stop Backend
+        # Not sure if strictly required?
+        run: |
+          docker compose down
+

--- a/docker-compose/cassandra-3.11/README.md
+++ b/docker-compose/cassandra-3.11/README.md
@@ -28,6 +28,12 @@ This alternate configuration runs the Stargate coordinator node in developer mod
 docker compose -f docker-compose-dev-mode.yml up -d
 ``` 
 
+To stop the configuration, use the command:
+
+```
+docker compose -f docker-compose-dev-mode.yml down
+``` 
+
 This configuration is useful for development and testing since it initializes more quickly, but is not recommended for production deployments. This configuration also has a convenience script: `start_cass_311_dev_mode.sh`.
 
 ## Script options

--- a/docker-compose/cassandra-3.11/README.md
+++ b/docker-compose/cassandra-3.11/README.md
@@ -25,7 +25,7 @@ Whether you use the shell script or start `docker compose` directly, you can rem
 This alternate configuration runs the Stargate coordinator node in developer mode, so that no separate Cassandra cluster is required.  This can be run with the command:
 
 ```
-docker compose up -f docker-compose-dev-mode.yaml -d
+docker compose -f docker-compose-dev-mode.yml up -d
 ``` 
 
 This configuration is useful for development and testing since it initializes more quickly, but is not recommended for production deployments. This configuration also has a convenience script: `start_cass_311_dev_mode.sh`.

--- a/docker-compose/cassandra-4.0/README.md
+++ b/docker-compose/cassandra-4.0/README.md
@@ -25,7 +25,7 @@ Whether you use the shell script or start `docker compose` directly, you can rem
 This alternate configuration runs the Stargate coordinator node in developer mode, so that no separate Cassandra cluster is required. This can be run with the command:
 
 ```
-docker compose up -f docker-compose-dev-mode.yaml -d
+docker compose -f docker-compose-dev-mode.yml up -d
 ``` 
 
 This configuration is useful for development and testing since it initializes more quickly, but is not recommended for production deployments. This configuration also has a convenience script: `start_cass_311_dev_mode.sh`.

--- a/docker-compose/cassandra-4.0/README.md
+++ b/docker-compose/cassandra-4.0/README.md
@@ -28,6 +28,12 @@ This alternate configuration runs the Stargate coordinator node in developer mod
 docker compose -f docker-compose-dev-mode.yml up -d
 ``` 
 
+To stop the configuration, use the command:
+
+```
+docker compose -f docker-compose-dev-mode.yml down
+``` 
+
 This configuration is useful for development and testing since it initializes more quickly, but is not recommended for production deployments. This configuration also has a convenience script: `start_cass_311_dev_mode.sh`.
 
 ## Script options

--- a/docker-compose/dse-6.8/README.md
+++ b/docker-compose/dse-6.8/README.md
@@ -28,6 +28,12 @@ This alternate configuration runs the Stargate coordinator node in developer mod
 docker compose -f docker-compose-dev-mode.yml up -d
 ``` 
 
+To stop the configuration, use the command:
+
+```
+docker compose -f docker-compose-dev-mode.yml down
+``` 
+
 This configuration is useful for development and testing since it initializes more quickly, but is not recommended for production deployments. This configuration also has a convenience script: `start_dse_68_dev_mode.sh`.
 
 ## Script options

--- a/docker-compose/dse-6.8/README.md
+++ b/docker-compose/dse-6.8/README.md
@@ -25,7 +25,7 @@ Whether you use the shell script or start `docker compose` directly, you can rem
 This alternate configuration runs the Stargate coordinator node in developer mode, so that no separate Cassandra cluster is required. This can be run with the command:
 
 ```
-docker compose up -f docker-compose-dev-mode.yaml -d
+docker compose -f docker-compose-dev-mode.yml up -d
 ``` 
 
 This configuration is useful for development and testing since it initializes more quickly, but is not recommended for production deployments. This configuration also has a convenience script: `start_dse_68_dev_mode.sh`.


### PR DESCRIPTION
Add a GitHub Actions workflow to run Stargate Postman collections using the Postman CLI against backends started using docker compose scripts.

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
