### PR TITLE
update v2 coordinator docker images to run as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,13 @@ RUN apt update -qq \
     && apt clean all \
     && rm -rf /var/lib/apt/lists/*
 
+RUN set -x \
+    && groupadd -r stargate --gid=999 \
+    && useradd -r -g stargate -d /stargate --uid=999 stargate
+
+USER stargate
+WORKDIR /stargate
+
 # CQL
 EXPOSE 9042
 
@@ -29,17 +36,16 @@ EXPOSE 8084
 # we use a script to build a directory with contents of ./stargate-lib, omitting all persistence jars
 # we can then add the proper set of persistence jars to each of the images below
 ARG LIBDIR
-COPY ${LIBDIR} /stargate-lib/
+COPY ${LIBDIR} stargate-lib/
 
-COPY ./starctl /starctl
-RUN chmod +x starctl
+COPY ./starctl ./starctl
 ENTRYPOINT ["./starctl"]
 
 FROM base as coordinator-4_0
-COPY stargate-lib/persistence-api*.jar stargate-lib/persistence-cassandra-4.0*.jar /stargate-lib/
+COPY stargate-lib/persistence-api*.jar stargate-lib/persistence-cassandra-4.0*.jar stargate-lib/
 
 FROM base as coordinator-3_11
-COPY stargate-lib/persistence-api*.jar stargate-lib/persistence-cassandra-3.11*.jar /stargate-lib/
+COPY stargate-lib/persistence-api*.jar stargate-lib/persistence-cassandra-3.11*.jar stargate-lib/
 
 FROM base as coordinator-dse-68
-COPY stargate-lib/persistence-api*.jar stargate-lib/persistence-dse*.jar /stargate-lib/
+COPY stargate-lib/persistence-api*.jar stargate-lib/persistence-dse*.jar stargate-lib/


### PR DESCRIPTION
Fixes #1707.

Coordinator images will now run as user `stargate`. No changes required to API service images created by Quarkus, they already run as non-root user `jboss`. 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
