### PR TITLE
Fix #2326: reduce amount of keyspaces created by ITs, add clean up

### DIFF
--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QCqlEnabledTestBase.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QCqlEnabledTestBase.java
@@ -12,8 +12,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
 public class RestApiV2QCqlEnabledTestBase extends RestApiV2QIntegrationTestBase {
-  protected RestApiV2QCqlEnabledTestBase(String keyspacePrefix, String tablePrefix) {
-    super(keyspacePrefix, tablePrefix);
+  protected RestApiV2QCqlEnabledTestBase(
+      String keyspacePrefix, String tablePrefix, KeyspaceCreation keyspaceCreation) {
+    super(keyspacePrefix, tablePrefix, keyspaceCreation);
   }
 
   protected CqlSession session;

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QCqlIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QCqlIT.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 public class RestApiV2QCqlIT extends RestApiV2QIntegrationTestBase {
 
   public RestApiV2QCqlIT() {
-    super("cql_ks_", "cql_t_");
+    super("cql_ks_", "cql_t_", KeyspaceCreation.NONE);
   }
 
   @Test

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowAddIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowAddIT.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 @QuarkusTestResource(StargateTestResource.class)
 public class RestApiV2QRowAddIT extends RestApiV2QIntegrationTestBase {
   public RestApiV2QRowAddIT() {
-    super("rowadd_ks_", "rowadd_t_");
+    super("rowadd_ks_", "rowadd_t_", KeyspaceCreation.PER_CLASS);
   }
 
   @Test

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowDeleteIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowDeleteIT.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 @QuarkusTestResource(StargateTestResource.class)
 public class RestApiV2QRowDeleteIT extends RestApiV2QIntegrationTestBase {
   public RestApiV2QRowDeleteIT() {
-    super("rowdel_ks_", "rowdel_t_");
+    super("rowdel_ks_", "rowdel_t_", KeyspaceCreation.PER_CLASS);
   }
 
   @Test

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowGetIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowGetIT.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 @QuarkusTestResource(StargateTestResource.class)
 public class RestApiV2QRowGetIT extends RestApiV2QIntegrationTestBase {
   public RestApiV2QRowGetIT() {
-    super("rowget_ks_", "rowget_t_");
+    super("rowget_ks_", "rowget_t_", KeyspaceCreation.PER_CLASS);
   }
 
   @Test
@@ -418,7 +418,7 @@ public class RestApiV2QRowGetIT extends RestApiV2QIntegrationTestBase {
         testKeyspaceName(),
         tableName,
         "attributes",
-        "attributes_map_index",
+        "attributes_mapentry_index",
         false,
         CollectionIndexingType.ENTRIES);
 
@@ -458,7 +458,7 @@ public class RestApiV2QRowGetIT extends RestApiV2QIntegrationTestBase {
         testKeyspaceName(),
         tableName,
         "attributes",
-        "attributes_map_index",
+        "attributes_mapkey_index",
         false,
         CollectionIndexingType.KEYS);
     insertTypedRows(

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowPatchIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowPatchIT.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 @QuarkusTestResource(StargateTestResource.class)
 public class RestApiV2QRowPatchIT extends RestApiV2QIntegrationTestBase {
   public RestApiV2QRowPatchIT() {
-    super("rowptc_ks_", "rowptc_t_");
+    super("rowptc_ks_", "rowptc_t_", KeyspaceCreation.PER_CLASS);
   }
 
   @Test

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowUpdateIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowUpdateIT.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 @QuarkusTestResource(StargateTestResource.class)
 public class RestApiV2QRowUpdateIT extends RestApiV2QIntegrationTestBase {
   public RestApiV2QRowUpdateIT() {
-    super("rowupd_ks_", "rowupd_t_");
+    super("rowupd_ks_", "rowupd_t_", KeyspaceCreation.PER_CLASS);
   }
 
   @Test

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaColumnsIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaColumnsIT.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 @QuarkusTestResource(StargateTestResource.class)
 public class RestApiV2QSchemaColumnsIT extends RestApiV2QIntegrationTestBase {
   public RestApiV2QSchemaColumnsIT() {
-    super("col_ks_", "col_t_");
+    super("col_ks_", "col_t_", KeyspaceCreation.PER_CLASS);
   }
 
   /*

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaIndexesIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaIndexesIT.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 @QuarkusTestResource(StargateTestResource.class)
 public class RestApiV2QSchemaIndexesIT extends RestApiV2QIntegrationTestBase {
   public RestApiV2QSchemaIndexesIT() {
-    super("idx_ks_", "idx_t_");
+    super("idx_ks_", "idx_t_", KeyspaceCreation.PER_CLASS);
   }
 
   /*

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaKeyspacesIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaKeyspacesIT.java
@@ -84,8 +84,6 @@ public class RestApiV2QSchemaKeyspacesIT extends RestApiV2QIntegrationTestBase {
             .asString();
   }
 
-  // 09-Aug-2022, tatu: Alas, Auth token seems not to be checked
-  // @Ignore("Auth token handling hard-coded, won't fail as expected")
   @Test
   public void keyspacesGetAllBadToken() {
     String response =

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaKeyspacesIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaKeyspacesIT.java
@@ -23,7 +23,6 @@ import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
-import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +36,7 @@ public class RestApiV2QSchemaKeyspacesIT extends RestApiV2QIntegrationTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(RestApiV2QSchemaKeyspacesIT.class);
 
   public RestApiV2QSchemaKeyspacesIT() {
-    super("ks_ks_", "ks_t_");
+    super("ks_ks_", "ks_t_", KeyspaceCreation.NONE);
   }
 
   /*
@@ -86,7 +85,8 @@ public class RestApiV2QSchemaKeyspacesIT extends RestApiV2QIntegrationTestBase {
   }
 
   // 09-Aug-2022, tatu: Alas, Auth token seems not to be checked
-  @Ignore("Auth token handling hard-coded, won't fail as expected")
+  // @Ignore("Auth token handling hard-coded, won't fail as expected")
+  @Test
   public void keyspacesGetAllBadToken() {
     String response =
         givenWithAuthToken("NotAPassword")

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaKeyspacesIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaKeyspacesIT.java
@@ -165,6 +165,8 @@ public class RestApiV2QSchemaKeyspacesIT extends RestApiV2QIntegrationTestBase {
             .asString();
     final Sgv2Keyspace keyspace = readJsonAs(response, Sgv2Keyspace.class);
     assertThat(keyspace).usingRecursiveComparison().isEqualTo(new Sgv2Keyspace(keyspaceName));
+
+    deleteKeyspace(keyspaceName);
   }
 
   // For [stargate#1817]. Unfortunately our current CI set up only has single DC ("dc1")
@@ -212,6 +214,8 @@ public class RestApiV2QSchemaKeyspacesIT extends RestApiV2QIntegrationTestBase {
         dcs.orElse(Collections.emptyList()).stream()
             .collect(Collectors.toMap(Sgv2Keyspace.Datacenter::getName, Function.identity()));
     assertThat(actualDCs).usingRecursiveComparison().isEqualTo(expectedDCs);
+
+    deleteKeyspace(keyspaceName);
   }
 
   // Verify that attempts to use non-existing DC produce useful fail message

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaTablesIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaTablesIT.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 @QuarkusTestResource(StargateTestResource.class)
 public class RestApiV2QSchemaTablesIT extends RestApiV2QIntegrationTestBase {
   public RestApiV2QSchemaTablesIT() {
-    super("tbl_ks_", "tbl_t_");
+    super("tbl_ks_", "tbl_t_", KeyspaceCreation.PER_CLASS);
   }
 
   /*

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaUserTypeIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaUserTypeIT.java
@@ -20,7 +20,8 @@ import org.junit.jupiter.api.Test;
 @QuarkusTestResource(StargateTestResource.class)
 public class RestApiV2QSchemaUserTypeIT extends RestApiV2QIntegrationTestBase {
   public RestApiV2QSchemaUserTypeIT() {
-    super("udt_ks_", "udt_t_");
+    // Need per-method due to "udtGetAll()" verifying that no UDTs exist
+    super("udt_ks_", "udt_t_", KeyspaceCreation.PER_METHOD);
   }
 
   /*

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/persistence/RestApiV2QDSETests_IT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/persistence/RestApiV2QDSETests_IT.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 @QuarkusTestResource(StargateTestResource.class)
 public class RestApiV2QDSETests_IT extends RestApiV2QCqlEnabledTestBase {
   public RestApiV2QDSETests_IT() {
-    super("dse_ks_", "dse_t_");
+    super("dse_ks_", "dse_t_", KeyspaceCreation.PER_CLASS);
   }
 
   /*

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/persistence/RestApiV2QIndexSASI_IT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/persistence/RestApiV2QIndexSASI_IT.java
@@ -27,7 +27,7 @@ public class RestApiV2QIndexSASI_IT extends RestApiV2QIntegrationTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(RestApiV2QIndexSASI_IT.class);
 
   public RestApiV2QIndexSASI_IT() {
-    super("sasi_ks_", "sasi_t_");
+    super("sasi_ks_", "sasi_t_", KeyspaceCreation.PER_CLASS);
   }
 
   /*

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/persistence/RestApiV2QMaterializedViewIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/persistence/RestApiV2QMaterializedViewIT.java
@@ -29,7 +29,7 @@ public class RestApiV2QMaterializedViewIT extends RestApiV2QCqlEnabledTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(RestApiV2QMaterializedViewIT.class);
 
   public RestApiV2QMaterializedViewIT() {
-    super("mv_ks_", "mv_t_");
+    super("mv_ks_", "mv_t_", KeyspaceCreation.PER_CLASS);
   }
 
   /*


### PR DESCRIPTION
**What this PR does**:

1. Reduces number of keyspaces REST API Integration tests create, and
2. Cleans up keyspaces that area created

**Which issue(s) this PR fixes**:
Fixes #2326

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
