### PR TITLE
Update Ubuntu version from deprecated 18.x for "coordinator-test" GH Action (main)

### DIFF
--- a/.github/workflows/coordinator-test.yml
+++ b/.github/workflows/coordinator-test.yml
@@ -6,8 +6,8 @@ on:
 jobs:
   integration-test:
     name: Integration Test
-    # CCM installation trickier on 20.04, alas; Python 2.x dep etc problematic
-    runs-on: ubuntu-18.04
+    # 05-Jan-2023, tatu: CCM install tested with this version, current ubuntu-latest:
+    runs-on: ubuntu-22.04
     strategy:
       # Defaults to "true" but let's let all runs finish
       # (see https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs)
@@ -20,7 +20,7 @@ jobs:
         name: Setup Java JDK
         with:
           distribution: 'temurin'
-          java-version: 8.0.332
+          java-version: 8.0.345
           cache: 'maven'
       - name: Setup Maven
         env:
@@ -45,7 +45,7 @@ jobs:
           </settings>
           EOF
       - name: Clone CCM
-        # 24-Jun-2022, tatu: CCM install copied from C2 repo's ".github/workflows/ci.yml":
+        # 05-Jan-2023, tatu: CCM install copied from C2 repo's ".github/workflows/ci.yml":
         uses: actions/checkout@v3
         with:
           repository: riptano/ccm
@@ -55,13 +55,15 @@ jobs:
       - name: Install CCM
         run: |
           sudo apt-get install python2.7
-          sudo apt-get install python-dev
+          sudo apt-get install python2-dev
           sudo apt-get install python-setuptools
-          sudo apt-get install python-yaml
-          python -m pip install --upgrade pip
-          python -m pip install psutil
+          sudo apt-get install python-six
+          curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
+          sudo python2 get-pip.py
+          sudo pip install --upgrade pip
+          sudo pip install psutil pyyaml
           cd ccm
-          sudo ./setup.py install
+          sudo python2 setup.py install
           ccm list
       - name: Run Unit and Integration Tests
         run: |


### PR DESCRIPTION
**What this PR does**:

As per title, updates Ubuntu image used by `coordinator-test.yml` (see #2281) to avoid deprecation warnings.

**Which issue(s) this PR fixes**:

n/a

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
