### PR TITLE
Fix #2345: Upgrade Jackson dep to 2.14.1 (from 2.13.4)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <commons-io.version>2.7</commons-io.version>
     <grpc.version>1.51.0</grpc.version>
     <immutables.version>2.8.8</immutables.version>
-    <jackson.version>2.13.4</jackson.version>
+    <jackson.version>2.14.1</jackson.version>
     <javatuples.version>1.2</javatuples.version>
     <!-- Make sure micrometer and prometheus versions are in sync  -->
     <micrometer.version>1.8.2</micrometer.version>
@@ -49,7 +49,7 @@
     <!-- SnakeYAML needs to be synced with jackson-dataformat-yaml
        most of the time, but occasionally higher for CVEs
       -->
-    <snakeyaml.version>1.32</snakeyaml.version>
+    <snakeyaml.version>1.33</snakeyaml.version>
     <swagger-ui.version>3.52.5</swagger-ui.version>
     <swagger-jersey2-jaxrs.version>1.6.3</swagger-jersey2-jaxrs.version>
     <!-- Netty version used by Cassandra 3.11/4.0 (DSE uses different version)
@@ -565,7 +565,7 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!-- SnakeYAML dependency from Jackson is 1.31 but Persistence backends
+      <!-- SnakeYAML dependency from Jackson 2.14.1 is 1.33 but Persistence backends
 	   try to bring in older versions, so:
 	-->
       <dependency>


### PR DESCRIPTION
**What this PR does**:

Updates Jackson dependency to 2.14.1 (from 2.13.4); forces use of newer SnakeYAML (1.33 from 1.32)

**Which issue(s) this PR fixes**:
Fixes #2345

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
