### PR TITLE
Avoid SchemaReadCheck optional for Row CRUD (leave for Schema access)

### DIFF
--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/RestResourceBase.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/RestResourceBase.java
@@ -78,7 +78,10 @@ public abstract class RestResourceBase {
   }
 
   protected Uni<Schema.CqlTable> getTableAsyncCheckExistence(
-      String keyspaceName, String tableName, boolean checkAuthzForTableMetadata, Response.Status failCode) {
+      String keyspaceName,
+      String tableName,
+      boolean checkAuthzForTableMetadata,
+      Response.Status failCode) {
     return getTableAsync(keyspaceName, tableName, checkAuthzForTableMetadata)
         .onItem()
         .ifNull()
@@ -101,8 +104,8 @@ public abstract class RestResourceBase {
   // // // Helper methods for Query execution
 
   /**
-   * Gets the metadata of a table (optionally verifying that the access to table metadata is authorized),
-   * then uses it to build another CQL query and executes it.
+   * Gets the metadata of a table (optionally verifying that the access to table metadata is
+   * authorized), then uses it to build another CQL query and executes it.
    */
   protected Uni<QueryOuterClass.Response> queryWithTableAsync(
       String keyspaceName,
@@ -112,7 +115,7 @@ public abstract class RestResourceBase {
     return executeQueryAsync(
         keyspaceName,
         tableName,
-            checkAuthzForTableMetadata,
+        checkAuthzForTableMetadata,
         maybeTable -> {
           Schema.CqlTable table =
               maybeTable.orElseThrow(
@@ -136,7 +139,8 @@ public abstract class RestResourceBase {
       Function<Optional<Schema.CqlTable>, QueryOuterClass.Query> queryProducer) {
 
     // TODO implement optimistic queries (probably requires changes directly in SchemaManager)
-    Uni<Optional<Schema.CqlTable>> maybeTable = findTableAsync(keyspaceName, tableName, checkAuthzForTableMetadata);
+    Uni<Optional<Schema.CqlTable>> maybeTable =
+        findTableAsync(keyspaceName, tableName, checkAuthzForTableMetadata);
     return maybeTable
         .onItem()
         .transformToUni(table -> executeQueryAsync(queryProducer.apply(table)));

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/RestResourceBase.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/RestResourceBase.java
@@ -56,8 +56,8 @@ public abstract class RestResourceBase {
   // // // Helper methods for Schema access
 
   protected Uni<Schema.CqlKeyspaceDescribe> getKeyspaceAsync(
-      String keyspaceName, boolean checkIfAuthorized) {
-    return checkIfAuthorized
+      String keyspaceName, boolean checkAuthzForKeyspaceMetadata) {
+    return checkAuthzForKeyspaceMetadata
         ? schemaManager.getKeyspaceAuthorized(keyspaceName)
         : schemaManager.getKeyspace(keyspaceName);
   }
@@ -132,11 +132,11 @@ public abstract class RestResourceBase {
   protected Uni<QueryOuterClass.Response> executeQueryAsync(
       String keyspaceName,
       String tableName,
-      boolean checkIfTableAuthorized,
+      boolean checkAuthzForTableMetadata,
       Function<Optional<Schema.CqlTable>, QueryOuterClass.Query> queryProducer) {
 
     // TODO implement optimistic queries (probably requires changes directly in SchemaManager)
-    Uni<Optional<Schema.CqlTable>> maybeTable = findTableAsync(keyspaceName, tableName, checkIfTableAuthorized);
+    Uni<Optional<Schema.CqlTable>> maybeTable = findTableAsync(keyspaceName, tableName, checkAuthzForTableMetadata);
     return maybeTable
         .onItem()
         .transformToUni(table -> executeQueryAsync(queryProducer.apply(table)));

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/Sgv2RowsResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/Sgv2RowsResourceImpl.java
@@ -51,6 +51,7 @@ public class Sgv2RowsResourceImpl extends RestResourceBase implements Sgv2RowsRe
     return queryWithTableAsync(
             keyspaceName,
             tableName,
+            false,
             tableDef -> {
               final ToProtoConverter toProtoConverter = findProtoConverter(tableDef);
 
@@ -106,6 +107,7 @@ public class Sgv2RowsResourceImpl extends RestResourceBase implements Sgv2RowsRe
     return queryWithTableAsync(
             keyspaceName,
             tableName,
+            false,
             tableDef -> {
               final ToProtoConverter toProtoConverter = findProtoConverter(tableDef);
               try {
@@ -179,6 +181,7 @@ public class Sgv2RowsResourceImpl extends RestResourceBase implements Sgv2RowsRe
     return queryWithTableAsync(
             keyspaceName,
             tableName,
+            false,
             tableDef -> {
               final ToProtoConverter toProtoConverter = findProtoConverter(tableDef);
 
@@ -219,6 +222,7 @@ public class Sgv2RowsResourceImpl extends RestResourceBase implements Sgv2RowsRe
     return queryWithTableAsync(
             keyspaceName,
             tableName,
+            false,
             (tableDef) -> {
               final ToProtoConverter toProtoConverter = findProtoConverter(tableDef);
               try {
@@ -249,6 +253,7 @@ public class Sgv2RowsResourceImpl extends RestResourceBase implements Sgv2RowsRe
     return queryWithTableAsync(
             keyspaceName,
             tableName,
+            false,
             tableDef -> {
               final ToProtoConverter toProtoConverter = findProtoConverter(tableDef);
               try {

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2ColumnsResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2ColumnsResourceImpl.java
@@ -35,6 +35,7 @@ public class Sgv2ColumnsResourceImpl extends RestResourceBase implements Sgv2Col
     return queryWithTableAsync(
             keyspaceName,
             tableName,
+            true,
             (tableDef) -> {
               Column.Kind kind =
                   columnDefinition.isStatic() ? Column.Kind.STATIC : Column.Kind.REGULAR;
@@ -83,6 +84,7 @@ public class Sgv2ColumnsResourceImpl extends RestResourceBase implements Sgv2Col
     return queryWithTableAsync(
             keyspaceName,
             tableName,
+            true,
             (tableDef) -> {
               // Optional, could let backend verify but this gives us better error reporting
               if (findColumn(tableDef, columnName) == null) {
@@ -106,6 +108,7 @@ public class Sgv2ColumnsResourceImpl extends RestResourceBase implements Sgv2Col
     return queryWithTableAsync(
             keyspaceName,
             tableName,
+            true,
             (tableDef) -> {
               // Optional, could let backend verify but this gives us better error reporting
               if (findColumn(tableDef, columnName) == null) {

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2IndexesResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2IndexesResourceImpl.java
@@ -46,7 +46,7 @@ public class Sgv2IndexesResourceImpl extends RestResourceBase implements Sgv2Ind
 
     // This call will authorize lookup on "table" so no separate access checks
     // should be needed
-    return queryWithTableAsync(keyspaceName, tableName, table -> query)
+    return queryWithTableAsync(keyspaceName, tableName, true, table -> query)
         .map(response -> convertRowsToResponse(response, true));
   }
 
@@ -57,6 +57,7 @@ public class Sgv2IndexesResourceImpl extends RestResourceBase implements Sgv2Ind
     return queryWithTableAsync(
             keyspaceName,
             tableName,
+            true,
             table -> {
               if (!hasColumn(table, columnName)) {
                 throw new WebApplicationException(
@@ -82,6 +83,7 @@ public class Sgv2IndexesResourceImpl extends RestResourceBase implements Sgv2Ind
     return queryWithTableAsync(
             keyspaceName,
             tableName,
+            true,
             table -> {
               if (!ifExists
                   && table.getIndexesList().stream()

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2TablesResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2TablesResourceImpl.java
@@ -126,6 +126,7 @@ public class Sgv2TablesResourceImpl extends RestResourceBase implements Sgv2Tabl
     return queryWithTableAsync(
             keyspaceName,
             tableName,
+            true,
             (tableDef) -> {
               Sgv2Table.TableOptions options = tableUpdate.tableOptions();
               List<?> clusteringExpressions = options.clusteringExpression();


### PR DESCRIPTION
**What this PR does**:

Changes schema-read-access check handling for table metadata access so that:

1. It WILL be performed when accessing Schema info directly (tables, indexes)
2. It WILL NOT be performed for Row CRUD: access check will be performed as part of actual query execution

The reason being that in either case query execution will still perform checks; but in case of schema operations (DDL) we can afford "double-checking" to catch issue earlier, despite higher overall latency.

Issue was found during performance testing

**Which issue(s) this PR fixes**:
Fixes #2349

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
