### PR TITLE
closes #2209: implement retriable bridge calls

### DIFF
--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/write/WriteBridgeService.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/write/WriteBridgeService.java
@@ -20,13 +20,13 @@ package io.stargate.sgv2.docsapi.service.write;
 import com.google.common.base.Splitter;
 import io.grpc.Metadata;
 import io.opentelemetry.extension.annotations.WithSpan;
-import io.quarkus.grpc.GrpcClient;
 import io.quarkus.grpc.GrpcClientUtils;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.bridge.proto.QueryOuterClass.Batch;
 import io.stargate.bridge.proto.QueryOuterClass.ResultSet;
 import io.stargate.bridge.proto.StargateBridge;
+import io.stargate.sgv2.api.common.StargateRequestInfo;
 import io.stargate.sgv2.api.common.config.QueriesConfig;
 import io.stargate.sgv2.api.common.properties.datastore.DataStoreProperties;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCode;
@@ -59,7 +59,7 @@ public class WriteBridgeService {
   // path splitter on dot
   private static final Splitter PATH_SPLITTER = Splitter.on(".");
 
-  private final StargateBridge bridge;
+  private final StargateRequestInfo requestInfo;
   private final TimeSource timeSource;
   private final InsertQueryBuilder insertQueryBuilder;
   private final boolean useLoggedBatches;
@@ -69,12 +69,12 @@ public class WriteBridgeService {
 
   @Inject
   public WriteBridgeService(
-      @GrpcClient("bridge") StargateBridge bridge,
+      StargateRequestInfo requestInfo,
       TimeSource timeSource,
       DataStoreProperties dataStoreProperties,
       DocumentProperties documentProperties,
       QueriesConfig queriesConfig) {
-    this.bridge = bridge;
+    this.requestInfo = requestInfo;
     this.insertQueryBuilder = new InsertQueryBuilder(documentProperties);
     this.timeSource = timeSource;
     this.useLoggedBatches = dataStoreProperties.loggedBatchesEnabled();
@@ -103,6 +103,8 @@ public class WriteBridgeService {
       List<JsonShreddedRow> rows,
       Integer ttl,
       ExecutionContext context) {
+
+    StargateBridge bridge = requestInfo.getStargateBridge();
 
     return Uni.createFrom()
         .item(
@@ -184,6 +186,8 @@ public class WriteBridgeService {
       List<JsonShreddedRow> rows,
       Integer ttl,
       ExecutionContext context) {
+
+    StargateBridge bridge = requestInfo.getStargateBridge();
 
     return Uni.createFrom()
         .item(
@@ -296,6 +300,8 @@ public class WriteBridgeService {
       Integer ttl,
       ExecutionContext context) {
 
+    StargateBridge bridge = requestInfo.getStargateBridge();
+
     return Uni.createFrom()
         .item(
             () -> {
@@ -372,6 +378,9 @@ public class WriteBridgeService {
       List<JsonShreddedRow> rows,
       Integer ttl,
       ExecutionContext context) {
+
+    StargateBridge bridge = requestInfo.getStargateBridge();
+
     return Uni.createFrom()
         .item(
             () -> {
@@ -446,6 +455,8 @@ public class WriteBridgeService {
       List<String> subDocumentPath,
       ExecutionContext context) {
 
+    StargateBridge bridge = requestInfo.getStargateBridge();
+
     return Uni.createFrom()
         .item(
             () -> {
@@ -483,6 +494,9 @@ public class WriteBridgeService {
       Map<String, Set<DeadLeaf>> deadLeaves,
       ExecutionContext context,
       Metadata metadata) {
+
+    StargateBridge bridge = requestInfo.getStargateBridge();
+
     return Uni.createFrom()
         .item(
             () -> {

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/write/WriteBridgeServiceTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/service/write/WriteBridgeServiceTest.java
@@ -29,7 +29,6 @@ import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.stargate.bridge.grpc.Values;
 import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.bridge.proto.QueryOuterClass.Batch;
-import io.stargate.sgv2.api.common.config.QueriesConfig;
 import io.stargate.sgv2.api.common.properties.datastore.DataStoreProperties;
 import io.stargate.sgv2.docsapi.DocsApiTestSchemaProvider;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCode;
@@ -63,11 +62,10 @@ import org.junit.jupiter.api.Test;
 @TestProfile(MaxDepth4TestProfile.class)
 class WriteBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
 
-  WriteBridgeService service;
+  @Inject WriteBridgeService service;
   @Inject DocsApiTestSchemaProvider schemaProvider;
   @Inject DataStoreProperties dataStoreProperties;
   @Inject DocumentProperties documentProperties;
-  @Inject QueriesConfig queriesConfig;
   @InjectMock TimeSource timeSource;
 
   String keyspaceName;
@@ -79,9 +77,6 @@ class WriteBridgeServiceTest extends AbstractValidatingStargateBridgeTest {
 
   @BeforeEach
   public void init() {
-    service =
-        new WriteBridgeService(
-            bridge, timeSource, dataStoreProperties, documentProperties, queriesConfig);
     keyspaceName = schemaProvider.getKeyspace().getName();
     tableName = schemaProvider.getTable().getName();
     expectedBatchType =

--- a/apis/sgv2-quarkus-common/CONFIGURATION.md
+++ b/apis/sgv2-quarkus-common/CONFIGURATION.md
@@ -27,9 +27,12 @@
 ### gRPC configuration
 *Configuration for the gRPC calls to the Bridge, defined by [GrpcConfig.java](src/main/java/io/stargate/sgv2/api/common/config/GrpcConfig.java).*
 
-| Property                      | Type       | Default | Description                                                  |
-|-------------------------------|------------|---------|--------------------------------------------------------------|
-| `stargate.grpc.call-deadline` | `Duration` | `PT30S` | Defines the client deadline for each RPC call to the bridge. |
+| Property                             | Type       | Default       | Description                                                                          |
+|--------------------------------------|------------|---------------|--------------------------------------------------------------------------------------|
+| `stargate.grpc.call-deadline`        | `Duration` | `PT30S`       | Defines the client deadline for each RPC call to the bridge.                         |
+| `stargate.grpc.retries.enabled`      | `boolean`  | `true`        | If retries of bridge calls is enabled.                                               |
+| `stargate.grpc.retries.status-codes` | `List`     | `UNAVAILABLE` | List of gRPC `Status.Code`s that must be returned in order for a call to be retried. |
+| `stargate.grpc.retries.max-attempts` | `int`      | `1`           | Maximum amount of retry attempts for a single call.                                  |
 
 ### gRPC metadata configuration
 *Configuration for the gRPC metadata passed to the Bridge, defined by [GrpcMetadataConfig.java](src/main/java/io/stargate/sgv2/api/common/config/GrpcMetadataConfig.java).*

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/StargateRequestInfo.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/StargateRequestInfo.java
@@ -17,8 +17,9 @@
 
 package io.stargate.sgv2.api.common;
 
-import io.quarkus.grpc.GrpcClient;
 import io.stargate.bridge.proto.StargateBridge;
+import io.stargate.sgv2.api.common.grpc.Retriable;
+import io.stargate.sgv2.api.common.grpc.RetriableStargateBridge;
 import io.stargate.sgv2.api.common.tenant.TenantResolver;
 import io.stargate.sgv2.api.common.token.CassandraTokenResolver;
 import io.vertx.ext.web.RoutingContext;
@@ -48,7 +49,7 @@ public class StargateRequestInfo {
   public StargateRequestInfo(
       RoutingContext routingContext,
       SecurityContext securityContext,
-      @GrpcClient("bridge") StargateBridge bridge,
+      @Retriable RetriableStargateBridge bridge,
       Instance<TenantResolver> tenantResolver,
       Instance<CassandraTokenResolver> tokenResolver) {
     this.tenantId = tenantResolver.get().resolve(routingContext, securityContext);

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/StargateRequestInfo.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/StargateRequestInfo.java
@@ -18,8 +18,8 @@
 package io.stargate.sgv2.api.common;
 
 import io.stargate.bridge.proto.StargateBridge;
-import io.stargate.sgv2.api.common.grpc.Retriable;
 import io.stargate.sgv2.api.common.grpc.RetriableStargateBridge;
+import io.stargate.sgv2.api.common.grpc.qualifier.Retriable;
 import io.stargate.sgv2.api.common.tenant.TenantResolver;
 import io.stargate.sgv2.api.common.token.CassandraTokenResolver;
 import io.vertx.ext.web.RoutingContext;

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/GrpcConfig.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/GrpcConfig.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
 
 /** Configuration for the gRPC calls to the Bridge. */
 @ConfigMapping(prefix = "stargate.grpc")
@@ -46,13 +47,17 @@ public interface GrpcConfig {
     @WithDefault("true")
     boolean enabled();
 
-    /** @return List of status codes to execute retries for. */
+    /**
+     * @return List of status codes to execute retries for. Defaults to <code>UNAVAILABLE</code>, as
+     *     this code means that the request never reached the bridge and it should be safe to retry.
+     */
     @WithDefault("UNAVAILABLE")
     @NotNull
     List<Status.Code> statusCodes();
 
     /** @return Maximum amount of retry attempts. */
     @WithDefault("1")
+    @Positive
     int maxAttempts();
   }
 }

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/GrpcConfig.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/GrpcConfig.java
@@ -17,10 +17,15 @@
 
 package io.stargate.sgv2.api.common.config;
 
+import io.grpc.Status;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
+import io.stargate.sgv2.api.common.grpc.RetriableStargateBridge;
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 
 /** Configuration for the gRPC calls to the Bridge. */
 @ConfigMapping(prefix = "stargate.grpc")
@@ -29,4 +34,25 @@ public interface GrpcConfig {
   /** @return Optional deadline duration for the each RPC to the bridge. Defaults to 30 seconds. */
   @WithDefault("PT30S")
   Optional<Duration> callDeadline();
+
+  /** @return Defines retry strategy for bridge calls when using {@link RetriableStargateBridge}. */
+  @Valid
+  @NotNull
+  Retries retries();
+
+  interface Retries {
+
+    /** @return If call retries are enabled. */
+    @WithDefault("true")
+    boolean enabled();
+
+    /** @return List of status codes to execute retries for. */
+    @WithDefault("UNAVAILABLE")
+    @NotNull
+    List<Status.Code> statusCodes();
+
+    /** @return Maximum amount of retry attempts. */
+    @WithDefault("1")
+    int maxAttempts();
+  }
 }

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/Retriable.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/Retriable.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.stargate.sgv2.api.common.grpc;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import io.stargate.bridge.proto.StargateBridge;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.inject.Qualifier;
+
+/** Qualifier for retriable {@link StargateBridge}. */
+@Qualifier
+@Retention(RUNTIME)
+@Target({METHOD, FIELD, PARAMETER, TYPE})
+public @interface Retriable {}

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/RetriableStargateBridge.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/RetriableStargateBridge.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.api.common.grpc;
+
+import io.grpc.StatusRuntimeException;
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.grpc.GrpcService;
+import io.smallrye.mutiny.Uni;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.bridge.proto.Schema;
+import io.stargate.bridge.proto.StargateBridge;
+import io.stargate.sgv2.api.common.config.GrpcConfig;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * An implementation of the {@link StargateBridge} that executes retries based on the
+ * GrpcConfig.Retries configuration.
+ */
+@Singleton
+@GrpcService
+@Retriable
+public class RetriableStargateBridge implements StargateBridge {
+
+  private final StargateBridge delegate;
+
+  private final GrpcConfig.Retries retriesConfig;
+
+  @Inject
+  public RetriableStargateBridge(
+      @GrpcClient("bridge") StargateBridge delegate, GrpcConfig grpcConfig) {
+    this.delegate = delegate;
+    retriesConfig = grpcConfig.retries();
+  }
+
+  @Override
+  public Uni<QueryOuterClass.Response> executeQuery(QueryOuterClass.Query request) {
+    return withRetries(delegate.executeQuery(request));
+  }
+
+  @Override
+  public Uni<Schema.QueryWithSchemaResponse> executeQueryWithSchema(
+      Schema.QueryWithSchema request) {
+    return withRetries(delegate.executeQueryWithSchema(request));
+  }
+
+  @Override
+  public Uni<QueryOuterClass.Response> executeBatch(QueryOuterClass.Batch request) {
+    return withRetries(delegate.executeBatch(request));
+  }
+
+  @Override
+  public Uni<Schema.CqlKeyspaceDescribe> describeKeyspace(Schema.DescribeKeyspaceQuery request) {
+    return withRetries(delegate.describeKeyspace(request));
+  }
+
+  @Override
+  public Uni<Schema.AuthorizeSchemaReadsResponse> authorizeSchemaReads(
+      Schema.AuthorizeSchemaReadsRequest request) {
+    return withRetries(delegate.authorizeSchemaReads(request));
+  }
+
+  @Override
+  public Uni<Schema.SupportedFeaturesResponse> getSupportedFeatures(
+      Schema.SupportedFeaturesRequest request) {
+    return withRetries(delegate.getSupportedFeatures(request));
+  }
+
+  private <T> Uni<T> withRetries(Uni<T> source) {
+    // if disabled do nothing
+    if (!retriesConfig.enabled()) {
+      return source;
+    }
+
+    // otherwise wrap in retry
+    return source
+        .onFailure(
+            t -> {
+              if (t instanceof StatusRuntimeException sre) {
+                return retriesConfig.statusCodes().contains(sre.getStatus().getCode());
+              }
+              return false;
+            })
+        .retry()
+        .atMost(retriesConfig.maxAttempts());
+  }
+}

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/RetriableStargateBridge.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/RetriableStargateBridge.java
@@ -25,6 +25,7 @@ import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.bridge.proto.Schema;
 import io.stargate.bridge.proto.StargateBridge;
 import io.stargate.sgv2.api.common.config.GrpcConfig;
+import io.stargate.sgv2.api.common.grpc.qualifier.Retriable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/qualifier/Retriable.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/qualifier/Retriable.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-package io.stargate.sgv2.api.common.grpc;
+package io.stargate.sgv2.api.common.grpc.qualifier;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/properties/datastore/configuration/DataStorePropertiesConfiguration.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/properties/datastore/configuration/DataStorePropertiesConfiguration.java
@@ -37,6 +37,7 @@ public class DataStorePropertiesConfiguration {
   /** Logger for the class. */
   private static final Logger LOG = LoggerFactory.getLogger(DataStorePropertiesConfiguration.class);
 
+  // note that here we explicitly want the blocking, non-retriable bridge
   @Produces
   @ApplicationScoped
   @Startup

--- a/apis/sgv2-quarkus-common/src/main/resources/application.yaml
+++ b/apis/sgv2-quarkus-common/src/main/resources/application.yaml
@@ -62,8 +62,6 @@ quarkus:
       bridge:
         host: localhost
         port: 8091
-        retry: true
-        max-hedged-attempts: 0
 
     # force no grpc server start in dev as we have no grpc service
     dev-mode:

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/grpc/RetriableStargateBridgeTest.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/grpc/RetriableStargateBridgeTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.api.common.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.collect.ImmutableMap;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.api.common.BridgeTest;
+import io.stargate.sgv2.api.common.grpc.qualifier.Retriable;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import java.util.Map;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(RetriableStargateBridgeTest.Profile.class)
+class RetriableStargateBridgeTest extends BridgeTest {
+
+  public static class Profile implements NoGlobalResourcesTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return ImmutableMap.<String, String>builder()
+          .put("stargate.grpc.retries.enabled", "true")
+          .put("stargate.grpc.retries.status-codes", "UNAVAILABLE,NOT_FOUND")
+          .put("stargate.grpc.retries.max-attempts", "2")
+          .build();
+    }
+  }
+
+  @Retriable @Inject RetriableStargateBridge bridge;
+
+  @Test
+  public void notRetriedOnResponse() {
+    QueryOuterClass.Response response = QueryOuterClass.Response.newBuilder().build();
+
+    doAnswer(
+            invocationOnMock -> {
+              StreamObserver<QueryOuterClass.Response> observer = invocationOnMock.getArgument(1);
+              observer.onNext(response);
+              observer.onCompleted();
+              return null;
+            })
+        .when(bridgeService)
+        .executeQuery(any(), any());
+
+    QueryOuterClass.Query request = QueryOuterClass.Query.newBuilder().build();
+    bridge
+        .executeQuery(request)
+        .subscribe()
+        .withSubscriber(UniAssertSubscriber.create())
+        .awaitItem()
+        .assertItem(response)
+        .assertCompleted();
+
+    // verify one call only
+    verify(bridgeService).executeQuery(eq(request), any());
+  }
+
+  @Test
+  public void notRetriedWrongStatusCode() {
+    doAnswer(
+            invocationOnMock -> {
+              StreamObserver<QueryOuterClass.Response> observer = invocationOnMock.getArgument(1);
+              Status status = Status.UNIMPLEMENTED;
+              observer.onError(new StatusRuntimeException(status));
+              return null;
+            })
+        .when(bridgeService)
+        .executeQuery(any(), any());
+
+    QueryOuterClass.Query request = QueryOuterClass.Query.newBuilder().build();
+    Throwable result =
+        bridge
+            .executeQuery(request)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create())
+            .awaitFailure()
+            .getFailure();
+
+    assertThat(result)
+        .isInstanceOfSatisfying(
+            StatusRuntimeException.class,
+            e -> assertThat(e.getStatus()).isEqualTo(Status.UNIMPLEMENTED));
+
+    // verify one call only
+    verify(bridgeService).executeQuery(eq(request), any());
+  }
+
+  @Test
+  public void retried() {
+    doAnswer(
+            invocationOnMock -> {
+              StreamObserver<QueryOuterClass.Response> observer = invocationOnMock.getArgument(1);
+              Status status = Status.UNAVAILABLE;
+              observer.onError(new StatusRuntimeException(status));
+              return null;
+            })
+        .when(bridgeService)
+        .executeQuery(any(), any());
+
+    QueryOuterClass.Query request = QueryOuterClass.Query.newBuilder().build();
+    Throwable result =
+        bridge
+            .executeQuery(request)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create())
+            .awaitFailure()
+            .getFailure();
+
+    assertThat(result)
+        .isInstanceOfSatisfying(
+            StatusRuntimeException.class,
+            e -> assertThat(e.getStatus()).isEqualTo(Status.UNAVAILABLE));
+
+    // verify 3 bridge calls, original + 2 retries
+    // always same query
+    verify(bridgeService, times(3)).executeQuery(eq(request), any());
+  }
+
+  @Test
+  public void retriedAdditionalStatusCode() {
+    doAnswer(
+            invocationOnMock -> {
+              StreamObserver<QueryOuterClass.Response> observer = invocationOnMock.getArgument(1);
+              Status status = Status.NOT_FOUND;
+              observer.onError(new StatusRuntimeException(status));
+              return null;
+            })
+        .when(bridgeService)
+        .executeQuery(any(), any());
+
+    QueryOuterClass.Query request = QueryOuterClass.Query.newBuilder().build();
+    Throwable result =
+        bridge
+            .executeQuery(request)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create())
+            .awaitFailure()
+            .getFailure();
+
+    assertThat(result)
+        .isInstanceOfSatisfying(
+            StatusRuntimeException.class,
+            e -> assertThat(e.getStatus()).isEqualTo(Status.NOT_FOUND));
+
+    // verify 3 bridge calls, original + 2 retries
+    // always same query
+    verify(bridgeService, times(3)).executeQuery(eq(request), any());
+  }
+}


### PR DESCRIPTION
**What this PR does**:
Adds our own configuration of the retriable bridge calls. By default, retries are enabled and done only once in case response status code in `UNAVAILABLE`.

From now, bridge must be received from `StargateRequestInfo`, except when you know what are you doing :)

**Which issue(s) this PR fixes**:
* Fixes #2209.
* Makes #2047 as won't fix.
* Makes #2353 as won't fix.

**Checklist**
- [x] Tests with retries
- [x] Configuration documentation