### PR TITLE
update quarkus to 2.15.3

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -15,7 +15,7 @@
     <module>sgv2-restapi</module>
   </modules>
   <properties>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
+    <compiler-plugin.version>3.10.1</compiler-plugin.version>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.release>17</maven.compiler.release>
@@ -23,7 +23,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.15.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.15.3.Final</quarkus.platform.version>
     <skipTests>false</skipTests>
     <skipUnitTests>${skipTests}</skipUnitTests>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/grpc/RetriableStargateBridgeTest.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/grpc/RetriableStargateBridgeTest.java
@@ -37,142 +37,191 @@ import io.stargate.sgv2.api.common.grpc.qualifier.Retriable;
 import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import java.util.Map;
 import javax.inject.Inject;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@TestProfile(RetriableStargateBridgeTest.Profile.class)
 class RetriableStargateBridgeTest extends BridgeTest {
-
-  public static class Profile implements NoGlobalResourcesTestProfile {
-
-    @Override
-    public Map<String, String> getConfigOverrides() {
-      return ImmutableMap.<String, String>builder()
-          .put("stargate.grpc.retries.enabled", "true")
-          .put("stargate.grpc.retries.status-codes", "UNAVAILABLE,NOT_FOUND")
-          .put("stargate.grpc.retries.max-attempts", "2")
-          .build();
-    }
-  }
 
   @Retriable @Inject RetriableStargateBridge bridge;
 
-  @Test
-  public void notRetriedOnResponse() {
-    QueryOuterClass.Response response = QueryOuterClass.Response.newBuilder().build();
+  @Nested
+  @TestProfile(RetriableStargateBridgeTest.Enabled.Profile.class)
+  class Enabled {
+    public static class Profile implements NoGlobalResourcesTestProfile {
 
-    doAnswer(
-            invocationOnMock -> {
-              StreamObserver<QueryOuterClass.Response> observer = invocationOnMock.getArgument(1);
-              observer.onNext(response);
-              observer.onCompleted();
-              return null;
-            })
-        .when(bridgeService)
-        .executeQuery(any(), any());
+      @Override
+      public Map<String, String> getConfigOverrides() {
+        return ImmutableMap.<String, String>builder()
+            .put("stargate.grpc.retries.status-codes", "UNAVAILABLE,NOT_FOUND")
+            .put("stargate.grpc.retries.max-attempts", "2")
+            .build();
+      }
+    }
 
-    QueryOuterClass.Query request = QueryOuterClass.Query.newBuilder().build();
-    bridge
-        .executeQuery(request)
-        .subscribe()
-        .withSubscriber(UniAssertSubscriber.create())
-        .awaitItem()
-        .assertItem(response)
-        .assertCompleted();
+    @Test
+    public void notRetriedOnResponse() {
+      QueryOuterClass.Response response = QueryOuterClass.Response.newBuilder().build();
 
-    // verify one call only
-    verify(bridgeService).executeQuery(eq(request), any());
+      doAnswer(
+              invocationOnMock -> {
+                StreamObserver<QueryOuterClass.Response> observer = invocationOnMock.getArgument(1);
+                observer.onNext(response);
+                observer.onCompleted();
+                return null;
+              })
+          .when(bridgeService)
+          .executeQuery(any(), any());
+
+      QueryOuterClass.Query request = QueryOuterClass.Query.newBuilder().build();
+      bridge
+          .executeQuery(request)
+          .subscribe()
+          .withSubscriber(UniAssertSubscriber.create())
+          .awaitItem()
+          .assertItem(response)
+          .assertCompleted();
+
+      // verify one call only
+      verify(bridgeService).executeQuery(eq(request), any());
+    }
+
+    @Test
+    public void notRetriedWrongStatusCode() {
+      doAnswer(
+              invocationOnMock -> {
+                StreamObserver<QueryOuterClass.Response> observer = invocationOnMock.getArgument(1);
+                Status status = Status.UNIMPLEMENTED;
+                observer.onError(new StatusRuntimeException(status));
+                return null;
+              })
+          .when(bridgeService)
+          .executeQuery(any(), any());
+
+      QueryOuterClass.Query request = QueryOuterClass.Query.newBuilder().build();
+      Throwable result =
+          bridge
+              .executeQuery(request)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitFailure()
+              .getFailure();
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              StatusRuntimeException.class,
+              e -> assertThat(e.getStatus()).isEqualTo(Status.UNIMPLEMENTED));
+
+      // verify one call only
+      verify(bridgeService).executeQuery(eq(request), any());
+    }
+
+    @Test
+    public void retried() {
+      doAnswer(
+              invocationOnMock -> {
+                StreamObserver<QueryOuterClass.Response> observer = invocationOnMock.getArgument(1);
+                Status status = Status.UNAVAILABLE;
+                observer.onError(new StatusRuntimeException(status));
+                return null;
+              })
+          .when(bridgeService)
+          .executeQuery(any(), any());
+
+      QueryOuterClass.Query request = QueryOuterClass.Query.newBuilder().build();
+      Throwable result =
+          bridge
+              .executeQuery(request)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitFailure()
+              .getFailure();
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              StatusRuntimeException.class,
+              e -> assertThat(e.getStatus()).isEqualTo(Status.UNAVAILABLE));
+
+      // verify 3 bridge calls, original + 2 retries
+      // always same query
+      verify(bridgeService, times(3)).executeQuery(eq(request), any());
+    }
+
+    @Test
+    public void retriedAdditionalStatusCode() {
+      doAnswer(
+              invocationOnMock -> {
+                StreamObserver<QueryOuterClass.Response> observer = invocationOnMock.getArgument(1);
+                Status status = Status.NOT_FOUND;
+                observer.onError(new StatusRuntimeException(status));
+                return null;
+              })
+          .when(bridgeService)
+          .executeQuery(any(), any());
+
+      QueryOuterClass.Query request = QueryOuterClass.Query.newBuilder().build();
+      Throwable result =
+          bridge
+              .executeQuery(request)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitFailure()
+              .getFailure();
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              StatusRuntimeException.class,
+              e -> assertThat(e.getStatus()).isEqualTo(Status.NOT_FOUND));
+
+      // verify 3 bridge calls, original + 2 retries
+      // always same query
+      verify(bridgeService, times(3)).executeQuery(eq(request), any());
+    }
   }
 
-  @Test
-  public void notRetriedWrongStatusCode() {
-    doAnswer(
-            invocationOnMock -> {
-              StreamObserver<QueryOuterClass.Response> observer = invocationOnMock.getArgument(1);
-              Status status = Status.UNIMPLEMENTED;
-              observer.onError(new StatusRuntimeException(status));
-              return null;
-            })
-        .when(bridgeService)
-        .executeQuery(any(), any());
+  @Nested
+  @TestProfile(RetriableStargateBridgeTest.Disabled.Profile.class)
+  class Disabled {
 
-    QueryOuterClass.Query request = QueryOuterClass.Query.newBuilder().build();
-    Throwable result =
-        bridge
-            .executeQuery(request)
-            .subscribe()
-            .withSubscriber(UniAssertSubscriber.create())
-            .awaitFailure()
-            .getFailure();
+    public static class Profile implements NoGlobalResourcesTestProfile {
 
-    assertThat(result)
-        .isInstanceOfSatisfying(
-            StatusRuntimeException.class,
-            e -> assertThat(e.getStatus()).isEqualTo(Status.UNIMPLEMENTED));
+      @Override
+      public Map<String, String> getConfigOverrides() {
+        return ImmutableMap.<String, String>builder()
+            .put("stargate.grpc.retries.enabled", "false")
+            .put("stargate.grpc.retries.status-codes", "UNAVAILABLE,NOT_FOUND")
+            .build();
+      }
+    }
 
-    // verify one call only
-    verify(bridgeService).executeQuery(eq(request), any());
-  }
+    @Test
+    public void disabledNoRetries() {
+      doAnswer(
+              invocationOnMock -> {
+                StreamObserver<QueryOuterClass.Response> observer = invocationOnMock.getArgument(1);
+                Status status = Status.UNAVAILABLE;
+                observer.onError(new StatusRuntimeException(status));
+                return null;
+              })
+          .when(bridgeService)
+          .executeQuery(any(), any());
 
-  @Test
-  public void retried() {
-    doAnswer(
-            invocationOnMock -> {
-              StreamObserver<QueryOuterClass.Response> observer = invocationOnMock.getArgument(1);
-              Status status = Status.UNAVAILABLE;
-              observer.onError(new StatusRuntimeException(status));
-              return null;
-            })
-        .when(bridgeService)
-        .executeQuery(any(), any());
+      QueryOuterClass.Query request = QueryOuterClass.Query.newBuilder().build();
+      Throwable result =
+          bridge
+              .executeQuery(request)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitFailure()
+              .getFailure();
 
-    QueryOuterClass.Query request = QueryOuterClass.Query.newBuilder().build();
-    Throwable result =
-        bridge
-            .executeQuery(request)
-            .subscribe()
-            .withSubscriber(UniAssertSubscriber.create())
-            .awaitFailure()
-            .getFailure();
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              StatusRuntimeException.class,
+              e -> assertThat(e.getStatus()).isEqualTo(Status.UNAVAILABLE));
 
-    assertThat(result)
-        .isInstanceOfSatisfying(
-            StatusRuntimeException.class,
-            e -> assertThat(e.getStatus()).isEqualTo(Status.UNAVAILABLE));
-
-    // verify 3 bridge calls, original + 2 retries
-    // always same query
-    verify(bridgeService, times(3)).executeQuery(eq(request), any());
-  }
-
-  @Test
-  public void retriedAdditionalStatusCode() {
-    doAnswer(
-            invocationOnMock -> {
-              StreamObserver<QueryOuterClass.Response> observer = invocationOnMock.getArgument(1);
-              Status status = Status.NOT_FOUND;
-              observer.onError(new StatusRuntimeException(status));
-              return null;
-            })
-        .when(bridgeService)
-        .executeQuery(any(), any());
-
-    QueryOuterClass.Query request = QueryOuterClass.Query.newBuilder().build();
-    Throwable result =
-        bridge
-            .executeQuery(request)
-            .subscribe()
-            .withSubscriber(UniAssertSubscriber.create())
-            .awaitFailure()
-            .getFailure();
-
-    assertThat(result)
-        .isInstanceOfSatisfying(
-            StatusRuntimeException.class,
-            e -> assertThat(e.getStatus()).isEqualTo(Status.NOT_FOUND));
-
-    // verify 3 bridge calls, original + 2 retries
-    // always same query
-    verify(bridgeService, times(3)).executeQuery(eq(request), any());
+      // verify one class only
+      verify(bridgeService).executeQuery(eq(request), any());
+    }
   }
 }


### PR DESCRIPTION
**What this PR does**:
Updates Quarkus to v2.15.3.. Hopefully we decrease chance of getting vulnerabilities and gets updating to next major version easier.

* I added small improvement for the retriable bridge test that I had in my mind after merging the #2363 