### PR TITLE
Fix #2362: separate "keyspace" as query param vs older as path param

### DIFF
--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/StargateRestApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/StargateRestApi.java
@@ -56,6 +56,13 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                   schema = @Schema(type = SchemaType.STRING)),
               @Parameter(
                   in = ParameterIn.QUERY,
+                  name = RestOpenApiConstants.Parameters.KEYSPACE_AS_QUERY_PARAM,
+                  description = "Name of the keyspace to use for the request",
+                  example = "cycling",
+                  required = false,
+                  schema = @Schema(type = SchemaType.STRING)),
+              @Parameter(
+                  in = ParameterIn.QUERY,
                   name = RestOpenApiConstants.Parameters.PAGE_SIZE,
                   description = "Restrict the number of returned items",
                   example = "10",

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/config/constants/RestOpenApiConstants.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/config/constants/RestOpenApiConstants.java
@@ -33,7 +33,11 @@ public interface RestOpenApiConstants {
   /** Parameters reference names. */
   interface Parameters {
     String FIELDS = "fields";
+    /** Keyspace as required Path Parameter */
     String KEYSPACE_NAME = "keyspaceName";
+    /** Keyspace as optional Query Parameter */
+    String KEYSPACE_AS_QUERY_PARAM = "keyspaceQP";
+
     String PAGE_SIZE = "page-size";
     String PAGE_STATE = "page-state";
     String PRIMARY_KEY = "primaryKey";

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/CQLResource.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/CQLResource.java
@@ -57,7 +57,7 @@ public class CQLResource {
         @APIResponse(ref = RestOpenApiConstants.Responses.GENERAL_500),
       })
   public Uni<RestResponse<Object>> cqlQuery(
-      @Parameter(name = "keyspace", ref = RestOpenApiConstants.Parameters.KEYSPACE_NAME)
+      @Parameter(name = "keyspace", ref = RestOpenApiConstants.Parameters.KEYSPACE_AS_QUERY_PARAM)
           @QueryParam("keyspace")
           final String keyspace,
       @Parameter(name = "page-size", ref = RestOpenApiConstants.Parameters.PAGE_SIZE)

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QCqlIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QCqlIT.java
@@ -7,7 +7,7 @@ import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.Map;
 import org.apache.http.HttpStatus;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -47,7 +47,7 @@ public class RestApiV2QCqlIT extends RestApiV2QIntegrationTestBase {
         .post(endpointPathForCQL())
         .then()
         .statusCode(200)
-        .body("$", Matchers.is(Arrays.asList(Collections.singletonMap("key", "local"))));
+        .body("$", Matchers.is(Arrays.asList(Map.of("key", "local"))));
   }
 
   @Test

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QCqlIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QCqlIT.java
@@ -7,7 +7,7 @@ import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import java.util.Arrays;
-import org.apache.groovy.util.Maps;
+import java.util.Collections;
 import org.apache.http.HttpStatus;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -47,7 +47,7 @@ public class RestApiV2QCqlIT extends RestApiV2QIntegrationTestBase {
         .post(endpointPathForCQL())
         .then()
         .statusCode(200)
-        .body("$", Matchers.is(Arrays.asList(Maps.of("key", "local"))));
+        .body("$", Matchers.is(Arrays.asList(Collections.singletonMap("key", "local"))));
   }
 
   @Test


### PR DESCRIPTION
**What this PR does**:

Removes a warning by Quarkus build (and incorrect definition of OpenAPI documentation based on discrepancy) by correcting definition of `keyspace` used by CQL endpoint to indicate it is a query, not path parameter

**Which issue(s) this PR fixes**:
Fixes #2362

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
