### PR TITLE
Fix typo in README #2382

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Stargate coordinator nodes also support a pluggable authentication and authoriza
 - [authnz](authnz): Interface for working with auth providers
 - [auth-api](auth-api): REST service for generating auth tokens
 - [auth-table-based-service](auth-table-based-service): Service to store tokens in the database
-- [auth-jtw-based-service](auth-jwt-based-service): Service to authenticate using externally generated JSON Web Tokens (JWTs)
+- [auth-jtw-service](auth-jwt-service): Service to authenticate using externally generated JSON Web Tokens (JWTs)
 
 #### Coordinator Node Testing
 The following modules provide support for testing:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: Fixes a typo in README file

**Which issue(s) this PR fixes**: Fix a typo in README file to create correct hyperlink to auth-jtw-service module instead of auth-jtw-based-service
Fixes #2382

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
