### PR TITLE
Fix #2384: revert DSE update (back to 6.8.29)

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -54,7 +54,7 @@ RUN git clone --branch master --single-branch https://github.com/riptano/ccm.git
 # Create clusters to pre-download necessary artifacts
 RUN ccm create -v 4.0.7 stargate_40 && ccm remove stargate_40
 RUN ccm create -v 3.11.14 stargate_311 && ccm remove stargate_311
-RUN ccm create -v 6.8.31 --dse stargate_dse68 && ccm remove stargate_dse68
+RUN ccm create -v 6.8.29 --dse stargate_dse68 && ccm remove stargate_dse68
 
 # init the maven user home dir with correct permissions
 # needed for running maven wrapper

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -1,7 +1,7 @@
 HOSTNAME        := gcr.io
 PROJECT         := stargateio
 NAME            := stargate-builder
-VERSION         := v1.0.15
+VERSION         := v1.0.16
 TAG             := ${VERSION}
 IMG             := ${NAME}:${TAG}
 IMG_GCP         := ${HOSTNAME}/${PROJECT}/${IMG}

--- a/cloudbuild-3_11.yaml
+++ b/cloudbuild-3_11.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.15'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.16'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'
@@ -30,7 +30,7 @@ steps:
         name: 'm2_cache'
   - id: 'cassandra-3.11'
     waitFor: [ 'fetch_secret', 'init_cache' ]
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.15'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.16'
     entrypoint: 'bash'
     args: [ 'ci/test.sh' ]
     volumes:

--- a/cloudbuild-4_0.yaml
+++ b/cloudbuild-4_0.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.15'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.16'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'
@@ -30,7 +30,7 @@ steps:
         name: 'm2_cache'
   - id: 'cassandra-4.0'
     waitFor: [ 'fetch_secret', 'init_cache' ]
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.15'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.16'
     entrypoint: 'bash'
     args: [ 'ci/test.sh' ]
     volumes:

--- a/cloudbuild-dse.yaml
+++ b/cloudbuild-dse.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'pull image'
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.15'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.16'
     entrypoint: 'bash'
     args: [ '-c', 'echo pulled builder' ]
   - id: 'fetch_secret'
@@ -30,7 +30,7 @@ steps:
         name: 'm2_cache'
   - id: 'dse-6.8'
     waitFor: [ 'fetch_secret', 'init_cache' ]
-    name: 'gcr.io/stargateio/stargate-builder:v1.0.15'
+    name: 'gcr.io/stargateio/stargate-builder:v1.0.16'
     entrypoint: 'bash'
     args: [ 'ci/test.sh' ]
     volumes:

--- a/persistence-dse-6.8/README.md
+++ b/persistence-dse-6.8/README.md
@@ -5,7 +5,7 @@ the DSE (DataStax Enterprise cassandra) `6.8.x` version.
 
 ## Cassandra version update
 
-The current Cassandra version this module depends on is `6.8.31`.
+The current Cassandra version this module depends on is `6.8.29`.
 In order to update to a newer patch version, please follow the guidelines below:
 
 * Update the `dse.version` property in the [pom.xml](pom.xml).

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -441,7 +441,7 @@
                 <configuration>
                   <systemPropertyVariables>
                     <ccm.dse>true</ccm.dse>
-                    <ccm.version>6.8.31</ccm.version>
+                    <ccm.version>6.8.29</ccm.version>
                     <stargate.test.nodes>1</stargate.test.nodes>
                   </systemPropertyVariables>
                   <failIfNoTests>true</failIfNoTests>


### PR DESCRIPTION
**What this PR does**:

As per #2384 revert DSE persistence dependency to 6.8.29.

**Which issue(s) this PR fixes**:
Fixes #2384

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
