### PR TITLE
Update APIs to use same C*/DSE versions as coordinator

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -32,7 +32,7 @@
       Please maintain default values for int-test in sync with io.stargate.sgv2.docsapi.testresource.StargateTestResource.Defaults
      -->
     <stargate.int-test.cassandra.image>cassandra</stargate.int-test.cassandra.image>
-    <stargate.int-test.cassandra.image-tag>4.0.4</stargate.int-test.cassandra.image-tag>
+    <stargate.int-test.cassandra.image-tag>4.0.7</stargate.int-test.cassandra.image-tag>
     <stargate.int-test.coordinator.image>stargateio/coordinator-4_0</stargate.int-test.coordinator.image>
     <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
     <stargate.int-test.cluster.name>cass-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
@@ -210,7 +210,7 @@
       <id>cassandra-311</id>
       <properties>
         <stargate.int-test.cassandra.image>cassandra</stargate.int-test.cassandra.image>
-        <stargate.int-test.cassandra.image-tag>3.11.13</stargate.int-test.cassandra.image-tag>
+        <stargate.int-test.cassandra.image-tag>3.11.14</stargate.int-test.cassandra.image-tag>
         <stargate.int-test.coordinator.image>stargateio/coordinator-3_11</stargate.int-test.coordinator.image>
         <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
         <stargate.int-test.cluster.name>cass-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
@@ -222,7 +222,7 @@
       <id>dse-68</id>
       <properties>
         <stargate.int-test.cassandra.image>datastax/dse-server</stargate.int-test.cassandra.image>
-        <stargate.int-test.cassandra.image-tag>6.8.29</stargate.int-test.cassandra.image-tag>
+        <stargate.int-test.cassandra.image-tag>6.8.31</stargate.int-test.cassandra.image-tag>
         <stargate.int-test.coordinator.image>stargateio/coordinator-dse-68</stargate.int-test.coordinator.image>
         <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
         <stargate.int-test.cluster.name>dse-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
@@ -72,7 +72,7 @@ public class StargateTestResource
   interface Defaults {
 
     String CASSANDRA_IMAGE = "cassandra";
-    String CASSANDRA_IMAGE_TAG = "4.0.4";
+    String CASSANDRA_IMAGE_TAG = "4.0.7";
 
     String STARGATE_IMAGE = "stargateio/coordinator-4_0";
     String STARGATE_IMAGE_TAG = "latest";


### PR DESCRIPTION
**What this PR does**:

As per title, syncs up Cassandra persistence versions.

Replicates PR #2361 which has problems passing CI due to access limitations.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
