### PR TITLE
Try to fix some of 3 ITs in Stargate 2.0.6/2.0.7 that fail against CNDB backend

### DIFF
--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QCqlEnabledTestBase.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QCqlEnabledTestBase.java
@@ -11,7 +11,7 @@ import java.time.Duration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-public class RestApiV2QCqlEnabledTestBase extends RestApiV2QIntegrationTestBase {
+public abstract class RestApiV2QCqlEnabledTestBase extends RestApiV2QIntegrationTestBase {
   protected RestApiV2QCqlEnabledTestBase(
       String keyspacePrefix, String tablePrefix, KeyspaceCreation keyspaceCreation) {
     super(keyspacePrefix, tablePrefix, keyspaceCreation);

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QCqlIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QCqlIT.java
@@ -116,6 +116,6 @@ public class RestApiV2QCqlIT extends RestApiV2QIntegrationTestBase {
         .body("code", Matchers.is(HttpStatus.SC_BAD_REQUEST))
         .body(
             "description",
-            Matchers.endsWith("INVALID_ARGUMENT: Keyspace 'no-such-keyspace' does not exist"));
+            Matchers.matchesPattern(".*INVALID_ARGUMENT: Keyspace .*no-such-keyspace.*does not exist.*"));
   }
 }

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QCqlIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QCqlIT.java
@@ -116,6 +116,7 @@ public class RestApiV2QCqlIT extends RestApiV2QIntegrationTestBase {
         .body("code", Matchers.is(HttpStatus.SC_BAD_REQUEST))
         .body(
             "description",
-            Matchers.matchesPattern(".*INVALID_ARGUMENT: Keyspace .*no-such-keyspace.*does not exist.*"));
+            Matchers.matchesPattern(
+                ".*INVALID_ARGUMENT: Keyspace .*no-such-keyspace.*does not exist.*"));
   }
 }

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaKeyspacesIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaKeyspacesIT.java
@@ -86,11 +86,11 @@ public class RestApiV2QSchemaKeyspacesIT extends RestApiV2QIntegrationTestBase {
 
   @Test
   public void keyspacesGetAllBadToken() {
-        givenWithAuthToken("NotAPassword")
-            .when()
-            .get(BASE_PATH)
-            .then()
-            .statusCode(HttpStatus.SC_UNAUTHORIZED);
+    givenWithAuthToken("NotAPassword")
+        .when()
+        .get(BASE_PATH)
+        .then()
+        .statusCode(HttpStatus.SC_UNAUTHORIZED);
   }
 
   @Test

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaKeyspacesIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaKeyspacesIT.java
@@ -86,14 +86,11 @@ public class RestApiV2QSchemaKeyspacesIT extends RestApiV2QIntegrationTestBase {
 
   @Test
   public void keyspacesGetAllBadToken() {
-    String response =
         givenWithAuthToken("NotAPassword")
             .when()
             .get(BASE_PATH)
             .then()
-            .statusCode(HttpStatus.SC_UNAUTHORIZED)
-            .extract()
-            .asString();
+            .statusCode(HttpStatus.SC_UNAUTHORIZED);
   }
 
   @Test


### PR DESCRIPTION
**What this PR does**:

Fixes couple of issues with REST API integration tests for Stargate v2:

1. Failure message for missing keyspace varies among backends, need looser validation
2. Some test set ups apparently try to run `RestApiV2QCqlEnabledTestBase` as a test and fail due to DI failing: change to abstract base class to avoid
3. There is a 500 failure for invalid token: may or may not be test issue. 

This PR should resolved first 2.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
