### PR TITLE
update to Quarkus 2.16.0

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -23,7 +23,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.15.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.16.0.Final</quarkus.platform.version>
     <skipTests>false</skipTests>
     <skipUnitTests>${skipTests}</skipUnitTests>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>


### PR DESCRIPTION
**What this PR does**:

Updated to `2.16.0`. @tatu-at-datastax You could use the new annotation for CQL endpoint disabling once this is merged.

* [x] enable new grpc support
