### PR TITLE
closes #2389: fix retriable stargate bridge being exposed as service

### DIFF
--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/RetriableStargateBridge.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/RetriableStargateBridge.java
@@ -18,33 +18,23 @@
 package io.stargate.sgv2.api.common.grpc;
 
 import io.grpc.StatusRuntimeException;
-import io.quarkus.grpc.GrpcClient;
-import io.quarkus.grpc.GrpcService;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.bridge.proto.Schema;
 import io.stargate.bridge.proto.StargateBridge;
 import io.stargate.sgv2.api.common.config.GrpcConfig;
-import io.stargate.sgv2.api.common.grpc.qualifier.Retriable;
-import javax.inject.Inject;
-import javax.inject.Singleton;
 
 /**
  * An implementation of the {@link StargateBridge} that executes retries based on the
  * GrpcConfig.Retries configuration.
  */
-@Singleton
-@GrpcService
-@Retriable
 public class RetriableStargateBridge implements StargateBridge {
 
   private final StargateBridge delegate;
 
   private final GrpcConfig.Retries retriesConfig;
 
-  @Inject
-  public RetriableStargateBridge(
-      @GrpcClient("bridge") StargateBridge delegate, GrpcConfig grpcConfig) {
+  public RetriableStargateBridge(StargateBridge delegate, GrpcConfig grpcConfig) {
     this.delegate = delegate;
     retriesConfig = grpcConfig.retries();
   }

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/configuration/RetriableStargateBridgeConfiguration.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/configuration/RetriableStargateBridgeConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.api.common.grpc.configuration;
+
+import io.quarkus.grpc.GrpcClient;
+import io.stargate.bridge.proto.StargateBridge;
+import io.stargate.sgv2.api.common.config.GrpcConfig;
+import io.stargate.sgv2.api.common.grpc.RetriableStargateBridge;
+import io.stargate.sgv2.api.common.grpc.qualifier.Retriable;
+import javax.ws.rs.Produces;
+
+public class RetriableStargateBridgeConfiguration {
+
+  @Produces
+  @Retriable
+  RetriableStargateBridge retriableStargateBridge(
+      @GrpcClient("bridge") StargateBridge stargateBridge, GrpcConfig grpcConfig) {
+    return new RetriableStargateBridge(stargateBridge, grpcConfig);
+  }
+}


### PR DESCRIPTION
**What this PR does**:
Fixes starting of the gRPC service. In fact the `RetriableStargateBridge` was exposed as a gRPC service. I will write some additional details in the code.

I am not sure if this should be considered as security risk and vulnerability in versions `2.0.6` and `2.0.7`. Having access to that exposed port, would enable one to gain schema information over the bridge. Any other op requires valid auth token, so no issues there. 

**Which issue(s) this PR fixes**:
Fixes #2389 
