### PR TITLE
Externalizing Cassandra and Coordinator timeout values for test container

### DIFF
--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
@@ -81,6 +81,10 @@ public class StargateTestResource
     String CLUSTER_VERSION = "4.0";
 
     String CLUSTER_DSE = null;
+
+    long CASSANDRA_STARTUP_TIMEOUT = 2;
+    long COORDINATOR_STARTUP_TIMEOUT = 3;
+
   }
 
   private static final Logger LOG = LoggerFactory.getLogger(StargateTestResource.class);
@@ -302,14 +306,16 @@ public class StargateTestResource
 
   /** @return Time to wait for the Cassandra container to start up before failing */
   private Duration getCassandraStartupTimeout() {
-    return Duration.ofMinutes(2);
+    long cassandraStartupTimeout = Long.getLong("testing.containers.cassandra-startup-timeout", Defaults.CASSANDRA_STARTUP_TIMEOUT);
+    return Duration.ofMinutes(cassandraStartupTimeout);
   }
 
   /** @return Time to wait for the Coordinator container to start up before failing */
   private Duration getCoordinatorStartupTimeout() {
     // 13-Sep-2022, tatu: Earlier baseline of 2 minutes was somehow slightly too low for
     //    REST API on local system (Macbook): 3 minutes appears to work much more reliably
-    return Duration.ofMinutes(3);
+    long coordinatorStartupTimeout = Long.getLong("testing.containers.coordinator-startup-timeout", Defaults.COORDINATOR_STARTUP_TIMEOUT);
+    return Duration.ofMinutes(coordinatorStartupTimeout);
   }
 
   private String getAuthToken(String host, int authPort) {

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
@@ -55,6 +55,8 @@ import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
  *   <li><code>testing.containers.stargate-image</code>
  *   <li><code>testing.containers.cluster-version</code>
  *   <li><code>testing.containers.cluster-dse</code>
+ *   <li><code>testing.containers.cassandra-startup-timeout</code>
+ *   <li><code>testing.containers.coordinator-startup-timeout</code>
  * </ol>
  *
  * <p>Note that this resource fetches the auth token and sets it via the properties, using the
@@ -82,7 +84,16 @@ public class StargateTestResource
 
     String CLUSTER_DSE = null;
 
+    /**
+     * Default cassandra start up timeout value in minutes, this can be override using System
+     * property testing.containers.cassandra-startup-timeout
+     */
     long CASSANDRA_STARTUP_TIMEOUT = 2;
+
+    /**
+     * Default coordinator start up timeout value in minutes, this can be override using System
+     * property testing.containers.coordinator-startup-timeout
+     */
     long COORDINATOR_STARTUP_TIMEOUT = 3;
   }
 

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
@@ -84,7 +84,6 @@ public class StargateTestResource
 
     long CASSANDRA_STARTUP_TIMEOUT = 2;
     long COORDINATOR_STARTUP_TIMEOUT = 3;
-
   }
 
   private static final Logger LOG = LoggerFactory.getLogger(StargateTestResource.class);
@@ -306,7 +305,9 @@ public class StargateTestResource
 
   /** @return Time to wait for the Cassandra container to start up before failing */
   private Duration getCassandraStartupTimeout() {
-    long cassandraStartupTimeout = Long.getLong("testing.containers.cassandra-startup-timeout", Defaults.CASSANDRA_STARTUP_TIMEOUT);
+    long cassandraStartupTimeout =
+        Long.getLong(
+            "testing.containers.cassandra-startup-timeout", Defaults.CASSANDRA_STARTUP_TIMEOUT);
     return Duration.ofMinutes(cassandraStartupTimeout);
   }
 
@@ -314,7 +315,9 @@ public class StargateTestResource
   private Duration getCoordinatorStartupTimeout() {
     // 13-Sep-2022, tatu: Earlier baseline of 2 minutes was somehow slightly too low for
     //    REST API on local system (Macbook): 3 minutes appears to work much more reliably
-    long coordinatorStartupTimeout = Long.getLong("testing.containers.coordinator-startup-timeout", Defaults.COORDINATOR_STARTUP_TIMEOUT);
+    long coordinatorStartupTimeout =
+        Long.getLong(
+            "testing.containers.coordinator-startup-timeout", Defaults.COORDINATOR_STARTUP_TIMEOUT);
     return Duration.ofMinutes(coordinatorStartupTimeout);
   }
 


### PR DESCRIPTION
Default value will remain the same as it is now.

**Checklist**
- [ x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
