### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-http to 11.0.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
       Note that this is currently aligned with the Jetty version that DropWizard transitively depends on.
       It's probably a good idea to keep the two versions in sync.
     -->
-    <jetty.version>9.4.49.v20220914</jetty.version>
+    <jetty.version>11.0.10</jetty.version>
     <!-- Logging framework likewise in sync -->
     <slf4j.version>1.7.36</slf4j.version>
     <logback.version>1.2.11</logback.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty:jetty-http 9.4.49.v20220914
- [CVE-2022-2047](https://www.oscs1024.com/hd/CVE-2022-2047)


### What did I do？
Upgrade org.eclipse.jetty:jetty-http from 9.4.49.v20220914 to 11.0.10 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS