### PR TITLE
sign images with additional tags during the release

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -456,10 +456,13 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
+      # we need to sign also images created by additional tags
+      # in this case v2 tag
       - name: Sign a docker image
         shell: bash
         env:
           COSIGN_IMAGE: ${{ secrets.ECR_REPOSITORY }}/stargateio/${{ matrix.image }}:${{ needs.resolve-tag.outputs.release-tag }}
+          COSIGN_IMAGE_V2: ${{ secrets.ECR_REPOSITORY }}/stargateio/${{ matrix.image }}:v2
           COSIGN_PRIVATE_BASE64: ${{ secrets.COSIGN_PRIVATE_BASE64}}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD}}
           COSIGN_KEY_FILE: _cosign_key_
@@ -469,6 +472,8 @@ jobs:
           echo $COSIGN_PRIVATE_BASE64 | base64 --decode > $COSIGN_KEY_FILE
           echo "=== signing image [$COSIGN_IMAGE] ..."
           cosign sign --key $COSIGN_KEY_FILE -a $AUX_KEY=$AUX_VALUE $COSIGN_IMAGE
+          echo "=== signing image [COSIGN_IMAGE_V2] ..."
+          cosign sign --key $COSIGN_KEY_FILE -a $AUX_KEY=$AUX_VALUE COSIGN_IMAGE_V2
 
   # creates a PR for bumping the versions to the next snapshot
   # only executed if we have created the new release

--- a/apis/sgv2-docsapi/pom.xml
+++ b/apis/sgv2-docsapi/pom.xml
@@ -9,6 +9,7 @@
   <artifactId>sgv2-docsapi</artifactId>
   <properties>
     <failsafe.useModulePath>false</failsafe.useModulePath>
+    <!-- Please update github workflows that build docker images if changing image/additional tags -->
     <quarkus.container-image.group>stargateio</quarkus.container-image.group>
     <quarkus.container-image.name>docsapi</quarkus.container-image.name>
     <quarkus.container-image.tag>v${project.version}</quarkus.container-image.tag>

--- a/apis/sgv2-graphqlapi/pom.xml
+++ b/apis/sgv2-graphqlapi/pom.xml
@@ -8,6 +8,7 @@
   </parent>
   <artifactId>sgv2-graphqlapi</artifactId>
   <properties>
+    <!-- Please update github workflows that build docker images if changing image/additional tags -->
     <quarkus.container-image.group>stargateio</quarkus.container-image.group>
     <quarkus.container-image.name>graphqlapi</quarkus.container-image.name>
     <quarkus.container-image.tag>v${project.version}</quarkus.container-image.tag>

--- a/apis/sgv2-restapi/pom.xml
+++ b/apis/sgv2-restapi/pom.xml
@@ -10,6 +10,7 @@
   <artifactId>sgv2-restapi</artifactId>
   <properties>
     <failsafe.useModulePath>false</failsafe.useModulePath>
+    <!-- Please update github workflows that build docker images if changing image/additional tags -->
     <quarkus.container-image.group>stargateio</quarkus.container-image.group>
     <quarkus.container-image.name>restapi</quarkus.container-image.name>
     <quarkus.container-image.tag>v${project.version}</quarkus.container-image.tag>


### PR DESCRIPTION
**What this PR does**:
During the release we sign images push to the ECR, but only the ones for the version that's being released. The images pushed with additional tags (`v2`) are not signed. This PR fixes that.
