### PR TITLE
always remove docker images in CI for APIs

### DIFF
--- a/.github/workflows/apis-v2.yaml
+++ b/.github/workflows/apis-v2.yaml
@@ -305,11 +305,11 @@ jobs:
           cd apis/
           ./mvnw -B -ntp verify -DskipUnitTests -pl ${{ matrix.project }} -am -P ${{ matrix.profile }} -Dquarkus.container-image.build=$CONTAINER_TEST -Dtesting.containers.stargate-image=${{ matrix.image }}
 
-  # runs only on success, deletes built docker image artifacts
-  # keep docker images for 3 days so we can re-run the workflows
+  # always delete built docker image artifacts
   clean-up:
     name: Clean up
     runs-on: ubuntu-latest
+    if: always()
     needs: int-tests
 
     steps:


### PR DESCRIPTION
Reduce usage of resources within GitHub account by always deleting docker images built during runs of the APIs CI workflow.

Rationale: we are storing docker images of the coordinator according to the commit sha that triggered the CI. While there is caching in this workflow of coordinator Jars from the maven build, the docker images are generated and stored as GH artifacts every time this workflow is executed. If there is a test failure, we are currently not deleting these images, which ties up storage for the retention period (currently set for 3 days). 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
