### PR TITLE
Fix #2438: rename back and forth of (id) column failing

### DIFF
--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/RestResourceBase.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/RestResourceBase.java
@@ -41,10 +41,16 @@ public abstract class RestResourceBase {
   protected static final int DEFAULT_PAGE_SIZE = 100;
 
   private static final Function<String, Uni<? extends Schema.CqlKeyspaceDescribe>>
-      MISSING_KEYSPACE = ks -> Uni.createFrom().nullItem();
+      MISSING_KEYSPACE =
+          ks ->
+              Uni.createFrom()
+                  .failure(
+                      new WebApplicationException(
+                          String.format("Keyspace '%s' not found", ks),
+                          Response.Status.BAD_REQUEST));
 
   private static final Function<String, Uni<? extends QueryOuterClass.Response>>
-      MISSING_KEYSPACE_RESPONSE =
+      MISSING_KEYSPACE_AS_RESPONSE =
           ks ->
               Uni.createFrom()
                   .failure(
@@ -130,10 +136,10 @@ public abstract class RestResourceBase {
 
     if (checkAuthzForTableMetadata) {
       return schemaManager.queryWithSchemaAuthorized(
-          keyspaceName, tableName, MISSING_KEYSPACE_RESPONSE, queryProducerUni);
+          keyspaceName, tableName, MISSING_KEYSPACE_AS_RESPONSE, queryProducerUni);
     }
     return schemaManager.queryWithSchema(
-        keyspaceName, tableName, MISSING_KEYSPACE_RESPONSE, queryProducerUni);
+        keyspaceName, tableName, MISSING_KEYSPACE_AS_RESPONSE, queryProducerUni);
   }
 
   protected Uni<QueryOuterClass.Response> executeQueryAsync(QueryOuterClass.Query query) {

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2ColumnsResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2ColumnsResourceImpl.java
@@ -93,7 +93,7 @@ public class Sgv2ColumnsResourceImpl extends RestResourceBase implements Sgv2Col
               }
               return column;
             })
-        .map(
+        .flatMap(
             column ->
                 executeQueryAsync(
                     new QueryBuilder()

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2TablesResourceImpl.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/schemas/Sgv2TablesResourceImpl.java
@@ -65,8 +65,10 @@ public class Sgv2TablesResourceImpl extends RestResourceBase implements Sgv2Tabl
     // Cannot use Bean Validation annotations because columns are optional for Update, only
     // mandatory here:
     if (columnDefs == null || columnDefs.isEmpty()) {
-      throw new WebApplicationException(
-          "TableAdd.columnDefinitions must be provided", Status.BAD_REQUEST);
+      return Uni.createFrom()
+          .failure(
+              new WebApplicationException(
+                  "TableAdd.columnDefinitions must be provided", Status.BAD_REQUEST));
     }
 
     for (Sgv2ColumnDefinition columnDef : columnDefs) {
@@ -126,14 +128,18 @@ public class Sgv2TablesResourceImpl extends RestResourceBase implements Sgv2Tabl
     Sgv2Table.TableOptions options = tableUpdate.tableOptions();
     List<?> clusteringExpressions = options.clusteringExpression();
     if (clusteringExpressions != null && !clusteringExpressions.isEmpty()) {
-      throw new WebApplicationException(
-          "Cannot update the clustering order of a table", Status.BAD_REQUEST);
+      return Uni.createFrom()
+          .failure(
+              new WebApplicationException(
+                  "Cannot update the clustering order of a table", Status.BAD_REQUEST));
     }
     final Integer defaultTTL = options.defaultTimeToLive();
     // 09-Dec-2021, tatu: Seems bit odd but this is the way SGv1/RESTv2 checks it,
     //    probably since this is the only thing that can actually be changed:
     if (defaultTTL == null) {
-      throw new WebApplicationException("No update provided for defaultTTL", Status.BAD_REQUEST);
+      return Uni.createFrom()
+          .failure(
+              new WebApplicationException("No update provided for defaultTTL", Status.BAD_REQUEST));
     }
     // We only want to validate keyspace, existence of table, before attempting update so:
     return getTableAsyncCheckExistence(keyspaceName, tableName, true, Response.Status.BAD_REQUEST)

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaColumnsIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaColumnsIT.java
@@ -266,7 +266,7 @@ public class RestApiV2QSchemaColumnsIT extends RestApiV2QIntegrationTestBase {
     assertThat(readJsonAs(response, NameResponse.class).name).isEqualTo(oldColumnName);
 
     Sgv2ColumnDefinition columnFound2 =
-        findOneColumn(testKeyspaceName(), tableName, newColumnName, true);
+        findOneColumn(testKeyspaceName(), tableName, oldColumnName, true);
     assertThat(columnFound2).isEqualTo(columnDef2);
   }
 

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaColumnsIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaColumnsIT.java
@@ -102,9 +102,7 @@ public class RestApiV2QSchemaColumnsIT extends RestApiV2QIntegrationTestBase {
     ApiError apiError = readJsonAs(response, ApiError.class);
 
     assertThat(apiError.code()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
-    // 02-Sep-2022, tatu: Error message is bit misleading but it is what it is; verify:
-    assertThat(apiError.description())
-        .matches("Table 'table' not found.*keyspace.*" + badKeyspace + ".*");
+    assertThat(apiError.description()).matches("Keyspace '" + badKeyspace + "' not found.*");
   }
 
   @Test
@@ -169,9 +167,7 @@ public class RestApiV2QSchemaColumnsIT extends RestApiV2QIntegrationTestBase {
     String response = tryFindAllColumns(badKeyspace, "table", HttpStatus.SC_BAD_REQUEST);
     ApiError apiError = readJsonAs(response, ApiError.class);
     assertThat(apiError.code()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
-    // 02-Sep-2022, tatu: Error message is bit misleading but it is what it is; verify:
-    assertThat(apiError.description())
-        .matches("Table 'table' not found.*keyspace.*" + badKeyspace + ".*");
+    assertThat(apiError.description()).matches("Keyspace '" + badKeyspace + "' not found.*");
   }
 
   @Test


### PR DESCRIPTION
**What this PR does**:

Will make sequence of rename-to-new-name-rename-back not fail, by using blocking access instead of optimistic query (`queryWithSchema()`).

And after doing that will do the same for all REST/Schema operations to prevent similar issues with table, index CRUD, not just columns.

**Which issue(s) this PR fixes**:
Fixes #2438

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
