### PR TITLE
reduce retention period for docker images generated by v2 APIs CI

### DIFF
--- a/.github/workflows/apis-v2.yaml
+++ b/.github/workflows/apis-v2.yaml
@@ -138,7 +138,7 @@ jobs:
         with:
           name: img-${{ matrix.image }}-${{ github.sha }}
           path: ${{ matrix.image }}-${{ github.sha }}.tar
-          retention-days: 3
+          retention-days: 1
 
   # runs unit tests for the sgv2-docsapi
   build:


### PR DESCRIPTION
Reduce utilization of GitHub actions artifact storage by setting a shorter retention period for coordinator docker images used in automated CI tests for Stargate v2 APIs. This is an alternate approach that was suggested in review of closed PR #2439.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
