### PR TITLE
option to include user agent info to the tenant metrics

### DIFF
--- a/apis/sgv2-quarkus-common/CONFIGURATION.md
+++ b/apis/sgv2-quarkus-common/CONFIGURATION.md
@@ -46,13 +46,15 @@
 ### Metrics configuration
 *Configuration mapping for the additional metrics properties, defined by [MetricsConfig.java](src/main/java/io/stargate/sgv2/api/common/config/MetricsConfig.java).*
 
-| Property                                              | Type                 | Default                             | Description                                                             |
-|-------------------------------------------------------|----------------------|-------------------------------------|-------------------------------------------------------------------------|
-| `stargate.metrics.global-tags`                        | `Map<String,String>` | `{"module": "docsapi"}`             | Map of global tags that will be applied to every meter.                 |
-| `stargate.metrics.tenant-request-counter.enabled`     | `boolean`            | `${stargate.multi-tenancy.enabled}` | If extra metric for counting the request per tenant should be recorded. |
-| `stargate.metrics.tenant-request-counter.metric-name` | `String`             | `http.server.requests.counter`      | Name of the metric.                                                     |
-| `stargate.metrics.tenant-request-counter.tenant-tag`  | `String`             | `tenant`                            | The tag key for tenant id.                                              |
-| `stargate.metrics.tenant-request-counter.error-tag`   | `String`             | `error`                             | The tag key for the request error flag (true/false).                    |
+| Property                                                         | Type                 | Default                             | Description                                                                                                                                                  |
+|------------------------------------------------------------------|----------------------|-------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `stargate.metrics.global-tags`                                   | `Map<String,String>` | `{"module": "docsapi"}`             | Map of global tags that will be applied to every meter.                                                                                                      |
+| `stargate.metrics.tenant-request-counter.enabled`                | `boolean`            | `${stargate.multi-tenancy.enabled}` | If extra metric for counting the request per tenant should be recorded.                                                                                      |
+| `stargate.metrics.tenant-request-counter.metric-name`            | `String`             | `http.server.requests.counter`      | Name of the metric.                                                                                                                                          |
+| `stargate.metrics.tenant-request-counter.tenant-tag`             | `String`             | `tenant`                            | The tag key for tenant id.                                                                                                                                   |
+| `stargate.metrics.tenant-request-counter.error-tag`              | `String`             | `error`                             | The tag key for the request error flag (true/false).                                                                                                         |
+| `stargate.metrics.tenant-request-counter.user-agent-tag`         | `String`             | `agent`                             | The tag key for the user agent, if capturing is enabled.                                                                                                     |
+| `stargate.metrics.tenant-request-counter.user-agent-tag-enabled` | `boolean`            | `false`                             | If user agent information should be included as a tag. The user agent value will be trimmed to the first appearance of the whitespace or forward slash char. |
 
 ### Multi-tenancy configuration
 *Configuration mapping for multi tenant operation mode, defined by [MultiTenancyConfig.java](src/main/java/io/stargate/sgv2/api/common/config/MultiTenancyConfig.java).*

--- a/apis/sgv2-quarkus-common/CONFIGURATION.md
+++ b/apis/sgv2-quarkus-common/CONFIGURATION.md
@@ -53,7 +53,7 @@
 | `stargate.metrics.tenant-request-counter.metric-name`            | `String`             | `http.server.requests.counter`      | Name of the metric.                                                                                                                                          |
 | `stargate.metrics.tenant-request-counter.tenant-tag`             | `String`             | `tenant`                            | The tag key for tenant id.                                                                                                                                   |
 | `stargate.metrics.tenant-request-counter.error-tag`              | `String`             | `error`                             | The tag key for the request error flag (true/false).                                                                                                         |
-| `stargate.metrics.tenant-request-counter.user-agent-tag`         | `String`             | `agent`                             | The tag key for the user agent, if capturing is enabled.                                                                                                     |
+| `stargate.metrics.tenant-request-counter.user-agent-tag`         | `String`             | `user_agent`                        | The tag key for the user agent, if capturing is enabled.                                                                                                     |
 | `stargate.metrics.tenant-request-counter.user-agent-tag-enabled` | `boolean`            | `false`                             | If user agent information should be included as a tag. The user agent value will be trimmed to the first appearance of the whitespace or forward slash char. |
 
 ### Multi-tenancy configuration

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/MetricsConfig.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/MetricsConfig.java
@@ -59,5 +59,14 @@ public interface MetricsConfig {
     @NotBlank
     @WithDefault("error")
     String errorTag();
+
+    /** @return The tag key for user-agent flag, defaults to <code>error</code>. */
+    @NotBlank
+    @WithDefault("agent")
+    String userAgentTag();
+
+    /** @return If tenant counting metric should include the user agent information. */
+    @WithDefault("false")
+    boolean userAgentTagEnabled();
   }
 }

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/MetricsConfig.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/MetricsConfig.java
@@ -62,7 +62,7 @@ public interface MetricsConfig {
 
     /** @return The tag key for user-agent flag, defaults to <code>error</code>. */
     @NotBlank
-    @WithDefault("agent")
+    @WithDefault("user_agent")
     String userAgentTag();
 
     /** @return If tenant counting metric should include the user agent information. */

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/metrics/TenantRequestMetricsFilter.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/metrics/TenantRequestMetricsFilter.java
@@ -22,8 +22,10 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.stargate.sgv2.api.common.StargateRequestInfo;
 import io.stargate.sgv2.api.common.config.MetricsConfig;
+import java.util.regex.Pattern;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import org.jboss.resteasy.reactive.server.ServerResponseFilter;
 
@@ -33,6 +35,9 @@ import org.jboss.resteasy.reactive.server.ServerResponseFilter;
  */
 @ApplicationScoped
 public class TenantRequestMetricsFilter {
+
+  // split pattern for the user agent, extract only first part of the agent
+  private static final Pattern USER_AGENT_SPLIT = Pattern.compile("[\\s/]");
 
   /** The {@link MeterRegistry} to report to. */
   private final MeterRegistry meterRegistry;
@@ -67,11 +72,13 @@ public class TenantRequestMetricsFilter {
   /**
    * Filter that this bean produces.
    *
-   * @param context ContainerResponseContext
+   * @param requestContext {@link ContainerRequestContext}
+   * @param responseContext {@link ContainerResponseContext}
    * @see https://quarkus.io/guides/resteasy-reactive#request-or-response-filters
    */
   @ServerResponseFilter
-  public void record(ContainerResponseContext context) {
+  public void record(
+      ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
     // only if enabled
     if (config.enabled()) {
 
@@ -80,11 +87,32 @@ public class TenantRequestMetricsFilter {
           requestInfo.getTenantId().map(id -> Tag.of(config.tenantTag(), id)).orElse(tenantUnknown);
 
       // resolve error
-      boolean error = context.getStatus() >= 500;
+      boolean error = responseContext.getStatus() >= 500;
       Tag errorTag = error ? errorTrue : errorFalse;
 
+      // check if we need user agent as well
+      Tags tags = Tags.of(tenantTag, errorTag);
+      if (config.userAgentTagEnabled()) {
+        String userAgentValue = getUserAgentValue(requestContext);
+        tags = tags.and(Tag.of(config.userAgentTag(), userAgentValue));
+      }
+
       // record
-      meterRegistry.counter(config.metricName(), Tags.of(tenantTag, errorTag)).increment();
+      meterRegistry.counter(config.metricName(), tags).increment();
+    }
+  }
+
+  private String getUserAgentValue(ContainerRequestContext requestContext) {
+    String headerString = requestContext.getHeaderString("user-agent");
+    if (null != headerString && !headerString.isBlank()) {
+      String[] split = USER_AGENT_SPLIT.split(headerString);
+      if (split.length > 0) {
+        return split[0];
+      } else {
+        return headerString;
+      }
+    } else {
+      return "UNKNOWN";
     }
   }
 }

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/metrics/TenantRequestMetricsFilterTest.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/metrics/TenantRequestMetricsFilterTest.java
@@ -82,6 +82,7 @@ class TenantRequestMetricsFilterTest {
             metric ->
                 assertThat(metric)
                     .contains("tenantTag=\"" + FixedTenantTestProfile.TENANT_ID + "\"")
-                    .contains("errorTag=\"false\""));
+                    .contains("errorTag=\"false\"")
+                    .doesNotContain("agent="));
   }
 }

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/metrics/TenantRequestMetricsFilterWithUserAgentTagTest.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/metrics/TenantRequestMetricsFilterWithUserAgentTagTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.api.common.metrics;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.api.common.testprofiles.FixedTenantTestProfile;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(TenantRequestMetricsFilterWithUserAgentTagTest.Profile.class)
+class TenantRequestMetricsFilterWithUserAgentTagTest {
+
+  public static class Profile extends TenantRequestMetricsFilterTest.Profile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      Map<String, String> configOverrides = super.getConfigOverrides();
+
+      return ImmutableMap.<String, String>builder()
+          .putAll(configOverrides)
+          .put("stargate.metrics.tenant-request-counter.user-agent-tag", "agentTag")
+          .put("stargate.metrics.tenant-request-counter.user-agent-tag-enabled", "true")
+          .build();
+    }
+  }
+
+  @Test
+  public void happyPath() {
+    // call endpoint
+    given()
+        .when()
+        .header("user-agent", "python-requests/2.27.1")
+        .get("/testing")
+        .then()
+        .statusCode(200);
+
+    // collect metrics
+    String result = given().when().get("/metrics").then().statusCode(200).extract().asString();
+
+    // find target metrics
+    List<String> meteredLines =
+        Arrays.stream(result.split(System.getProperty("line.separator")))
+            .filter(line -> line.startsWith("test_metrics_total"))
+            .collect(Collectors.toList());
+
+    assertThat(meteredLines)
+        .anySatisfy(
+            metric ->
+                assertThat(metric)
+                    .contains("tenantTag=\"" + FixedTenantTestProfile.TENANT_ID + "\"")
+                    .contains("errorTag=\"false\"")
+                    .contains("agentTag=\"python-requests\""));
+  }
+
+  @Test
+  public void spaceInAgentName() {
+    // call endpoint
+    given()
+        .when()
+        .header("user-agent", "Symfony HttpClient/Curl")
+        .get("/testing")
+        .then()
+        .statusCode(200);
+
+    // collect metrics
+    String result = given().when().get("/metrics").then().statusCode(200).extract().asString();
+
+    // find target metrics
+    List<String> meteredLines =
+        Arrays.stream(result.split(System.getProperty("line.separator")))
+            .filter(line -> line.startsWith("test_metrics_total"))
+            .collect(Collectors.toList());
+
+    assertThat(meteredLines)
+        .anySatisfy(
+            metric ->
+                assertThat(metric)
+                    .contains("tenantTag=\"" + FixedTenantTestProfile.TENANT_ID + "\"")
+                    .contains("errorTag=\"false\"")
+                    .contains("agentTag=\"Symfony\""));
+  }
+
+  @Test
+  public void blankHeader() {
+    // call endpoint
+    given().header("user-agent", " ").when().get("/testing").then().statusCode(200);
+
+    // collect metrics
+    String result = given().when().get("/metrics").then().statusCode(200).extract().asString();
+
+    // find target metrics
+    List<String> meteredLines =
+        Arrays.stream(result.split(System.getProperty("line.separator")))
+            .filter(line -> line.startsWith("test_metrics_total"))
+            .collect(Collectors.toList());
+
+    assertThat(meteredLines)
+        .anySatisfy(
+            metric ->
+                assertThat(metric)
+                    .contains("tenantTag=\"" + FixedTenantTestProfile.TENANT_ID + "\"")
+                    .contains("errorTag=\"false\"")
+                    .contains("agentTag=\"UNKNOWN\""));
+  }
+}


### PR DESCRIPTION
**What this PR does**:
Adds ability to optionally include the user agent to the tenant request counter metrics. By default it's disabled, controlled by the configuration options.

**Which issue(s) this PR fixes**:
Internal issue.