### PR TITLE
align v1 and v2 unknown metric value

### DIFF
--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/metrics/TenantRequestMetricsFilter.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/metrics/TenantRequestMetricsFilter.java
@@ -39,6 +39,9 @@ public class TenantRequestMetricsFilter {
   // split pattern for the user agent, extract only first part of the agent
   private static final Pattern USER_AGENT_SPLIT = Pattern.compile("[\\s/]");
 
+  // same as V1 io.stargate.core.metrics.StargateMetricConstants#UNKNOWN
+  private static final String UNKNOWN_VALUE = "unknown";
+
   /** The {@link MeterRegistry} to report to. */
   private final MeterRegistry meterRegistry;
 
@@ -66,7 +69,7 @@ public class TenantRequestMetricsFilter {
     this.config = metricsConfig.tenantRequestCounter();
     errorTrue = Tag.of(config.errorTag(), "true");
     errorFalse = Tag.of(config.errorTag(), "false");
-    tenantUnknown = Tag.of(config.tenantTag(), "UNKNOWN");
+    tenantUnknown = Tag.of(config.tenantTag(), UNKNOWN_VALUE);
   }
 
   /**
@@ -112,7 +115,7 @@ public class TenantRequestMetricsFilter {
         return headerString;
       }
     } else {
-      return "UNKNOWN";
+      return UNKNOWN_VALUE;
     }
   }
 }

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/metrics/TenantRequestMetricsFilterWithUserAgentTagTest.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/metrics/TenantRequestMetricsFilterWithUserAgentTagTest.java
@@ -124,6 +124,6 @@ class TenantRequestMetricsFilterWithUserAgentTagTest {
                 assertThat(metric)
                     .contains("tenantTag=\"" + FixedTenantTestProfile.TENANT_ID + "\"")
                     .contains("errorTag=\"false\"")
-                    .contains("agentTag=\"UNKNOWN\""));
+                    .contains("agentTag=\"unknown\""));
   }
 }


### PR DESCRIPTION
**What this PR does**:
Small fix to align the unknown value for a metric tag between v1 and v2. 

