### PR TITLE
automated release support: changelog and event dispatching 

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -541,6 +541,7 @@ jobs:
     name: Dispatch release event
     needs: [ 'resolve-tag', 'build', 'publish-ossrh', 'publish-docker']
     if: ${{ always() }}
+    continue-on-error: true
     runs-on: ubuntu-latest
 
     strategy:
@@ -561,4 +562,4 @@ jobs:
           token: ${{ matrix.token }}
           repository: ${{ matrix.repo }}
           event-type: stargate-v2-release
-          client-payload: '{"release-train": "v2", "version": "${{ needs.resolve-tag.outputs.release-tag}}"}'
+          client-payload: '{"version": "${{ needs.resolve-tag.outputs.release-tag}}"}'

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -550,7 +550,7 @@ jobs:
         repo: [ 'stargate/jsonapi', 'riptano/c2']
         include:
           - repo: stargate/jsonapi
-            token: ${{ secrets.JSONAPI_PAT }}
+            token: ${{ secrets.SG_EVENTS_PAT }}
 
           - repo: riptano/c2
             token: ${{ secrets.C2_PAT}}

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -507,6 +507,12 @@ jobs:
           </settings>
           EOF
 
+      - name: Generate changelog
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./update_changelog.sh
+
       - name: Update version numbers (coordinator)
         run: |
           ./mvnw -B -ntp release:update-versions -DautoVersionSubmodules=true versions:commit -Pdse

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -535,3 +535,30 @@ jobs:
           branch-suffix: "short-commit-hash"
           base: "main"
           labels: "stargate-v2"
+
+  # dispatch release event
+  dispatch:
+    name: Dispatch release event
+    needs: [ 'resolve-tag', 'build', 'publish-ossrh', 'publish-docker']
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        repo: [ 'stargate/jsonapi', 'riptano/c2']
+        include:
+          - repo: stargate/jsonapi
+            token: ${{ secrets.JSONAPI_PAT }}
+
+          - repo: riptano/c2
+            token: ${{ secrets.C2_PAT}}
+
+    steps:
+      - name: Repository dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ matrix.token }}
+          repository: ${{ matrix.repo }}
+          event-type: stargate-v2-release
+          client-payload: '{"release-train": "v2", "version": "${{ needs.resolve-tag.outputs.release-tag}}"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,3 +182,30 @@ jobs:
           title: "Bumping version for next release"
           branch-suffix: "short-commit-hash"
           base: "v1"
+
+  # dispatch release event
+  dispatch:
+    name: Dispatch release event
+    needs: [ 'create-release', 'build', 'publish']
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        repo: [ 'stargate/stargate', 'riptano/c2']
+        include:
+          - repo: stargate/stargate
+            token: ${{ secrets.GITHUB_TOKEN }}
+
+          - repo: riptano/c2
+            token: ${{ secrets.C2_PAT }}
+
+    steps:
+      - name: Repository dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ matrix.token }}
+          repository: ${{ matrix.repo }}
+          event-type: stargate-v1-release
+          client-payload: '{"release-train": "v1", "version": "${{ needs.create-release.outputs.release-tag }}"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,12 @@ jobs:
           ./mvnw -B -ntp versions:set -DremoveSnapshot versions:commit
           ./mvnw -B -ntp -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} clean deploy -DskipTests -P deploy,dse
 
+      - name: Generate changelog
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./update_changelog.sh
+
       - name: Bump versions
         run: |
           ./mvnw -B -ntp release:update-versions -DautoVersionSubmodules=true versions:commit -Pdse

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,15 +188,19 @@ jobs:
     name: Dispatch release event
     needs: [ 'create-release', 'build', 'publish']
     if: ${{ always() }}
+    continue-on-error: true
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        repo: [ 'stargate/stargate', 'riptano/c2']
+        repo: [ 'stargate/stargate', 'stargate/docker-images', 'riptano/c2']
         include:
           - repo: stargate/stargate
             token: ${{ secrets.GITHUB_TOKEN }}
+
+          - repo: stargate/docker-images
+            token: ${{ secrets.DOCKER_IMAGES_PAT }}
 
           - repo: riptano/c2
             token: ${{ secrets.C2_PAT }}
@@ -208,4 +212,4 @@ jobs:
           token: ${{ matrix.token }}
           repository: ${{ matrix.repo }}
           event-type: stargate-v1-release
-          client-payload: '{"release-train": "v1", "version": "${{ needs.create-release.outputs.release-tag }}"}'
+          client-payload: '{"version": "${{ needs.create-release.outputs.release-tag }}"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,7 +200,7 @@ jobs:
             token: ${{ secrets.GITHUB_TOKEN }}
 
           - repo: stargate/docker-images
-            token: ${{ secrets.DOCKER_IMAGES_PAT }}
+            token: ${{ secrets.SG_EVENTS_PAT }}
 
           - repo: riptano/c2
             token: ${{ secrets.C2_PAT }}


### PR DESCRIPTION
**What this PR does**:

Adds first step for release automation:
* changelog generation as part of the bump version PR
    * continues on error, just in case we endup in some API limits or so
* dispatches events about releases to numerous repositories
    * includes release train and version   
    * does not fail fast so matrix executes all of the items
    * still missing `C2_PAT` variable

Based on `v1`, will propagate to main with a merge.

**Which issue(s) this PR fixes**:
Internal.


