### PR TITLE
closes #2470: respect limit in the ValidatingStargateBridge

### DIFF
--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/bridge/ValidatingPaginator.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/bridge/ValidatingPaginator.java
@@ -58,12 +58,20 @@ public class ValidatingPaginator {
   }
 
   public <T> List<T> filter(List<T> data) {
+    return filter(data, -1);
+  }
+
+  public <T> List<T> filter(List<T> data, int limit) {
     int from = Math.max(offset, 0);
     if (from >= data.size()) {
       return Collections.emptyList();
     }
 
     int to = from + pageSize;
+    if (limit > 0) {
+      to = Math.min(to, limit);
+    }
+
     if (to > data.size()) {
       to = data.size();
     } else {

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/bridge/ValidatingPaginator.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/bridge/ValidatingPaginator.java
@@ -85,6 +85,10 @@ public class ValidatingPaginator {
     return pagingState(nextOffset);
   }
 
+  public boolean limitExhausted(int limit) {
+    return limit > 0 && offset + pageSize >= limit;
+  }
+
   public ByteBuffer pagingStateForRow(int index) {
     // for the row just current offset
     // + index of the row

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/bridge/ValidatingStargateBridge.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/bridge/ValidatingStargateBridge.java
@@ -353,7 +353,7 @@ public class ValidatingStargateBridge implements StargateBridge {
 
       // filter rows in order to respect the page size
       // and get next paging state
-      List<List<QueryOuterClass.Value>> filterRows = paginator.filter(rows);
+      List<List<QueryOuterClass.Value>> filterRows = paginator.filter(rows, limit);
       boolean limitExhausted = paginator.limitExhausted(limit);
       if (!limitExhausted) {
         ByteBuffer nextPagingState = paginator.pagingState();


### PR DESCRIPTION
**What this PR does**:
Ensures that `ValidatingStargateBridge` respects `LIMIT` in the CQL queries and simulates Cassandra behavor correctly. Until now, the limit was not respected, and page state was returned even if there are rows available but above limit. This fixes the buggy behavior.

I will add a test for testing this.. We need to ensure this is working fine as this testing utility is used across projects.

**Which issue(s) this PR fixes**:
Fixes #2470
