### PR TITLE
Fix an out-of-date "cassandra-all" dependency

### DIFF
--- a/persistence-api/pom.xml
+++ b/persistence-api/pom.xml
@@ -104,7 +104,7 @@
     <dependency>
       <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-all</artifactId>
-      <version>4.0.3</version>
+      <version>4.0.7</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
**What this PR does**:

Fixes an obsolete dependency to `cassandra-all` 4.0.3 (has been left out in C*4 updates)

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated -- relying on passing of existing ITs
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
