### PR TITLE
enable changelog update to run in actions

### DIFF
--- a/update_changelog.sh
+++ b/update_changelog.sh
@@ -16,7 +16,11 @@ fi
 # Remove the header so we can append the additions
 tail -n +3 "$CHANGELOG_FILE" > "$CHANGELOG_FILE.tmp" && mv "$CHANGELOG_FILE.tmp" "$CHANGELOG_FILE"
 
-docker run -it --rm -v "$(pwd)":/usr/local/src/your-app ferrarimarco/github-changelog-generator -u stargate -p stargate -t $GITHUB_TOKEN --since-tag $previous_version --base $CHANGELOG_FILE --output $CHANGELOG_FILE --release-branch 'v1' --exclude-tags-regex 'v2.*' --exclude-labels 'stargate-v2,duplicate,question,invalid,wontfix'
+INTERACTIVE=""
+if [[ -t 1 ]]; then
+  INTERACTIVE="-it"
+fi
+docker run $INTERACTIVE --rm -v "$(pwd)":/usr/local/src/your-app ferrarimarco/github-changelog-generator -u stargate -p stargate -t $GITHUB_TOKEN --since-tag $previous_version --base $CHANGELOG_FILE --output $CHANGELOG_FILE --release-branch 'v1' --exclude-tags-regex 'v2.*' --exclude-labels 'stargate-v2,duplicate,question,invalid,wontfix'
 
 # Remove the additional footer added
 head -n $(( $(wc -l < $CHANGELOG_FILE) - 3 )) $CHANGELOG_FILE > "$CHANGELOG_FILE.tmp" && mv "$CHANGELOG_FILE.tmp" "$CHANGELOG_FILE"


### PR DESCRIPTION
**What this PR does**:

Solves the issue:

```
Run ./update_changelog.sh
the input device is not a TTY
Error: Process completed with exit code 1.
```

Seen in the https://github.com/stargate/stargate/actions/runs/4313308336/jobs/7524956196. 

I would like somebody to confirm this would actually fix the issue in the action.

* [ ] merge with main when done
