### PR TITLE
disable auto-merge on the release

### DIFF
--- a/.github/workflows/merge-main-v1.yaml
+++ b/.github/workflows/merge-main-v1.yaml
@@ -2,11 +2,8 @@
 name: Merge main/v1
 
 # runs on
-# * stargate v1 release event
 # * manual trigger
 on:
-  repository_dispatch:
-    types: [ stargate-v1-release ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
**What this PR does**:

After discussion with @jeffreyscarpenter we agreed that performing auto merge on the release should be avoided as conflict resolution we can do without a human can not guarantee correctness. And thus it's too risky to have it.

Keeping it for developers to manually trigger, when they know what are they doing :).