### PR TITLE
cache coordinator docker images and reuse

### DIFF
--- a/.github/workflows/apis-v2.yaml
+++ b/.github/workflows/apis-v2.yaml
@@ -245,7 +245,7 @@ jobs:
             repository-login: false
             image-cache-key: docker-coordinator-4_0-${{ needs.resolve-coordinator-docker.outputs.sha }}
             image-file: coordinator-4_0-${{ needs.resolve-coordinator-docker.outputs.sha }}.tar
-            image: stargateio/coordinator-4_0:-${{ needs.resolve-coordinator-docker.outputs.sha }}
+            image: stargateio/coordinator-4_0:${{ needs.resolve-coordinator-docker.outputs.sha }}
 
           - name: cassandra-311
             profile: cassandra-311
@@ -253,14 +253,14 @@ jobs:
             image-artifact: img-coordinator-3_11-${{ github.sha }}
             image-cache-key: docker-coordinator-3_11-${{ needs.resolve-coordinator-docker.outputs.sha }}
             image-file: coordinator-3_11-${{ needs.resolve-coordinator-docker.outputs.sha }}.tar
-            image: stargateio/coordinator-3_11:-${{ needs.resolve-coordinator-docker.outputs.sha }}
+            image: stargateio/coordinator-3_11:${{ needs.resolve-coordinator-docker.outputs.sha }}
 
           - name: dse-68
             profile: dse-68
             repository-login: false
             image-cache-key: docker-coordinator-dse-68-${{ needs.resolve-coordinator-docker.outputs.sha }}
             image-file: coordinator-dse-68-${{ needs.resolve-coordinator-docker.outputs.sha }}.tar
-            image: stargateio/coordinator-dse-68:-${{ needs.resolve-coordinator-docker.outputs.sha }}
+            image: stargateio/coordinator-dse-68:${{ needs.resolve-coordinator-docker.outputs.sha }}
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
**What this PR does**:
Avoids building coordinator docker images on each run, but rather build only if the image does not exist. Furthermore, we use the SHA of the latest changes in the `coordinator/` folder, thus avoiding building images if there were no changes in the coord.
