### PR TITLE
Update hpa version removed in K8s 1.25

### DIFF
--- a/helm/stargate/templates/stargate_coordinator_hpa.yaml
+++ b/helm/stargate/templates/stargate_coordinator_hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: stargate-coordinator-hpa

--- a/helm/stargate/templates/stargate_docsapi_hpa.yaml
+++ b/helm/stargate/templates/stargate_docsapi_hpa.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.autoscaling.enabled }}
 {{ if .Values.docsapi.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: stargate-docsapi-hpa

--- a/helm/stargate/templates/stargate_graphql_hpa.yaml
+++ b/helm/stargate/templates/stargate_graphql_hpa.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.autoscaling.enabled }}
 {{ if .Values.graphqlapi.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: stargate-graphqlapi-hpa

--- a/helm/stargate/templates/stargate_restapi_hpa.yaml
+++ b/helm/stargate/templates/stargate_restapi_hpa.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.autoscaling.enabled }}
 {{ if .Values.restapi.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: stargate-restapi-hpa


### PR DESCRIPTION
Update hpa version from "v2beta1" to "v2". "v2beta1" is removed in kubernetes 1.25

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
