### PR TITLE
closes #2493: cancel existing ci workflows on pull request updates

### DIFF
--- a/.github/workflows/apis-v2.yaml
+++ b/.github/workflows/apis-v2.yaml
@@ -33,6 +33,9 @@ jobs:
     name: Coordinator build
     runs-on: ubuntu-latest
 
+    # max run time 10 minutes
+    timeout-minutes: 10
+
     steps:
       - uses: actions/checkout@v3
 
@@ -101,6 +104,9 @@ jobs:
     needs: build-coordinator
     runs-on: ubuntu-latest
 
+    # max run time 10 minutes
+    timeout-minutes: 10
+
     # image name needed only
     strategy:
       matrix:
@@ -153,6 +159,9 @@ jobs:
     name: Unit tests
     needs: build-coordinator
     runs-on: ubuntu-latest
+
+    # max run time 10 minutes
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v3
@@ -207,6 +216,9 @@ jobs:
     name: Integration tests
     needs: [ build-coordinator-docker, build ]
     runs-on: ubuntu-latest
+
+    # max run time 30 minutes
+    timeout-minutes: 30
 
     strategy:
 

--- a/.github/workflows/apis-v2.yaml
+++ b/.github/workflows/apis-v2.yaml
@@ -11,6 +11,11 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+# cancel same workflows in progress for pull request branches
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 # Jobs structure:
 #
 # 1. Builds the coordinator without tests in order to get snapshot jar versions

--- a/.github/workflows/coordinator-test.yml
+++ b/.github/workflows/coordinator-test.yml
@@ -46,6 +46,9 @@ jobs:
     name: Coordinator unit tests
     runs-on: ubuntu-latest
 
+    # max run time 30 minutes
+    timeout-minutes: 30
+
     steps:
       - uses: actions/checkout@v3
 
@@ -95,6 +98,9 @@ jobs:
   integration-test:
     name: Integration tests
     runs-on: ubuntu-latest
+
+    # max run time 120 minutes
+    timeout-minutes: 120
 
     strategy:
       # Defaults to "true" but let's let all runs finish

--- a/.github/workflows/coordinator-test.yml
+++ b/.github/workflows/coordinator-test.yml
@@ -29,6 +29,11 @@ on:
 
   workflow_dispatch:
 
+# cancel same workflows in progress for pull request branches
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/v1' }}
+
 # global env vars, available in all jobs and steps
 env:
   ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}


### PR DESCRIPTION
**What this PR does**:
Cancel existing workflows for PR branches on update. Meaning once you push a new commit to a PR branch, we will cancel the workflow that might still be running. This ensures even more saving of minutes and cancelling runs of unnecessary CI.

**Which issue(s) this PR fixes**:
Fixes #2493

