### PR TITLE
Fix #2477: update DSE dependency 6.8.32 -> 6.8.33

### DIFF
--- a/coordinator/persistence-dse-6.8/README.md
+++ b/coordinator/persistence-dse-6.8/README.md
@@ -5,13 +5,11 @@ the DSE (DataStax Enterprise cassandra) `6.8.x` version.
 
 ## Cassandra version update
 
-The current Cassandra version this module depends on is `6.8.32`.
+The current Cassandra version this module depends on is `6.8.33`.
 In order to update to a newer patch version, please follow the guidelines below:
 
 * Update the `dse.version` property in the [pom.xml](pom.xml).
 * Update the `ccm.version` property (`it-dse-6.8` profile section) in [testing/pom.xml](../testing/pom.xml)
-* Update the [CI Dockerfile](../ci/Dockerfile) and set the new version in the `ccm create` command related to DSE 6.8.
-Note that this will have no effect until the docker image is rebuilt and pushed to the remote repository, thus creating an issue for that would be a good idea (see below for one such PR)
 * Create a separate PR for bumping the DSE version in the Quarkus-based API integration tests on the `v2.0.0` branch. Test profiles are defined in the `apis/pom.xml`.
 * Make sure everything compiles and CI tests are green.
 * Update this `README.md` file with the new or updated instructions.
@@ -19,9 +17,5 @@ Note that this will have no effect until the docker image is rebuilt and pushed 
 It's always good to validate your work against the pull requests that bumped the version in the past:
 
 * `6.8.16` -> `6.8.20` [stargate/stargate#1652](https://github.com/stargate/stargate/pull/1652)
-* `6.8.20` -> `6.8.21` [stargate/stargate#1699](https://github.com/stargate/stargate/pull/1699)
 * `6.8.21` -> `6.8.24` [stargate/stargate#1898](https://github.com/stargate/stargate/pull/1898)
-
-And PR(s) for Docker image build for Stargate-builders:
-
-* `6.8.24`: [stargate/stargate#1906](https://github.com/stargate/stargate/pull/1906)
+* `6.8.31` -> `6.8.32` [stargate/stargate#2430](https://github.com/stargate/stargate/pull/2430)

--- a/coordinator/persistence-dse-6.8/pom.xml
+++ b/coordinator/persistence-dse-6.8/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>persistence-dse-6.8</artifactId>
   <name>Stargate - Coordinator - Persistence DSE 6.8</name>
   <properties>
-    <dse.version>6.8.32</dse.version>
+    <dse.version>6.8.33</dse.version>
   </properties>
   <repositories>
     <repository>

--- a/coordinator/testing/pom.xml
+++ b/coordinator/testing/pom.xml
@@ -441,7 +441,7 @@
                 <configuration>
                   <systemPropertyVariables>
                     <ccm.dse>true</ccm.dse>
-                    <ccm.version>6.8.32</ccm.version>
+                    <ccm.version>6.8.33</ccm.version>
                     <stargate.test.nodes>1</stargate.test.nodes>
                   </systemPropertyVariables>
                   <failIfNoTests>true</failIfNoTests>


### PR DESCRIPTION
**What this PR does**:

Updates DSE persistence to use 6.8.33

**Which issue(s) this PR fixes**:
Fixes #2477

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
