### PR TITLE
increase timeouts for tests

### DIFF
--- a/.github/workflows/apis-v2.yaml
+++ b/.github/workflows/apis-v2.yaml
@@ -160,8 +160,8 @@ jobs:
     needs: build-coordinator
     runs-on: ubuntu-latest
 
-    # max run time 10 minutes
-    timeout-minutes: 10
+    # max run time 15 minutes
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v3

--- a/coordinator/testing/src/main/java/io/stargate/it/KeycloakContainer.java
+++ b/coordinator/testing/src/main/java/io/stargate/it/KeycloakContainer.java
@@ -8,6 +8,7 @@ import io.stargate.it.http.models.AuthProviderResponse;
 import io.stargate.it.http.models.KeycloakCredential;
 import io.stargate.it.http.models.KeycloakUser;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -42,7 +43,8 @@ public class KeycloakContainer {
             .withClasspathResourceMapping(
                 "stargate-realm.json", "/tmp/realm.json", BindMode.READ_ONLY)
             .withCommand("-Djboss.http.port=" + keycloakPort)
-            .waitingFor(Wait.forHttp("/auth/realms/master"));
+            .waitingFor(
+                Wait.forHttp("/auth/realms/master").withStartupTimeout(Duration.ofMinutes(2)));
 
     keycloakContainer.start();
 

--- a/coordinator/testing/src/main/java/io/stargate/it/grpc/AuthApiServerMetricsTest.java
+++ b/coordinator/testing/src/main/java/io/stargate/it/grpc/AuthApiServerMetricsTest.java
@@ -37,10 +37,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
     initQueries = {
       "CREATE TABLE IF NOT EXISTS test (k text, v int, PRIMARY KEY(k, v))",
     })
-@Order()
+@Order(AuthApiServerMetricsTest.ORDER)
 public class AuthApiServerMetricsTest extends GrpcIntegrationTest {
-  // run this at the begining when there are not a lot of metrics (faster)
-  private static final int ORDER = TestOrder.FIRST + 1;
+
+  // run this at the beginning when there are not a lot of metrics (faster)
+  static final int ORDER = TestOrder.FIRST + 1;
 
   private static String host;
 

--- a/coordinator/testing/src/main/java/io/stargate/it/grpc/AuthApiServerMetricsTest.java
+++ b/coordinator/testing/src/main/java/io/stargate/it/grpc/AuthApiServerMetricsTest.java
@@ -9,6 +9,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
 import io.grpc.StatusRuntimeException;
 import io.stargate.grpc.Values;
+import io.stargate.it.TestOrder;
 import io.stargate.it.driver.CqlSessionExtension;
 import io.stargate.it.driver.CqlSessionSpec;
 import io.stargate.it.driver.TestKeyspace;
@@ -27,6 +28,7 @@ import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -35,7 +37,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
     initQueries = {
       "CREATE TABLE IF NOT EXISTS test (k text, v int, PRIMARY KEY(k, v))",
     })
+@Order()
 public class AuthApiServerMetricsTest extends GrpcIntegrationTest {
+  // run this at the begining when there are not a lot of metrics (faster)
+  private static final int ORDER = TestOrder.FIRST + 1;
 
   private static String host;
 
@@ -62,7 +67,7 @@ public class AuthApiServerMetricsTest extends GrpcIntegrationTest {
     assertThat(response.hasResultSet()).isTrue();
 
     await()
-        .atMost(Duration.ofSeconds(5))
+        .atMost(Duration.ofSeconds(10))
         .untilAsserted(
             () -> {
               String result =
@@ -131,7 +136,7 @@ public class AuthApiServerMetricsTest extends GrpcIntegrationTest {
     assertThat(response).isNotNull();
 
     await()
-        .atMost(Duration.ofSeconds(5))
+        .atMost(Duration.ofSeconds(10))
         .untilAsserted(
             () -> {
               String result =
@@ -193,7 +198,7 @@ public class AuthApiServerMetricsTest extends GrpcIntegrationTest {
         .hasMessageContaining("Invalid token");
 
     await()
-        .atMost(Duration.ofSeconds(5))
+        .atMost(Duration.ofSeconds(10))
         .untilAsserted(
             () -> {
               String result =

--- a/coordinator/testing/src/main/java/io/stargate/it/http/MetricsTest.java
+++ b/coordinator/testing/src/main/java/io/stargate/it/http/MetricsTest.java
@@ -84,7 +84,7 @@ public class MetricsTest extends BaseIntegrationTest {
     int status = execute(client, request);
 
     await()
-        .atMost(Duration.ofSeconds(5))
+        .atMost(Duration.ofSeconds(10))
         .untilAsserted(
             () -> {
               String result =
@@ -148,7 +148,7 @@ public class MetricsTest extends BaseIntegrationTest {
     int status = execute(client, request);
 
     await()
-        .atMost(Duration.ofSeconds(5))
+        .atMost(Duration.ofSeconds(10))
         .untilAsserted(
             () -> {
               String result =
@@ -215,7 +215,7 @@ public class MetricsTest extends BaseIntegrationTest {
     int status = execute(client, request);
 
     await()
-        .atMost(Duration.ofSeconds(5))
+        .atMost(Duration.ofSeconds(10))
         .untilAsserted(
             () -> {
               String result =
@@ -282,7 +282,7 @@ public class MetricsTest extends BaseIntegrationTest {
     int status = execute(client, request);
 
     await()
-        .atMost(Duration.ofSeconds(5))
+        .atMost(Duration.ofSeconds(10))
         .untilAsserted(
             () -> {
               String result =
@@ -344,7 +344,7 @@ public class MetricsTest extends BaseIntegrationTest {
     int status = execute(client, request);
 
     await()
-        .atMost(Duration.ofSeconds(5))
+        .atMost(Duration.ofSeconds(10))
         .untilAsserted(
             () -> {
               String result =
@@ -409,7 +409,7 @@ public class MetricsTest extends BaseIntegrationTest {
     int status = execute(client, request);
 
     await()
-        .atMost(Duration.ofSeconds(5))
+        .atMost(Duration.ofSeconds(10))
         .untilAsserted(
             () -> {
               String result =
@@ -479,7 +479,7 @@ public class MetricsTest extends BaseIntegrationTest {
     int status = execute(client, request);
 
     await()
-        .atMost(Duration.ofSeconds(5))
+        .atMost(Duration.ofSeconds(10))
         .untilAsserted(
             () -> {
               String result =


### PR DESCRIPTION
* increases keycloack timeout, as it's unstable since we moved to github
* increases unit tests timeout for CI as we have seen situations that limit is reached
