### PR TITLE
use docker compose wait flag if available

### DIFF
--- a/docker-compose/cassandra-3.11/start_cass_311.sh
+++ b/docker-compose/cassandra-3.11/start_cass_311.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Default to INFO as root log level
 LOGLEVEL=INFO
@@ -36,4 +36,11 @@ export SGTAG
 
 echo "Running Stargate version $SGTAG with Cassandra 3.11"
 
-docker-compose up -d
+COMPOSE_ARGS=("-d")
+
+# only use --wait flag if Docker Compose is v2
+if [[ $(docker-compose version) =~ "v2" ]]; then
+   COMPOSE_ARGS+=("--wait")
+fi
+
+docker-compose up "${COMPOSE_ARGS[@]}"

--- a/docker-compose/cassandra-3.11/start_cass_311_dev_mode.sh
+++ b/docker-compose/cassandra-3.11/start_cass_311_dev_mode.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Default to INFO as root log level
 LOGLEVEL=INFO
@@ -36,4 +36,11 @@ export SGTAG
 
 echo "Running Stargate version $SGTAG with Cassandra 3.11 (developer mode)"
 
-docker-compose -f docker-compose-dev-mode.yml up -d
+COMPOSE_ARGS=("-d")
+
+# only use --wait flag if Docker Compose is v2
+if [[ $(docker-compose version) =~ "v2" ]]; then
+   COMPOSE_ARGS+=("--wait")
+fi
+
+docker-compose -f docker-compose-dev-mode.yml up "${COMPOSE_ARGS[@]}"

--- a/docker-compose/cassandra-4.0/start_cass_40.sh
+++ b/docker-compose/cassandra-4.0/start_cass_40.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Default to INFO as root log level
 LOGLEVEL=INFO
@@ -36,4 +36,11 @@ export SGTAG
 
 echo "Running Stargate version $SGTAG with Cassandra 4.0"
 
-docker-compose up -d
+COMPOSE_ARGS=("-d")
+
+# only use --wait flag if Docker Compose is v2
+if [[ $(docker-compose version) =~ "v2" ]]; then
+   COMPOSE_ARGS+=("--wait")
+fi
+
+docker-compose up "${COMPOSE_ARGS[@]}"

--- a/docker-compose/cassandra-4.0/start_cass_40_dev_mode.sh
+++ b/docker-compose/cassandra-4.0/start_cass_40_dev_mode.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Default to INFO as root log level
 LOGLEVEL=INFO
@@ -36,4 +36,11 @@ export SGTAG
 
 echo "Running Stargate version $SGTAG with Cassandra 4.0 (developer mode)"
 
-docker-compose -f docker-compose-dev-mode.yml up -d
+COMPOSE_ARGS=("-d")
+
+# only use --wait flag if Docker Compose is v2
+if [[ $(docker-compose version) =~ "v2" ]]; then
+   COMPOSE_ARGS+=("--wait")
+fi
+
+docker-compose -f docker-compose-dev-mode.yml up "${COMPOSE_ARGS[@]}"

--- a/docker-compose/dse-6.8/start_dse_68.sh
+++ b/docker-compose/dse-6.8/start_dse_68.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Default to INFO as root log level
 LOGLEVEL=INFO
@@ -36,4 +36,11 @@ export SGTAG
 
 echo "Running Stargate version $SGTAG with DSE 6.8"
 
-docker-compose up -d
+COMPOSE_ARGS=("-d")
+
+# only use --wait flag if Docker Compose is v2
+if [[ $(docker-compose version) =~ "v2" ]]; then
+   COMPOSE_ARGS+=("--wait")
+fi
+
+docker-compose up "${COMPOSE_ARGS[@]}"

--- a/docker-compose/dse-6.8/start_dse_68_dev_mode.sh
+++ b/docker-compose/dse-6.8/start_dse_68_dev_mode.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Default to INFO as root log level
 LOGLEVEL=INFO
@@ -36,4 +36,11 @@ export SGTAG
 
 echo "Running Stargate version $SGTAG with DSE 6.8 (developer mode)"
 
-docker-compose -f docker-compose-dev-mode.yml up -d
+COMPOSE_ARGS=("-d")
+
+# only use --wait flag if Docker Compose is v2
+if [[ $(docker-compose version) =~ "v2" ]]; then
+   COMPOSE_ARGS+=("--wait")
+fi
+
+docker-compose -f docker-compose-dev-mode.yml up "${COMPOSE_ARGS[@]}"


### PR DESCRIPTION
adds usage of the `--wait` option (if available) on scripts used to start docker compose configurations. The option is only available on docker compose v2.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
