### PR TITLE
fix running integration tests from IDE

### DIFF
--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
@@ -162,6 +162,11 @@ public class StargateTestResource
 
     // log props and return them
     ImmutableMap<String, String> props = propsBuilder.build();
+
+    // flush all props on the system as well
+    props.forEach(System::setProperty);
+
+    // log and return
     LOG.info("Using props map for the integration tests: %s".formatted(props));
     return props;
   }


### PR DESCRIPTION
**What this PR does**:

Fix so that integration tests can be run from the command line. And debugged. This used to work before, but seems that some Quarkus update screwed it up..

Anyway every integration test can be run from IDE if you change `@QuarkusIntegrationTest` to `@QuarkusTest` temporary.. Debug works as well.. If you review this, please confirm that is the case.
