### PR TITLE
allow specification of custom grpc retry policy

### DIFF
--- a/apis/sgv2-quarkus-common/CONFIGURATION.md
+++ b/apis/sgv2-quarkus-common/CONFIGURATION.md
@@ -27,12 +27,13 @@
 ### gRPC configuration
 *Configuration for the gRPC calls to the Bridge, defined by [GrpcConfig.java](src/main/java/io/stargate/sgv2/api/common/config/GrpcConfig.java).*
 
-| Property                             | Type       | Default       | Description                                                                          |
-|--------------------------------------|------------|---------------|--------------------------------------------------------------------------------------|
-| `stargate.grpc.call-deadline`        | `Duration` | `PT30S`       | Defines the client deadline for each RPC call to the bridge.                         |
-| `stargate.grpc.retries.enabled`      | `boolean`  | `true`        | If retries of bridge calls is enabled.                                               |
-| `stargate.grpc.retries.status-codes` | `List`     | `UNAVAILABLE` | List of gRPC `Status.Code`s that must be returned in order for a call to be retried. |
-| `stargate.grpc.retries.max-attempts` | `int`      | `1`           | Maximum amount of retry attempts for a single call.                                  |
+| Property                             | Type       | Default        | Description                                                                                                                         |
+|--------------------------------------|------------|----------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `stargate.grpc.call-deadline`        | `Duration` | `PT30S`        | Defines the client deadline for each RPC call to the bridge.                                                                        |
+| `stargate.grpc.retries.enabled`      | `boolean`  | `true`         | If retries of bridge calls is enabled.                                                                                              |
+| `stargate.grpc.retries.policy`       | `String`   | `status-codes` | Retry policy type. Possible options are `status-codes`, `custom` or unset. If unset, noop policy is used (never retries).           |
+| `stargate.grpc.retries.status-codes` | `List`     | `UNAVAILABLE`  | In case of a `status-codes` policy, provides a list of gRPC `Status.Code`s that must be returned in order for a call to be retried. |
+| `stargate.grpc.retries.max-attempts` | `int`      | `1`            | Maximum amount of retry attempts for a single call.                                                                                 |
 
 ### gRPC metadata configuration
 *Configuration for the gRPC metadata passed to the Bridge, defined by [GrpcMetadataConfig.java](src/main/java/io/stargate/sgv2/api/common/config/GrpcMetadataConfig.java).*

--- a/apis/sgv2-quarkus-common/CONFIGURATION.md
+++ b/apis/sgv2-quarkus-common/CONFIGURATION.md
@@ -31,7 +31,7 @@
 |--------------------------------------|------------|----------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | `stargate.grpc.call-deadline`        | `Duration` | `PT30S`        | Defines the client deadline for each RPC call to the bridge.                                                                        |
 | `stargate.grpc.retries.enabled`      | `boolean`  | `true`         | If retries of bridge calls is enabled.                                                                                              |
-| `stargate.grpc.retries.policy`       | `String`   | `status-codes` | Retry policy type. Possible options are `status-codes`, `custom` or unset. If unset, noop policy is used (never retries).           |
+| `stargate.grpc.retries.policy`       | `String`   | `status-codes` | Retry policy type. Possible options are `status-codes` or `custom`.                                                                 |
 | `stargate.grpc.retries.status-codes` | `List`     | `UNAVAILABLE`  | In case of a `status-codes` policy, provides a list of gRPC `Status.Code`s that must be returned in order for a call to be retried. |
 | `stargate.grpc.retries.max-attempts` | `int`      | `1`            | Maximum amount of retry attempts for a single call.                                                                                 |
 

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/GrpcConfig.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/GrpcConfig.java
@@ -59,7 +59,8 @@ public interface GrpcConfig {
      *
      * If unset, noop policy will be used (never retries).
      *
-     * @return The type of the {@link io.stargate.sgv2.api.common.grpc.retries.GrpcRetryPredicate} used.
+     * @return The type of the {@link io.stargate.sgv2.api.common.grpc.retries.GrpcRetryPredicate}
+     *     used.
      */
     @WithDefault("status-codes")
     Optional<@Pattern(regexp = "status-codes|custom") String> policy();

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/GrpcConfig.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/GrpcConfig.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Positive;
 
 /** Configuration for the gRPC calls to the Bridge. */
@@ -48,8 +49,25 @@ public interface GrpcConfig {
     boolean enabled();
 
     /**
+     * What type of retry policy to use.
+     *
+     * <ol>
+     *   <li><code>status-codes</code> - based on status codes (see {@link
+     *       io.stargate.sgv2.api.common.grpc.retries.impl.StatusCodesRetryPredicate}}
+     *   <li><code>custom</code> - allows configuring custom policy
+     * </ol>
+     *
+     * If unset, noop policy will be used (never retries).
+     *
+     * @return The type of the {@link io.stargate.sgv2.api.common.grpc.retries.GrpcRetryPredicate} used.
+     */
+    @WithDefault("status-codes")
+    Optional<@Pattern(regexp = "status-codes|custom") String> policy();
+
+    /**
      * @return List of status codes to execute retries for. Defaults to <code>UNAVAILABLE</code>, as
-     *     this code means that the request never reached the bridge and it should be safe to retry.
+     *     this code means that the request never reached the bridge or C* responded with
+     *     Unavailable exception, thus it should be safe to retry.
      */
     @WithDefault("UNAVAILABLE")
     @NotNull

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/GrpcConfig.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/GrpcConfig.java
@@ -63,7 +63,9 @@ public interface GrpcConfig {
      *     used.
      */
     @WithDefault("status-codes")
-    Optional<@Pattern(regexp = "status-codes|custom") String> policy();
+    @NotNull
+    @Pattern(regexp = "status-codes|custom")
+    String policy();
 
     /**
      * @return List of status codes to execute retries for. Defaults to <code>UNAVAILABLE</code>, as

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/configuration/RetriableStargateBridgeConfiguration.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/configuration/RetriableStargateBridgeConfiguration.java
@@ -22,6 +22,8 @@ import io.stargate.bridge.proto.StargateBridge;
 import io.stargate.sgv2.api.common.config.GrpcConfig;
 import io.stargate.sgv2.api.common.grpc.RetriableStargateBridge;
 import io.stargate.sgv2.api.common.grpc.qualifier.Retriable;
+import io.stargate.sgv2.api.common.grpc.retries.GrpcRetryPredicate;
+import javax.enterprise.inject.Instance;
 import javax.ws.rs.Produces;
 
 public class RetriableStargateBridgeConfiguration {
@@ -29,7 +31,9 @@ public class RetriableStargateBridgeConfiguration {
   @Produces
   @Retriable
   RetriableStargateBridge retriableStargateBridge(
-      @GrpcClient("bridge") StargateBridge stargateBridge, GrpcConfig grpcConfig) {
-    return new RetriableStargateBridge(stargateBridge, grpcConfig);
+      @GrpcClient("bridge") StargateBridge stargateBridge,
+      Instance<GrpcRetryPredicate> predicate,
+      GrpcConfig grpcConfig) {
+    return new RetriableStargateBridge(stargateBridge, predicate.get(), grpcConfig);
   }
 }

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/retries/GrpcRetryPredicate.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/retries/GrpcRetryPredicate.java
@@ -1,0 +1,7 @@
+package io.stargate.sgv2.api.common.grpc.retries;
+
+import io.grpc.StatusRuntimeException;
+import java.util.function.Predicate;
+
+/** Simple predicate that can define what {@link StatusRuntimeException}s should be retried. */
+public interface GrpcRetryPredicate extends Predicate<StatusRuntimeException> {}

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/retries/configuration/GrpcRetriesConfiguration.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/retries/configuration/GrpcRetriesConfiguration.java
@@ -1,0 +1,31 @@
+package io.stargate.sgv2.api.common.grpc.retries.configuration;
+
+import io.grpc.Status;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.stargate.sgv2.api.common.config.GrpcConfig;
+import io.stargate.sgv2.api.common.grpc.retries.GrpcRetryPredicate;
+import io.stargate.sgv2.api.common.grpc.retries.impl.StatusCodesRetryPredicate;
+import java.util.List;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+public class GrpcRetriesConfiguration {
+
+  @Produces
+  @ApplicationScoped
+  @LookupIfProperty(name = "stargate.grpc.retries.policy", stringValue = "status-codes")
+  GrpcRetryPredicate statusCodes(GrpcConfig config) {
+    List<Status.Code> statusCodes = config.retries().statusCodes();
+    return new StatusCodesRetryPredicate(statusCodes);
+  }
+
+  @Produces
+  @ApplicationScoped
+  @LookupIfProperty(
+      name = "stargate.grpc.retries.policy",
+      stringValue = "noop",
+      lookupIfMissing = true)
+  GrpcRetryPredicate noop() {
+    return e -> false;
+  }
+}

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/retries/configuration/GrpcRetriesConfiguration.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/retries/configuration/GrpcRetriesConfiguration.java
@@ -18,14 +18,4 @@ public class GrpcRetriesConfiguration {
     List<Status.Code> statusCodes = config.retries().statusCodes();
     return new StatusCodesRetryPredicate(statusCodes);
   }
-
-  @Produces
-  @ApplicationScoped
-  @LookupIfProperty(
-      name = "stargate.grpc.retries.policy",
-      stringValue = "noop",
-      lookupIfMissing = true)
-  GrpcRetryPredicate noop() {
-    return e -> false;
-  }
 }

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/retries/impl/StatusCodesRetryPredicate.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/retries/impl/StatusCodesRetryPredicate.java
@@ -1,0 +1,25 @@
+package io.stargate.sgv2.api.common.grpc.retries.impl;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.stargate.sgv2.api.common.grpc.retries.GrpcRetryPredicate;
+import java.util.List;
+
+/** {@link GrpcRetryPredicate} based on status code matching. */
+public class StatusCodesRetryPredicate implements GrpcRetryPredicate {
+
+  private final List<Status.Code> statusCodes;
+
+  public StatusCodesRetryPredicate(List<Status.Code> statusCodes) {
+    this.statusCodes = statusCodes;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean test(StatusRuntimeException e) {
+    if (null != statusCodes) {
+      return statusCodes.contains(e.getStatus().getCode());
+    }
+    return false;
+  }
+}

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/grpc/RetriableStargateBridgeCustomPolicyTest.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/grpc/RetriableStargateBridgeCustomPolicyTest.java
@@ -1,0 +1,127 @@
+package io.stargate.sgv2.api.common.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.collect.ImmutableMap;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.api.common.grpc.qualifier.Retriable;
+import io.stargate.sgv2.api.common.grpc.retries.GrpcRetryPredicate;
+import io.stargate.sgv2.common.bridge.BridgeTest;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(RetriableStargateBridgeCustomPolicyTest.Profile.class)
+class RetriableStargateBridgeCustomPolicyTest extends BridgeTest {
+
+  public static class Profile implements NoGlobalResourcesTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return ImmutableMap.<String, String>builder()
+          .put("stargate.grpc.retries.policy", "custom")
+          .put("stargate.grpc.retries.status-codes", "UNAVAILABLE,NOT_FOUND")
+          .put("stargate.grpc.retries.max-attempts", "3")
+          .build();
+    }
+  }
+
+  public static final Metadata.Key<String> key =
+      Metadata.Key.of("test-key", Metadata.ASCII_STRING_MARSHALLER);
+
+  @Produces
+  @ApplicationScoped
+  @LookupIfProperty(name = "stargate.grpc.retries.policy", stringValue = "custom")
+  GrpcRetryPredicate custom() {
+    return e -> {
+      Metadata trailers = e.getTrailers();
+      return null != trailers && trailers.containsKey(key);
+    };
+  }
+
+  @Retriable @Inject RetriableStargateBridge bridge;
+
+  @Test
+  public void retried() {
+    doAnswer(
+            invocationOnMock -> {
+              StreamObserver<QueryOuterClass.Response> observer = invocationOnMock.getArgument(1);
+              Status status = Status.UNAVAILABLE;
+              Metadata trailer = new Metadata();
+              trailer.put(key, "value");
+              observer.onError(new StatusRuntimeException(status, trailer));
+              return null;
+            })
+        .when(bridgeService)
+        .executeQuery(any(), any());
+
+    QueryOuterClass.Query request = QueryOuterClass.Query.newBuilder().build();
+    Throwable result =
+        bridge
+            .executeQuery(request)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create())
+            .awaitFailure()
+            .getFailure();
+
+    assertThat(result)
+        .isInstanceOfSatisfying(
+            StatusRuntimeException.class,
+            e -> {
+              assertThat(e.getStatus()).isEqualTo(Status.UNAVAILABLE);
+              assertThat(e.getTrailers()).isNotNull();
+              assertThat(e.getTrailers().get(key)).isEqualTo("value");
+            });
+
+    // verify 4 bridge calls, original + 3 retries
+    // always same query
+    verify(bridgeService, times(4)).executeQuery(eq(request), any());
+  }
+
+  @Test
+  public void notRetried() {
+    doAnswer(
+            invocationOnMock -> {
+              StreamObserver<QueryOuterClass.Response> observer = invocationOnMock.getArgument(1);
+              Status status = Status.UNAVAILABLE;
+              observer.onError(new StatusRuntimeException(status));
+              return null;
+            })
+        .when(bridgeService)
+        .executeQuery(any(), any());
+
+    QueryOuterClass.Query request = QueryOuterClass.Query.newBuilder().build();
+    Throwable result =
+        bridge
+            .executeQuery(request)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create())
+            .awaitFailure()
+            .getFailure();
+
+    assertThat(result)
+        .isInstanceOfSatisfying(
+            StatusRuntimeException.class,
+            e -> assertThat(e.getStatus()).isEqualTo(Status.UNAVAILABLE));
+
+    // no retry
+    verify(bridgeService).executeQuery(eq(request), any());
+  }
+}

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/grpc/RetriableStargateBridgeDisabledTest.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/grpc/RetriableStargateBridgeDisabledTest.java
@@ -1,0 +1,70 @@
+package io.stargate.sgv2.api.common.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.collect.ImmutableMap;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.api.common.grpc.qualifier.Retriable;
+import io.stargate.sgv2.common.bridge.BridgeTest;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import java.util.Map;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(RetriableStargateBridgeDisabledTest.Profile.class)
+class RetriableStargateBridgeDisabledTest extends BridgeTest {
+
+  public static class Profile implements NoGlobalResourcesTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return ImmutableMap.<String, String>builder()
+          .put("stargate.grpc.retries.enabled", "false")
+          .put("stargate.grpc.retries.status-codes", "UNAVAILABLE,NOT_FOUND")
+          .build();
+    }
+  }
+
+  @Retriable @Inject RetriableStargateBridge bridge;
+
+  @Test
+  public void disabledNoRetries() {
+    doAnswer(
+            invocationOnMock -> {
+              StreamObserver<QueryOuterClass.Response> observer = invocationOnMock.getArgument(1);
+              Status status = Status.UNAVAILABLE;
+              observer.onError(new StatusRuntimeException(status));
+              return null;
+            })
+        .when(bridgeService)
+        .executeQuery(any(), any());
+
+    QueryOuterClass.Query request = QueryOuterClass.Query.newBuilder().build();
+    Throwable result =
+        bridge
+            .executeQuery(request)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create())
+            .awaitFailure()
+            .getFailure();
+
+    assertThat(result)
+        .isInstanceOfSatisfying(
+            StatusRuntimeException.class,
+            e -> assertThat(e.getStatus()).isEqualTo(Status.UNAVAILABLE));
+
+    // verify one class only
+    verify(bridgeService).executeQuery(eq(request), any());
+  }
+}

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/grpc/RetriableStargateBridgeTest.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/grpc/RetriableStargateBridgeTest.java
@@ -43,6 +43,8 @@ import org.junit.jupiter.api.Test;
 @TestProfile(RetriableStargateBridgeTest.Profile.class)
 class RetriableStargateBridgeTest extends BridgeTest {
 
+  // tests the default retry policy status-codes
+
   public static class Profile implements NoGlobalResourcesTestProfile {
 
     @Override


### PR DESCRIPTION
**What this PR does**:

Allows project that depend on the `sgv2-quarkus-common` to provide their own `custom` grpc retry policy.

**Which issue(s) this PR fixes**:
Internal issue.