### PR TITLE
retry grpc status codes config as set

### DIFF
--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/GrpcConfig.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/GrpcConfig.java
@@ -22,8 +22,8 @@ import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import io.stargate.sgv2.api.common.grpc.RetriableStargateBridge;
 import java.time.Duration;
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
@@ -68,13 +68,13 @@ public interface GrpcConfig {
     String policy();
 
     /**
-     * @return List of status codes to execute retries for. Defaults to <code>UNAVAILABLE</code>, as
+     * @return Set of status codes to execute retries for. Defaults to <code>UNAVAILABLE</code>, as
      *     this code means that the request never reached the bridge or C* responded with
      *     Unavailable exception, thus it should be safe to retry.
      */
     @WithDefault("UNAVAILABLE")
     @NotNull
-    List<Status.Code> statusCodes();
+    Set<Status.Code> statusCodes();
 
     /** @return Maximum amount of retry attempts. */
     @WithDefault("1")

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/retries/configuration/GrpcRetriesConfiguration.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/retries/configuration/GrpcRetriesConfiguration.java
@@ -5,7 +5,7 @@ import io.quarkus.arc.lookup.LookupIfProperty;
 import io.stargate.sgv2.api.common.config.GrpcConfig;
 import io.stargate.sgv2.api.common.grpc.retries.GrpcRetryPredicate;
 import io.stargate.sgv2.api.common.grpc.retries.impl.StatusCodesRetryPredicate;
-import java.util.List;
+import java.util.Set;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 
@@ -15,7 +15,7 @@ public class GrpcRetriesConfiguration {
   @ApplicationScoped
   @LookupIfProperty(name = "stargate.grpc.retries.policy", stringValue = "status-codes")
   GrpcRetryPredicate statusCodes(GrpcConfig config) {
-    List<Status.Code> statusCodes = config.retries().statusCodes();
+    Set<Status.Code> statusCodes = config.retries().statusCodes();
     return new StatusCodesRetryPredicate(statusCodes);
   }
 }

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/retries/impl/StatusCodesRetryPredicate.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/grpc/retries/impl/StatusCodesRetryPredicate.java
@@ -3,14 +3,14 @@ package io.stargate.sgv2.api.common.grpc.retries.impl;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.stargate.sgv2.api.common.grpc.retries.GrpcRetryPredicate;
-import java.util.List;
+import java.util.Set;
 
 /** {@link GrpcRetryPredicate} based on status code matching. */
 public class StatusCodesRetryPredicate implements GrpcRetryPredicate {
 
-  private final List<Status.Code> statusCodes;
+  private final Set<Status.Code> statusCodes;
 
-  public StatusCodesRetryPredicate(List<Status.Code> statusCodes) {
+  public StatusCodesRetryPredicate(Set<Status.Code> statusCodes) {
     this.statusCodes = statusCodes;
   }
 


### PR DESCRIPTION
**What this PR does**:
Followup of #2519, missed to use `Set` as @tatu-at-datastax suggested..