### PR TITLE
fix the starctl exit too soon due to grep

### DIFF
--- a/coordinator/starctl
+++ b/coordinator/starctl
@@ -75,12 +75,12 @@ case "`uname -s`" in
                 dirs="$dirs `ldconfig -v 2>/dev/null | grep -v '^\s' | sed 's/^\([^:]*\):.*$/\1/'`"
             fi
             if [ -f /etc/ld.so.conf ]; then
-                dirs="$dirs `cat /etc/ld.so.conf | grep '^/'`"
+                dirs="$dirs `cat /etc/ld.so.conf | { grep '^/' || true; }`"
             fi
             additional_configs=$(ls /etc/ld.so.conf.d/*.conf 2>&1)
             if [ $? = 0 ]; then
                 for conf in $additional_configs; do
-                    dirs="$dirs `cat $conf | grep '^/'`"
+                    dirs="$dirs `cat $conf | { grep '^/' || true; }`"
                 done
             fi
             dirs=`echo $dirs | tr " " ":"`


### PR DESCRIPTION
**What this PR does**:

Fixing the `starctl` script not working on Linux. Explanation:

* script has `set -e` on line two which means exit on any error
* grep returns exit code `1` in case nothing is found, thus this is considered as error and aborts

Why and how this works in the original cassandra script I don't know.. But it could be that the bang here is `#!/bin/bash` and in https://github.com/apache/cassandra/blob/trunk/bin/cassandra it's `#!/bin/sh`..

On my machine now:

```
$ ./starctl --cluster-name test --cluster-version 4.0 --developer-mode
Running java -server -Dstargate.libdir=./stargate-lib -Djava.awt.headless=true -jar ./stargate-lib/stargate-starter-1.0.76-SNAPSHOT.jar --cluster-name test --cluster-version 4.0 --developer-mode
[INFO] JAR DIR: ./stargate-lib
[INFO] Loading persistence backend persistence-cassandra-4.0-1.0.76-snapshot.jar
[INFO] Installing bundle persistence-cassandra-4.0-1.0.76-SNAPSHOT.jar
[INFO] Installing bundle animal-sniffer-annotations-1.9.jar
[INFO] Installing bundle asm-7.1.jar
[INFO] Installing bundle asm-analysis-7.1.jar
[INFO] Installing bundle asm-tree-7.1.jar
```

And with following command:

```
ise        93180  128  3.1 16446184 1030656 pts/4 Sl+ 14:42   0:23 java -server -Dstargate.libdir=./stargate-lib -Djava.awt.headless=true -jar ./stargate-lib/stargate-starter-1.0.76-SNAPSHOT.jar --cluster-name test --cluster-version 4.0 --developer-mode
```

Then after installing `sudo apt-install libjemalloc2` I get correct startup and command:

```
ise        93961  163  1.6 10342596 531792 pts/4 Sl+  14:45   0:09 java -server -Dcassandra.libjemalloc=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 -Dstargate.libdir=./stargate-lib -Djava.awt.headless=true -jar ./stargate-lib/stargate-starter-1.0.76-SNAPSHOT.jar --cluster-name test --cluster-version 4.0 --developer-mode
``` 

