### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  # should pick up both apis and coordinators poms
+  directory: "/"
+  schedule:
+    interval: weekly
+  ignore:
+    # ignore Maven APIs/SPIs
+    - dependency-name: org.apache.maven:*
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: weekly


### PR DESCRIPTION
I've been looking at our current approach using a homegrown workflow running maven commands to track dependency updates and vulnerabilities. After reading the dependabot docs in more detail I think it has the potential to be a better solution, with support for checking more than just Java dependencies, and better automation to help us keep current more quickly. I'd like to give it a shot on this repo and then see if we want to also enable on other repos.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
