### PR TITLE
Fix #2547, upgrade Jetty test dep (only relevant wrt SGv1 endpoints)

### DIFF
--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -55,12 +55,12 @@
     <doclint>none</doclint>
     <driver.version>4.15.0</driver.version>
     <!-- First DropWizard version and things it directly depends on that make sense to sync -->
-    <dropwizard.version>2.1.6</dropwizard.version>
+    <dropwizard.version>2.0.35</dropwizard.version>
     <!--
       Note that this is currently aligned with the metrics version that DropWizard transitively depends on.
       It's probably a good idea to keep the two versions in sync.
     -->
-    <dropwizard.metrics.version>4.2.18</dropwizard.metrics.version>
+    <dropwizard.metrics.version>4.1.36</dropwizard.metrics.version>
     <!--
       Note that this is currently aligned with the Jetty version that DropWizard transitively depends on.
       It's probably a good idea to keep the two versions in sync (or close)

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -55,12 +55,12 @@
     <doclint>none</doclint>
     <driver.version>4.15.0</driver.version>
     <!-- First DropWizard version and things it directly depends on that make sense to sync -->
-    <dropwizard.version>2.0.35</dropwizard.version>
+    <dropwizard.version>2.1.6</dropwizard.version>
     <!--
       Note that this is currently aligned with the metrics version that DropWizard transitively depends on.
       It's probably a good idea to keep the two versions in sync.
     -->
-    <dropwizard.metrics.version>4.1.36</dropwizard.metrics.version>
+    <dropwizard.metrics.version>4.2.18</dropwizard.metrics.version>
     <!--
       Note that this is currently aligned with the Jetty version that DropWizard transitively depends on.
       It's probably a good idea to keep the two versions in sync (or close)
@@ -68,7 +68,7 @@
     <jetty.version>9.4.51.v20230217</jetty.version>
     <!-- Logging framework likewise in sync -->
     <slf4j.version>1.7.36</slf4j.version>
-    <logback.version>1.2.11</logback.version>
+    <logback.version>1.2.12</logback.version>
     <!-- And then other 3rd party version dependencies, compile/runtime -->
     <caffeine.version>2.9.3</caffeine.version>
     <commons-io.version>2.7</commons-io.version>

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -63,9 +63,9 @@
     <dropwizard.metrics.version>4.1.36</dropwizard.metrics.version>
     <!--
       Note that this is currently aligned with the Jetty version that DropWizard transitively depends on.
-      It's probably a good idea to keep the two versions in sync.
+      It's probably a good idea to keep the two versions in sync (or close)
     -->
-    <jetty.version>9.4.50.v20221201</jetty.version>
+    <jetty.version>9.4.51.v20230217</jetty.version>
     <!-- Logging framework likewise in sync -->
     <slf4j.version>1.7.36</slf4j.version>
     <logback.version>1.2.11</logback.version>


### PR DESCRIPTION
**What this PR does**:

Updates Jetty-core dependency (used by DropWizard, used by SGv1 endpoints)

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
