### PR TITLE
post quarkus 2.16.6 upgrade fixes

### DIFF
--- a/apis/sgv2-quarkus-common/src/main/resources/application.yaml
+++ b/apis/sgv2-quarkus-common/src/main/resources/application.yaml
@@ -75,6 +75,10 @@ quarkus:
   #  HTTP settings
   http:
 
+    # disable basic auth completely
+    auth:
+      basic: false
+
     # access log format, must be explicitly enabled
     access-log:
       pattern: "%h %l %t \"%r\" %s %b"

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -72,7 +72,7 @@
     <!-- And then other 3rd party version dependencies, compile/runtime -->
     <caffeine.version>2.9.3</caffeine.version>
     <commons-io.version>2.7</commons-io.version>
-    <grpc.version>1.51.0</grpc.version>
+    <grpc.version>1.51.1</grpc.version>
     <immutables.version>2.8.8</immutables.version>
     <jackson.version>2.14.2</jackson.version>
     <javatuples.version>1.2</javatuples.version>


### PR DESCRIPTION
**What this PR does**:

Two things that came out, not directly related to `2.16.6` upgrade, but could be:

* Doing a Quarkus 3.x upgrade work I saw strange behavior of the Swagger wrt to authentication. There the basic auth scheme is added by default, which is strange as we define our own security scheme. It turns out that `quarkus.http.auth.basic` property must be explicitly set to false to disable any activation of the basic auth mechanism. We are not using basic auth, but per docmentation: `If basic auth should be enabled. If both basic and form auth is enabled then basic auth will be enabled in silent mode. If no authentication mechanisms are configured basic auth is the default.` I am not sure what this means, we are registering our own mechanism, thus just to be safe disable it. In 3.x branch disabling it has effect on Swagger and the basic security scheme is not added anymore
* Small alignment of the grpc versions in the apis and coordinator