### PR TITLE
protect against prepared statement cache returning null

### DIFF
--- a/coordinator/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/StargateQueryHandler.java
+++ b/coordinator/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/StargateQueryHandler.java
@@ -131,7 +131,8 @@ public class StargateQueryHandler implements QueryHandler {
         .map(
             p -> {
               // we need to protect against the case where the statement was dropped from the cache
-              CQLStatement statement = Optional.ofNullable(QueryProcessor.instance.getPrepared(p.statementId))
+              CQLStatement statement =
+                  Optional.ofNullable(QueryProcessor.instance.getPrepared(p.statementId))
                       .map(prepared -> prepared.statement)
                       .orElseGet(() -> QueryProcessor.getStatement(query, queryState));
               boolean idempotent = IdempotencyAnalyzer.isIdempotent(statement);

--- a/coordinator/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/StargateQueryHandler.java
+++ b/coordinator/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/StargateQueryHandler.java
@@ -130,8 +130,10 @@ public class StargateQueryHandler implements QueryHandler {
         .prepare(query, queryState, customPayload)
         .map(
             p -> {
-              Prepared prepared = QueryProcessor.instance.getPrepared(p.statementId);
-              CQLStatement statement = prepared.statement;
+              // we need to protect against the case where the statement was dropped from the cache
+              CQLStatement statement = Optional.ofNullable(QueryProcessor.instance.getPrepared(p.statementId))
+                      .map(prepared -> prepared.statement)
+                      .orElseGet(() -> QueryProcessor.getStatement(query, queryState));
               boolean idempotent = IdempotencyAnalyzer.isIdempotent(statement);
               boolean useKeyspace = statement instanceof UseStatement;
               return new PreparedWithInfo(p, idempotent, useKeyspace);


### PR DESCRIPTION
**What this PR does**:

There could be a situation where just prepared statement is not in a cache anymore (for whatever reason).. This is adding a safety, similar to the C 3.11 and C 4.0 implementations..

Basing on `v1` as agreed with @tatu-at-datastax cause this is a bug and we want to be available there as well.

**Which issue(s) this PR fixes**:
Internal issue.
