### PR TITLE
Fix #2551: upgrade DropWizard (2.0.35 -> 2.1.6)

### DIFF
--- a/coordinator/core/src/main/java/io/stargate/core/metrics/impl/PrefixingMetricRegistry.java
+++ b/coordinator/core/src/main/java/io/stargate/core/metrics/impl/PrefixingMetricRegistry.java
@@ -108,7 +108,7 @@ public class PrefixingMetricRegistry extends MetricRegistry {
 
   @Override
   @SuppressWarnings("rawtypes")
-  public Gauge gauge(String name, MetricSupplier<Gauge> supplier) {
+  public <T extends Gauge> T gauge(String name, MetricSupplier<T> supplier) {
     return backingRegistry.gauge(addPrefix(name), supplier);
   }
 

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -55,20 +55,20 @@
     <doclint>none</doclint>
     <driver.version>4.15.0</driver.version>
     <!-- First DropWizard version and things it directly depends on that make sense to sync -->
-    <dropwizard.version>2.0.35</dropwizard.version>
+    <dropwizard.version>2.1.6</dropwizard.version>
     <!--
       Note that this is currently aligned with the metrics version that DropWizard transitively depends on.
       It's probably a good idea to keep the two versions in sync.
     -->
-    <dropwizard.metrics.version>4.1.36</dropwizard.metrics.version>
+    <dropwizard.metrics.version>4.2.18</dropwizard.metrics.version>
     <!--
       Note that this is currently aligned with the Jetty version that DropWizard transitively depends on.
       It's probably a good idea to keep the two versions in sync.
     -->
-    <jetty.version>9.4.50.v20221201</jetty.version>
+    <jetty.version>9.4.51.v20230217</jetty.version>
     <!-- Logging framework likewise in sync -->
     <slf4j.version>1.7.36</slf4j.version>
-    <logback.version>1.2.11</logback.version>
+    <logback.version>1.2.12</logback.version>
     <!-- And then other 3rd party version dependencies, compile/runtime -->
     <caffeine.version>2.9.3</caffeine.version>
     <commons-io.version>2.7</commons-io.version>

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -613,7 +613,7 @@
         <artifactId>metrics-graphite</artifactId>
         <version>${dropwizard.metrics.version}</version>
       </dependency>
-      <!-- 24-Apr-2023, tatu: Sync with DropWizard 2.0.6 again -->
+      <!-- 24-Apr-2023, tatu: Sync with DropWizard 2.1.6 again -->
       <dependency>
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>jersey-bom</artifactId>

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -613,14 +613,11 @@
         <artifactId>metrics-graphite</artifactId>
         <version>${dropwizard.metrics.version}</version>
       </dependency>
-      <!-- 30-Mar-2022, tatu: temporarily force newer jersey-common
-	   (over what DW asks) to get vuln fixes; make sure we have enforcer rules to alert if this
-	   becomes less than latest
-	  -->
+      <!-- 24-Apr-2023, tatu: Sync with DropWizard 2.0.6 again -->
       <dependency>
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>jersey-bom</artifactId>
-        <version>2.34</version>
+        <version>2.39.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
**What this PR does**:

Upgrades DropWizard from 2.0.x to 2.1.x to remain on supported version.

**Which issue(s) this PR fixes**:
Fixes #2551

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
