### PR TITLE
Fix #2556: upgrade graphql-java dep (18.3 -> 18.5)

### DIFF
--- a/coordinator/graphqlapi/pom.xml
+++ b/coordinator/graphqlapi/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>com.graphql-java</groupId>
       <artifactId>graphql-java</artifactId>
-      <version>18.3</version>
+      <version>18.5</version>
     </dependency>
     <dependency>
       <groupId>io.dropwizard</groupId>


### PR DESCRIPTION
**What this PR does**:

Upgrades `graphql-java` dependency to resolve Dependabot vuln warning wrt version 18.3

**Which issue(s) this PR fixes**:
Fixes #2556

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
