### PR TITLE
Fix #2559: Override SnakeYAML dependency for APIs to 2.0 to resolve CVE-2022-1471

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -65,6 +65,8 @@
     <skipTests>false</skipTests>
     <skipUnitTests>${skipTests}</skipUnitTests>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
+    <!-- Dependency version overrides -->
+    <snakeyaml.version>2.0</snakeyaml.version>
     <!--
       Integration test properties, defaults to cassandra-40
       Please maintain default values for int-test in sync with io.stargate.sgv2.docsapi.testresource.StargateTestResource.Defaults
@@ -95,6 +97,11 @@
         <groupId>org.immutables</groupId>
         <artifactId>value</artifactId>
         <version>2.9.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>${snakeyaml.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>


### PR DESCRIPTION
**What this PR does**:

Adds an override for `apis/` to SnakeYAML dependency to use latest version (and prevent CVE-2022-1471)

**Which issue(s) this PR fixes**:
Fixes #2559

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
