### PR TITLE
Fix #2562: update C*4 to c-4.0.9

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -70,7 +70,7 @@
       Please maintain default values for int-test in sync with io.stargate.sgv2.docsapi.testresource.StargateTestResource.Defaults
      -->
     <stargate.int-test.cassandra.image>cassandra</stargate.int-test.cassandra.image>
-    <stargate.int-test.cassandra.image-tag>4.0.7</stargate.int-test.cassandra.image-tag>
+    <stargate.int-test.cassandra.image-tag>4.0.9</stargate.int-test.cassandra.image-tag>
     <stargate.int-test.coordinator.image>stargateio/coordinator-4_0</stargate.int-test.coordinator.image>
     <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
     <stargate.int-test.cluster.name>cass-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>

--- a/coordinator/cql/pom.xml
+++ b/coordinator/cql/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-all</artifactId>
-      <version>4.0.7</version>
+      <version>4.0.9</version>
       <exclusions>
         <exclusion>
           <groupId>org.gridkit.jvmtool</groupId>

--- a/coordinator/persistence-api/pom.xml
+++ b/coordinator/persistence-api/pom.xml
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-all</artifactId>
-      <version>4.0.7</version>
+      <version>4.0.9</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/coordinator/persistence-cassandra-4.0/pom.xml
+++ b/coordinator/persistence-cassandra-4.0/pom.xml
@@ -13,8 +13,8 @@
   <name>Stargate - Coordinator - Persistence C* 4.0</name>
   <properties>
     <!-- If you update this, make sure to keep `cassandra.bundled-driver.version` in sync -->
-    <!-- 4.0.7 depends on 3.11.0: https://mvnrepository.com/artifact/org.apache.cassandra/cassandra-all/4.0.7 -->
-    <cassandra.version>4.0.7</cassandra.version>
+    <!-- 4.0.9 depends on 3.11.0: https://mvnrepository.com/artifact/org.apache.cassandra/cassandra-all/4.0.9 -->
+    <cassandra.version>4.0.9</cassandra.version>
     <!--
       The driver used internally by cassandra-all for UDFs (must match the version declared in
       cassandra-all's POM).

--- a/coordinator/testing/pom.xml
+++ b/coordinator/testing/pom.xml
@@ -393,7 +393,7 @@
                 </goals>
                 <configuration>
                   <systemPropertyVariables>
-                    <ccm.version>4.0.7</ccm.version>
+                    <ccm.version>4.0.9</ccm.version>
                     <stargate.test.nodes>1</stargate.test.nodes>
                   </systemPropertyVariables>
                   <failIfNoTests>true</failIfNoTests>


### PR DESCRIPTION
**What this PR does**:

Updates C*4 persistence, APIs to depend on Cassandra 4.0.9 instead of 4.0.7. The main reason is to allow use of newest version of SnakeYAML, as per [https://issues.apache.org/jira/browse/CASSANDRA-18150]

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
