### PR TITLE
Backport org.json upgrade from SGv2 (issue #2543, PR #2544) into v1 b…

### DIFF
--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -722,7 +722,7 @@
       <dependency>
         <groupId>org.json</groupId>
         <artifactId>json</artifactId>
-        <version>20220320</version>
+        <version>20230227</version>
       </dependency>
       <dependency>
         <groupId>com.bpodgursky</groupId>


### PR DESCRIPTION
**What this PR does**:

Updates `org.json` dependency to latest to resolve a sec scan alert

**Which issue(s) this PR fixes**:
Fixes #2543 (backport from v2 branch)

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
