### PR TITLE
Support count function with no column name arg

### DIFF
--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/cql/builder/QueryBuilderImpl.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/cql/builder/QueryBuilderImpl.java
@@ -342,6 +342,10 @@ public class QueryBuilderImpl {
     count(columnName.name());
   }
 
+  public void count() {
+    count((String) null);
+  }
+
   public void max(String maxColumnName) {
     functionCalls.add(FunctionCall.max(maxColumnName));
   }
@@ -1466,16 +1470,24 @@ public class QueryBuilderImpl {
     return where;
   }
 
+  private static final String COUNT_FUNCTION_NAME = "COUNT";
+
   private static String formatFunctionCall(FunctionCall functionCall) {
     StringBuilder builder = new StringBuilder();
-    builder
-        .append(functionCall.getFunctionName())
-        .append('(')
-        .append(cqlName(functionCall.getColumnName()))
-        .append(')');
+    if (functionCall.getColumnName() == null
+        && functionCall.getFunctionName().equals(COUNT_FUNCTION_NAME)) {
+      builder.append(functionCall.getFunctionName()).append("(1)");
+    } else {
+      builder
+          .append(functionCall.getFunctionName())
+          .append('(')
+          .append(cqlName(functionCall.getColumnName()))
+          .append(')');
+    }
     if (functionCall.getAlias() != null) {
       builder.append(" AS ").append(cqlName(functionCall.getAlias()));
     }
+
     return builder.toString();
   }
 
@@ -1492,6 +1504,10 @@ public class QueryBuilderImpl {
 
     public static FunctionCall function(String name, String alias, String functionName) {
       return new FunctionCall(name, alias, functionName);
+    }
+
+    public static FunctionCall count() {
+      return count(null, null);
     }
 
     public static FunctionCall count(String columnName) {

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/cql/builder/QueryBuilderImpl.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/cql/builder/QueryBuilderImpl.java
@@ -1475,7 +1475,7 @@ public class QueryBuilderImpl {
   private static String formatFunctionCall(FunctionCall functionCall) {
     StringBuilder builder = new StringBuilder();
     if (functionCall.getColumnName() == null
-        && functionCall.getFunctionName().equals(COUNT_FUNCTION_NAME)) {
+        && COUNT_FUNCTION_NAME.equals(functionCall.getFunctionName())) {
       builder.append(functionCall.getFunctionName()).append("(1)");
     } else {
       builder

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/cql/builder/QueryBuilderTest.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/cql/builder/QueryBuilderTest.java
@@ -336,6 +336,9 @@ public class QueryBuilderTest {
           new QueryBuilder().select().count("a").from("ks", "tbl").build().getCql(),
           "SELECT COUNT(a) FROM ks.tbl"),
       arguments(
+          new QueryBuilder().select().count().from("ks", "tbl").build().getCql(),
+          "SELECT COUNT(1) FROM ks.tbl"),
+      arguments(
           new QueryBuilder().select().count("a").from("ks", "tbl").limit(1).build().getCql(),
           "SELECT COUNT(a) FROM ks.tbl LIMIT 1"),
       arguments(


### PR DESCRIPTION


**What this PR does**:
Api QueryBuilder to support count function with no column name arg.

**Which issue(s) this PR fixes**:
Fixes #2571 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
