### PR TITLE
C2-2717: small optimizations for result conversion

### DIFF
--- a/coordinator/persistence-api/src/main/java/io/stargate/db/schema/Column.java
+++ b/coordinator/persistence-api/src/main/java/io/stargate/db/schema/Column.java
@@ -876,10 +876,6 @@ public abstract class Column implements SchemaEntity, Comparable<Column> {
                   .collect(Collectors.toMap(r -> r.javaType, r -> r)))
           .build();
 
-  @Nullable
-  @Value.Parameter(order = 5)
-  public abstract ColumnType type();
-
   public boolean ofTypeText() {
     return ofTypeText(type());
   }
@@ -929,10 +925,6 @@ public abstract class Column implements SchemaEntity, Comparable<Column> {
   }
 
   @Nullable
-  @Value.Parameter(order = 4)
-  public abstract Kind kind();
-
-  @Nullable
   @Value.Parameter(order = 1)
   public abstract String keyspace();
 
@@ -943,6 +935,14 @@ public abstract class Column implements SchemaEntity, Comparable<Column> {
   @Override
   @Value.Parameter(order = 3)
   public abstract String name();
+
+  @Nullable
+  @Value.Parameter(order = 4)
+  public abstract Kind kind();
+
+  @Nullable
+  @Value.Parameter(order = 5)
+  public abstract ColumnType type();
 
   public Column reference() {
     return reference(name());

--- a/coordinator/persistence-api/src/main/java/io/stargate/db/schema/Column.java
+++ b/coordinator/persistence-api/src/main/java/io/stargate/db/schema/Column.java
@@ -877,6 +877,7 @@ public abstract class Column implements SchemaEntity, Comparable<Column> {
           .build();
 
   @Nullable
+  @Value.Parameter(order = 5)
   public abstract ColumnType type();
 
   public boolean ofTypeText() {
@@ -928,35 +929,44 @@ public abstract class Column implements SchemaEntity, Comparable<Column> {
   }
 
   @Nullable
+  @Value.Parameter(order = 4)
   public abstract Kind kind();
 
   @Nullable
+  @Value.Parameter(order = 1)
   public abstract String keyspace();
 
   @Nullable
+  @Value.Parameter(order = 2)
   public abstract String table();
+
+  @Override
+  @Value.Parameter(order = 3)
+  public abstract String name();
 
   public Column reference() {
     return reference(name());
   }
 
   public static Column reference(String name) {
-    return ImmutableColumn.builder().name(name).build();
+    return ImmutableColumn.of(null, null, name, null, null);
   }
 
   public static Column create(String name, Kind kind) {
-    return ImmutableColumn.builder().name(name).kind(kind).build();
+    return ImmutableColumn.of(null, null, name, kind, null);
   }
 
   public static Column create(String name, Column.ColumnType type) {
-    return ImmutableColumn.builder().name(name).type(type).kind(Regular).build();
+    return create(name, Regular, type);
   }
 
   public static Column create(String name, Kind kind, Column.ColumnType type) {
-    return ImmutableColumn.builder().name(name).kind(kind).type(type).build();
+    return ImmutableColumn.of(null, null, name, kind, type);
   }
 
   public static Column create(String name, Kind kind, Column.ColumnType type, Order order) {
+    // keep using builder here, to set order
+    // order has calculated default, so can not be a parameter
     if (kind == Kind.Clustering && order == null) {
       order = Order.ASC;
     }

--- a/coordinator/persistence-api/src/test/java/io/stargate/db/schema/ColumnTest.java
+++ b/coordinator/persistence-api/src/test/java/io/stargate/db/schema/ColumnTest.java
@@ -35,6 +35,18 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 public class ColumnTest {
+
+  @Test
+  public void orderDefaultRespected() {
+    // clustering
+    Column clustering = Column.create("test", Column.Kind.Clustering);
+    assertThat(clustering.order()).isEqualTo(Column.Order.ASC);
+
+    // non clustering column, no order
+    Column nonClustering = Column.create("test", Column.Kind.Regular);
+    assertThat(nonClustering.order()).isNull();
+  }
+
   @Test
   public void testFromString() throws UnknownHostException {
     assertThat(Type.Ascii.fromString("2")).isEqualTo("2");


### PR DESCRIPTION
**What this PR does**:

Small optimizations for the `Conversion` class that is on the hot path:

* avoid creating builders, go directly to impl classes to save builder allocation
* optimize `toResultMetadata` to help c2 compiler & inline 

Tasks: 

* [ ] Maybe base on `v1`