### PR TITLE
C2-2717: do not pre-calculate schema hash for non-keyspace objects

### DIFF
--- a/coordinator/persistence-api/src/main/java/io/stargate/db/schema/Column.java
+++ b/coordinator/persistence-api/src/main/java/io/stargate/db/schema/Column.java
@@ -986,8 +986,6 @@ public abstract class Column implements SchemaEntity, Comparable<Column> {
   }
 
   @Override
-  @Value.Derived
-  @Value.Auxiliary
   public int schemaHashCode() {
     return SchemaHashable.combine(
         SchemaHashable.hashCode(name()),

--- a/coordinator/persistence-api/src/main/java/io/stargate/db/schema/Keyspace.java
+++ b/coordinator/persistence-api/src/main/java/io/stargate/db/schema/Keyspace.java
@@ -157,6 +157,14 @@ public abstract class Keyspace implements SchemaEntity {
     return table;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Note that here we are pre-calculating the schema hash, as it's immutable for the keyspace
+   * and we use it frequently in the {@link
+   * io.stargate.bridge.service.BridgeService#executeQueryWithSchema(io.stargate.bridge.proto.Schema.QueryWithSchema,
+   * io.grpc.stub.StreamObserver)}.
+   */
   @Override
   @Value.Derived
   @Value.Auxiliary

--- a/coordinator/persistence-api/src/main/java/io/stargate/db/schema/MaterializedView.java
+++ b/coordinator/persistence-api/src/main/java/io/stargate/db/schema/MaterializedView.java
@@ -69,8 +69,6 @@ public abstract class MaterializedView extends AbstractTable implements Index {
   }
 
   @Override
-  @Value.Derived
-  @Value.Auxiliary
   public int schemaHashCode() {
     return SchemaHashable.combine(
         SchemaHashable.hashCode(name()),

--- a/coordinator/persistence-api/src/main/java/io/stargate/db/schema/ParameterizedType.java
+++ b/coordinator/persistence-api/src/main/java/io/stargate/db/schema/ParameterizedType.java
@@ -153,8 +153,6 @@ public abstract class ParameterizedType implements Column.ColumnType {
     }
 
     @Override
-    @Value.Derived
-    @Value.Auxiliary
     public int schemaHashCode() {
       return SchemaHashable.combine(
           SchemaHashable.hashCode(isFrozen()), SchemaHashable.hash(parameters()));
@@ -227,8 +225,6 @@ public abstract class ParameterizedType implements Column.ColumnType {
     }
 
     @Override
-    @Value.Derived
-    @Value.Auxiliary
     public int schemaHashCode() {
       return SchemaHashable.combine(
           SchemaHashable.hashCode(isFrozen()), SchemaHashable.hash(parameters()));
@@ -320,8 +316,6 @@ public abstract class ParameterizedType implements Column.ColumnType {
     }
 
     @Override
-    @Value.Derived
-    @Value.Auxiliary
     public int schemaHashCode() {
       return SchemaHashable.combine(
           SchemaHashable.hashCode(isFrozen()), SchemaHashable.hash(parameters()));
@@ -457,8 +451,6 @@ public abstract class ParameterizedType implements Column.ColumnType {
     }
 
     @Override
-    @Value.Derived
-    @Value.Auxiliary
     public int schemaHashCode() {
       return SchemaHashable.hash(parameters());
     }

--- a/coordinator/persistence-api/src/main/java/io/stargate/db/schema/SchemaHashable.java
+++ b/coordinator/persistence-api/src/main/java/io/stargate/db/schema/SchemaHashable.java
@@ -19,6 +19,10 @@ public interface SchemaHashable {
    * or {@link System#identityHashCode(Object)}, etc. to avoid an error that produces a
    * non-deterministic hash code.
    *
+   * <p>Note that currently only {@link Keyspace} calculates the schema hash during the object
+   * initialization. If you call this method from the external component, double-check if
+   * pre-calculation is necessary for any other implementing type.
+   *
    * @return a deterministic hash code for the schema object.
    */
   int schemaHashCode();

--- a/coordinator/persistence-api/src/main/java/io/stargate/db/schema/SecondaryIndex.java
+++ b/coordinator/persistence-api/src/main/java/io/stargate/db/schema/SecondaryIndex.java
@@ -85,8 +85,6 @@ public abstract class SecondaryIndex implements Index, QualifiedSchemaEntity {
   }
 
   @Override
-  @Value.Derived
-  @Value.Auxiliary
   public int schemaHashCode() {
     return SchemaHashable.combine(
         SchemaHashable.hashCode(keyspace()),

--- a/coordinator/persistence-api/src/main/java/io/stargate/db/schema/Table.java
+++ b/coordinator/persistence-api/src/main/java/io/stargate/db/schema/Table.java
@@ -117,8 +117,6 @@ public abstract class Table extends AbstractTable {
   }
 
   @Override
-  @Value.Derived
-  @Value.Auxiliary
   public int schemaHashCode() {
     return SchemaHashable.combine(
         SchemaHashable.hashCode(name()),

--- a/coordinator/persistence-api/src/main/java/io/stargate/db/schema/TableName.java
+++ b/coordinator/persistence-api/src/main/java/io/stargate/db/schema/TableName.java
@@ -49,8 +49,6 @@ public interface TableName extends QualifiedSchemaEntity {
   }
 
   @Override
-  @Value.Derived
-  @Value.Auxiliary
   default int schemaHashCode() {
     return SchemaHashable.combine(
         SchemaHashable.hashCode(keyspace()), SchemaHashable.hashCode(name()));

--- a/coordinator/persistence-api/src/main/java/io/stargate/db/schema/UserDefinedType.java
+++ b/coordinator/persistence-api/src/main/java/io/stargate/db/schema/UserDefinedType.java
@@ -177,8 +177,6 @@ public abstract class UserDefinedType implements Column.ColumnType, SchemaEntity
   }
 
   @Override
-  @Value.Derived
-  @Value.Auxiliary
   public int schemaHashCode() {
     return SchemaHashable.combine(
         SchemaHashable.hashCode(isFrozen()),


### PR DESCRIPTION
**What this PR does**:
Looking at the allocation profile of the `Conversion.toResultMetadata`, I noticed that when `ImmutableColumn` is created, we are per-calculating the schema hash (see pile on the right):

![image](https://github.com/stargate/stargate/assets/10600041/737c6bcf-7d82-4699-ba52-c7b5aa27e3c3)

This was odd to me, because we don't need the schema hash here, as hash is only used in one single place:

https://github.com/stargate/stargate/blob/e25166320bcce062324118652e0fba6f454b63cb/coordinator/bridge/src/main/java/io/stargate/bridge/service/BridgeService.java#L114

So `io.stargate.db.schema.SchemaHashable#schemaHashCode` is only invoked on the `Keyspace` schema object and then delegated to the all schema objects.

So I guess there was no need to have value derived in other types.

I could have used `@Value.Lazy`, but I actually wanted to avoid as:
* it adds synchronization when calculating the first time
* we will anyway call all `schemaHashCode` methods once per keyspace, so I guess it's really fine to not cache anything
