### PR TITLE
C2-2727: improve loadAuthenticationSubject performance

### DIFF
--- a/coordinator/authnz/src/main/java/io/stargate/auth/AuthenticationSubject.java
+++ b/coordinator/authnz/src/main/java/io/stargate/auth/AuthenticationSubject.java
@@ -15,8 +15,9 @@
  */
 package io.stargate.auth;
 
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import io.stargate.db.AuthenticatedUser;
-import java.util.Collections;
+import io.stargate.db.ImmutableAuthenticatedUser;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
@@ -25,52 +26,39 @@ import org.immutables.value.Value;
 public interface AuthenticationSubject {
 
   @Nullable
+  @Value.Parameter
   String token();
 
+  @Value.Parameter
   String roleName();
 
+  @Value.Parameter
   boolean isFromExternalAuth();
 
-  Map<String, String> customProperties();
+  @Value.Parameter
+  ImmutableMap<String, String> customProperties();
 
   default AuthenticatedUser asUser() {
-    return AuthenticatedUser.of(roleName(), token(), isFromExternalAuth(), customProperties());
+    return ImmutableAuthenticatedUser.of(
+        roleName(), token(), isFromExternalAuth(), customProperties());
   }
 
   static AuthenticationSubject of(
       String token, String roleName, boolean fromExternalAuth, Map<String, String> properties) {
-    return ImmutableAuthenticationSubject.builder()
-        .token(token)
-        .roleName(roleName)
-        .isFromExternalAuth(fromExternalAuth)
-        .customProperties(properties)
-        .build();
+    return ImmutableAuthenticationSubject.of(
+        token, roleName, fromExternalAuth, ImmutableMap.copyOf(properties));
   }
 
   static AuthenticationSubject of(String token, String roleName, boolean fromExternalAuth) {
-    return ImmutableAuthenticationSubject.builder()
-        .token(token)
-        .roleName(roleName)
-        .isFromExternalAuth(fromExternalAuth)
-        .customProperties(Collections.emptyMap())
-        .build();
+    return ImmutableAuthenticationSubject.of(token, roleName, fromExternalAuth, ImmutableMap.of());
   }
 
   static AuthenticationSubject of(String token, String roleName) {
-    return ImmutableAuthenticationSubject.builder()
-        .token(token)
-        .roleName(roleName)
-        .isFromExternalAuth(false)
-        .customProperties(Collections.emptyMap())
-        .build();
+    return ImmutableAuthenticationSubject.of(token, roleName, false, ImmutableMap.of());
   }
 
   static AuthenticationSubject of(AuthenticatedUser user) {
-    return ImmutableAuthenticationSubject.builder()
-        .token(user.token())
-        .roleName(user.name())
-        .isFromExternalAuth(user.isFromExternalAuth())
-        .customProperties(user.customProperties())
-        .build();
+    return ImmutableAuthenticationSubject.of(
+        user.token(), user.name(), user.isFromExternalAuth(), user.customProperties());
   }
 }

--- a/coordinator/authnz/src/main/java/io/stargate/auth/AuthenticationSubject.java
+++ b/coordinator/authnz/src/main/java/io/stargate/auth/AuthenticationSubject.java
@@ -15,14 +15,15 @@
  */
 package io.stargate.auth;
 
-import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import io.stargate.db.AuthenticatedUser;
 import io.stargate.db.ImmutableAuthenticatedUser;
+import java.util.Collections;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
 @Value.Immutable
+@Value.Style(builtinContainerAttributes = false)
 public interface AuthenticationSubject {
 
   @Nullable
@@ -36,7 +37,7 @@ public interface AuthenticationSubject {
   boolean isFromExternalAuth();
 
   @Value.Parameter
-  ImmutableMap<String, String> customProperties();
+  Map<String, String> customProperties();
 
   default AuthenticatedUser asUser() {
     return ImmutableAuthenticatedUser.of(
@@ -46,15 +47,16 @@ public interface AuthenticationSubject {
   static AuthenticationSubject of(
       String token, String roleName, boolean fromExternalAuth, Map<String, String> properties) {
     return ImmutableAuthenticationSubject.of(
-        token, roleName, fromExternalAuth, ImmutableMap.copyOf(properties));
+        token, roleName, fromExternalAuth, Collections.unmodifiableMap(properties));
   }
 
   static AuthenticationSubject of(String token, String roleName, boolean fromExternalAuth) {
-    return ImmutableAuthenticationSubject.of(token, roleName, fromExternalAuth, ImmutableMap.of());
+    return ImmutableAuthenticationSubject.of(
+        token, roleName, fromExternalAuth, Collections.emptyMap());
   }
 
   static AuthenticationSubject of(String token, String roleName) {
-    return ImmutableAuthenticationSubject.of(token, roleName, false, ImmutableMap.of());
+    return ImmutableAuthenticationSubject.of(token, roleName, false, Collections.emptyMap());
   }
 
   static AuthenticationSubject of(AuthenticatedUser user) {

--- a/coordinator/microbench/pom.xml
+++ b/coordinator/microbench/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <!-- Parent -->
+  <parent>
+    <groupId>io.stargate</groupId>
+    <artifactId>stargate</artifactId>
+    <version>2.0.14-SNAPSHOT</version>
+  </parent>
+  <!-- Artifact props -->
+  <artifactId>microbench</artifactId>
+  <name>Stargate - Coordinator - Micro-benchmarking</name>
+  <properties>
+    <jmh.version>1.36</jmh.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>io.stargate.db</groupId>
+      <artifactId>persistence-api</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.stargate.auth</groupId>
+      <artifactId>authnz</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${jmh.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.12.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>pw.krejci</groupId>
+        <artifactId>jmh-maven-plugin</artifactId>
+        <version>0.2.2</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/coordinator/microbench/src/test/java/io/stargate/jmh/auth/AuthenticationSerializationBench.java
+++ b/coordinator/microbench/src/test/java/io/stargate/jmh/auth/AuthenticationSerializationBench.java
@@ -1,0 +1,72 @@
+package io.stargate.jmh.auth;
+
+import io.stargate.auth.AuthenticationSubject;
+import io.stargate.db.AuthenticatedUser;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Benchmarks for {@link AuthenticationSubject} serialization.
+ *
+ * <p>Run with: <code>../mvnw jmh:benchmark -Djmh.prof=gc</code>, gave these results: <code>
+ * Benchmark                                                                       (propertyCount)   Mode  Cnt     Score    Error   Units
+ * AuthenticationSerializationBench.loadAuthenticationSubject                                    2  thrpt    5     1.642 ±  0.044  ops/us
+ * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.alloc.rate                     2  thrpt    5  2630.386 ± 70.494  MB/sec
+ * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.alloc.rate.norm                2  thrpt    5  1680.000 ±  0.001    B/op
+ * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.count                          2  thrpt    5   333.000           counts
+ * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.time                           2  thrpt    5   223.000               ms
+ * AuthenticationSerializationBench.loadAuthenticationSubject                                    4  thrpt    5     1.103 ±  0.045  ops/us
+ * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.alloc.rate                     4  thrpt    5  2440.713 ± 99.410  MB/sec
+ * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.alloc.rate.norm                4  thrpt    5  2320.000 ±  0.001    B/op
+ * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.count                          4  thrpt    5   338.000           counts
+ * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.time                           4  thrpt    5   228.000               ms
+ * </code>
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 5)
+@Measurement(iterations = 5, time = 5)
+@Fork(1)
+public class AuthenticationSerializationBench {
+
+  private Map<String, ByteBuffer> payload;
+
+  @Param({"2", "4"})
+  int propertyCount;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    Map<String, String> properties = new HashMap<>();
+    for (int i = 0; i < propertyCount; i++) {
+      properties.put(
+          RandomStringUtils.randomAlphanumeric(10), RandomStringUtils.randomAlphanumeric(10));
+    }
+
+    AuthenticatedUser user = AuthenticatedUser.of("role", "token", true, properties);
+    payload = AuthenticatedUser.Serializer.serialize(user);
+  }
+
+  @Benchmark
+  public void loadAuthenticationSubject(Blackhole bh) {
+    AuthenticatedUser user = AuthenticatedUser.Serializer.load(payload);
+    AuthenticationSubject subject = AuthenticationSubject.of(user);
+    bh.consume(subject);
+  }
+}

--- a/coordinator/microbench/src/test/java/io/stargate/jmh/auth/AuthenticationSerializationBench.java
+++ b/coordinator/microbench/src/test/java/io/stargate/jmh/auth/AuthenticationSerializationBench.java
@@ -24,18 +24,22 @@ import org.openjdk.jmh.infra.Blackhole;
 /**
  * Benchmarks for {@link AuthenticationSubject} serialization.
  *
- * <p>Run with: <code>../mvnw jmh:benchmark -Djmh.prof=gc</code>, gave these results: <code>
- * Benchmark                                                                       (propertyCount)   Mode  Cnt     Score    Error   Units
- * AuthenticationSerializationBench.loadAuthenticationSubject                                    2  thrpt    5     1.642 ±  0.044  ops/us
- * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.alloc.rate                     2  thrpt    5  2630.386 ± 70.494  MB/sec
- * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.alloc.rate.norm                2  thrpt    5  1680.000 ±  0.001    B/op
- * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.count                          2  thrpt    5   333.000           counts
- * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.time                           2  thrpt    5   223.000               ms
- * AuthenticationSerializationBench.loadAuthenticationSubject                                    4  thrpt    5     1.103 ±  0.045  ops/us
- * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.alloc.rate                     4  thrpt    5  2440.713 ± 99.410  MB/sec
- * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.alloc.rate.norm                4  thrpt    5  2320.000 ±  0.001    B/op
- * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.count                          4  thrpt    5   338.000           counts
- * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.time                           4  thrpt    5   228.000               ms
+ * <p>Run with: <code>
+ * ../mvnw jmh:benchmark -Djmh.benchmarks=AuthenticationSerializationBench -Djmh.prof=gc</code>,
+ * gave these results:
+ *
+ * <p><code>
+ * Benchmark                                                                       (propertyCount)   Mode  Cnt     Score     Error   Units
+ * AuthenticationSerializationBench.loadAuthenticationSubject                                    2  thrpt    5     3.384 ±   0.230  ops/us
+ * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.alloc.rate                     2  thrpt    5  1807.395 ± 123.001  MB/sec
+ * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.alloc.rate.norm                2  thrpt    5   560.000 ±   0.001    B/op
+ * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.count                          2  thrpt    5   338.000            counts
+ * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.time                           2  thrpt    5   228.000                ms
+ * AuthenticationSerializationBench.loadAuthenticationSubject                                    4  thrpt    5     2.137 ±   0.029  ops/us
+ * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.alloc.rate                     4  thrpt    5  1728.442 ±  23.497  MB/sec
+ * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.alloc.rate.norm                4  thrpt    5   848.000 ±   0.001    B/op
+ * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.count                          4  thrpt    5   333.000            counts
+ * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.time                           4  thrpt    5   227.000                ms
  * </code>
  */
 @BenchmarkMode(Mode.Throughput)

--- a/coordinator/persistence-api/src/main/java/io/stargate/db/AuthenticatedUser.java
+++ b/coordinator/persistence-api/src/main/java/io/stargate/db/AuthenticatedUser.java
@@ -19,7 +19,6 @@ import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import javax.annotation.Nullable;
@@ -28,30 +27,25 @@ import org.immutables.value.Value;
 @Value.Immutable
 public interface AuthenticatedUser extends Serializable {
 
+  @Value.Parameter
   String name();
 
   @Nullable
+  @Value.Parameter
   String token();
 
+  @Value.Parameter
   boolean isFromExternalAuth();
 
-  Map<String, String> customProperties();
+  @Value.Parameter
+  ImmutableMap<String, String> customProperties();
 
   static AuthenticatedUser of(String userName) {
-    return ImmutableAuthenticatedUser.builder()
-        .name(userName)
-        .isFromExternalAuth(false)
-        .customProperties(Collections.emptyMap())
-        .build();
+    return ImmutableAuthenticatedUser.of(userName, null, false, ImmutableMap.of());
   }
 
   static AuthenticatedUser of(String userName, String token) {
-    return ImmutableAuthenticatedUser.builder()
-        .name(userName)
-        .token(token)
-        .isFromExternalAuth(false)
-        .customProperties(Collections.emptyMap())
-        .build();
+    return ImmutableAuthenticatedUser.of(userName, token, false, ImmutableMap.of());
   }
 
   static AuthenticatedUser of(
@@ -59,12 +53,8 @@ public interface AuthenticatedUser extends Serializable {
       String token,
       boolean useTransitionalAuth,
       Map<String, String> customProperties) {
-    return ImmutableAuthenticatedUser.builder()
-        .name(userName)
-        .token(token)
-        .isFromExternalAuth(useTransitionalAuth)
-        .customProperties(customProperties)
-        .build();
+    return ImmutableAuthenticatedUser.of(
+        userName, token, useTransitionalAuth, ImmutableMap.copyOf(customProperties));
   }
 
   class Serializer {
@@ -122,7 +112,7 @@ public interface AuthenticatedUser extends Serializable {
         }
       }
 
-      return AuthenticatedUser.of(
+      return ImmutableAuthenticatedUser.of(
           StandardCharsets.UTF_8.decode(roleName).toString(),
           StandardCharsets.UTF_8.decode(token).toString(),
           (isFromExternalAuth != null),

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -215,6 +215,7 @@
         <module>grpc-proto</module>
         <module>bridge-proto</module>
         <module>grpc</module>
+        <module>microbench</module>
         <module>metrics-jersey</module>
         <module>grpc-examples</module>
         <!-- testing last -->
@@ -250,6 +251,7 @@
         <module>grpc-proto</module>
         <module>bridge-proto</module>
         <module>grpc</module>
+        <module>microbench</module>
         <module>metrics-jersey</module>
         <module>grpc-examples</module>
         <!-- testing last -->


### PR DESCRIPTION
**What this PR does**:
Improves perf of the authentication user serialization, as it appears on the hot path with 10% alloc samples:

* remove the  `builtinContainerAttributes` for immutable classes
* avoid using builders
* better map construction

Micro-benchmarking shows 2x throughput and 3x less allocation per op:

*Before*
```
 * Benchmark                                                                       (propertyCount)   Mode  Cnt     Score    Error   Units
 * AuthenticationSerializationBench.loadAuthenticationSubject                                    2  thrpt    5     1.642 ±  0.044  ops/us
 * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.alloc.rate                     2  thrpt    5  2630.386 ± 70.494  MB/sec
 * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.alloc.rate.norm                2  thrpt    5  1680.000 ±  0.001    B/op
 * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.count                          2  thrpt    5   333.000           counts
 * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.time                           2  thrpt    5   223.000               ms
 * AuthenticationSerializationBench.loadAuthenticationSubject                                    4  thrpt    5     1.103 ±  0.045  ops/us
 * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.alloc.rate                     4  thrpt    5  2440.713 ± 99.410  MB/sec
 * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.alloc.rate.norm                4  thrpt    5  2320.000 ±  0.001    B/op
 * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.count                          4  thrpt    5   338.000           counts
 * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.time                           4  thrpt    5   228.000               ms
```

*After*
```
 * Benchmark                                                                       (propertyCount)   Mode  Cnt     Score     Error   Units
 * AuthenticationSerializationBench.loadAuthenticationSubject                                    2  thrpt    5     3.384 ±   0.230  ops/us
 * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.alloc.rate                     2  thrpt    5  1807.395 ± 123.001  MB/sec
 * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.alloc.rate.norm                2  thrpt    5   560.000 ±   0.001    B/op
 * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.count                          2  thrpt    5   338.000            counts
 * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.time                           2  thrpt    5   228.000                ms
 * AuthenticationSerializationBench.loadAuthenticationSubject                                    4  thrpt    5     2.137 ±   0.029  ops/us
 * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.alloc.rate                     4  thrpt    5  1728.442 ±  23.497  MB/sec
 * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.alloc.rate.norm                4  thrpt    5   848.000 ±   0.001    B/op
 * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.count                          4  thrpt    5   333.000            counts
 * AuthenticationSerializationBench.loadAuthenticationSubject:·gc.time                           4  thrpt    5   227.000                ms
```

**Which issue(s) this PR fixes**:
Internal issue.

**Tasks**:
* [ ] add readme for the `microbench` module
