### PR TITLE
Remove SERVER_VERSION and PRODUCT_TYPE assertions

### DIFF
--- a/coordinator/testing/src/main/java/io/stargate/it/cql/SupportedOptionsTest.java
+++ b/coordinator/testing/src/main/java/io/stargate/it/cql/SupportedOptionsTest.java
@@ -26,8 +26,6 @@ public class SupportedOptionsTest extends BaseIntegrationTest {
     assertThat(options).containsKey("COMPRESSION");
     if (backend.isDse()) {
       assertThat(options).containsKey("PAGE_UNIT");
-      assertThat(options).containsKey("SERVER_VERSION");
-      assertThat(options).containsKey("PRODUCT_TYPE");
       assertThat(options).containsKey("EMULATE_DBAAS_DEFAULTS");
     }
   }


### PR DESCRIPTION
**What this PR does**:
In the `SupportedOptionsTest`, we check the SERVER_VERSION and PRODUCT_TYPE if the backend is of type DSE. In some of the variants of DSE, these are not available, hence removing them from the assertions.

**Which issue(s) this PR fixes**:
Fixes #2599 

**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [X] Documentation added/updated
- [X] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
