### PR TITLE
Update C*4 dep to 4.0.10, C*3.11 to 3.11.15

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -70,7 +70,7 @@
       Please maintain default values for int-test in sync with io.stargate.sgv2.docsapi.testresource.StargateTestResource.Defaults
      -->
     <stargate.int-test.cassandra.image>cassandra</stargate.int-test.cassandra.image>
-    <stargate.int-test.cassandra.image-tag>4.0.9</stargate.int-test.cassandra.image-tag>
+    <stargate.int-test.cassandra.image-tag>4.0.10</stargate.int-test.cassandra.image-tag>
     <stargate.int-test.coordinator.image>stargateio/coordinator-4_0</stargate.int-test.coordinator.image>
     <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
     <stargate.int-test.cluster.name>cass-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
@@ -74,7 +74,7 @@ public class StargateTestResource
   interface Defaults {
 
     String CASSANDRA_IMAGE = "cassandra";
-    String CASSANDRA_IMAGE_TAG = "4.0.9";
+    String CASSANDRA_IMAGE_TAG = "4.0.10";
 
     String STARGATE_IMAGE = "stargateio/coordinator-4_0";
     String STARGATE_IMAGE_TAG = "latest";

--- a/coordinator/cql/pom.xml
+++ b/coordinator/cql/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-all</artifactId>
-      <version>4.0.9</version>
+      <version>4.0.10</version>
       <exclusions>
         <exclusion>
           <groupId>org.gridkit.jvmtool</groupId>

--- a/coordinator/persistence-api/pom.xml
+++ b/coordinator/persistence-api/pom.xml
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-all</artifactId>
-      <version>4.0.9</version>
+      <version>4.0.10</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/coordinator/persistence-cassandra-3.11/README.md
+++ b/coordinator/persistence-cassandra-3.11/README.md
@@ -6,7 +6,7 @@ This module represents the implementation of the [persistence-api](../persistenc
 
 ## Cassandra version update
 
-The current Cassandra version this module depends on is `3.11.14`.
+The current Cassandra version this module depends on is `3.11.15`.
 In order to update to a newer patch version, please follow the guidelines below:
 
 * Update the `cassandra.version` property in the [pom.xml](pom.xml).
@@ -28,6 +28,7 @@ Note that this will have no effect until the docker image is rebuilt and pushed 
 
 It's always good to validate your work against the pull requests that bumped the version in the past:
 
+* `3.11.14 -> 3.11.15` [stargate/stargate#2602](https://github.com/stargate/stargate/pull/2602)
 * `3.11.11 -> 3.11.12` [stargate/stargate#1646](https://github.com/stargate/stargate/pull/1646)
 * `3.11.9 -> 3.11.11` [stargate/stargate#1507](https://github.com/stargate/stargate/pull/1507)
 * `3.11.8 -> 3.11.9` [stargate/stargate#1337](https://github.com/stargate/stargate/pull/1337) & [stargate/stargate#1346](https://github.com/stargate/stargate/pull/1346)

--- a/coordinator/persistence-cassandra-3.11/pom.xml
+++ b/coordinator/persistence-cassandra-3.11/pom.xml
@@ -13,8 +13,8 @@
   <name>Stargate - Coordinator - Persistence C* 3.11</name>
   <properties>
     <!-- If you update this, make sure to keep `cassandra.bundled-driver.version` in sync -->
-    <!-- 3.11.14 depends on 3.0.1: https://mvnrepository.com/artifact/org.apache.cassandra/cassandra-all/3.11.14 -->
-    <cassandra.version>3.11.14</cassandra.version>
+    <!-- 3.11.15 depends on 3.0.1: https://mvnrepository.com/artifact/org.apache.cassandra/cassandra-all/3.11.15 -->
+    <cassandra.version>3.11.15</cassandra.version>
     <!--
       The driver used internally by cassandra-all for UDFs (must match the version declared in
       cassandra-all's POM).

--- a/coordinator/persistence-cassandra-3.11/src/test/java/org/apache/cassandra/metrics/Cassandra311MetricsRegistryTest.java
+++ b/coordinator/persistence-cassandra-3.11/src/test/java/org/apache/cassandra/metrics/Cassandra311MetricsRegistryTest.java
@@ -50,7 +50,7 @@ public class Cassandra311MetricsRegistryTest {
 
   @Test
   public void versionCheck() {
-    String supportedVersion = "3.11.14";
+    String supportedVersion = "3.11.15";
     String currentVersion = FBUtilities.getReleaseVersionString();
 
     assertThat(currentVersion)

--- a/coordinator/persistence-cassandra-4.0/README.md
+++ b/coordinator/persistence-cassandra-4.0/README.md
@@ -4,7 +4,7 @@ This module represents the implementation of the [persistence-api](../persistenc
 
 ## Cassandra version update
 
-The current Cassandra version this module depends on is `4.0.7`.
+The current Cassandra version this module depends on is `4.0.10`.
 In order to update to a newer patch version, please follow the guidelines below:
 
 * Update the `cassandra.version` property in the [pom.xml](pom.xml).
@@ -12,7 +12,7 @@ In order to update to a newer patch version, please follow the guidelines below:
 * Check the transitive dependencies of the `org.apache.cassandra:cassandra-all` for the new version.
 Make sure that the version of the `com.datastax.cassandra:cassandra-driver-core` that `cassandra-all` depends on, is same as in the `cassandra.bundled-driver.version` property in the [pom.xml](pom.xml).
 This dependency is set as optional in the `cassandra-all`, but we need it to correctly handle UDFs.
-Note that transitive dependencies can be seen on [mvnrepository.com](https://mvnrepository.com/artifact/org.apache.cassandra/cassandra-all/4.0.7).
+Note that transitive dependencies can be seen on [mvnrepository.com](https://mvnrepository.com/artifact/org.apache.cassandra/cassandra-all/4.0.10).
 * Update the [CI Dockerfile](../ci/Dockerfile) and set the new version in the `ccm create` command related to 4.0.
 Note that this will have no effect until the docker image is rebuilt and pushed to the remote repository, thus creating an issue for that would be a good idea.
 * Create a separate PR for bumping the Cassandra 4 version in the Quarkus-based API integration tests on the `v2.0.0` branch. Test profiles are defined in the `apis/pom.xml`.
@@ -22,4 +22,5 @@ Note that this will have no effect until the docker image is rebuilt and pushed 
 
 It's always good to validate your work against the pull requests that bumped the version in the past:
 
+* `4.0.9` -> `4.0.10` [stargate/stargate#2602](https://github.com/stargate/stargate/pull/2602)
 * `4.0.1` -> `4.0.3` [stargate/stargate#1647](https://github.com/stargate/stargate/pull/1647)

--- a/coordinator/persistence-cassandra-4.0/pom.xml
+++ b/coordinator/persistence-cassandra-4.0/pom.xml
@@ -13,8 +13,8 @@
   <name>Stargate - Coordinator - Persistence C* 4.0</name>
   <properties>
     <!-- If you update this, make sure to keep `cassandra.bundled-driver.version` in sync -->
-    <!-- 4.0.9 depends on 3.11.0: https://mvnrepository.com/artifact/org.apache.cassandra/cassandra-all/4.0.9 -->
-    <cassandra.version>4.0.9</cassandra.version>
+    <!-- 4.0.10 depends on 3.11.0: https://mvnrepository.com/artifact/org.apache.cassandra/cassandra-all/4.0.10 -->
+    <cassandra.version>4.0.10</cassandra.version>
     <!--
       The driver used internally by cassandra-all for UDFs (must match the version declared in
       cassandra-all's POM).

--- a/coordinator/persistence-test/src/main/java/io/stargate/it/storage/ExternalStorage.java
+++ b/coordinator/persistence-test/src/main/java/io/stargate/it/storage/ExternalStorage.java
@@ -68,7 +68,7 @@ public class ExternalStorage extends ExternalResource<ClusterSpec, ExternalStora
       System.getProperty("stargate.test.backend.cluster.impl.class", CcmCluster.class.getName());
 
   static {
-    String version = System.getProperty(CCM_VERSION, "3.11.14");
+    String version = System.getProperty(CCM_VERSION, "3.11.15");
     System.setProperty(CCM_VERSION, version);
   }
 

--- a/coordinator/testing/pom.xml
+++ b/coordinator/testing/pom.xml
@@ -362,7 +362,7 @@
                 </goals>
                 <configuration>
                   <systemPropertyVariables>
-                    <ccm.version>3.11.14</ccm.version>
+                    <ccm.version>3.11.15</ccm.version>
                     <stargate.test.nodes>1</stargate.test.nodes>
                   </systemPropertyVariables>
                   <failIfNoTests>true</failIfNoTests>
@@ -393,7 +393,7 @@
                 </goals>
                 <configuration>
                   <systemPropertyVariables>
-                    <ccm.version>4.0.9</ccm.version>
+                    <ccm.version>4.0.10</ccm.version>
                     <stargate.test.nodes>1</stargate.test.nodes>
                   </systemPropertyVariables>
                   <failIfNoTests>true</failIfNoTests>


### PR DESCRIPTION
**What this PR does**:

Updates Cassandra-3.11 and 4.0 dependencies; to 3.11.15 (from .14) and 4.0.10 (from .9) respectively

**Which issue(s) this PR fixes**:
Fixes #2601

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
