### PR TITLE
update to quarkus 3.1.0

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -60,7 +60,7 @@
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.0.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>3.1.0.Final</quarkus.platform.version>
     <!-- Testing -->
     <skipTests>false</skipTests>
     <skipUnitTests>${skipTests}</skipUnitTests>


### PR DESCRIPTION
**What this PR does**:
Updates to Quarkus `3.1.0`. I checked for updates in docker images and all other places as well, only version bump is needed.