### PR TITLE
make sure DSE persistence jar is available for Dockerfile

### DIFF
--- a/coordinator/build_docker_images.sh
+++ b/coordinator/build_docker_images.sh
@@ -55,6 +55,12 @@ echo "Building version $SGTAG"
 # Persistence images
 #
 
+# Verify existence of persistence jars
+if [ ! -f ./stargate-lib/persistence-dse*.jar ]; then
+  echo "No matching DSE Persistence jar found: ./stargate-lib/persistence-dse*.jar"
+  exit 1
+fi
+
 # Create a temp directory under current directory to use as a staging area for image creation
 # This is a workaround since Docker COPY command provides no way to exclude files.
 # We could build a base image and then remove files, but this is wasteful


### PR DESCRIPTION
Fixes #2605.

It's possible to generate a malformed local coordinator docker image using the `build_docker_images.sh` script if you forget to include the DSE package when doing a maven build (i.e. `mvn install -P dse`). If you omit the `-P dse` the `persistence-dse` JAR is not built, and then when you build the docker image the file is missing.

This PR adds a check to the `build_docker_images.sh` script to make sure the `persistence-dse` JAR is present.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
