### PR TITLE
Docker compose improvements for DSE on Mac M1 machines

### DIFF
--- a/docker-compose/cassandra-3.11/README.md
+++ b/docker-compose/cassandra-3.11/README.md
@@ -8,6 +8,14 @@ This directory provides two configurations to start Stargate with Cassandra 3.11
 
 Make sure that you have Docker engine 20.x installed, which should include Docker compose 2.x. Our compose files rely on features only available in the Docker compose v2 file format.
 
+### Docker Resource Settings
+
+We recommend the following minimum settings for Docker resources:
+* 4 CPUs
+* 8 GB RAM
+* 1 GB swap
+* 8 GB disk space
+* 
 ### Building local Docker images
 If you want to use locally built versions of the Docker images rather than pulling released versions from Docker Hub, build the snapshot version locally using instructions for the [coordinator](../../coordinator/README.md) and [apis](../../apis/README.md).
 

--- a/docker-compose/cassandra-4.0/README.md
+++ b/docker-compose/cassandra-4.0/README.md
@@ -8,6 +8,14 @@ This directory provides two ways to start Stargate with Cassandra 4.0 using `doc
 
 Make sure that you have Docker engine 20.x installed, which should include Docker compose 2.x. Our compose files rely on features only available in the Docker compose v2 file format.
 
+### Docker Resource Settings
+
+We recommend the following minimum settings for Docker resources:
+* 4 CPUs
+* 8 GB RAM
+* 1 GB swap
+* 8 GB disk space
+
 ### Building local Docker images
 If you want to use locally built versions of the Docker images rather than pulling released versions from Docker Hub, build the snapshot version locally using instructions for the [coordinator](../../coordinator/README.md) and [apis](../../apis/README.md).
 

--- a/docker-compose/dse-6.8/README.md
+++ b/docker-compose/dse-6.8/README.md
@@ -37,6 +37,9 @@ The default environment settings in the `.env` file include variables that descr
 
 Once done using the containers, you can stop them using the command `docker compose down`.
 
+> **Running on M1 Macs**
+> Currently DSE Docker images do not support the ARM64 architecture used by M1 Macs. For this reason, the `docker-compose.yml` file hardcodes DSE containers to run using the `linux/amd64` architecture. You will need to make sure that Rosetta 2 emulation is enabled in the Docker Desktop settings for this to work on your M1 Mac. 
+
 ## Stargate with embedded DSE 6.8 (developer mode)
 
 This alternate configuration runs the Stargate coordinator node in developer mode, so that no separate Cassandra cluster is required. This configuration is useful for development and testing since it initializes more quickly, but is not recommended for production deployments. This can be run with the command:

--- a/docker-compose/dse-6.8/README.md
+++ b/docker-compose/dse-6.8/README.md
@@ -8,6 +8,14 @@ This directory provides two ways to start Stargate with DSE 6.8 using `docker co
 
 Make sure that you have Docker engine 20.x installed, which should include Docker compose 2.x. Our compose files rely on features only available in the Docker compose v2 file format.
 
+### Docker Resource Settings
+
+We recommend the following minimum settings for Docker resources:
+* 4 CPUs
+* 8 GB RAM
+* 1 GB swap
+* 8 GB disk space
+
 ### Building local Docker images
 If you want to use locally built versions of the Docker images rather than pulling released versions from Docker Hub, build the snapshot version locally using instructions for the [coordinator](../../coordinator/README.md) and [apis](../../apis/README.md).
 

--- a/docker-compose/dse-6.8/docker-compose.yml
+++ b/docker-compose/dse-6.8/docker-compose.yml
@@ -3,9 +3,10 @@ version: '2'
 services:
   dse-1:
     image: datastax/dse-server:${DSETAG}
+    platform: linux/amd64
     networks:
       - stargate
-    mem_limit: 2G
+    mem_limit: 2560M
     cap_add:
       - IPC_LOCK
     ulimits:
@@ -24,9 +25,10 @@ services:
 
   dse-2:
     image: datastax/dse-server:${DSETAG}
+    platform: linux/amd64
     networks:
       - stargate
-    mem_limit: 2G
+    mem_limit: 2560M
     cap_add:
       - IPC_LOCK
     ulimits:
@@ -40,30 +42,6 @@ services:
       - CLUSTER_NAME=dse-${DSETAG}-cluster
       - DC=dc1
       - RACK=rack1
-      - DS_LICENSE=accept
-    healthcheck:
-      test: [ "CMD", "cqlsh", "-u cassandra", "-p cassandra" ,"-e describe keyspaces" ]
-      interval: 15s
-      timeout: 10s
-      retries: 10
-
-  dse-3:
-    image: datastax/dse-server:${DSETAG}
-    networks:
-      - stargate
-    mem_limit: 2G
-    cap_add:
-      - IPC_LOCK
-    ulimits:
-      memlock: -1
-    depends_on:
-      dse-2:
-        condition: service_healthy
-    environment:
-      - MAX_HEAP_SIZE=1536M
-      - SEEDS=dse-1
-      - CLUSTER_NAME=dse-${DSETAG}-cluster
-      - DC=dc1
       - DS_LICENSE=accept
     healthcheck:
       test: [ "CMD", "cqlsh", "-u cassandra", "-p cassandra" ,"-e describe keyspaces" ]


### PR DESCRIPTION
updates to docker compose scripts for DSE: 
- increase memory allocation for DSE nodes to 2.5 GB
- reduce from 3 nodes to 2
- add platform option to force usage of amd64 architecture for DSE nodes, since DSE does not currently publish images with arm64 architecture. This enables running on Macs with M1.

Also adds recommended minimum Docker resource settings to READMEs for all supported backends.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
