### PR TITLE
Remove use of errorprone static analyzer plugin (see #2616 for rationale)

### DIFF
--- a/coordinator/graphqlapi/pom.xml
+++ b/coordinator/graphqlapi/pom.xml
@@ -116,10 +116,6 @@
       <version>0.9.1</version>
     </dependency>
     <dependency>
-      <groupId>com.google.errorprone</groupId>
-      <artifactId>error_prone_annotations</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.apollographql.federation</groupId>
       <artifactId>federation-graphql-java-support</artifactId>
       <version>2.0.3</version>

--- a/coordinator/persistence-api/pom.xml
+++ b/coordinator/persistence-api/pom.xml
@@ -85,10 +85,6 @@
       <groupId>org.javatuples</groupId>
       <artifactId>javatuples</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.google.errorprone</groupId>
-      <artifactId>error_prone_annotations</artifactId>
-    </dependency>
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/coordinator/persistence-api/src/main/java/io/stargate/db/query/TypedValue.java
+++ b/coordinator/persistence-api/src/main/java/io/stargate/db/query/TypedValue.java
@@ -3,8 +3,6 @@ package io.stargate.db.query;
 import static java.lang.String.format;
 
 import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
-import com.google.errorprone.annotations.FormatMethod;
-import com.google.errorprone.annotations.FormatString;
 import io.stargate.db.Persistence;
 import io.stargate.db.schema.Column;
 import io.stargate.db.schema.Column.ColumnType;
@@ -178,8 +176,7 @@ public class TypedValue {
     }
   }
 
-  @FormatMethod
-  private static IllegalArgumentException invalid(@FormatString String format, Object... args) {
+  private static IllegalArgumentException invalid(String format, Object... args) {
     return new IllegalArgumentException(format(format, args));
   }
 

--- a/coordinator/persistence-api/src/main/java/io/stargate/db/query/builder/QueryBuilderImpl.java
+++ b/coordinator/persistence-api/src/main/java/io/stargate/db/query/builder/QueryBuilderImpl.java
@@ -27,8 +27,6 @@ import com.github.misberner.apcommons.util.AFModifier;
 import com.github.misberner.duzzt.annotations.DSLAction;
 import com.github.misberner.duzzt.annotations.GenerateEmbeddedDSL;
 import com.github.misberner.duzzt.annotations.SubExpr;
-import com.google.errorprone.annotations.FormatMethod;
-import com.google.errorprone.annotations.FormatString;
 import io.stargate.db.query.AsyncQueryExecutor;
 import io.stargate.db.query.BindMarker;
 import io.stargate.db.query.Modification.Operation;
@@ -890,8 +888,7 @@ public class QueryBuilderImpl {
     throw new AssertionError("Unknown query type");
   }
 
-  @FormatMethod
-  private static IllegalArgumentException invalid(@FormatString String format, Object... args) {
+  private static IllegalArgumentException invalid(String format, Object... args) {
     return new IllegalArgumentException(format(format, args));
   }
 

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -91,11 +91,6 @@
       -->
     <netty.version>4.1.75.Final</netty.version>
     <netty-boringssl.version>2.0.51.Final</netty-boringssl.version>
-    <!-- And finally test/build deps -->
-    <!-- 16-Dec-2021, tatu:  This is an old version (2.10.0 now latest)
-        but build fails with newer versions so keeping at this level
-      -->
-    <errorprone.version>2.3.4</errorprone.version>
     <jacoco.version>0.8.8</jacoco.version>
     <junit.version>5.8.2</junit.version>
     <mockito.version>3.12.4</mockito.version>
@@ -467,31 +462,11 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.10.1</version>
           <configuration>
-            <compilerId>javac-with-errorprone</compilerId>
-            <forceJavacCompilerUse>true</forceJavacCompilerUse>
             <source>1.8</source>
             <target>1.8</target>
-            <compilerArgs combine.children="override">
-              <compilerArg>-Xep:MixedMutabilityReturnType:OFF</compilerArg>
-              <compilerArg>-Xep:ImmutableEnumChecker:OFF</compilerArg>
-              <compilerArg>-Xep:FutureReturnValueIgnored:OFF</compilerArg>
-              <compilerArg>-XepExcludedPaths:.*/target/(?:generated-sources|generated-test-sources)/.*</compilerArg>
-            </compilerArgs>
             <showWarnings>true</showWarnings>
             <failOnWarning>false</failOnWarning>
           </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>org.codehaus.plexus</groupId>
-              <artifactId>plexus-compiler-javac-errorprone</artifactId>
-              <version>2.8.6</version>
-            </dependency>
-            <dependency>
-              <groupId>com.google.errorprone</groupId>
-              <artifactId>error_prone_core</artifactId>
-              <version>${errorprone.version}</version>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.felix</groupId>
@@ -763,11 +738,6 @@
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-query-builder</artifactId>
         <version>${driver.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.errorprone</groupId>
-        <artifactId>error_prone_annotations</artifactId>
-        <version>${errorprone.version}</version>
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
**What this PR does**:

Removes use of "errorprone" static analyzer Java plug-in, related annotations, to help clean up logs and remove one (minor) blocker to allow use of JDK 11 for eventually building and running coordinators.

**Which issue(s) this PR fixes**:
Fixes #2616

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
