### PR TITLE
add java exports to stargate extension cmd line

### DIFF
--- a/coordinator/testing/src/main/java/io/stargate/it/storage/StargateExtension.java
+++ b/coordinator/testing/src/main/java/io/stargate/it/storage/StargateExtension.java
@@ -392,6 +392,7 @@ public class StargateExtension extends ExternalResource<StargateSpec, StargateEx
       cmd.addArgument("-Dstargate.libdir=" + LIB_DIR.getAbsolutePath());
       cmd.addArgument("-Dstargate.bundle.cache.dir=" + cacheDir.getAbsolutePath());
 
+      // Java 11+ requires these flags to allow reflection to work
       cmd.addArgument("--add-exports");
       cmd.addArgument("java.base/jdk.internal.ref=ALL-UNNAMED");
       cmd.addArgument("--add-exports");

--- a/coordinator/testing/src/main/java/io/stargate/it/storage/StargateExtension.java
+++ b/coordinator/testing/src/main/java/io/stargate/it/storage/StargateExtension.java
@@ -392,6 +392,11 @@ public class StargateExtension extends ExternalResource<StargateSpec, StargateEx
       cmd.addArgument("-Dstargate.libdir=" + LIB_DIR.getAbsolutePath());
       cmd.addArgument("-Dstargate.bundle.cache.dir=" + cacheDir.getAbsolutePath());
 
+      cmd.addArgument("--add-exports");
+      cmd.addArgument("java.base/jdk.internal.ref=ALL-UNNAMED");
+      cmd.addArgument("--add-exports");
+      cmd.addArgument("java.base/jdk.internal.misc=ALL-UNNAMED");
+
       if (backend.isDse()) {
         cmd.addArgument("-Dstargate.request_timeout_in_ms=60000");
         cmd.addArgument("-Dstargate.write_request_timeout_in_ms=60000");

--- a/coordinator/testing/src/main/java/io/stargate/it/tools/NodeToolTest.java
+++ b/coordinator/testing/src/main/java/io/stargate/it/tools/NodeToolTest.java
@@ -55,6 +55,13 @@ public class NodeToolTest extends BaseIntegrationTest {
   protected CommandLine baseStarterCommand() throws IOException {
     CommandLine cmd = new CommandLine("java");
     cmd.addArgument("-Dstargate.libdir=" + starterJar.getParentFile().getCanonicalPath());
+
+    // Java 11+ requires these flags to allow reflection to work
+    cmd.addArgument("--add-exports");
+    cmd.addArgument("java.base/jdk.internal.ref=ALL-UNNAMED");
+    cmd.addArgument("--add-exports");
+    cmd.addArgument("java.base/jdk.internal.misc=ALL-UNNAMED");
+    
     cmd.addArgument("-jar");
     cmd.addArgument(starterJar.getCanonicalPath());
 


### PR DESCRIPTION
Should allow ITs to pass. ITs use StargateExtension which builds its own command line. This PR incorporates the `add-exports` flag previously added to `starctl`