### PR TITLE
closes #2623: extend prepared with info with var indexes

### DIFF
--- a/coordinator/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/Conversion.java
+++ b/coordinator/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/Conversion.java
@@ -22,10 +22,8 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.cql3.PageSize;
-import org.apache.cassandra.cql3.QueryHandler;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.QueryOptions.PagingOptions;
-import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.cql3.ResultSet;
 import org.apache.cassandra.cql3.statements.BatchStatement;
 import org.apache.cassandra.db.Clustering;
@@ -572,15 +570,12 @@ public class Conversion {
       case PREPARED:
         ResultMessage.Prepared prepared = (ResultMessage.Prepared) resultMessage;
         PreparedWithInfo preparedWithInfo = (PreparedWithInfo) prepared;
-        QueryHandler.Prepared preparedStatement =
-            QueryProcessor.instance.getPrepared(prepared.statementId);
         return new Result.Prepared(
             Conversion.toExternal(prepared.statementId),
             Conversion.toExternal(prepared.resultMetadataId),
             toResultMetadata(prepared.resultMetadata, null),
             toPreparedMetadata(
-                prepared.metadata.names,
-                preparedStatement.statement.getPartitionKeyBindVariableIndexes()),
+                prepared.metadata.names, preparedWithInfo.getPartitionKeyBindVariableIndexes()),
             preparedWithInfo.isIdempotent(),
             preparedWithInfo.isUseKeyspace());
     }

--- a/coordinator/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/PreparedWithInfo.java
+++ b/coordinator/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/PreparedWithInfo.java
@@ -21,7 +21,13 @@ public class PreparedWithInfo extends ResultMessage.Prepared {
   private final boolean idempotent;
   private final boolean useKeyspace;
 
-  public PreparedWithInfo(Prepared prepared, boolean idempotent, boolean useKeyspace) {
+  private final short[] partitionKeyBindVariableIndexes;
+
+  public PreparedWithInfo(
+      Prepared prepared,
+      boolean idempotent,
+      boolean useKeyspace,
+      short[] partitionKeyBindVariableIndexes) {
     super(
         prepared.statementId,
         prepared.resultMetadataId,
@@ -29,6 +35,7 @@ public class PreparedWithInfo extends ResultMessage.Prepared {
         prepared.resultMetadata);
     this.idempotent = idempotent;
     this.useKeyspace = useKeyspace;
+    this.partitionKeyBindVariableIndexes = partitionKeyBindVariableIndexes;
   }
 
   public boolean isIdempotent() {
@@ -37,5 +44,9 @@ public class PreparedWithInfo extends ResultMessage.Prepared {
 
   public boolean isUseKeyspace() {
     return useKeyspace;
+  }
+
+  public short[] getPartitionKeyBindVariableIndexes() {
+    return partitionKeyBindVariableIndexes;
   }
 }

--- a/coordinator/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/StargateQueryHandler.java
+++ b/coordinator/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/StargateQueryHandler.java
@@ -137,7 +137,8 @@ public class StargateQueryHandler implements QueryHandler {
                       .orElseGet(() -> QueryProcessor.getStatement(query, queryState));
               boolean idempotent = IdempotencyAnalyzer.isIdempotent(statement);
               boolean useKeyspace = statement instanceof UseStatement;
-              return new PreparedWithInfo(p, idempotent, useKeyspace);
+              return new PreparedWithInfo(
+                  p, idempotent, useKeyspace, statement.getPartitionKeyBindVariableIndexes());
             });
   }
 


### PR DESCRIPTION
**What this PR does**:
Removes the call to `QueryProcessor.instance.getPrepared` in the conversion. To do so, we need to extend the `PreparedWithInfo` with the data directly in the query processor.

Note that this fix is done only for DSE, as the Cassandra persistence implementations are already using the same solution. How and why was this not applied to DSE, I don't know.

Basing on `v1`.

**Which issue(s) this PR fixes**:
Fixes #2623
