### PR TITLE
Remove unnecessary maven-failsafe-plugin (IT) settings

### DIFF
--- a/coordinator/stargate-starter/pom.xml
+++ b/coordinator/stargate-starter/pom.xml
@@ -83,9 +83,6 @@
             <version>${junit.version}</version>
           </dependency>
         </dependencies>
-        <configuration>
-          <argLine>${jdk11.module-exports}</argLine>
-        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/coordinator/testing/pom.xml
+++ b/coordinator/testing/pom.xml
@@ -250,7 +250,7 @@
             <jacoco-agent.args>${failsafe.jacoco.args}</jacoco-agent.args>
             <junit.jupiter.testclass.order.default>org.junit.jupiter.api.ClassOrderer$OrderAnnotation</junit.jupiter.testclass.order.default>
           </systemPropertyVariables>
-          <argLine>${failsafe.jacoco.args} ${jdk11.module-exports}</argLine>
+          <argLine>${failsafe.jacoco.args}</argLine>
           <includes>
             <include>io.stargate.it.**</include>
           </includes>
@@ -297,7 +297,7 @@
               </includes>
               <dataFile>${code.coverage.overall.data.folder}/aggregate.exec</dataFile>
               <outputDirectory>${code.coverage.overall.data.folder}/jacoco</outputDirectory>
-            </configuration>
+           </configuration>
           </execution>
         </executions>
       </plugin>
@@ -364,7 +364,6 @@
                     <ccm.version>4.0.10</ccm.version>
                     <stargate.test.nodes>1</stargate.test.nodes>
                   </systemPropertyVariables>
-                  <argLine>${jdk11.module-exports}</argLine>
                   <failIfNoTests>true</failIfNoTests>
                   <reportsDirectory>target/failsafe-reports/cassandra-4.0</reportsDirectory>
                   <summaryFile>target/failsafe-reports/summary-cassandra-4.0.xml</summaryFile>
@@ -397,7 +396,6 @@
                     <ccm.version>6.8.36</ccm.version>
                     <stargate.test.nodes>1</stargate.test.nodes>
                   </systemPropertyVariables>
-                  <argLine>${jdk11.module-exports}</argLine>
                   <failIfNoTests>true</failIfNoTests>
                   <reportsDirectory>target/failsafe-reports/dse-6.8</reportsDirectory>
                   <summaryFile>target/failsafe-reports/summary-dse-6.8.xml</summaryFile>

--- a/coordinator/testing/pom.xml
+++ b/coordinator/testing/pom.xml
@@ -297,7 +297,7 @@
               </includes>
               <dataFile>${code.coverage.overall.data.folder}/aggregate.exec</dataFile>
               <outputDirectory>${code.coverage.overall.data.folder}/jacoco</outputDirectory>
-           </configuration>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
**What this PR does**:

Removes settings not needed for IT: JDK args not passed via Maven but by code -- this unlike unit tests where Maven settings needed

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
