### PR TITLE
Fix GH actions to run for v2.1 too

### DIFF
--- a/.github/workflows/apis-v2.yaml
+++ b/.github/workflows/apis-v2.yaml
@@ -6,9 +6,9 @@ name: Stargate APIs V2
 # * manual trigger
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "v2.1" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "v2.1" ]
   workflow_dispatch:
 
 # cancel same workflows in progress for pull request branches

--- a/.github/workflows/coordinator-test.yml
+++ b/.github/workflows/coordinator-test.yml
@@ -13,7 +13,7 @@ name: Coordinator Tests
 on:
 
   push:
-    branches: [ "main", "v1" ]
+    branches: [ "main", "v1", "V2.1" ]
     paths:
       - 'coordinator/**pom.xml'
       - 'coordinator/**/src/**'


### PR DESCRIPTION
**What this PR does**:

Fixes Github action applicability to get API tests to run for v2.1 too, not just v1/main/PRs.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
