### PR TITLE
Fix #2638: update Guava to 32.0.1 to resolve CVE

### DIFF
--- a/coordinator/persistence-dse-6.8/pom.xml
+++ b/coordinator/persistence-dse-6.8/pom.xml
@@ -30,11 +30,11 @@
   </repositories>
   <dependencyManagement>
     <dependencies>
-      <!-- DSE version beginning 6.8.30 depends on guava 31.1 -->
+      <!-- DSE version beginning 6.8.30 depends on guava 31+ -->
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>32.0.0-jre</version>
+        <version>32.0.1-jre</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
**What this PR does**:

Closes #2638; updates Guava dependency for DSE backend.

**Which issue(s) this PR fixes**:
Fixes #2638

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
