### PR TITLE
Add JSON as an API option

### DIFF
--- a/coordinator/Dockerfile
+++ b/coordinator/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile for building coordinator node images
 #
 
-FROM adoptopenjdk/openjdk11:jre-11.0.19_7 as base
+FROM adoptopenjdk/openjdk11:jre-11.0.19_7-debian as base
 
 RUN apt update -qq \
     && apt install iproute2 libaio1 libjemalloc2 -y \

--- a/coordinator/authnz/src/main/java/io/stargate/auth/SourceAPI.java
+++ b/coordinator/authnz/src/main/java/io/stargate/auth/SourceAPI.java
@@ -34,7 +34,10 @@ public enum SourceAPI {
   CQL("cql"),
 
   /** Used for REST and Docs API, as historically they were one. */
-  REST("rest");
+  REST("rest"),
+
+  /** Used for JSON API. */
+  JSON("json");
 
   public static final String CUSTOM_PAYLOAD_KEY = "stargate.sourceAPI";
   private final String name;

--- a/coordinator/bridge-proto/proto/schema.proto
+++ b/coordinator/bridge-proto/proto/schema.proto
@@ -115,6 +115,7 @@ message SchemaRead {
   enum SourceApi {
     GRAPHQL = 0;
     REST = 1;
+    JSON = 2;
   }
   enum ElementType {
     KEYSPACE = 0;

--- a/coordinator/persistence-cassandra-4.0/src/test/java/io/stargate/db/cassandra/impl/StargateQueryHandlerTest.java
+++ b/coordinator/persistence-cassandra-4.0/src/test/java/io/stargate/db/cassandra/impl/StargateQueryHandlerTest.java
@@ -1067,7 +1067,8 @@ class StargateQueryHandlerTest extends BaseCassandraTest {
       new Object[] {null},
       new Object[] {SourceAPI.REST},
       new Object[] {SourceAPI.GRAPHQL},
-      new Object[] {SourceAPI.CQL}
+      new Object[] {SourceAPI.CQL},
+      new Object[] {SourceAPI.JSON}
     };
   }
 


### PR DESCRIPTION
Update enumerations in the Stargate codebase (Authentication and bridge) that list available APIs to include JSON API.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
