### PR TITLE
add HTTP status tagging to tenant metrics

### DIFF
--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/MetricsConfig.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/config/MetricsConfig.java
@@ -60,7 +60,7 @@ public interface MetricsConfig {
     @WithDefault("error")
     String errorTag();
 
-    /** @return The tag key for user-agent flag, defaults to <code>error</code>. */
+    /** @return The tag key for user-agent flag, defaults to <code>user_agent</code>. */
     @NotBlank
     @WithDefault("user_agent")
     String userAgentTag();
@@ -68,5 +68,14 @@ public interface MetricsConfig {
     /** @return If tenant counting metric should include the user agent information. */
     @WithDefault("false")
     boolean userAgentTagEnabled();
+
+    /** @return The tag key for HTTP status flag, defaults to <code>status</code>. */
+    @NotBlank
+    @WithDefault("status")
+    String statusTag();
+
+    /** @return If tenant counting metric should include the HTTP status information. */
+    @WithDefault("true")
+    boolean statusTagEnabled();
   }
 }

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/metrics/TenantRequestMetricsFilter.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/metrics/TenantRequestMetricsFilter.java
@@ -100,6 +100,11 @@ public class TenantRequestMetricsFilter {
         tags = tags.and(Tag.of(config.userAgentTag(), userAgentValue));
       }
 
+      // add http status code
+      if (config.statusTagEnabled()) {
+        tags = tags.and(Tag.of(config.statusTag(), String.valueOf(responseContext.getStatus())));
+      }
+
       // record
       meterRegistry.counter(config.metricName(), tags).increment();
     }

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/metrics/TenantRequestMetricsFilterTest.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/metrics/TenantRequestMetricsFilterTest.java
@@ -48,6 +48,7 @@ class TenantRequestMetricsFilterTest {
           .put("stargate.metrics.tenant-request-counter.metric-name", "test.metrics")
           .put("stargate.metrics.tenant-request-counter.tenant-tag", "tenantTag")
           .put("stargate.metrics.tenant-request-counter.error-tag", "errorTag")
+          .put("stargate.metrics.tenant-request-counter.status-tag", "statusTag")
           .build();
     }
   }
@@ -83,6 +84,7 @@ class TenantRequestMetricsFilterTest {
                 assertThat(metric)
                     .contains("tenantTag=\"" + FixedTenantTestProfile.TENANT_ID + "\"")
                     .contains("errorTag=\"false\"")
+                    .contains("statusTag=\"200\"")
                     .doesNotContain("agent="));
   }
 }


### PR DESCRIPTION
Add option to include tagging of per-tenant metrics by HTTP status code. This allows more detailed analysis of error data by tenant.

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
