### PR TITLE
preserve path element encoding on REST API

### DIFF
--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/Sgv2RowsResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/Sgv2RowsResourceApi.java
@@ -127,6 +127,7 @@ public interface Sgv2RowsResourceApi {
           final String tableName,
       @Parameter(name = "primaryKey", ref = RestOpenApiConstants.Parameters.PRIMARY_KEY)
           @PathParam("primaryKey")
+          @Encoded
           List<PathSegment> path,
       @Parameter(name = "fields", ref = RestOpenApiConstants.Parameters.FIELDS)
           @QueryParam("fields")
@@ -237,6 +238,7 @@ public interface Sgv2RowsResourceApi {
           final String tableName,
       @Parameter(name = "primaryKey", ref = RestOpenApiConstants.Parameters.PRIMARY_KEY)
           @PathParam("primaryKey")
+          @Encoded
           List<PathSegment> path,
       @Parameter(name = "raw", ref = RestOpenApiConstants.Parameters.RAW) @QueryParam("raw")
           final boolean raw,
@@ -269,6 +271,7 @@ public interface Sgv2RowsResourceApi {
           final String tableName,
       @Parameter(name = "primaryKey", ref = RestOpenApiConstants.Parameters.PRIMARY_KEY)
           @PathParam("primaryKey")
+          @Encoded
           List<PathSegment> path,
       @Parameter(name = "raw", ref = RestOpenApiConstants.Parameters.RAW) @QueryParam("raw")
           final boolean raw,
@@ -296,5 +299,6 @@ public interface Sgv2RowsResourceApi {
           final String tableName,
       @Parameter(name = "primaryKey", ref = RestOpenApiConstants.Parameters.PRIMARY_KEY)
           @PathParam("primaryKey")
+          @Encoded
           List<PathSegment> path);
 }

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/Sgv2RowsResourceApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/Sgv2RowsResourceApi.java
@@ -30,6 +30,7 @@ import org.jboss.resteasy.reactive.RestResponse;
  */
 @ApplicationScoped
 @Path("/v2/keyspaces/{keyspaceName}/{tableName}")
+@Encoded
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @SecurityRequirement(name = RestOpenApiConstants.SecuritySchemes.TOKEN)
@@ -127,7 +128,6 @@ public interface Sgv2RowsResourceApi {
           final String tableName,
       @Parameter(name = "primaryKey", ref = RestOpenApiConstants.Parameters.PRIMARY_KEY)
           @PathParam("primaryKey")
-          @Encoded
           List<PathSegment> path,
       @Parameter(name = "fields", ref = RestOpenApiConstants.Parameters.FIELDS)
           @QueryParam("fields")
@@ -238,7 +238,6 @@ public interface Sgv2RowsResourceApi {
           final String tableName,
       @Parameter(name = "primaryKey", ref = RestOpenApiConstants.Parameters.PRIMARY_KEY)
           @PathParam("primaryKey")
-          @Encoded
           List<PathSegment> path,
       @Parameter(name = "raw", ref = RestOpenApiConstants.Parameters.RAW) @QueryParam("raw")
           final boolean raw,
@@ -271,7 +270,6 @@ public interface Sgv2RowsResourceApi {
           final String tableName,
       @Parameter(name = "primaryKey", ref = RestOpenApiConstants.Parameters.PRIMARY_KEY)
           @PathParam("primaryKey")
-          @Encoded
           List<PathSegment> path,
       @Parameter(name = "raw", ref = RestOpenApiConstants.Parameters.RAW) @QueryParam("raw")
           final boolean raw,
@@ -299,6 +297,5 @@ public interface Sgv2RowsResourceApi {
           final String tableName,
       @Parameter(name = "primaryKey", ref = RestOpenApiConstants.Parameters.PRIMARY_KEY)
           @PathParam("primaryKey")
-          @Encoded
           List<PathSegment> path);
 }

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QIntegrationTestBase.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QIntegrationTestBase.java
@@ -677,7 +677,7 @@ public abstract class RestApiV2QIntegrationTestBase {
     row.put("pk1", "two");
     row.put("pk2", -2);
     row.put("ck0", 10);
-    row.put("ck1", "bar");
+    row.put("ck1", "bar%2Fbaz");
     row.put("v", 18);
     insertRow(keyspaceName, tableName, row);
   }


### PR DESCRIPTION
preserve path element encoding on REST API

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
