### PR TITLE
Map data in REST API changed back to previous format for compatibility

### DIFF
--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/grpc/FromProtoValueCodecs.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/grpc/FromProtoValueCodecs.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -558,11 +559,12 @@ public class FromProtoValueCodecs {
     public Object fromProtoValue(QueryOuterClass.Value value) {
       QueryOuterClass.Collection coll = value.getCollection();
       int len = verifyMapLength(coll);
-      Map<Object, Object> result = new LinkedHashMap<>(len);
+      List<Object> result = new LinkedList<>();
       for (int i = 0; i < len; i += 2) {
-        result.put(
-            keyCodec.fromProtoValue(coll.getElements(i)),
-            valueCodec.fromProtoValue(coll.getElements(i + 1)));
+        Map<Object, Object> mapEntry = new LinkedHashMap<>();
+        mapEntry.put("key", keyCodec.fromProtoValue(coll.getElements(i)));
+        mapEntry.put("value", valueCodec.fromProtoValue(coll.getElements(i + 1)));
+        result.add(mapEntry);
       }
       return result;
     }
@@ -571,13 +573,14 @@ public class FromProtoValueCodecs {
     public JsonNode jsonNodeFrom(QueryOuterClass.Value value) {
       QueryOuterClass.Collection coll = value.getCollection();
       int len = verifyMapLength(coll);
-      ObjectNode map = jsonNodeFactory.objectNode();
+      ArrayNode list = jsonNodeFactory.arrayNode();
       for (int i = 0; i < len; i += 2) {
-        map.set(
-            keyCodec.jsonNodeFrom(coll.getElements(i)).asText(),
-            valueCodec.jsonNodeFrom(coll.getElements(i + 1)));
+        ObjectNode mapEntry = jsonNodeFactory.objectNode();
+        mapEntry.set("key", keyCodec.jsonNodeFrom(coll.getElements(i)));
+        mapEntry.set("value", valueCodec.jsonNodeFrom(coll.getElements(i + 1)));
+        list.add(mapEntry);
       }
-      return map;
+      return list;
     }
 
     private int verifyMapLength(QueryOuterClass.Collection mapValue) {

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/grpc/ToProtoValueCodecs.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/grpc/ToProtoValueCodecs.java
@@ -13,13 +13,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 public class ToProtoValueCodecs {
   /**
@@ -804,12 +798,13 @@ public class ToProtoValueCodecs {
 
     @Override
     public QueryOuterClass.Value protoValueFromStrictlyTyped(Object mapValue) {
-      if (mapValue instanceof Map<?, ?>) {
+      if (mapValue instanceof List<?>) {
         // Maps are actually encoded as Collections where keys and values are interleaved
         List<QueryOuterClass.Value> elements = new ArrayList<>();
-        for (Map.Entry<?, ?> entry : ((Map<?, ?>) mapValue).entrySet()) {
-          elements.add(keyCodec.protoValueFromStrictlyTyped(entry.getKey()));
-          elements.add(valueCodec.protoValueFromStrictlyTyped(entry.getValue()));
+        for (Object entry : (List<?>) mapValue) {
+          Map<?, ?> entryNode = (Map<?, ?>) entry;
+          elements.add(keyCodec.protoValueFromStrictlyTyped(entryNode.get("key")));
+          elements.add(valueCodec.protoValueFromStrictlyTyped(entryNode.get("value")));
         }
         return Values.of(elements);
       }

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/restapi/grpc/FromProtoConverterTest.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/restapi/grpc/FromProtoConverterTest.java
@@ -1,21 +1,18 @@
 package io.stargate.sgv2.restapi.grpc;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
-
 import io.stargate.bridge.grpc.CqlDuration;
 import io.stargate.bridge.grpc.Values;
 import io.stargate.bridge.proto.QueryOuterClass;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class FromProtoConverterTest {
   private static final String TEST_COLUMN = "test_column";
@@ -57,14 +54,33 @@ public class FromProtoConverterTest {
 
       // Maps
       arguments(
-          Collections.singletonMap("foo", "bar"),
+          Collections.singletonList(
+              new HashMap<>() {
+                {
+                  put("key", "foo");
+                  put("value", "bar");
+                }
+              }),
           mapType(QueryOuterClass.TypeSpec.Basic.VARCHAR, QueryOuterClass.TypeSpec.Basic.VARCHAR),
           // since internal representation is just as Collection...
           Values.of(Arrays.asList(Values.of("foo"), Values.of("bar")))),
       arguments(
-          Collections.singletonMap(123, Boolean.TRUE),
+          Arrays.asList(
+              new HashMap<>() {
+                {
+                  put("key", 123);
+                  put("value", true);
+                }
+              },
+              new HashMap<>() {
+                {
+                  put("key", 456);
+                  put("value", false);
+                }
+              }),
           mapType(QueryOuterClass.TypeSpec.Basic.INT, QueryOuterClass.TypeSpec.Basic.BOOLEAN),
-          Values.of(Arrays.asList(Values.of(123), Values.of(true))))
+          Values.of(
+              Arrays.asList(Values.of(123), Values.of(true), Values.of(456), Values.of(false))))
     };
   }
 


### PR DESCRIPTION
**What this PR does**:
Fixes https://github.com/stargate/stargate/issues/2577

Changes to accept and return map data in the old format in the REST API

For example
```json
"characteristics": [
                {
                    "key": "accuracy",
                    "value": "medium"
                },
                {
                    "key": "sensitivity",
                    "value": "high"
                }
            ]
```

instead of 
```json
"characteristics": {
                "accuracy": "medium",
                "sensitivity": "high"
            }
```

**Which issue(s) this PR fixes**:
Fixes #2577 

**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [ ] Documentation added/updated
- [X] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
