### PR TITLE
Fix #2664: update `cassandra-driver-core` dep for C-4.0 persistence to 3.11.3

### DIFF
--- a/coordinator/persistence-cassandra-4.0/pom.xml
+++ b/coordinator/persistence-cassandra-4.0/pom.xml
@@ -19,7 +19,8 @@
       The driver used internally by cassandra-all for UDFs (must match the version declared in
       cassandra-all's POM).
     -->
-    <cassandra.bundled-driver.version>3.11.0</cassandra.bundled-driver.version>
+    <!-- Later patch version should be fine -->
+    <cassandra.bundled-driver.version>3.11.3</cassandra.bundled-driver.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
**What this PR does**:

Updates a dependency for security fixes

**Which issue(s) this PR fixes**:
Fixes #2664

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
