### PR TITLE
fix docker image tagging for apis

### DIFF
--- a/apis/sgv2-docsapi/pom.xml
+++ b/apis/sgv2-docsapi/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.container-image.group>stargateio</quarkus.container-image.group>
     <quarkus.container-image.name>docsapi</quarkus.container-image.name>
     <quarkus.container-image.tag>v${project.version}</quarkus.container-image.tag>
-    <quarkus.container-image.additional-tags>v2.1</quarkus.container-image.additional-tags>
+    <quarkus.container-image.additional-tags>v2</quarkus.container-image.additional-tags>
   </properties>
   <dependencies>
     <dependency>

--- a/apis/sgv2-graphqlapi/pom.xml
+++ b/apis/sgv2-graphqlapi/pom.xml
@@ -15,7 +15,7 @@
     <quarkus.container-image.group>stargateio</quarkus.container-image.group>
     <quarkus.container-image.name>graphqlapi</quarkus.container-image.name>
     <quarkus.container-image.tag>v${project.version}</quarkus.container-image.tag>
-    <quarkus.container-image.additional-tags>v2.1</quarkus.container-image.additional-tags>
+    <quarkus.container-image.additional-tags>v2</quarkus.container-image.additional-tags>
   </properties>
   <dependencies>
     <dependency>

--- a/apis/sgv2-restapi/pom.xml
+++ b/apis/sgv2-restapi/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.container-image.group>stargateio</quarkus.container-image.group>
     <quarkus.container-image.name>restapi</quarkus.container-image.name>
     <quarkus.container-image.tag>v${project.version}</quarkus.container-image.tag>
-    <quarkus.container-image.additional-tags>v2.1</quarkus.container-image.additional-tags>
+    <quarkus.container-image.additional-tags>v2</quarkus.container-image.additional-tags>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
Reverting changes to image tagging for APIs that incorrectly applied `v2.1` tag to `v2` release images.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
