### PR TITLE
Fixes #2674: support microsecond fractions for ISO-8601 date/time for REST API

### DIFF
--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/grpc/ToProtoValueCodecs.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/grpc/ToProtoValueCodecs.java
@@ -14,6 +14,8 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 import java.util.*;
 
 public class ToProtoValueCodecs {
@@ -23,6 +25,7 @@ public class ToProtoValueCodecs {
    * <ul>
    *   <li>https://stackoverflow.com/questions/43360852/cannot-parse-string-in-iso-8601-format-lacking-colon-in-offset-to-java-8-date
    *   <li>https://stackoverflow.com/questions/34637626/java-datetimeformatter-for-time-zone-with-an-optional-colon-separator
+   *   <li>https://stackoverflow.com/questions/54682028/java-localdatetime-parse-with-millisecond-precision-but-optional-microsecond-pre
    * </ul>
    *
    * <p>Notes:
@@ -32,10 +35,18 @@ public class ToProtoValueCodecs {
    *       without colon)
    *   <li>[.SSS] is needed to make millisecond part optional (and not required)
    *   <li>Date part is mandatory; similarly hours/minutes/seconds time part
+   *   <li>Must use DateTimeFormatterBuilder for flexible fraction support
    * </ul>
    */
   private static final DateTimeFormatter ISO_OFFSET_DATE_TIME_OPTIONAL_COLON =
-      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss[.SSS][XXX][X]");
+      new DateTimeFormatterBuilder()
+          .append(DateTimeFormatter.ISO_LOCAL_DATE)
+          .appendLiteral('T')
+          .appendPattern("HH:mm:ss")
+          // Allow optional second fraction with flexible length down to microseconds
+          .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
+          .appendPattern("[XXX][X]")
+          .toFormatter();
 
   protected static final QueryOuterClass.Value VALUE_FALSE = Values.of(false);
   protected static final QueryOuterClass.Value VALUE_TRUE = Values.of(true);

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowGetIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowGetIT.java
@@ -847,7 +847,9 @@ public class RestApiV2QRowGetIT extends RestApiV2QIntegrationTestBase {
             map("id", 3, "firstName", "Graham", "created", "2021-04-22T18:42:22.139-0800"),
             map("id", 4, "firstName", "Joel", "created", "2021-04-22T18:42:22.139+07"),
             map("id", 4, "firstName", "Deborah", "created", "2021-04-22T18:42:22.139-05"),
-            map("id", 5, "firstName", "Timothy", "created", timestampAsMsecs)));
+            map("id", 5, "firstName", "Timothy", "created", timestampAsMsecs),
+            // 13-Jul-2023, tatu: [stargaate#2674] Support microsecond fractions too
+            map("id", 6, "firstName", "Jerome", "created", "2023-07-13T14:02:06.018850Z")));
 
     String whereClause =
         String.format("{\"id\":{\"$eq\":\"1\"},\"created\":{\"$in\":[\"%s\"]}}", timestamp);

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/restapi/grpc/ToProtoConverterTest.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/restapi/grpc/ToProtoConverterTest.java
@@ -208,6 +208,12 @@ public class ToProtoConverterTest {
           "2021-04-23T18:42:22-03",
           Values.of(Instant.parse("2021-04-23T21:42:22Z").toEpochMilli())),
 
+      // Should allow 6 digits of fractional seconds (issue #2674); truncating extra digits
+      // beyond milliseconds (first 3 digits)
+      arguments(
+          "2023-07-13T14:02:06.018850Z",
+          Values.of(Instant.parse("2023-07-13T14:02:06.018Z").toEpochMilli())),
+
       // Also: timestamp as Long should be supported
       arguments(DEFAULT_INSTANT.toEpochMilli(), Values.of(DEFAULT_INSTANT.toEpochMilli()))
     };


### PR DESCRIPTION
**What this PR does**:

Fixes handling of date/time fields to allow second fraction for microseconds (up to 6 digits) instead of just millis (3); similar to what SGv1/REST supported.

**Which issue(s) this PR fixes**:
Fixes #2674

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
