### PR TITLE
Reduce Guava usage/dependencies to help against transitive Guava dep conflicts

### DIFF
--- a/coordinator/bridge-proto/src/main/java/io/stargate/bridge/grpc/CqlDuration.java
+++ b/coordinator/bridge-proto/src/main/java/io/stargate/bridge/grpc/CqlDuration.java
@@ -16,7 +16,6 @@
 package io.stargate.bridge.grpc;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import java.time.Duration;
 import java.time.Period;
 import java.time.temporal.ChronoUnit;
@@ -24,6 +23,7 @@ import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAmount;
 import java.time.temporal.TemporalUnit;
 import java.time.temporal.UnsupportedTemporalTypeException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -71,8 +71,8 @@ public final class CqlDuration implements TemporalAmount {
   private static final Pattern ISO8601_ALTERNATIVE_PATTERN =
       Pattern.compile("P(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})");
 
-  private static final ImmutableList<TemporalUnit> TEMPORAL_UNITS =
-      ImmutableList.of(ChronoUnit.MONTHS, ChronoUnit.DAYS, ChronoUnit.NANOS);
+  private static final List<TemporalUnit> TEMPORAL_UNITS =
+          Arrays.asList(ChronoUnit.MONTHS, ChronoUnit.DAYS, ChronoUnit.NANOS);
 
   private final int months;
   private final int days;

--- a/coordinator/bridge-proto/src/main/java/io/stargate/bridge/grpc/CqlDuration.java
+++ b/coordinator/bridge-proto/src/main/java/io/stargate/bridge/grpc/CqlDuration.java
@@ -72,7 +72,7 @@ public final class CqlDuration implements TemporalAmount {
       Pattern.compile("P(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})");
 
   private static final List<TemporalUnit> TEMPORAL_UNITS =
-          Arrays.asList(ChronoUnit.MONTHS, ChronoUnit.DAYS, ChronoUnit.NANOS);
+      Arrays.asList(ChronoUnit.MONTHS, ChronoUnit.DAYS, ChronoUnit.NANOS);
 
   private final int months;
   private final int days;

--- a/coordinator/bridge-proto/src/test/java/io/stargate/bridge/grpc/TypeSpecsTest.java
+++ b/coordinator/bridge-proto/src/test/java/io/stargate/bridge/grpc/TypeSpecsTest.java
@@ -22,6 +22,8 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import io.stargate.bridge.proto.QueryOuterClass.TypeSpec;
 import io.stargate.bridge.proto.QueryOuterClass.TypeSpec.Map;
 import io.stargate.bridge.proto.QueryOuterClass.TypeSpec.Udt;
+
+import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/coordinator/bridge-proto/src/test/java/io/stargate/bridge/grpc/TypeSpecsTest.java
+++ b/coordinator/bridge-proto/src/test/java/io/stargate/bridge/grpc/TypeSpecsTest.java
@@ -19,8 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.stargate.bridge.proto.QueryOuterClass.TypeSpec;
 import io.stargate.bridge.proto.QueryOuterClass.TypeSpec.Map;
 import io.stargate.bridge.proto.QueryOuterClass.TypeSpec.Udt;
@@ -48,7 +46,7 @@ public class TypeSpecsTest {
   public void shouldParseWithStrictUdtResolution() {
     Udt udtA = Udt.newBuilder().setName("a").putFields("i", TypeSpecs.INT).build();
     Udt udtB = Udt.newBuilder().setName("b").putFields("s", TypeSpecs.VARCHAR).build();
-    java.util.List<Udt> udts = ImmutableList.of(udtA, udtB);
+    java.util.List<Udt> udts = Arrays.asList(udtA, udtB);
 
     assertThat(TypeSpecs.parse("frozen<map<a,b>>", udts, true))
         .satisfies(
@@ -120,8 +118,8 @@ public class TypeSpecsTest {
           TypeSpecs.frozenList(TypeSpecs.set(TypeSpecs.INT)),
           TypeSpecs.list(TypeSpecs.set(TypeSpecs.INT))),
       arguments(
-          TypeSpecs.frozenUdt("a", ImmutableMap.of("i", TypeSpecs.INT)),
-          TypeSpecs.udt("a", ImmutableMap.of("i", TypeSpecs.INT))),
+          TypeSpecs.frozenUdt("a", Collections.singletonMap("i", TypeSpecs.INT)),
+          TypeSpecs.udt("a", Collections.singletonMap("i", TypeSpecs.INT))),
       arguments(
           TypeSpecs.tuple(TypeSpecs.INT, TypeSpecs.VARCHAR),
           TypeSpecs.tuple(TypeSpecs.INT, TypeSpecs.VARCHAR)),

--- a/coordinator/bridge-proto/src/test/java/io/stargate/bridge/grpc/TypeSpecsTest.java
+++ b/coordinator/bridge-proto/src/test/java/io/stargate/bridge/grpc/TypeSpecsTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import io.stargate.bridge.proto.QueryOuterClass.TypeSpec;
 import io.stargate.bridge.proto.QueryOuterClass.TypeSpec.Map;
 import io.stargate.bridge.proto.QueryOuterClass.TypeSpec.Udt;
-
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;

--- a/coordinator/cql/src/main/java/org/apache/cassandra/stargate/config/EncryptionOptions.java
+++ b/coordinator/cql/src/main/java/org/apache/cassandra/stargate/config/EncryptionOptions.java
@@ -17,8 +17,8 @@
  */
 package org.apache.cassandra.stargate.config;
 
-import com.google.common.collect.ImmutableList;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import org.apache.cassandra.stargate.security.SSLFactory;
@@ -209,7 +209,7 @@ public class EncryptionOptions {
    */
   public void setaccepted_protocols(List<String> accepted_protocols) {
     this.accepted_protocols =
-        accepted_protocols == null ? null : ImmutableList.copyOf(accepted_protocols);
+        accepted_protocols == null ? null : new ArrayList<>(accepted_protocols);
   }
 
   /* This list is substituted in configurations that have explicitly specified the original "TLS" default,

--- a/coordinator/cql/src/main/java/org/apache/cassandra/stargate/config/EncryptionOptions.java
+++ b/coordinator/cql/src/main/java/org/apache/cassandra/stargate/config/EncryptionOptions.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.stargate.config;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import org.apache.cassandra.stargate.security.SSLFactory;
@@ -237,7 +238,7 @@ public class EncryptionOptions {
         return TLS_PROTOCOL_SUBSTITUTION;
       } else // the user was trying to limit to a single specific protocol, so try that
       {
-        return ImmutableList.of(protocol);
+        return Arrays.asList(protocol);
       }
     }
 
@@ -246,7 +247,9 @@ public class EncryptionOptions {
         && accepted_protocols.stream().noneMatch(ap -> ap.equalsIgnoreCase(protocol))) {
       // If the user provided a non-generic default protocol, append it to accepted_protocols - they
       // wanted it after all.
-      return ImmutableList.<String>builder().addAll(accepted_protocols).add(protocol).build();
+      List<String> accepted = new ArrayList<>(accepted_protocols);
+      accepted.add(protocol);
+      return accepted;
     } else {
       return accepted_protocols;
     }
@@ -367,7 +370,7 @@ public class EncryptionOptions {
             keystore_password,
             truststore,
             truststore_password,
-            ImmutableList.copyOf(cipher_suites),
+            Arrays.asList(cipher_suites),
             protocol,
             accepted_protocols,
             algorithm,
@@ -405,7 +408,7 @@ public class EncryptionOptions {
             truststore_password,
             cipher_suites,
             protocol,
-            accepted_protocols == null ? null : ImmutableList.copyOf(accepted_protocols),
+            accepted_protocols == null ? null : new ArrayList<>(accepted_protocols),
             algorithm,
             store_type,
             require_client_auth,

--- a/coordinator/grpc-proto/src/main/java/io/stargate/grpc/CqlDuration.java
+++ b/coordinator/grpc-proto/src/main/java/io/stargate/grpc/CqlDuration.java
@@ -16,7 +16,6 @@
 package io.stargate.grpc;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import java.time.Duration;
 import java.time.Period;
 import java.time.temporal.ChronoUnit;
@@ -24,6 +23,7 @@ import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAmount;
 import java.time.temporal.TemporalUnit;
 import java.time.temporal.UnsupportedTemporalTypeException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -71,8 +71,8 @@ public final class CqlDuration implements TemporalAmount {
   private static final Pattern ISO8601_ALTERNATIVE_PATTERN =
       Pattern.compile("P(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})");
 
-  private static final ImmutableList<TemporalUnit> TEMPORAL_UNITS =
-      ImmutableList.of(ChronoUnit.MONTHS, ChronoUnit.DAYS, ChronoUnit.NANOS);
+  private static final List<TemporalUnit> TEMPORAL_UNITS =
+          Arrays.asList(ChronoUnit.MONTHS, ChronoUnit.DAYS, ChronoUnit.NANOS);
 
   private final int months;
   private final int days;

--- a/coordinator/grpc-proto/src/main/java/io/stargate/grpc/CqlDuration.java
+++ b/coordinator/grpc-proto/src/main/java/io/stargate/grpc/CqlDuration.java
@@ -72,7 +72,7 @@ public final class CqlDuration implements TemporalAmount {
       Pattern.compile("P(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})");
 
   private static final List<TemporalUnit> TEMPORAL_UNITS =
-          Arrays.asList(ChronoUnit.MONTHS, ChronoUnit.DAYS, ChronoUnit.NANOS);
+      Arrays.asList(ChronoUnit.MONTHS, ChronoUnit.DAYS, ChronoUnit.NANOS);
 
   private final int months;
   private final int days;

--- a/coordinator/persistence-api/src/test/java/io/stargate/db/schema/SchemaHashStabilityTest.java
+++ b/coordinator/persistence-api/src/test/java/io/stargate/db/schema/SchemaHashStabilityTest.java
@@ -2,8 +2,8 @@ package io.stargate.db.schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -123,8 +123,9 @@ public class SchemaHashStabilityTest {
   }
 
   private Keyspace buildKeyspace() {
-    Map<String, String> keyspaceReplication =
-        ImmutableMap.of("class", "SimpleStrategy", "eu-west-1", "3");
+    Map<String, String> keyspaceReplication = new LinkedHashMap<>();
+    keyspaceReplication.put("class", "SimpleStrategy");
+    keyspaceReplication.put("eu-west-1", "3");
     return ImmutableKeyspace.builder()
         .name("users_keyspace")
         .replication(keyspaceReplication)

--- a/coordinator/persistence-api/src/test/java/io/stargate/db/schema/SchemaHashableTest.java
+++ b/coordinator/persistence-api/src/test/java/io/stargate/db/schema/SchemaHashableTest.java
@@ -2,10 +2,10 @@ package io.stargate.db.schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.ImmutableMap;
 import io.stargate.db.schema.Column.Kind;
 import io.stargate.db.schema.Column.Order;
 import io.stargate.db.schema.Column.Type;
+import java.util.Collections;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -25,13 +25,13 @@ public class SchemaHashableTest {
       assertThat(
               ImmutableKeyspace.builder()
                   .name("ks")
-                  .replication(ImmutableMap.of("class", "SimpleStrategy"))
+                  .replication(Collections.singletonMap("class", "SimpleStrategy"))
                   .build()
                   .schemaHashCode())
           .isNotEqualTo(
               ImmutableKeyspace.builder()
                   .name("ks")
-                  .replication(ImmutableMap.of("class", "NetworkTopologyStrategy"))
+                  .replication(Collections.singletonMap("class", "NetworkTopologyStrategy"))
                   .build()
                   .schemaHashCode());
     }

--- a/coordinator/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/db/impl/DocumentTtlQueryBuilder.java
+++ b/coordinator/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/db/impl/DocumentTtlQueryBuilder.java
@@ -25,7 +25,6 @@ import io.stargate.db.query.builder.QueryBuilder;
 import io.stargate.db.query.builder.QueryBuilderImpl;
 import io.stargate.web.docsapi.service.query.DocsApiConstants;
 import io.stargate.web.docsapi.service.query.search.db.AbstractSearchQueryBuilder;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -46,7 +45,7 @@ public class DocumentTtlQueryBuilder extends AbstractSearchQueryBuilder {
   public BuiltQuery<? extends BoundQuery> buildQuery(
       Supplier<QueryBuilder> queryBuilder, String keyspace, String table, String... columns) {
     List<QueryBuilderImpl.FunctionCall> ttlFunction =
-            Arrays.asList(QueryBuilderImpl.FunctionCall.ttl(DocsApiConstants.LEAF_COLUMN_NAME));
+        Arrays.asList(QueryBuilderImpl.FunctionCall.ttl(DocsApiConstants.LEAF_COLUMN_NAME));
     return buildQuery(
         queryBuilder, keyspace, table, null, ttlFunction, DocsApiConstants.KEY_COLUMN_NAME);
   }

--- a/coordinator/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/db/impl/DocumentTtlQueryBuilder.java
+++ b/coordinator/restapi/src/main/java/io/stargate/web/docsapi/service/query/search/db/impl/DocumentTtlQueryBuilder.java
@@ -17,7 +17,6 @@
 
 package io.stargate.web.docsapi.service.query.search.db.impl;
 
-import com.google.common.collect.ImmutableList;
 import io.stargate.db.query.BoundQuery;
 import io.stargate.db.query.Predicate;
 import io.stargate.db.query.builder.BuiltCondition;
@@ -26,6 +25,8 @@ import io.stargate.db.query.builder.QueryBuilder;
 import io.stargate.db.query.builder.QueryBuilderImpl;
 import io.stargate.web.docsapi.service.query.DocsApiConstants;
 import io.stargate.web.docsapi.service.query.search.db.AbstractSearchQueryBuilder;
+
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,7 +46,7 @@ public class DocumentTtlQueryBuilder extends AbstractSearchQueryBuilder {
   public BuiltQuery<? extends BoundQuery> buildQuery(
       Supplier<QueryBuilder> queryBuilder, String keyspace, String table, String... columns) {
     List<QueryBuilderImpl.FunctionCall> ttlFunction =
-        ImmutableList.of(QueryBuilderImpl.FunctionCall.ttl(DocsApiConstants.LEAF_COLUMN_NAME));
+            Arrays.asList(QueryBuilderImpl.FunctionCall.ttl(DocsApiConstants.LEAF_COLUMN_NAME));
     return buildQuery(
         queryBuilder, keyspace, table, null, ttlFunction, DocsApiConstants.KEY_COLUMN_NAME);
   }


### PR DESCRIPTION
**What this PR does**:

Reduces usage of Guava classes, to help reduce likelihood of conflicts between transitively included Guava versions; eventually needed to remove use of OSGi.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
