### PR TITLE
Fix #2680: shade cassandra-all/4.0 dependency by cql module

### DIFF
--- a/coordinator/cql/pom.xml
+++ b/coordinator/cql/pom.xml
@@ -172,6 +172,53 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.4.1</version>
+        <configuration>
+          <createDependencyReducedPom>true</createDependencyReducedPom>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+                <exclude>META-INF/*.RSA</exclude>
+              </excludes>
+            </filter>
+          </filters>
+          <artifactSet>
+            <includes>
+              <include>org.apache.cassandra:cassandra-all</include>
+            </includes>
+          </artifactSet>
+          <relocations>
+            <relocation>
+              <pattern>org.apache.cassandra</pattern>
+              <shadedPattern>shaded.org.apache.cassandra</shadedPattern>
+              <excludes>
+                <exclude>org.apache.cassandra.stargate.**</exclude>
+              </excludes>
+            </relocation>
+            <relocation>
+              <pattern>com.datastax.driver.core</pattern>
+              <shadedPattern>shaded.com.datastax.driver.core</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createSourcesJar>true</createSourcesJar>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/coordinator/cql/src/main/java/org/apache/cassandra/stargate/metrics/ClientMetrics.java
+++ b/coordinator/cql/src/main/java/org/apache/cassandra/stargate/metrics/ClientMetrics.java
@@ -39,7 +39,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.apache.cassandra.metrics.DefaultNameFactory;
 import org.apache.cassandra.stargate.transport.internal.CBUtil;
 import org.apache.cassandra.stargate.transport.internal.CqlServer;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
@@ -52,9 +51,6 @@ public final class ClientMetrics {
 
   /** Singleton instance to use. */
   public static final ClientMetrics instance = new ClientMetrics();
-
-  /** Default name factory for the cassandra metrics. */
-  private static final DefaultNameFactory factory = new DefaultNameFactory("Client");
 
   // these are our metric names used
   private static final String REQUESTS_PROCESSED_METRIC;
@@ -293,8 +289,14 @@ public final class ClientMetrics {
    */
   private static String metric(String name) {
     // to keep the back-ward compatibility, init all metric names with cql. + DefaultNameFactory
-    String metricName = factory.createMetricName(name).getMetricName();
-    return "cql." + metricName;
+    // 14-Jul-2023, tatu: To avoid problem with Maven shade plug-in, class relocation,
+    //    copy logic from `org.apache.cassandra.metrics.DefaultNameFactory` here
+    //
+    // String metricName = new
+    // org.apache.cassandra.metrics.DefaultNameFactory("Client").createMetricName(name).getMetricName();
+    // return "cql." + metricName;
+
+    return "cql.org.apache.cassandra.metrics.Client." + name;
   }
 
   private class ConnectionMetricsImpl implements ConnectionMetrics {

--- a/coordinator/persistence-api/pom.xml
+++ b/coordinator/persistence-api/pom.xml
@@ -97,12 +97,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.cassandra</groupId>
-      <artifactId>cassandra-all</artifactId>
-      <version>4.0.10</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -305,6 +305,7 @@
           <excludes>
             <exclude>.idea/**</exclude>
             <exclude>**/target/**</exclude>
+            <exclude>**/dependency-reduced-pom.xml</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
**What this PR does**:

As per title, uses shade plugin to hide cql module's dependency to cassandra-all 4.0.x.

**Which issue(s) this PR fixes**:
Fixes #2680

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
