### PR TITLE
Fix #2679: handle dup table creation via REST

### DIFF
--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/exception/StatusRuntimeExceptionMapper.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/exception/StatusRuntimeExceptionMapper.java
@@ -64,6 +64,8 @@ public class StatusRuntimeExceptionMapper {
       case UNAUTHENTICATED:
         return grpcResponseNoLog(
             sc, Response.Status.UNAUTHORIZED, "Unauthenticated gRPC operation", msg);
+      case ALREADY_EXISTS:
+        return grpcResponseNoLog(sc, Response.Status.CONFLICT, "Resource already exists", msg);
 
         // server-side problems, do log
       case UNAVAILABLE:
@@ -80,7 +82,6 @@ public class StatusRuntimeExceptionMapper {
       case OK:
       case CANCELLED:
       case UNKNOWN:
-      case ALREADY_EXISTS:
       case RESOURCE_EXHAUSTED:
       case ABORTED:
       case OUT_OF_RANGE:

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/exception/StatusRuntimeExceptionMapper.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/exception/StatusRuntimeExceptionMapper.java
@@ -47,6 +47,8 @@ public class StatusRuntimeExceptionMapper {
     switch (sc) {
 
         // client-side problems, do not log
+      case ALREADY_EXISTS:
+        return grpcResponseNoLog(sc, Response.Status.CONFLICT, "Resource already exists", msg);
       case FAILED_PRECONDITION:
         return grpcResponseNoLog(
             sc,
@@ -64,8 +66,6 @@ public class StatusRuntimeExceptionMapper {
       case UNAUTHENTICATED:
         return grpcResponseNoLog(
             sc, Response.Status.UNAUTHORIZED, "Unauthenticated gRPC operation", msg);
-      case ALREADY_EXISTS:
-        return grpcResponseNoLog(sc, Response.Status.CONFLICT, "Resource already exists", msg);
 
         // server-side problems, do log
       case UNAVAILABLE:

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/exception/StatusRuntimeExceptionMapperTest.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/exception/StatusRuntimeExceptionMapperTest.java
@@ -43,7 +43,7 @@ public class StatusRuntimeExceptionMapperTest {
     RestResponse<ApiError> response = mapper.statusRuntimeException(error);
     assertThat(response.getEntity().description().endsWith(error.getMessage())).isTrue();
     assertThat(response.getEntity().grpcStatus()).isEqualTo(Status.Code.ALREADY_EXISTS.toString());
-    assertThat(response.getEntity().code()).isEqualTo(500);
+    assertThat(response.getEntity().code()).isEqualTo(409);
   }
 
   @Test

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QIntegrationTestBase.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QIntegrationTestBase.java
@@ -382,17 +382,21 @@ public abstract class RestApiV2QIntegrationTestBase {
   }
 
   protected NameResponse createTable(String keyspaceName, Sgv2TableAddRequest addRequest) {
-    String response =
-        givenWithAuth()
-            .contentType(ContentType.JSON)
-            .body(asJsonString(addRequest))
-            .when()
-            .post(endpointPathForTables(keyspaceName))
-            .then()
-            .statusCode(HttpStatus.SC_CREATED)
-            .extract()
-            .asString();
+    String response = tryCreateTable(keyspaceName, addRequest, HttpStatus.SC_CREATED);
     return readJsonAs(response, NameResponse.class);
+  }
+
+  protected String tryCreateTable(
+      String keyspaceName, Sgv2TableAddRequest addRequest, int expStatus) {
+    return givenWithAuth()
+        .contentType(ContentType.JSON)
+        .body(asJsonString(addRequest))
+        .when()
+        .post(endpointPathForTables(keyspaceName))
+        .then()
+        .statusCode(expStatus)
+        .extract()
+        .asString();
   }
 
   protected Sgv2Table findTable(String keyspaceName, String tableName) {

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaTablesIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaTablesIT.java
@@ -340,8 +340,9 @@ public class RestApiV2QSchemaTablesIT extends RestApiV2QIntegrationTestBase {
     ApiError error = readJsonAs(responseStr, ApiError.class);
     assertThat(error.code()).isEqualTo(HttpStatus.SC_CONFLICT);
     assertThat(error.grpcStatus()).isEqualTo("ALREADY_EXISTS");
-    assertThat(error.description()).startsWith("Resource already exists")
-            .contains("Cannot add already existing table");
+    assertThat(error.description())
+        .startsWith("Resource already exists")
+        .contains("Cannot add already existing table");
   }
 
   /*


### PR DESCRIPTION
**What this PR does**:

Changes mapping of Bridge gRPC "ALREADY_EXISTS" to map to HTTP 409 (Conflict) with appropriate error code, message.

**Which issue(s) this PR fixes**:
Fixes #2679

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
