### PR TITLE
Fix in tests related to Index definition retrieval

### DIFF
--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QMapTestsImplIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QMapTestsImplIT.java
@@ -1,17 +1,16 @@
 package io.stargate.sgv2.it;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.Assert.assertTrue;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
 import io.stargate.sgv2.api.common.cql.builder.CollectionIndexingType;
-import org.apache.http.HttpStatus;
-
 import java.util.*;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.junit.Assert.assertTrue;
+import org.apache.http.HttpStatus;
 
 /**
  * Tests for MAP data type.

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QMapTestsImplIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QMapTestsImplIT.java
@@ -1,15 +1,17 @@
 package io.stargate.sgv2.it;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
 import io.stargate.sgv2.api.common.cql.builder.CollectionIndexingType;
-import java.util.*;
 import org.apache.http.HttpStatus;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for MAP data type.
@@ -813,6 +815,8 @@ public class RestApiV2QMapTestsImplIT {
         Arrays.asList(testBase.readJsonAs(response, RestApiV2QSchemaIndexesIT.IndexDesc[].class));
     assertThat(indexList).hasSize(1);
     assertThat(indexList.get(0).index_name()).isEqualTo(indexName);
+    // Based on the backend indexing type, there could be more than one 'options' returned.
+    assertThat(indexList.get(0).options().size()).isGreaterThanOrEqualTo(1);
     assertThat(indexList.get(0).options().get("target")).isEqualTo("entries(attributes)");
   }
 
@@ -843,8 +847,20 @@ public class RestApiV2QMapTestsImplIT {
                 response, RestApiV2QSchemaIndexesIT.IndexDescOptionsAsList[].class));
     assertThat(indexList).hasSize(1);
     assertThat(indexList.get(0).index_name()).isEqualTo(indexName);
-    assertThat(indexList.get(0).options().get(0).get("key")).isEqualTo("target");
-    assertThat(indexList.get(0).options().get(0).get("value")).isEqualTo("entries(attributes)");
+    // Based on the backend indexing type, there could be more than one 'options' returned.
+    // At the minimum, the 'options' should have one entry with key as target and value as
+    // entries(attributes)
+    assertThat(indexList.get(0).options().size()).isGreaterThanOrEqualTo(1);
+    boolean foundAtleastTargat = false;
+    for (Map<String, String> mapOptions : indexList.get(0).options()) {
+      if (mapOptions.get("key").equals("target")) {
+        assertThat(mapOptions.get("value")).isEqualTo("entries(attributes)");
+        foundAtleastTargat = true;
+      }
+    }
+    if (!foundAtleastTargat) {
+      fail("target option not found");
+    }
   }
 
   private static Boolean getFlagForCompactDataTest(boolean serverFlag, boolean testDefault) {


### PR DESCRIPTION
**What this PR does**:
Below test assumes that the `options` field returned as part of the get index definition API call is always 1 in size. But based on the backend, it could return more options. This PR removes that assumption and tests for the presence of known field.

https://github.com/stargate/stargate/blob/407eec45bada5bf69ea6ed41634f4e2e56bc8b92/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QMapTestsImplIT.java#L846

**Which issue(s) this PR fixes**:
Fixes #2687 

**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [X] Documentation added/updated
- [X] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
