### PR TITLE
Fix an issue with running ITs locally: should not use "latest" tag but "v2"

### DIFF
--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
@@ -77,7 +77,7 @@ public class StargateTestResource
     String CASSANDRA_IMAGE_TAG = "4.0.10";
 
     String STARGATE_IMAGE = "stargateio/coordinator-4_0";
-    String STARGATE_IMAGE_TAG = "latest";
+    String STARGATE_IMAGE_TAG = "v2";
 
     String CLUSTER_NAME = "int-test-cluster";
     String CLUSTER_VERSION = "4.0";


### PR DESCRIPTION
**What this PR does**:

Fixes issue running ITs locally: coordinator image tag expected was wrong and only worked if dev happened to have coordinator image tagged as `latest`; something our docker image build does not do.
Did not affect CI since it overrides settings.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
