### PR TITLE
Increse CI timeouts for Coordinator, API tests from 30 to 45 minutes to reduce transient fails

### DIFF
--- a/.github/workflows/apis-v2.yaml
+++ b/.github/workflows/apis-v2.yaml
@@ -239,8 +239,8 @@ jobs:
     needs: [ resolve-coordinator-docker, build-coordinator-docker, build ]
     runs-on: ubuntu-latest
 
-    # max run time 30 minutes
-    timeout-minutes: 30
+    # max run time 45 minutes
+    timeout-minutes: 45
 
     strategy:
 

--- a/.github/workflows/apis-v21.yaml
+++ b/.github/workflows/apis-v21.yaml
@@ -239,8 +239,8 @@ jobs:
     needs: [ resolve-coordinator-docker, build-coordinator-docker, build ]
     runs-on: ubuntu-latest
 
-    # max run time 30 minutes
-    timeout-minutes: 30
+    # max run time 45 minutes
+    timeout-minutes: 45
 
     strategy:
 

--- a/.github/workflows/coordinator-test-v21.yml
+++ b/.github/workflows/coordinator-test-v21.yml
@@ -47,8 +47,8 @@ jobs:
     name: Coordinator unit tests
     runs-on: ubuntu-latest
 
-    # max run time 30 minutes
-    timeout-minutes: 30
+    # max run time 45 minutes
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/coordinator-test.yml
+++ b/.github/workflows/coordinator-test.yml
@@ -47,8 +47,8 @@ jobs:
     name: Coordinator unit tests
     runs-on: ubuntu-latest
 
-    # max run time 30 minutes
-    timeout-minutes: 30
+    # max run time 45 minutes
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
**What this PR does**:

Increase timeouts for CI ITs for APIs, Coordinator to 45 minutes from current 30 minutes: we have observed fairly common bogus timeout fails so 30 minutes seem too slow.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
