### PR TITLE
Update `dse-db-all` jar to latest as of 2023-07-25 (4.0.7-336cdd7405ee)

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -256,7 +256,7 @@
       <id>dse-next</id>
       <properties>
         <stargate.int-test.cassandra.image>stargateio/dse-next</stargate.int-test.cassandra.image>
-        <stargate.int-test.cassandra.image-tag>4.0.7-0acaae364c19</stargate.int-test.cassandra.image-tag>
+        <stargate.int-test.cassandra.image-tag>4.0.7-336cdd7405ee</stargate.int-test.cassandra.image-tag>
         <stargate.int-test.coordinator.image>stargateio/dse-next</stargate.int-test.coordinator.image>
         <stargate.int-test.coordinator.image-tag>v${project.version}</stargate.int-test.coordinator.image-tag>
         <stargate.int-test.cluster.name>cass-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>

--- a/coordinator/persistence-dse-next/pom.xml
+++ b/coordinator/persistence-dse-next/pom.xml
@@ -13,7 +13,8 @@
   <name>Stargate - Coordinator - Persistence DSE Next</name>
   <properties>
     <!-- If you update this, make sure to keep `cassandra.bundled-driver.version` in sync -->
-    <cassandra.version>4.0.7-0acaae364c19</cassandra.version>
+    <!-- Latest as of 2023-07-25: 4.0.7-336cdd7405ee -->
+    <cassandra.version>4.0.7-336cdd7405ee</cassandra.version>
     <!--
       The driver used internally by cassandra-all for UDFs (must match the version declared in
       cassandra-all's POM).


### PR DESCRIPTION
**What this PR does**:

Updates dse-db-all dependency to latest (for vector search work)

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
