### PR TITLE
Add `size()` method for `ColumnType`, implemented by `VectorType`

### DIFF
--- a/coordinator/persistence-api/src/main/java/io/stargate/db/schema/Column.java
+++ b/coordinator/persistence-api/src/main/java/io/stargate/db/schema/Column.java
@@ -145,6 +145,10 @@ public abstract class Column implements SchemaEntity, Comparable<Column> {
       return frozen(true);
     }
 
+    default int size() {
+      throw new UnsupportedOperationException("ColumnType.size() not supported by " + rawType());
+    }
+
     default ColumnType of(ColumnType... types) {
       throw new UnsupportedOperationException("ColumnType.of() not supported by " + rawType());
     }

--- a/coordinator/persistence-api/src/main/java/io/stargate/db/schema/VectorType.java
+++ b/coordinator/persistence-api/src/main/java/io/stargate/db/schema/VectorType.java
@@ -31,6 +31,11 @@ public class VectorType extends Column.DelegatingColumnType {
   }
 
   @Override
+  public int size() {
+    return dimensions;
+  }
+
+  @Override
   public int schemaHashCode() {
     return delegate.schemaHashCode() ^ SchemaHashable.hashCode(elementTypeName) + dimensions;
   }


### PR DESCRIPTION
**What this PR does**:

As per title exposes VectorType `size`

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
