### PR TITLE
Fix #2712: make QueryBuilder avoid quoting numbers

### DIFF
--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/cql/CqlStrings.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/cql/CqlStrings.java
@@ -167,7 +167,7 @@ public class CqlStrings {
       if (BUILT_IN_TYPES.contains(dataTypeName) || Character.isDigit(firstChar)) {
         return dataTypeName;
       }
-      return BUILT_IN_TYPES.contains(dataTypeName) ? dataTypeName : quote(dataTypeName, '"');
+      return quote(dataTypeName, '"');
     } else {
       String baseTypeName = dataTypeName.substring(0, paramsIdx).trim();
       if (dataTypeName.charAt(lastCharIdx) != '>') {

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/cql/CqlStrings.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/cql/CqlStrings.java
@@ -140,7 +140,8 @@ public class CqlStrings {
     }
 
     int lastCharIdx = dataTypeName.length() - 1;
-    if (dataTypeName.charAt(0) == '\'') {
+    final char firstChar = dataTypeName.charAt(0);
+    if (firstChar == '\'') {
       // The quote should be terminated, and we should have at least 1 character + the quotes,
       if (dataTypeName.charAt(lastCharIdx) != '\'' || dataTypeName.length() < 3) {
         throw new IllegalArgumentException(
@@ -151,7 +152,7 @@ public class CqlStrings {
 
     // Normally we shouldn't get double-quoted types in the input, but if we do handle them
     // correctly
-    if (dataTypeName.charAt(0) == '"') {
+    if (firstChar == '"') {
       if (dataTypeName.charAt(lastCharIdx) != '"' || dataTypeName.length() < 3) {
         throw new IllegalArgumentException(
             "Malformed type name (missing closing quote): " + dataTypeName);
@@ -161,6 +162,11 @@ public class CqlStrings {
 
     int paramsIdx = dataTypeName.indexOf('<');
     if (paramsIdx < 0) {
+      // No quoting for known scalar types OR numbers (enough to check first char since
+      // no legal type name starts with a digit)
+      if (BUILT_IN_TYPES.contains(dataTypeName) || Character.isDigit(firstChar)) {
+        return dataTypeName;
+      }
       return BUILT_IN_TYPES.contains(dataTypeName) ? dataTypeName : quote(dataTypeName, '"');
     } else {
       String baseTypeName = dataTypeName.substring(0, paramsIdx).trim();

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/cql/CqlStringsTest.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/cql/CqlStringsTest.java
@@ -28,6 +28,7 @@ public class CqlStringsTest {
     assertThat(CqlStrings.doubleQuoteUdts("list<map<int, text>>"))
         .isEqualTo("list<map<int, text>>");
     assertThat(CqlStrings.doubleQuoteUdts("frozen<set<bigint>>")).isEqualTo("frozen<set<bigint>>");
+    assertThat(CqlStrings.doubleQuoteUdts("vector<float, 5>")).isEqualTo("vector<float, 5>");
 
     assertThat(CqlStrings.doubleQuoteUdts("address")).isEqualTo("\"address\"");
     assertThat(CqlStrings.doubleQuoteUdts("Address")).isEqualTo("\"Address\"");


### PR DESCRIPTION
**What this PR does**:

Prevents quoting of numbers in type declarations like:

```
   vector<float, 5>
```

where currently token `5` would be quoted as '"5"` as it is not a known type token.

**Which issue(s) this PR fixes**:
Fixes #2712

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
