### PR TITLE
cassandra 4.0 docker compose updates

### DIFF
--- a/docker-compose/cassandra-4.0/docker-compose.yml
+++ b/docker-compose/cassandra-4.0/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       memlock: -1
     environment:
       - MAX_HEAP_SIZE=1536M
+      - HEAP_NEWSIZE=400M
       - CASSANDRA_CLUSTER_NAME=c4-${CASSTAG}-cluster
     healthcheck:
       test: [ "CMD", "cqlsh", "-u cassandra", "-p cassandra" ,"-e describe keyspaces" ]
@@ -33,28 +34,7 @@ services:
         condition: service_healthy
     environment:
       - MAX_HEAP_SIZE=1536M
-      - CASSANDRA_SEEDS=cassandra-1
-      - CASSANDRA_CLUSTER_NAME=c4-${CASSTAG}-cluster
-    healthcheck:
-      test: [ "CMD", "cqlsh", "-u cassandra", "-p cassandra" ,"-e describe keyspaces" ]
-      interval: 15s
-      timeout: 10s
-      retries: 10
-
-  cassandra-3:
-    image: cassandra:${CASSTAG}
-    networks:
-      - stargate
-    mem_limit: 2G
-    cap_add:
-      - IPC_LOCK
-    ulimits:
-      memlock: -1
-    depends_on:
-      cassandra-2:
-        condition: service_healthy
-    environment:
-      - MAX_HEAP_SIZE=1536M
+      - HEAP_NEWSIZE=400M
       - CASSANDRA_SEEDS=cassandra-1
       - CASSANDRA_CLUSTER_NAME=c4-${CASSTAG}-cluster
     healthcheck:


### PR DESCRIPTION
While doing some local testing with the Cassandra 4.0 docker compose, I observed an error running the `start_cass_40.sh` script. The Cassandra container was failing with a message to the effect that if you set `MAX_HEAP_SIZE` you must also set `HEAP_NEWSIZE`. This seems to be something introduced more recently? This PR updates the configuration to set both parameters and also removes the third Cassandra container as it doesn't really add much but consumes more resources.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
