### PR TITLE
fix dse-next-persistence intercept

### DIFF
--- a/coordinator/persistence-dse-next/src/main/java/io/stargate/db/cassandra/impl/StargateLegacyPeersView.java
+++ b/coordinator/persistence-dse-next/src/main/java/io/stargate/db/cassandra/impl/StargateLegacyPeersView.java
@@ -1,0 +1,38 @@
+package io.stargate.db.cassandra.impl;
+
+import org.apache.cassandra.db.virtual.SimpleDataSet;
+import org.apache.cassandra.nodes.virtual.NodesSystemViews;
+
+public class StargateLegacyPeersView extends StargateNodeView {
+  StargateLegacyPeersView() {
+    super(
+        StargateSystemKeyspace.virtualFromLegacy(
+            NodesSystemViews.LegacyPeersMetadata, StargateSystemKeyspace.LEGACY_PEERS_TABLE_NAME));
+  }
+
+  @Override
+  @SuppressWarnings("RxReturnValueIgnored")
+  public DataSet data() {
+
+    SimpleDataSet dataset = new SimpleDataSet(metadata());
+
+    StargateSystemKeyspace.instance.getPeers().values().stream()
+        .forEach(
+            p -> {
+              // Have to copy the current PeerInfo object as it may change while we're constructing
+              // the row,
+              // so null-values could sneak in and cause NPEs during serialization.
+              p = p.copy();
+
+              dataset
+                  .row(p.getPeer().address)
+                  // + "preferred_ip inet,"
+                  .column("preferred_ip", p.getRpcAddress())
+                  // + "rpc_address inet,"
+                  .column("rpc_address", p.getRpcAddress());
+              completeRow(dataset, p);
+            });
+
+    return dataset;
+  }
+}

--- a/coordinator/persistence-dse-next/src/main/java/io/stargate/db/cassandra/impl/StargateLocalInfo.java
+++ b/coordinator/persistence-dse-next/src/main/java/io/stargate/db/cassandra/impl/StargateLocalInfo.java
@@ -1,0 +1,71 @@
+package io.stargate.db.cassandra.impl;
+
+import java.net.InetAddress;
+import org.apache.cassandra.utils.CassandraVersion;
+import org.apache.cassandra.utils.Throwables;
+
+public class StargateLocalInfo extends StargateNodeInfo {
+  private volatile InetAddress broadcastAddress;
+  private volatile String clusterName;
+  private volatile CassandraVersion cqlVersion;
+  private volatile InetAddress listenAddress;
+  private volatile String nativeProtocolVersion;
+  private volatile String partitioner;
+
+  public InetAddress getBroadcastAddress() {
+    return broadcastAddress;
+  }
+
+  public void setBroadcastAddress(InetAddress broadcastAddress) {
+    this.broadcastAddress = broadcastAddress;
+  }
+
+  public String getClusterName() {
+    return clusterName;
+  }
+
+  public void setClusterName(String clusterName) {
+    this.clusterName = clusterName;
+  }
+
+  public CassandraVersion getCqlVersion() {
+    return cqlVersion;
+  }
+
+  public void setCqlVersion(CassandraVersion cqlVersion) {
+    this.cqlVersion = cqlVersion;
+  }
+
+  public InetAddress getListenAddress() {
+    return listenAddress;
+  }
+
+  public void setListenAddress(InetAddress listenAddress) {
+    this.listenAddress = listenAddress;
+  }
+
+  public String getNativeProtocolVersion() {
+    return nativeProtocolVersion;
+  }
+
+  public void setNativeProtocolVersion(String nativeProtocolVersion) {
+    this.nativeProtocolVersion = nativeProtocolVersion;
+  }
+
+  public String getPartitioner() {
+    return partitioner;
+  }
+
+  public void setPartitioner(String partitioner) {
+    this.partitioner = partitioner;
+  }
+
+  @Override
+  public StargateLocalInfo copy() {
+    try {
+      return (StargateLocalInfo) clone();
+    } catch (CloneNotSupportedException e) {
+      throw Throwables.unchecked(e);
+    }
+  }
+}

--- a/coordinator/persistence-dse-next/src/main/java/io/stargate/db/cassandra/impl/StargateLocalView.java
+++ b/coordinator/persistence-dse-next/src/main/java/io/stargate/db/cassandra/impl/StargateLocalView.java
@@ -1,0 +1,56 @@
+package io.stargate.db.cassandra.impl;
+
+import org.apache.cassandra.db.virtual.SimpleDataSet;
+import org.apache.cassandra.nodes.BootstrapState;
+import org.apache.cassandra.nodes.virtual.LocalNodeSystemView;
+import org.apache.cassandra.nodes.virtual.NodesSystemViews;
+
+public class StargateLocalView extends StargateNodeView {
+  StargateLocalView() {
+    super(
+        StargateSystemKeyspace.virtualFromLegacy(
+            NodesSystemViews.LocalMetadata, StargateSystemKeyspace.LOCAL_TABLE_NAME));
+  }
+
+  @Override
+  @SuppressWarnings("RxReturnValueIgnored")
+  public DataSet data() {
+    SimpleDataSet dataset = new SimpleDataSet(metadata());
+
+    StargateLocalInfo info = StargateSystemKeyspace.instance.getLocal().copy();
+
+    dataset =
+        dataset
+            .row(LocalNodeSystemView.KEY)
+            // + "bootstrapped text,"
+            .column("bootstrapped", safeToString(BootstrapState.COMPLETED.name()))
+            // + "broadcast_address inet,"
+            .column("broadcast_address", info.getBroadcastAddress())
+            // + "broadcast_port int,"
+            .column("broadcast_port", info.getRpcPort())
+            // + "cluster_name text,"
+            .column("cluster_name", info.getClusterName())
+            // + "cql_version text,"
+            .column("cql_version", safeToString(info.getCqlVersion()))
+            // + "data_center text,"
+            .column("data_center", safeToString(info.getDataCenter()))
+            // + "gossip_generation int,"
+            .column("gossip_generation", null)
+            // + "listen_address inet,"
+            .column("listen_address", info.getListenAddress())
+            // + "listen_address int,"
+            .column("listen_port", info.getRpcPort())
+            // + "rpc_address inet,"
+            .column("rpc_address", info.getRpcAddress())
+            // + "rpc_port int,"
+            .column("rpc_port", info.getRpcPort())
+            // + "native_protocol_version text,"
+            .column("native_protocol_version", info.getNativeProtocolVersion())
+            // + "partitioner text,"
+            .column("partitioner", info.getPartitioner())
+            // + "truncated_at map<uuid, blob>,"
+            .column("truncated_at", null);
+
+    return completeRow(dataset, info);
+  }
+}

--- a/coordinator/persistence-dse-next/src/main/java/io/stargate/db/cassandra/impl/StargateNodeInfo.java
+++ b/coordinator/persistence-dse-next/src/main/java/io/stargate/db/cassandra/impl/StargateNodeInfo.java
@@ -1,0 +1,85 @@
+package io.stargate.db.cassandra.impl;
+
+import java.net.InetAddress;
+import java.util.Set;
+import java.util.UUID;
+
+public abstract class StargateNodeInfo implements Cloneable {
+  private volatile UUID hostId;
+  private volatile String dataCenter;
+  private volatile String rack;
+  private volatile String releaseVersion;
+  private volatile InetAddress nativeAddress;
+  private volatile Integer nativePort;
+  private volatile Integer nativePortSsl;
+  private volatile Integer jmxPort;
+  private volatile Integer storagePort;
+  private volatile Integer storagePortSsl;
+  private volatile Set<String> tokens;
+
+  public UUID getHostId() {
+    return hostId;
+  }
+
+  public void setHostId(UUID hostId) {
+    this.hostId = hostId;
+  }
+
+  public String getDataCenter() {
+    return dataCenter;
+  }
+
+  public void setDataCenter(String dataCenter) {
+    this.dataCenter = dataCenter;
+  }
+
+  public String getRack() {
+    return rack;
+  }
+
+  public void setRack(String rack) {
+    this.rack = rack;
+  }
+
+  public String getReleaseVersion() {
+    return releaseVersion;
+  }
+
+  public void setReleaseVersion(String releaseVersion) {
+    this.releaseVersion = releaseVersion;
+  }
+
+  public InetAddress getRpcAddress() {
+    return nativeAddress;
+  }
+
+  public InetAddress getNativeAddress() {
+    return nativeAddress;
+  }
+
+  public void setNativeAddress(InetAddress nativeAddress) {
+    this.nativeAddress = nativeAddress;
+  }
+
+  public Integer getNativePort() {
+    return nativePort;
+  }
+
+  public Integer getRpcPort() {
+    return nativePort;
+  }
+
+  public void setNativePort(Integer nativePort) {
+    this.nativePort = nativePort;
+  }
+
+  public Set<String> getTokens() {
+    return tokens;
+  }
+
+  public void setTokens(Set<String> tokens) {
+    this.tokens = tokens;
+  }
+
+  public abstract StargateNodeInfo copy();
+}

--- a/coordinator/persistence-dse-next/src/main/java/io/stargate/db/cassandra/impl/StargateNodeView.java
+++ b/coordinator/persistence-dse-next/src/main/java/io/stargate/db/cassandra/impl/StargateNodeView.java
@@ -1,0 +1,31 @@
+package io.stargate.db.cassandra.impl;
+
+import org.apache.cassandra.db.virtual.AbstractVirtualTable;
+import org.apache.cassandra.db.virtual.SimpleDataSet;
+import org.apache.cassandra.schema.TableMetadata;
+
+public abstract class StargateNodeView extends AbstractVirtualTable {
+  StargateNodeView(TableMetadata metadata) {
+    super(metadata);
+  }
+
+  DataSet completeRow(SimpleDataSet dataset, StargateNodeInfo info) {
+    // + "data_center text,"
+    return dataset
+        .column("data_center", info.getDataCenter())
+        // + "host_id uuid,"
+        .column("host_id", info.getHostId())
+        // + "rack text,"
+        .column("rack", info.getRack())
+        // + "release_version text,"
+        .column("release_version", safeToString(info.getReleaseVersion()))
+        // + "schema_version uuid,"
+        .column("schema_version", StargateSystemKeyspace.SCHEMA_VERSION)
+        // + "tokens set<varchar>,"
+        .column("tokens", info.getTokens());
+  }
+
+  static String safeToString(Object o) {
+    return o != null ? o.toString() : null;
+  }
+}

--- a/coordinator/persistence-dse-next/src/main/java/io/stargate/db/cassandra/impl/StargatePeerInfo.java
+++ b/coordinator/persistence-dse-next/src/main/java/io/stargate/db/cassandra/impl/StargatePeerInfo.java
@@ -1,0 +1,27 @@
+package io.stargate.db.cassandra.impl;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.utils.Throwables;
+
+public class StargatePeerInfo extends StargateNodeInfo {
+  private final InetAddressAndPort peer;
+
+  public StargatePeerInfo(InetAddressAndPort peer) {
+    this.peer = peer;
+    setTokens(StargateSystemKeyspace.generateRandomTokens(peer, DatabaseDescriptor.getNumTokens()));
+  }
+
+  public InetAddressAndPort getPeer() {
+    return peer;
+  }
+
+  @Override
+  public StargatePeerInfo copy() {
+    try {
+      return (StargatePeerInfo) clone();
+    } catch (CloneNotSupportedException e) {
+      throw Throwables.unchecked(e);
+    }
+  }
+}

--- a/coordinator/persistence-dse-next/src/main/java/io/stargate/db/cassandra/impl/StargatePeersView.java
+++ b/coordinator/persistence-dse-next/src/main/java/io/stargate/db/cassandra/impl/StargatePeersView.java
@@ -1,0 +1,43 @@
+package io.stargate.db.cassandra.impl;
+
+import org.apache.cassandra.db.virtual.SimpleDataSet;
+import org.apache.cassandra.nodes.virtual.NodesSystemViews;
+
+public class StargatePeersView extends StargateNodeView {
+  StargatePeersView() {
+    super(
+        StargateSystemKeyspace.virtualFromLegacy(
+            NodesSystemViews.PeersV2Metadata, StargateSystemKeyspace.PEERS_V2_TABLE_NAME));
+  }
+
+  @Override
+  @SuppressWarnings("RxReturnValueIgnored")
+  public DataSet data() {
+
+    SimpleDataSet dataset = new SimpleDataSet(metadata());
+
+    StargateSystemKeyspace.instance.getPeers().values().stream()
+        .forEach(
+            p -> {
+              // Have to copy the current PeerInfo object as it may change while we're constructing
+              // the row,
+              // so null-values could sneak in and cause NPEs during serialization.
+              p = p.copy();
+
+              dataset
+                  .row(p.getPeer().address, p.getPeer().port)
+                  // + "preferred_ip inet,"
+                  .column("preferred_ip", p.getRpcAddress())
+                  // + "preferred_port int,"
+                  .column("preferred_port", p.getRpcPort())
+                  // + "native_address inet,"
+                  .column("native_address", p.getNativeAddress())
+                  // + "native_port int,"
+                  .column("native_port", p.getNativePort());
+
+              completeRow(dataset, p);
+            });
+
+    return dataset;
+  }
+}

--- a/coordinator/persistence-dse-next/src/main/java/io/stargate/db/cassandra/impl/StargateSystemKeyspace.java
+++ b/coordinator/persistence-dse-next/src/main/java/io/stargate/db/cassandra/impl/StargateSystemKeyspace.java
@@ -9,12 +9,12 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLStatement;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.cql3.statements.SelectStatement;
-import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.virtual.*;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Token.TokenFactory;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.nodes.Nodes;
+import org.apache.cassandra.nodes.virtual.NodeConstants;
 import org.apache.cassandra.schema.*;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.FBUtilities;
@@ -67,21 +67,13 @@ public class StargateSystemKeyspace extends VirtualKeyspace {
             FBUtilities.getBroadcastNativeAddressAndPort(), DatabaseDescriptor.getNumTokens()));
   }
 
-  public static boolean isSystemPeers(SelectStatement statement) {
-    return statement.columnFamily().equals(SystemKeyspace.LEGACY_PEERS);
-  }
-
-  public static boolean isSystemPeersV2(SelectStatement statement) {
-    return statement.columnFamily().equals(SystemKeyspace.PEERS_V2);
-  }
-
   public static boolean isSystemLocalOrPeers(CQLStatement statement) {
     if (statement instanceof SelectStatement) {
       SelectStatement selectStatement = (SelectStatement) statement;
-      return selectStatement.keyspace().equals(SchemaConstants.SYSTEM_KEYSPACE_NAME)
-          && (selectStatement.columnFamily().equals(SystemKeyspace.LOCAL)
-              || isSystemPeers(selectStatement)
-              || isSystemPeersV2(selectStatement));
+      return selectStatement.keyspace().equals(SchemaConstants.SYSTEM_VIEWS_KEYSPACE_NAME)
+          && (selectStatement.columnFamily().equals(NodeConstants.LEGACY_PEERS_VIEW_NAME)
+              || selectStatement.columnFamily().equals(NodeConstants.PEERS_V2_VIEW_NAME)
+              || selectStatement.columnFamily().equals(NodeConstants.LOCAL_VIEW_NAME));
     }
     return false;
   }

--- a/coordinator/persistence-dse-next/src/main/java/io/stargate/db/cassandra/impl/StargateSystemKeyspace.java
+++ b/coordinator/persistence-dse-next/src/main/java/io/stargate/db/cassandra/impl/StargateSystemKeyspace.java
@@ -1,194 +1,70 @@
 package io.stargate.db.cassandra.impl;
 
-import static java.lang.String.format;
-import static org.apache.cassandra.cql3.QueryProcessor.executeInternal;
-import static org.apache.cassandra.cql3.QueryProcessor.executeOnceInternal;
-
-import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.collect.ImmutableList;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Random;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLStatement;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.cql3.statements.SelectStatement;
-import org.apache.cassandra.cql3.statements.schema.CreateTableStatement;
-import org.apache.cassandra.db.ColumnFamilyStore;
-import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.SystemKeyspace;
-import org.apache.cassandra.db.commitlog.CommitLogPosition;
-import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.virtual.*;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Token.TokenFactory;
-import org.apache.cassandra.locator.IEndpointSnitch;
 import org.apache.cassandra.locator.InetAddressAndPort;
-import org.apache.cassandra.nodes.BootstrapState;
 import org.apache.cassandra.nodes.Nodes;
 import org.apache.cassandra.schema.*;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.MurmurHash;
-import org.apache.commons.lang3.ArrayUtils;
 
-public class StargateSystemKeyspace {
+public class StargateSystemKeyspace extends VirtualKeyspace {
   public static final String SYSTEM_KEYSPACE_NAME = "stargate_system";
   public static final String LOCAL_TABLE_NAME = "local";
-  public static final String PEERS_TABLE_NAME = "peers";
+  public static final String LEGACY_PEERS_TABLE_NAME = "peers";
   public static final String PEERS_V2_TABLE_NAME = "peers_v2";
 
   public static final UUID SCHEMA_VERSION = UUID.fromString("17846767-28a1-4acd-a967-f609ff1375f1");
 
-  public static final TableMetadata Local =
-      parse(
-              LOCAL_TABLE_NAME,
-              "information about the local node",
-              "CREATE TABLE %s ("
-                  + "key text,"
-                  + "bootstrapped text,"
-                  + "broadcast_address inet,"
-                  + "broadcast_port int,"
-                  + "cluster_name text,"
-                  + "cql_version text,"
-                  + "data_center text,"
-                  + "gossip_generation int,"
-                  + "host_id uuid,"
-                  + "listen_address inet,"
-                  + "listen_port int,"
-                  + "native_protocol_version text,"
-                  + "partitioner text,"
-                  + "rack text,"
-                  + "release_version text,"
-                  + "rpc_address inet,"
-                  + "rpc_port int,"
-                  + "schema_version uuid,"
-                  + "tokens set<varchar>,"
-                  + "truncated_at map<uuid, blob>,"
-                  + "PRIMARY KEY ((key)))")
-          .recordColumnDrop(
-              ColumnMetadata.regularColumn(
-                  SYSTEM_KEYSPACE_NAME, LOCAL_TABLE_NAME, "thrift_version", UTF8Type.instance),
-              Long.MAX_VALUE) // Record deprecated
-          .build();
+  public static final StargateSystemKeyspace instance = new StargateSystemKeyspace();
 
-  public static final TableMetadata Peers =
-      parse(
-              PEERS_TABLE_NAME,
-              "information about known peers in the cluster",
-              "CREATE TABLE %s ("
-                  + "peer inet,"
-                  + "data_center text,"
-                  + "host_id uuid,"
-                  + "preferred_ip inet,"
-                  + "rack text,"
-                  + "release_version text,"
-                  + "rpc_address inet,"
-                  + "schema_version uuid,"
-                  + "tokens set<varchar>,"
-                  + "PRIMARY KEY ((peer)))")
-          .build();
-
-  public static final TableMetadata PeersV2 =
-      parse(
-              PEERS_V2_TABLE_NAME,
-              "information about known peers in the cluster",
-              "CREATE TABLE %s ("
-                  + "peer inet,"
-                  + "peer_port int,"
-                  + "data_center text,"
-                  + "host_id uuid,"
-                  + "preferred_ip inet,"
-                  + "preferred_port int,"
-                  + "rack text,"
-                  + "release_version text,"
-                  + "native_address inet,"
-                  + "native_port int,"
-                  + "schema_version uuid,"
-                  + "tokens set<varchar>,"
-                  + "PRIMARY KEY ((peer), peer_port))")
-          .build();
-
-  private static TableMetadata.Builder parse(String table, String description, String cql) {
-    return CreateTableStatement.parse(format(cql, table), SYSTEM_KEYSPACE_NAME)
-        .id(forSystemTable(SYSTEM_KEYSPACE_NAME, table))
-        .gcGraceSeconds(0)
-        .memtableFlushPeriod((int) TimeUnit.HOURS.toMillis(1))
-        .comment(description);
-  }
-
-  /** Copy of {@link TableId#forSystemTable(String, String)} without assertion. */
-  private static TableId forSystemTable(String keyspace, String table) {
-    return TableId.fromUUID(
-        UUID.nameUUIDFromBytes(
-            ArrayUtils.addAll(
-                // Keyspace and tables names are limited to [a-zA-Z_0-9]+, so ASCII will do
-                keyspace.getBytes(StandardCharsets.US_ASCII),
-                table.getBytes(StandardCharsets.US_ASCII))));
-  }
-
-  public static Tables tables() {
-    return Tables.of(Local, Peers, PeersV2);
-  }
-
-  public static KeyspaceMetadata metadata() {
-    return KeyspaceMetadata.create(
+  private StargateSystemKeyspace() {
+    super(
         SYSTEM_KEYSPACE_NAME,
-        KeyspaceParams.local(),
-        tables(),
-        Views.none(),
-        Types.none(),
-        UserFunctions.none());
+        ImmutableList.of(
+            new StargatePeersView(), new StargateLegacyPeersView(), new StargateLocalView()));
   }
 
-  public static void persistLocalMetadata() {
-    String req =
-        "INSERT INTO %s.%s ("
-            + "key,"
-            + "cluster_name,"
-            + "release_version,"
-            + "cql_version,"
-            + "native_protocol_version,"
-            + "data_center,"
-            + "rack,"
-            + "partitioner,"
-            + "rpc_address,"
-            + "rpc_port,"
-            + "broadcast_address,"
-            + "broadcast_port,"
-            + "listen_address,"
-            + "listen_port,"
-            + "bootstrapped,"
-            + "host_id,"
-            + "tokens,"
-            + "schema_version"
-            + ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
-    IEndpointSnitch snitch = DatabaseDescriptor.getEndpointSnitch();
-    executeOnceInternal(
-        format(req, SYSTEM_KEYSPACE_NAME, LOCAL_TABLE_NAME),
-        SystemKeyspace.LOCAL,
-        DatabaseDescriptor.getClusterName(),
-        FBUtilities.getReleaseVersionString(),
-        QueryProcessor.CQL_VERSION.toString(),
-        String.valueOf(ProtocolVersion.CURRENT.asInt()),
-        snitch.getLocalDatacenter(),
-        snitch.getLocalRack(),
-        DatabaseDescriptor.getPartitioner().getClass().getName(),
-        FBUtilities.getJustBroadcastNativeAddress(),
-        DatabaseDescriptor.getNativeTransportPort(),
-        FBUtilities.getJustBroadcastAddress(),
-        DatabaseDescriptor.getStoragePort(),
-        FBUtilities.getJustLocalAddress(),
-        DatabaseDescriptor.getStoragePort(),
-        BootstrapState.COMPLETED.name(),
-        Nodes.local().get().getHostId(),
+  private final ConcurrentMap<InetAddressAndPort, StargatePeerInfo> peers =
+      new ConcurrentHashMap<>();
+  private final StargateLocalInfo local = new StargateLocalInfo();
+
+  public ConcurrentMap<InetAddressAndPort, StargatePeerInfo> getPeers() {
+    return peers;
+  }
+
+  public StargateLocalInfo getLocal() {
+    return local;
+  }
+
+  public void persistLocalMetadata() {
+    local.setClusterName(DatabaseDescriptor.getClusterName());
+    local.setReleaseVersion(FBUtilities.getReleaseVersionString());
+    local.setCqlVersion(QueryProcessor.CQL_VERSION);
+    local.setNativeProtocolVersion(String.valueOf(ProtocolVersion.CURRENT.asInt()));
+    local.setDataCenter(DatabaseDescriptor.getLocalDataCenter());
+    local.setRack(DatabaseDescriptor.getEndpointSnitch().getLocalRack());
+    local.setPartitioner(DatabaseDescriptor.getPartitioner().getClass().getName());
+    local.setBroadcastAddress(FBUtilities.getJustBroadcastAddress());
+    local.setListenAddress(FBUtilities.getJustLocalAddress());
+    local.setNativeAddress(FBUtilities.getJustBroadcastNativeAddress());
+    local.setNativePort(DatabaseDescriptor.getNativeTransportPort());
+    local.setHostId(Nodes.local().get().getHostId());
+    local.setTokens(
         StargateSystemKeyspace.generateRandomTokens(
-            FBUtilities.getBroadcastNativeAddressAndPort(), DatabaseDescriptor.getNumTokens()),
-        SCHEMA_VERSION);
+            FBUtilities.getBroadcastNativeAddressAndPort(), DatabaseDescriptor.getNumTokens()));
   }
 
   public static boolean isSystemPeers(SelectStatement statement) {
@@ -210,64 +86,14 @@ public class StargateSystemKeyspace {
     return false;
   }
 
-  public static synchronized void updatePeerInfo(
-      InetAddressAndPort ep, String columnName, Object value) {
-    if (ep.equals(FBUtilities.getBroadcastAddressAndPort())) return;
-
-    String req = "INSERT INTO %s.%s (peer, %s) VALUES (?, ?)";
-    executeInternal(
-        String.format(req, SYSTEM_KEYSPACE_NAME, PEERS_TABLE_NAME, columnName), ep.address, value);
-    // This column doesn't match across the two tables
-    if (columnName.equals("rpc_address")) {
-      columnName = "native_address";
-    }
-    req = "INSERT INTO %s.%s (peer, peer_port, %s) VALUES (?, ?, ?)";
-    executeInternal(
-        String.format(req, SYSTEM_KEYSPACE_NAME, PEERS_V2_TABLE_NAME, columnName),
-        ep.address,
-        ep.port,
-        value);
-  }
-
-  public static synchronized void updatePeerNativeAddress(
-      InetAddressAndPort ep, InetAddressAndPort address) {
-    if (ep.equals(FBUtilities.getBroadcastAddressAndPort())) return;
-
-    String req = "INSERT INTO %s.%s (peer, rpc_address) VALUES (?, ?)";
-    executeInternal(
-        String.format(req, SYSTEM_KEYSPACE_NAME, PEERS_TABLE_NAME), ep.address, address.address);
-    req = "INSERT INTO %s.%s (peer, peer_port, native_address, native_port) VALUES (?, ?, ?, ?)";
-    executeInternal(
-        String.format(req, SYSTEM_KEYSPACE_NAME, PEERS_V2_TABLE_NAME),
-        ep.address,
-        ep.port,
-        address.address,
-        address.port);
-  }
-
-  public static synchronized void removeEndpoint(InetAddressAndPort ep) {
-    String req = "DELETE FROM %s.%s WHERE peer = ?";
-    executeInternal(String.format(req, SYSTEM_KEYSPACE_NAME, PEERS_TABLE_NAME), ep.address);
-    req =
-        String.format(
-            "DELETE FROM %s.%s WHERE peer = ? AND peer_port = ?",
-            SYSTEM_KEYSPACE_NAME, PEERS_V2_TABLE_NAME);
-    executeInternal(req, ep.address, ep.port);
-    forceBlockingFlush(PEERS_TABLE_NAME, PEERS_V2_TABLE_NAME);
-  }
-
-  public static void forceBlockingFlush(String... cfnames) {
-    if (!DatabaseDescriptor.isUnsafeSystem()) {
-      List<ListenableFuture<CommitLogPosition>> futures = new ArrayList<>();
-
-      for (String cfname : cfnames) {
-        futures.add(
-            Keyspace.open(SYSTEM_KEYSPACE_NAME)
-                .getColumnFamilyStore(cfname)
-                .forceFlush(ColumnFamilyStore.FlushReason.INTERNALLY_FORCED));
-      }
-      FBUtilities.waitOnFutures(futures);
-    }
+  public static TableMetadata virtualFromLegacy(TableMetadata legacy, String table) {
+    TableMetadata.Builder builder =
+        TableMetadata.builder(SYSTEM_KEYSPACE_NAME, table).kind(TableMetadata.Kind.VIRTUAL);
+    legacy.partitionKeyColumns().forEach(cm -> builder.addPartitionKeyColumn(cm.name, cm.type));
+    legacy.staticColumns().forEach(cm -> builder.addStaticColumn(cm.name, cm.type.freeze()));
+    legacy.clusteringColumns().forEach(cm -> builder.addClusteringColumn(cm.name, cm.type));
+    legacy.regularColumns().forEach(cm -> builder.addRegularColumn(cm.name, cm.type.freeze()));
+    return builder.build();
   }
 
   public static Set<String> generateRandomTokens(InetAddressAndPort inetAddress, int numTokens) {

--- a/coordinator/persistence-dse-next/src/main/java/io/stargate/db/cassandra/impl/interceptors/DefaultQueryInterceptor.java
+++ b/coordinator/persistence-dse-next/src/main/java/io/stargate/db/cassandra/impl/interceptors/DefaultQueryInterceptor.java
@@ -6,6 +6,7 @@ import static io.stargate.db.cassandra.impl.StargateSystemKeyspace.isSystemPeers
 
 import com.datastax.oss.driver.shaded.guava.common.collect.Sets;
 import io.stargate.db.EventListener;
+import io.stargate.db.cassandra.impl.StargatePeerInfo;
 import io.stargate.db.cassandra.impl.StargateSystemKeyspace;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -16,22 +17,24 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import org.apache.cassandra.config.DatabaseDescriptor;
+import java.util.function.BiConsumer;
 import org.apache.cassandra.cql3.CQLStatement;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.ResultSet;
 import org.apache.cassandra.cql3.statements.SelectStatement;
+import org.apache.cassandra.db.virtual.VirtualKeyspaceRegistry;
 import org.apache.cassandra.gms.ApplicationState;
 import org.apache.cassandra.gms.EndpointState;
 import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.gms.IEndpointStateChangeSubscriber;
 import org.apache.cassandra.gms.VersionedValue;
 import org.apache.cassandra.locator.InetAddressAndPort;
-import org.apache.cassandra.schema.Schema;
+import org.apache.cassandra.nodes.virtual.NodesSystemViews;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.transport.messages.ResultMessage;
+import org.apache.cassandra.utils.FBUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,9 +55,9 @@ public class DefaultQueryInterceptor implements QueryInterceptor, IEndpointState
 
   @Override
   public void initialize() {
-    Schema.instance.load(StargateSystemKeyspace.metadata());
+    VirtualKeyspaceRegistry.instance.register(StargateSystemKeyspace.instance);
     Gossiper.instance.register(this);
-    StargateSystemKeyspace.persistLocalMetadata();
+    StargateSystemKeyspace.instance.persistLocalMetadata();
   }
 
   @Override
@@ -69,9 +72,9 @@ public class DefaultQueryInterceptor implements QueryInterceptor, IEndpointState
     }
 
     SelectStatement selectStatement = (SelectStatement) statement;
-    TableMetadata tableMetadata = StargateSystemKeyspace.Local;
-    if (isSystemPeers(selectStatement)) tableMetadata = StargateSystemKeyspace.Peers;
-    else if (isSystemPeersV2(selectStatement)) tableMetadata = StargateSystemKeyspace.PeersV2;
+    TableMetadata tableMetadata = NodesSystemViews.LocalMetadata;
+    if (isSystemPeers(selectStatement)) tableMetadata = NodesSystemViews.LegacyPeersMetadata;
+    else if (isSystemPeersV2(selectStatement)) tableMetadata = NodesSystemViews.PeersV2Metadata;
     SelectStatement interceptStatement =
         new SelectStatement(
             selectStatement.getRawCQLStatement(),
@@ -161,8 +164,6 @@ public class DefaultQueryInterceptor implements QueryInterceptor, IEndpointState
       return false;
     }
 
-    updateTokens(endpoint);
-
     for (Map.Entry<ApplicationState, VersionedValue> entry : state.states()) {
       applyState(endpoint, entry.getKey(), entry.getValue(), state);
     }
@@ -180,7 +181,7 @@ public class DefaultQueryInterceptor implements QueryInterceptor, IEndpointState
     if (!liveStargateNodes.remove(endpoint)) {
       return;
     }
-    StargateSystemKeyspace.removeEndpoint(endpoint);
+    StargateSystemKeyspace.instance.getPeers().remove(endpoint);
     InetAddressAndPort nativeAddress = getNativeAddress(endpoint);
     for (EventListener listener : listeners) {
       listener.onLeaveCluster(nativeAddress.address, nativeAddress.port);
@@ -224,18 +225,18 @@ public class DefaultQueryInterceptor implements QueryInterceptor, IEndpointState
       EndpointState epState) {
     switch (state) {
       case RELEASE_VERSION:
-        StargateSystemKeyspace.updatePeerInfo(endpoint, "release_version", value.value);
+        updatePeer(endpoint, value.value, StargatePeerInfo::setReleaseVersion);
         break;
       case DC:
-        StargateSystemKeyspace.updatePeerInfo(endpoint, "data_center", value.value);
+        updatePeer(endpoint, value.value, StargatePeerInfo::setDataCenter);
         break;
       case RACK:
-        StargateSystemKeyspace.updatePeerInfo(endpoint, "rack", value.value);
+        updatePeer(endpoint, value.value, StargatePeerInfo::setRack);
         break;
       case RPC_ADDRESS:
         try {
-          StargateSystemKeyspace.updatePeerInfo(
-              endpoint, "rpc_address", InetAddress.getByName(value.value));
+          updatePeer(
+              endpoint, InetAddress.getByName(value.value), StargatePeerInfo::setNativeAddress);
         } catch (UnknownHostException e) {
           throw new RuntimeException(e);
         }
@@ -243,19 +244,14 @@ public class DefaultQueryInterceptor implements QueryInterceptor, IEndpointState
       case NATIVE_ADDRESS_AND_PORT:
         try {
           InetAddressAndPort address = InetAddressAndPort.getByName(value.value);
-          StargateSystemKeyspace.updatePeerNativeAddress(endpoint, address);
+          updatePeer(endpoint, address.address, StargatePeerInfo::setNativeAddress);
+          updatePeer(endpoint, address.port, StargatePeerInfo::setNativePort);
         } catch (UnknownHostException e) {
           throw new RuntimeException(e);
         }
         break;
-      case SCHEMA:
-        // Use a fix schema version for all peers (always in agreement) because stargate waits
-        // for DDL queries to reach agreement before returning.
-        StargateSystemKeyspace.updatePeerInfo(
-            endpoint, "schema_version", StargateSystemKeyspace.SCHEMA_VERSION);
-        break;
       case HOST_ID:
-        StargateSystemKeyspace.updatePeerInfo(endpoint, "host_id", UUID.fromString(value.value));
+        updatePeer(endpoint, UUID.fromString(value.value), StargatePeerInfo::setHostId);
         break;
       case RPC_READY:
         notifyRpcChange(endpoint, epState.isRpcReady());
@@ -265,11 +261,16 @@ public class DefaultQueryInterceptor implements QueryInterceptor, IEndpointState
     }
   }
 
-  private void updateTokens(InetAddressAndPort endpoint) {
-    StargateSystemKeyspace.updatePeerInfo(
-        endpoint,
-        "tokens",
-        StargateSystemKeyspace.generateRandomTokens(endpoint, DatabaseDescriptor.getNumTokens()));
+  private <V> void updatePeer(
+      InetAddressAndPort endpoint, V value, BiConsumer<StargatePeerInfo, V> updater) {
+
+    if (!endpoint.equals(FBUtilities.getBroadcastAddressAndPort())) {
+      StargatePeerInfo peer =
+          StargateSystemKeyspace.instance
+              .getPeers()
+              .computeIfAbsent(endpoint, StargatePeerInfo::new);
+      updater.accept(peer, value);
+    }
   }
 
   private void notifyDown(InetAddressAndPort endpoint) {

--- a/coordinator/testing/log/debug.log.2023-08-12.0698220784251666.tmp
+++ b/coordinator/testing/log/debug.log.2023-08-12.0698220784251666.tmp
@@ -1,0 +1,686 @@
+INFO  [main] 2023-08-13 14:49:07,411 BaseActivator.java:97 - Starting persistence-dse-next ...
+INFO  [main] 2023-08-13 14:49:07,805 BaseActivator.java:97 - Starting authApiServer ...
+INFO  [main] 2023-08-13 14:49:07,888 BaseActivator.java:97 - Starting authnTableBasedService and authzTableBasedServie ...
+INFO  [main] 2023-08-13 14:49:08,026 BaseActivator.java:97 - Starting bridge ...
+INFO  [main] 2023-08-13 14:49:08,084 BaseActivator.java:97 - Starting Config Store YAML ...
+INFO  [main] 2023-08-13 14:49:08,087 BaseActivator.java:97 - Starting core services ...
+INFO  [main] 2023-08-13 14:49:08,140 BaseActivator.java:178 - Registering core services as io.stargate.core.metrics.api.Metrics
+INFO  [main] 2023-08-13 14:49:08,332 AbstractCassandraPersistence.java:105 - Initializing Apache Cassandra
+INFO  [main] 2023-08-13 14:49:08,495 DatabaseDescriptor.java:498 - DiskAccessMode 'auto' determined to be standard, indexAccessMode is standard
+INFO  [main] 2023-08-13 14:49:08,496 DatabaseDescriptor.java:560 - Global memtable on-heap threshold is enabled at 2048MB
+INFO  [main] 2023-08-13 14:49:08,496 DatabaseDescriptor.java:564 - Global memtable off-heap threshold is enabled at 2048MB
+INFO  [main] 2023-08-13 14:49:08,496 DatabaseDescriptor.java:635 - Native transport rate-limiting disabled.
+INFO  [main] 2023-08-13 14:49:08,615 GossipingPropertyFileSnitch.java:67 - Unable to load cassandra-topology.properties; compatibility mode disabled
+INFO  [main] 2023-08-13 14:49:09,237 JMXServerUtils.java:271 - Configured JMX server at: service:jmx:rmi://0.0.0.0/jndi/rmi://0.0.0.0:51393/jmxrmi
+INFO  [main] 2023-08-13 14:49:09,271 CassandraDaemon.java:613 - Hostname: jeffs-mbp.lan:7000:7001
+INFO  [main] 2023-08-13 14:49:09,272 CassandraDaemon.java:620 - JVM vendor/version: OpenJDK 64-Bit Server VM/11.0.20
+INFO  [main] 2023-08-13 14:49:09,274 CassandraDaemon.java:621 - Heap size: 512.000MiB/8.000GiB
+WARN  [main] 2023-08-13 14:49:09,492 StartupChecks.java:155 - jemalloc shared library could not be preloaded to speed up memory allocations
+INFO  [main] 2023-08-13 14:49:09,609 StartupChecks.java:206 - JMX is enabled to receive remote connections on port: 51393
+WARN  [main] 2023-08-13 14:49:09,610 StartupChecks.java:250 - The JVM is not configured to stop on OutOfMemoryError which can cause data corruption. Use one of the following JVM options to configure the behavior on OutOfMemoryError:  -XX:+ExitOnOutOfMemoryError, -XX:+CrashOnOutOfMemoryError, or -XX:OnOutOfMemoryError="<cmd args>;<cmd args>"
+INFO  [main] 2023-08-13 14:49:09,630 SigarLibrary.java:57 - Could not initialize SIGAR library 'org.hyperic.sigar.FileSystem[] org.hyperic.sigar.Sigar.getFileSystemListNative()' 
+INFO  [main] 2023-08-13 14:49:09,631 SigarLibrary.java:185 - Sigar could not be initialized, test for checking degraded mode omitted.
+WARN  [main] 2023-08-13 14:49:10,408 Nodes.java:650 - No host ID found, created c745b01f-20b4-4442-9bc8-e863d26b360e (Note: This should happen exactly once per node).
+INFO  [main] 2023-08-13 14:49:10,539 ClientState.java:105 - Using io.stargate.db.cassandra.impl.StargateQueryHandler as query handler for native protocol queries (as requested with -Dcassandra.custom_query_handler_class)
+INFO  [main] 2023-08-13 14:49:12,616 StorageService.java:965 - Token metadata: 
+INFO  [main] 2023-08-13 14:49:24,781 CommitLog.java:214 - No commitlog files found; skipping replay
+INFO  [main] 2023-08-13 14:49:24,783 StorageService.java:965 - Token metadata: 
+INFO  [main] 2023-08-13 14:49:24,880 StorageService.java:869 - Cassandra version: 4.0.7-336cdd7405ee
+INFO  [main] 2023-08-13 14:49:24,881 StorageService.java:870 - CQL version: 3.4.5
+INFO  [main] 2023-08-13 14:49:24,882 StorageService.java:871 - Native protocol supported versions: 3/v3, 4/v4, 5/v5, 6/v6-beta (default: 5/v5)
+INFO  [main] 2023-08-13 14:49:24,920 InboundConnectionInitiator.java:127 - Listening on address: (/127.0.2.1:7000), nic: lo0, encryption: unencrypted
+INFO  [main] 2023-08-13 14:49:24,939 BufferPools.java:49 - Global buffer pool limit is 2.000GiB for chunk-cache and 128.000MiB for networking
+INFO  [Messaging-EventLoop-3-3] 2023-08-13 14:49:25,179 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.0.1:51417)->/127.0.0.1:7000-URGENT_MESSAGES-1d0b0cde successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-4] 2023-08-13 14:49:25,307 InboundConnectionInitiator.java:464 - /127.0.0.1:7000(/127.0.2.1:51419)->/127.0.2.1:7000-URGENT_MESSAGES-73d2eda9 messaging connection established, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-5] 2023-08-13 14:49:27,435 InboundConnectionInitiator.java:464 - /127.0.2.2:7000(/127.0.2.1:51420)->/127.0.2.1:7000-URGENT_MESSAGES-8926d936 messaging connection established, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-8] 2023-08-13 14:49:27,460 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.2.2:51421)->/127.0.2.2:7000-URGENT_MESSAGES-8deebe68 successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [GossipStage:1] 2023-08-13 14:49:32,124 Gossiper.java:1374 - Node /127.0.2.2:7000 is now part of the cluster
+INFO  [GossipStage:1] 2023-08-13 14:49:32,131 Gossiper.java:1374 - Node /127.0.0.1:7000 is now part of the cluster
+WARN  [MigrationStage:1] 2023-08-13 14:49:32,156 MigrationCoordinator.java:682 - Can't send schema pull request: node /127.0.0.1:7000 is down.
+INFO  [GossipStage:1] 2023-08-13 14:49:32,168 TokenMetadata.java:512 - Updating topology for /127.0.0.1:7000
+INFO  [GossipStage:1] 2023-08-13 14:49:32,170 TokenMetadata.java:512 - Updating topology for /127.0.0.1:7000
+INFO  [GossipStage:1] 2023-08-13 14:49:32,174 Gossiper.java:1322 - InetAddress /127.0.2.2:7000 is now UP
+INFO  [GossipStage:1] 2023-08-13 14:49:32,175 Gossiper.java:1322 - InetAddress /127.0.0.1:7000 is now UP
+INFO  [main] 2023-08-13 14:49:32,298 StorageService.java:950 - Not joining ring as requested. Use JMX (StorageService->joinRing()) to initiate ring joining
+INFO  [main] 2023-08-13 14:49:32,299 Gossiper.java:2229 - Waiting for gossip to settle...
+INFO  [Messaging-EventLoop-3-1] 2023-08-13 14:49:32,300 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.0.1:51424)->/127.0.0.1:7000-SMALL_MESSAGES-4178fc9d successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-6] 2023-08-13 14:49:32,300 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.2.2:51425)->/127.0.2.2:7000-SMALL_MESSAGES-99f1e8a5 successfully connected, version = 100, framing = CRC, encryption = unencrypted
+WARN  [GossipTasks:1] 2023-08-13 14:49:33,124 FailureDetector.java:316 - Not marking nodes down due to local pause of 22940483875ns > 5000000000ns
+INFO  [MigrationStage:1] 2023-08-13 14:49:35,169 MigrationCoordinator.java:704 - Sending schema pull request to /127.0.0.1:7000
+INFO  [Messaging-EventLoop-3-9] 2023-08-13 14:49:35,226 InboundConnectionInitiator.java:464 - /127.0.0.1:7000(/127.0.2.1:51426)->/127.0.2.1:7000-SMALL_MESSAGES-0b56dbcd messaging connection established, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-10] 2023-08-13 14:49:38,453 InboundConnectionInitiator.java:464 - /127.0.2.2:7000(/127.0.2.1:51427)->/127.0.2.1:7000-SMALL_MESSAGES-d022c775 messaging connection established, version = 100, framing = CRC, encryption = unencrypted
+INFO  [main] 2023-08-13 14:49:40,315 Gossiper.java:2260 - No gossip backlog; proceeding
+INFO  [Messaging-EventLoop-3-1] 2023-08-13 14:49:40,541 InboundConnectionInitiator.java:464 - /127.0.2.2:7000(/127.0.2.1:51428)->/127.0.2.1:7000-LARGE_MESSAGES-d5a187e0 messaging connection established, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-7] 2023-08-13 14:49:40,591 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.2.2:51431)->/127.0.2.2:7000-LARGE_MESSAGES-16592c34 successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [main] 2023-08-13 14:49:41,475 StartupClusterConnectivityChecker.java:111 - Blocking coordination until only a single peer is DOWN in the local datacenter, timeout=10s
+INFO  [Messaging-EventLoop-3-2] 2023-08-13 14:49:41,489 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.0.1:51432)->/127.0.0.1:7000-LARGE_MESSAGES-79d6cf31 successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [main] 2023-08-13 14:49:41,490 StartupClusterConnectivityChecker.java:166 - Ensured sufficient healthy connections with [dc1] after 12 milliseconds
+INFO  [main] 2023-08-13 14:49:41,490 CassandraDaemon.java:685 - Not starting native transport as requested. Use JMX (StorageService->startNativeTransport()) or nodetool (enablebinary) to start it
+INFO  [Messaging-EventLoop-3-2] 2023-08-13 14:49:41,498 InboundConnectionInitiator.java:464 - /127.0.0.1:7000(/127.0.2.1:51433)->/127.0.2.1:7000-LARGE_MESSAGES-056d9969 messaging connection established, version = 100, framing = CRC, encryption = unencrypted
+INFO  [main] 2023-08-13 14:49:41,639 BaseActivator.java:178 - Registering persistence-dse-next as io.stargate.db.Persistence
+INFO  [main] 2023-08-13 14:49:41,646 BaseActivator.java:185 - Started persistence-dse-next
+INFO  [main] 2023-08-13 14:49:41,650 ConfigStoreActivator.java:57 - Creating Config Store YAML for config file location: /etc/stargate/stargate-config.yaml 
+INFO  [main] 2023-08-13 14:49:41,822 BaseActivator.java:178 - Registering Config Store YAML as io.stargate.config.store.api.ConfigStore
+INFO  [main] 2023-08-13 14:49:41,823 BaseActivator.java:185 - Started Config Store YAML
+INFO  [main] 2023-08-13 14:49:41,823 BaseActivator.java:178 - Registering core services as io.stargate.core.metrics.api.MetricsScraper
+INFO  [main] 2023-08-13 14:49:41,823 BaseActivator.java:178 - Registering core services as com.codahale.metrics.health.HealthCheckRegistry
+INFO  [main] 2023-08-13 14:49:41,825 BaseActivator.java:178 - Registering core services as io.stargate.core.metrics.api.HttpMetricsTagProvider
+INFO  [main] 2023-08-13 14:49:41,825 BaseActivator.java:185 - Started core services
+INFO  [main] 2023-08-13 14:49:42,200 BaseActivator.java:97 - Starting CQL ...
+INFO  [main] 2023-08-13 14:49:42,398 BaseActivator.java:97 - Starting gRPC ...
+INFO  [main] 2023-08-13 14:49:42,570 BaseActivator.java:97 - Starting healthchecker ...
+INFO  [main] 2023-08-13 14:49:42,623 BaseActivator.java:97 - Starting DB services ...
+INFO  [main] 2023-08-13 14:49:42,626 BaseActivator.java:178 - Registering DB services as io.stargate.db.Persistence
+INFO  [main] 2023-08-13 14:49:42,628 BaseActivator.java:178 - Registering DB services as io.stargate.db.datastore.DataStoreFactory
+INFO  [main] 2023-08-13 14:49:42,629 HealthCheckerActivator.java:50 - Starting healthchecker....
+INFO  [main] 2023-08-13 14:49:42,872 Version.java:21 - HV000001: Hibernate Validator null
+INFO  [main] 2023-08-13 14:49:43,044 FileUtil.java:249 - No oshi.properties file found from ClassLoader jdk.internal.loader.ClassLoaders$AppClassLoader@277050dc
+INFO  [main] 2023-08-13 14:49:43,045 FileUtil.java:249 - No oshi.properties file found from ClassLoader jdk.internal.loader.ClassLoaders$AppClassLoader@277050dc
+INFO  [main] 2023-08-13 14:49:44,108 Log.java:170 - Logging initialized @39322ms to org.eclipse.jetty.util.log.Slf4jLog
+INFO  [main] 2023-08-13 14:49:44,206 SimpleServerFactory.java:143 - Registering jersey handler with root path prefix: /
+INFO  [main] 2023-08-13 14:49:44,208 SimpleServerFactory.java:146 - Registering admin handler with root path prefix: /admin
+INFO  [main] 2023-08-13 14:49:44,225 SimpleServerFactory.java:143 - Registering jersey handler with root path prefix: /
+INFO  [main] 2023-08-13 14:49:44,225 SimpleServerFactory.java:146 - Registering admin handler with root path prefix: /admin
+INFO  [main] 2023-08-13 14:49:44,225 AbstractServerFactory.java:750 - Starting Server
+INFO  [main] 2023-08-13 14:49:44,308 SetUIDListener.java:217 - Opened Server@7ba38cce{HTTP/1.1, (http/1.1)}{127.0.2.1:8084}
+INFO  [main] 2023-08-13 14:49:44,312 Server.java:375 - jetty-9.4.51.v20230217; built: 2023-02-17T08:19:37.309Z; git: b45c405e4544384de066f814ed42ae3dceacdd49; jvm 11.0.20+0
+INFO  [main] 2023-08-13 14:49:44,328 AdminEnvironment.java:74 - tasks = 
+
+    POST    /tasks/log-level (io.dropwizard.servlets.tasks.LogConfigurationTask)
+    POST    /tasks/gc (io.dropwizard.servlets.tasks.GarbageCollectionTask)
+
+INFO  [main] 2023-08-13 14:49:44,335 ContextHandler.java:921 - Started i.d.j.MutableServletContextHandler@6272936b{/admin,null,AVAILABLE}
+INFO  [main] 2023-08-13 14:49:44,955 DropwizardResourceConfig.java:257 - The following paths were found for the configured resources:
+
+    GET     /checker/liveness (io.stargate.health.CheckerResource)
+    GET     /checker/readiness (io.stargate.health.CheckerResource)
+    GET     /metrics (io.stargate.health.PrometheusResource)
+
+INFO  [main] 2023-08-13 14:49:44,962 ContextHandler.java:921 - Started i.d.j.MutableServletContextHandler@6d6e8dfc{/,null,AVAILABLE}
+INFO  [main] 2023-08-13 14:49:44,986 AbstractConnector.java:333 - Started Server@7ba38cce{HTTP/1.1, (http/1.1)}{127.0.2.1:8084}
+INFO  [main] 2023-08-13 14:49:44,988 Server.java:415 - Started @40201ms
+INFO  [main] 2023-08-13 14:49:44,993 HealthCheckerActivator.java:69 - Started healthchecker....
+INFO  [main] 2023-08-13 14:49:44,994 BaseActivator.java:185 - Started healthchecker
+INFO  [main] 2023-08-13 14:49:45,011 AuthnTableBasedService.java:78 - Initializing keyspace data_endpoint_auth and table token for table based auth
+INFO  [main] 2023-08-13 14:49:52,768 BaseActivator.java:178 - Registering authnTableBasedService and authzTableBasedServie as io.stargate.auth.AuthenticationService
+INFO  [main] 2023-08-13 14:49:53,002 BaseActivator.java:185 - Started gRPC
+INFO  [main] 2023-08-13 14:49:53,004 BaseActivator.java:164 - The persistence-dse-next is already started. Ignoring the start request.
+INFO  [main] 2023-08-13 14:49:53,318 Version.java:21 - HV000001: Hibernate Validator null
+INFO  [main] 2023-08-13 14:49:54,178 Log.java:170 - Logging initialized @49391ms to org.eclipse.jetty.util.log.Slf4jLog
+INFO  [main] 2023-08-13 14:49:54,278 AbstractServerFactory.java:750 - Starting AuthApiServer
+INFO  [main] 2023-08-13 14:49:54,346 SetUIDListener.java:217 - Opened AuthApiServer@31809f2b{HTTP/1.1, (http/1.1)}{127.0.2.1:8081}
+INFO  [main] 2023-08-13 14:49:54,349 Server.java:375 - jetty-9.4.51.v20230217; built: 2023-02-17T08:19:37.309Z; git: b45c405e4544384de066f814ed42ae3dceacdd49; jvm 11.0.20+0
+INFO  [main] 2023-08-13 14:49:54,874 DropwizardResourceConfig.java:257 - The following paths were found for the configured resources:
+
+    GET     /swagger-ui/ (io.stargate.auth.api.swagger.SwaggerUIResource)
+    GET     /swagger-ui/{fileName} (io.stargate.auth.api.swagger.SwaggerUIResource)
+    GET     /swagger.{type:json|yaml} (io.swagger.jaxrs.listing.ApiListingResource)
+    POST    /v1/admin/auth/usernametoken (io.stargate.auth.api.resources.AuthResource)
+    POST    /v1/auth (io.stargate.auth.api.resources.AuthResource)
+    POST    /v1/auth/token/generate (io.stargate.auth.api.resources.AuthResource)
+
+INFO  [main] 2023-08-13 14:49:54,896 ContextHandler.java:921 - Started i.d.j.MutableServletContextHandler@5c447983{/,null,AVAILABLE}
+INFO  [main] 2023-08-13 14:49:54,915 AbstractConnector.java:333 - Started AuthApiServer@31809f2b{HTTP/1.1, (http/1.1)}{127.0.2.1:8081}
+INFO  [main] 2023-08-13 14:49:54,916 Server.java:415 - Started @50130ms
+INFO  [main] 2023-08-13 14:49:54,918 BaseActivator.java:185 - Started authApiServer
+INFO  [main] 2023-08-13 14:49:54,920 BaseActivator.java:178 - Registering authnTableBasedService and authzTableBasedServie as io.stargate.auth.AuthorizationService
+INFO  [main] 2023-08-13 14:49:54,921 BaseActivator.java:164 - The gRPC is already started. Ignoring the start request.
+INFO  [main] 2023-08-13 14:49:54,922 BaseActivator.java:164 - The persistence-dse-next is already started. Ignoring the start request.
+INFO  [main] 2023-08-13 14:49:54,922 BaseActivator.java:164 - The authApiServer is already started. Ignoring the start request.
+INFO  [main] 2023-08-13 14:49:55,194 BaseActivator.java:185 - Started bridge
+INFO  [main] 2023-08-13 14:49:55,195 BaseActivator.java:185 - Started authnTableBasedService and authzTableBasedServie
+INFO  [main] 2023-08-13 14:49:55,197 BaseActivator.java:178 - Registering DB services as io.stargate.db.metrics.api.ClientInfoMetricsTagProvider
+INFO  [main] 2023-08-13 14:49:55,828 CqlImpl.java:75 - Netty using Java NIO event loop
+INFO  [main] 2023-08-13 14:49:55,922 PipelineConfigurator.java:129 - Using Netty Version: []
+INFO  [main] 2023-08-13 14:49:55,923 PipelineConfigurator.java:130 - Starting listening for CQL clients on /127.0.2.1:9043 (unencrypted)...
+INFO  [main] 2023-08-13 14:49:55,958 BaseActivator.java:185 - Started CQL
+INFO  [main] 2023-08-13 14:49:55,959 BaseActivator.java:185 - Started DB services
+INFO  [main] 2023-08-13 14:49:55,979 BaseActivator.java:97 - Starting testing-services ...
+INFO  [main] 2023-08-13 14:49:55,980 BaseActivator.java:185 - Started testing-services
+WARN  [nioEventLoopGroup-2-2] 2023-08-13 14:50:00,442 NoSpamLogger.java:95 - Protocol exception with client networking: org.apache.cassandra.stargate.transport.ProtocolException: Invalid or unsupported protocol version (66); supported versions are (3/v3, 4/v4, 5/v5, 6/v6-beta)
+WARN  [nioEventLoopGroup-2-3] 2023-08-13 14:50:00,467 NoSpamLogger.java:95 - Protocol exception with client networking: org.apache.cassandra.stargate.transport.ProtocolException: Invalid or unsupported protocol version (65); supported versions are (3/v3, 4/v4, 5/v5, 6/v6-beta)
+INFO  [nioEventLoopGroup-2-4] 2023-08-13 14:50:00,678 BufferPools.java:54 - Global buffer pool limit is 0.000KiB for chunk-cache and 0.000KiB for networking
+INFO  [nioEventLoopGroup-2-4] 2023-08-13 14:50:00,703 MonotonicClock.java:202 - Scheduling approximate time conversion task with an interval of 10000 milliseconds
+INFO  [nioEventLoopGroup-2-4] 2023-08-13 14:50:00,705 MonotonicClock.java:338 - Scheduling approximate time-check task with a precision of 2 milliseconds
+INFO  [GossipStage:1] 2023-08-13 14:50:36,496 Gossiper.java:1374 - Node /127.0.2.3:7000 is now part of the cluster
+INFO  [Messaging-EventLoop-3-5] 2023-08-13 14:50:36,521 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.2.3:51467)->/127.0.2.3:7000-URGENT_MESSAGES-5aea52ad successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-6] 2023-08-13 14:50:36,536 InboundConnectionInitiator.java:464 - /127.0.2.3:7000(/127.0.2.1:51468)->/127.0.2.1:7000-URGENT_MESSAGES-893c563b messaging connection established, version = 100, framing = CRC, encryption = unencrypted
+INFO  [GossipStage:1] 2023-08-13 14:50:36,538 Gossiper.java:1322 - InetAddress /127.0.2.3:7000 is now UP
+INFO  [Messaging-EventLoop-3-7] 2023-08-13 14:50:39,831 InboundConnectionInitiator.java:464 - /127.0.2.3:7000(/127.0.2.1:51471)->/127.0.2.1:7000-SMALL_MESSAGES-552cc1d1 messaging connection established, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-3] 2023-08-13 14:50:48,196 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.2.3:51473)->/127.0.2.3:7000-SMALL_MESSAGES-7c6cf13d successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-8] 2023-08-13 14:50:48,283 InboundConnectionInitiator.java:464 - /127.0.2.3:7000(/127.0.2.1:51475)->/127.0.2.1:7000-LARGE_MESSAGES-0744425b messaging connection established, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-4] 2023-08-13 14:50:48,308 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.2.3:51479)->/127.0.2.3:7000-LARGE_MESSAGES-14aa9354 successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [StorageServiceShutdownHook] 2023-08-13 14:53:21,634 HintsService.java:226 - Paused hints dispatch
+INFO  [JettyShutdownThread] 2023-08-13 14:53:21,646 AbstractConnector.java:383 - Stopped AuthApiServer@31809f2b{HTTP/1.1, (http/1.1)}{127.0.2.1:8081}
+INFO  [JettyShutdownThread] 2023-08-13 14:53:21,635 AbstractConnector.java:383 - Stopped Server@7ba38cce{HTTP/1.1, (http/1.1)}{127.0.2.1:8084}
+INFO  [GossipStage:1] 2023-08-13 14:53:21,659 Gossiper.java:1338 - InetAddress /127.0.0.1:7000 is now DOWN
+WARN  [StorageServiceShutdownHook] 2023-08-13 14:53:21,663 Gossiper.java:2047 - No local state, state is in silent shutdown, or node hasn't joined, not announcing shutdown
+INFO  [StorageServiceShutdownHook] 2023-08-13 14:53:21,673 MessagingService.java:485 - Waiting for messaging service to quiesce
+INFO  [GossipStage:1] 2023-08-13 14:53:21,776 StorageService.java:2950 - Node /127.0.0.1:7000 state jump to shutdown
+INFO  [Messaging-EventLoop-3-3] 2023-08-13 14:53:21,833 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.0.1:51509)->/127.0.0.1:7000-URGENT_MESSAGES-a4086291 successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-2] 2023-08-13 14:53:21,836 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.0.1:51508)->/127.0.0.1:7000-LARGE_MESSAGES-39fba583 successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-1] 2023-08-13 14:53:21,834 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.0.1:51510)->/127.0.0.1:7000-SMALL_MESSAGES-da07d39e successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [JettyShutdownThread] 2023-08-13 14:53:22,082 ContextHandler.java:1159 - Stopped i.d.j.MutableServletContextHandler@6d6e8dfc{/,null,STOPPED}
+INFO  [JettyShutdownThread] 2023-08-13 14:53:22,085 ContextHandler.java:1159 - Stopped i.d.j.MutableServletContextHandler@6272936b{/admin,null,STOPPED}
+INFO  [JettyShutdownThread] 2023-08-13 14:53:22,093 ContextHandler.java:1159 - Stopped i.d.j.MutableServletContextHandler@5c447983{/,null,STOPPED}
+WARN  [MemtableFlushWriter:4] 2023-08-13 14:53:24,252 NativeLibrary.java:326 - open(/private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86, O_RDONLY) failed, errno (2).
+WARN  [MemtableFlushWriter:3] 2023-08-13 14:53:24,252 NativeLibrary.java:326 - open(/private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca, O_RDONLY) failed, errno (2).
+ERROR [MemtableFlushWriter:3] 2023-08-13 14:53:24,258 LogReplicaSet.java:98 - Failed to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca/nc_txn_flush_d3848d91-3a23-11ee-ba59-f9f5c571a32b.log
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca
+	... 27 common frames omitted
+ERROR [MemtableFlushWriter:4] 2023-08-13 14:53:24,258 LogReplicaSet.java:98 - Failed to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86/nc_txn_flush_d3848d90-3a23-11ee-ba59-f9f5c571a32b.log
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86
+	... 27 common frames omitted
+WARN  [MemtableFlushWriter:3] 2023-08-13 14:53:24,262 DisallowedDirectories.java:109 - Disallowing /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca for writes
+WARN  [MemtableFlushWriter:4] 2023-08-13 14:53:24,262 DisallowedDirectories.java:109 - Disallowing /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86 for writes
+WARN  [MemtableFlushWriter:3] 2023-08-13 14:53:24,263 DisallowedDirectories.java:88 - Disallowing /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca for reads
+WARN  [MemtableFlushWriter:4] 2023-08-13 14:53:24,263 DisallowedDirectories.java:88 - Disallowing /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86 for reads
+ERROR [MemtableFlushWriter:3] 2023-08-13 14:53:24,273 ColumnFamilyStore.java:1376 - Flushing Memtable-compaction_history@2116703795(720B serialized bytes, 3 ops, 1.652KiB (0%) on-heap, 916B (0%) off-heap) failed with error
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca
+	... 27 common frames omitted
+ERROR [MemtableFlushWriter:4] 2023-08-13 14:53:24,273 ColumnFamilyStore.java:1376 - Flushing Memtable-size_estimates@758332333(0B serialized bytes, 1 ops, 500B (0%) on-heap, 64B (0%) off-heap) failed with error
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86
+	... 27 common frames omitted
+WARN  [MemtableFlushWriter:3] 2023-08-13 14:53:24,370 NativeLibrary.java:326 - open(/private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288, O_RDONLY) failed, errno (2).
+ERROR [MemtablePostFlush:2] 2023-08-13 14:53:24,365 CassandraDaemon.java:568 - Exception in thread Thread[MemtablePostFlush:2,5,main]
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca
+	... 27 common frames omitted
+WARN  [MemtableFlushWriter:4] 2023-08-13 14:53:24,370 NativeLibrary.java:326 - open(/private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e, O_RDONLY) failed, errno (2).
+ERROR [MemtableFlushWriter:3] 2023-08-13 14:53:24,373 LogReplicaSet.java:98 - Failed to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288/nc_txn_flush_d39cd080-3a23-11ee-ba59-f9f5c571a32b.log
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288
+	... 27 common frames omitted
+ERROR [MemtableFlushWriter:4] 2023-08-13 14:53:24,373 LogReplicaSet.java:98 - Failed to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e/nc_txn_flush_d39c8260-3a23-11ee-ba59-f9f5c571a32b.log
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e
+	... 27 common frames omitted
+WARN  [MemtableFlushWriter:4] 2023-08-13 14:53:24,373 DisallowedDirectories.java:109 - Disallowing /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e for writes
+WARN  [MemtableFlushWriter:3] 2023-08-13 14:53:24,373 DisallowedDirectories.java:109 - Disallowing /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288 for writes
+WARN  [MemtableFlushWriter:4] 2023-08-13 14:53:24,373 DisallowedDirectories.java:88 - Disallowing /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e for reads
+WARN  [MemtableFlushWriter:3] 2023-08-13 14:53:24,374 DisallowedDirectories.java:88 - Disallowing /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288 for reads
+ERROR [MemtablePostFlush:2] 2023-08-13 14:53:24,375 CassandraDaemon.java:568 - Exception in thread Thread[MemtablePostFlush:2,5,main]
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86
+	... 27 common frames omitted
+ERROR [MemtableFlushWriter:3] 2023-08-13 14:53:24,390 ColumnFamilyStore.java:1376 - Flushing Memtable-sstable_activity_v2@250371380(0B serialized bytes, 18 ops, 2.461KiB (0%) on-heap, 2.375KiB (0%) off-heap) failed with error
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288
+	... 27 common frames omitted
+ERROR [MemtableFlushWriter:4] 2023-08-13 14:53:24,390 ColumnFamilyStore.java:1376 - Flushing Memtable-table_estimates@116183166(0B serialized bytes, 1 ops, 500B (0%) on-heap, 64B (0%) off-heap) failed with error
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e
+	... 27 common frames omitted
+ERROR [MemtablePostFlush:2] 2023-08-13 14:53:24,394 CassandraDaemon.java:568 - Exception in thread Thread[MemtablePostFlush:2,5,main]
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e
+	... 27 common frames omitted
+ERROR [MemtablePostFlush:2] 2023-08-13 14:53:24,395 CassandraDaemon.java:568 - Exception in thread Thread[MemtablePostFlush:2,5,main]
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288
+	... 27 common frames omitted
+ERROR [StorageServiceShutdownHook] 2023-08-13 14:53:24,397 StorageService.java:5299 - Caught an exception while draining 
+java.lang.RuntimeException: java.util.concurrent.ExecutionException: FSReadError in /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca
+	at org.apache.cassandra.utils.Throwables.maybeFail(Throwables.java:89)
+	at org.apache.cassandra.utils.FBUtilities.waitOnFutures(FBUtilities.java:505)
+	at org.apache.cassandra.utils.FBUtilities.waitOnFutures(FBUtilities.java:468)
+	at org.apache.cassandra.service.StorageService.drain(StorageService.java:5257)
+	at org.apache.cassandra.service.StorageService$1.runMayThrow(StorageService.java:900)
+	at org.apache.cassandra.utils.WrappedRunnable.run(WrappedRunnable.java:28)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.util.concurrent.ExecutionException: FSReadError in /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca
+	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
+	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191)
+	at org.apache.cassandra.utils.FBUtilities.waitOnFutures(FBUtilities.java:492)
+	... 6 common frames omitted
+	Suppressed: java.util.concurrent.ExecutionException: FSReadError in /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86
+		... 9 common frames omitted
+	Caused by: org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86
+		at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+		at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+		at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+		at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+		at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+		at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+		at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+		at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+		at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+		at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+		at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+		at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+		at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+		at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+		at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+		at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+		at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+		at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+		at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+		at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+		at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+		at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+		at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+		at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+		at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+		... 2 common frames omitted
+	Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86
+		... 27 common frames omitted
+	Suppressed: java.util.concurrent.ExecutionException: FSReadError in /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e
+		... 9 common frames omitted
+	Caused by: org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e
+		at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+		at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+		at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+		at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+		at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+		at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+		at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+		at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+		at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+		at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+		at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+		at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+		at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+		at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+		at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+		at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+		at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+		at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+		at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+		at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+		at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+		at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+		at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+		at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+		at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+		... 2 common frames omitted
+	Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e
+		... 27 common frames omitted
+	Suppressed: java.util.concurrent.ExecutionException: FSReadError in /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288
+		... 9 common frames omitted
+	Caused by: org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288
+		at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+		at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+		at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+		at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+		at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+		at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+		at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+		at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+		at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+		at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+		at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+		at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+		at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+		at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+		at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+		at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+		at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+		at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+		at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+		at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+		at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+		at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+		at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+		at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+		at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+		... 2 common frames omitted
+	Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288
+		... 27 common frames omitted
+Caused by: org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	... 2 common frames omitted
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca
+	... 27 common frames omitted

--- a/coordinator/testing/log/system.log.2023-08-12.0698220763703625.tmp
+++ b/coordinator/testing/log/system.log.2023-08-12.0698220763703625.tmp
@@ -1,0 +1,686 @@
+INFO  [main] 2023-08-13 14:49:07,411 BaseActivator.java:97 - Starting persistence-dse-next ...
+INFO  [main] 2023-08-13 14:49:07,805 BaseActivator.java:97 - Starting authApiServer ...
+INFO  [main] 2023-08-13 14:49:07,888 BaseActivator.java:97 - Starting authnTableBasedService and authzTableBasedServie ...
+INFO  [main] 2023-08-13 14:49:08,026 BaseActivator.java:97 - Starting bridge ...
+INFO  [main] 2023-08-13 14:49:08,084 BaseActivator.java:97 - Starting Config Store YAML ...
+INFO  [main] 2023-08-13 14:49:08,087 BaseActivator.java:97 - Starting core services ...
+INFO  [main] 2023-08-13 14:49:08,140 BaseActivator.java:178 - Registering core services as io.stargate.core.metrics.api.Metrics
+INFO  [main] 2023-08-13 14:49:08,332 AbstractCassandraPersistence.java:105 - Initializing Apache Cassandra
+INFO  [main] 2023-08-13 14:49:08,495 DatabaseDescriptor.java:498 - DiskAccessMode 'auto' determined to be standard, indexAccessMode is standard
+INFO  [main] 2023-08-13 14:49:08,496 DatabaseDescriptor.java:560 - Global memtable on-heap threshold is enabled at 2048MB
+INFO  [main] 2023-08-13 14:49:08,496 DatabaseDescriptor.java:564 - Global memtable off-heap threshold is enabled at 2048MB
+INFO  [main] 2023-08-13 14:49:08,496 DatabaseDescriptor.java:635 - Native transport rate-limiting disabled.
+INFO  [main] 2023-08-13 14:49:08,615 GossipingPropertyFileSnitch.java:67 - Unable to load cassandra-topology.properties; compatibility mode disabled
+INFO  [main] 2023-08-13 14:49:09,237 JMXServerUtils.java:271 - Configured JMX server at: service:jmx:rmi://0.0.0.0/jndi/rmi://0.0.0.0:51393/jmxrmi
+INFO  [main] 2023-08-13 14:49:09,271 CassandraDaemon.java:613 - Hostname: jeffs-mbp.lan:7000:7001
+INFO  [main] 2023-08-13 14:49:09,272 CassandraDaemon.java:620 - JVM vendor/version: OpenJDK 64-Bit Server VM/11.0.20
+INFO  [main] 2023-08-13 14:49:09,274 CassandraDaemon.java:621 - Heap size: 512.000MiB/8.000GiB
+WARN  [main] 2023-08-13 14:49:09,492 StartupChecks.java:155 - jemalloc shared library could not be preloaded to speed up memory allocations
+INFO  [main] 2023-08-13 14:49:09,609 StartupChecks.java:206 - JMX is enabled to receive remote connections on port: 51393
+WARN  [main] 2023-08-13 14:49:09,610 StartupChecks.java:250 - The JVM is not configured to stop on OutOfMemoryError which can cause data corruption. Use one of the following JVM options to configure the behavior on OutOfMemoryError:  -XX:+ExitOnOutOfMemoryError, -XX:+CrashOnOutOfMemoryError, or -XX:OnOutOfMemoryError="<cmd args>;<cmd args>"
+INFO  [main] 2023-08-13 14:49:09,630 SigarLibrary.java:57 - Could not initialize SIGAR library 'org.hyperic.sigar.FileSystem[] org.hyperic.sigar.Sigar.getFileSystemListNative()' 
+INFO  [main] 2023-08-13 14:49:09,631 SigarLibrary.java:185 - Sigar could not be initialized, test for checking degraded mode omitted.
+WARN  [main] 2023-08-13 14:49:10,408 Nodes.java:650 - No host ID found, created c745b01f-20b4-4442-9bc8-e863d26b360e (Note: This should happen exactly once per node).
+INFO  [main] 2023-08-13 14:49:10,539 ClientState.java:105 - Using io.stargate.db.cassandra.impl.StargateQueryHandler as query handler for native protocol queries (as requested with -Dcassandra.custom_query_handler_class)
+INFO  [main] 2023-08-13 14:49:12,616 StorageService.java:965 - Token metadata: 
+INFO  [main] 2023-08-13 14:49:24,781 CommitLog.java:214 - No commitlog files found; skipping replay
+INFO  [main] 2023-08-13 14:49:24,783 StorageService.java:965 - Token metadata: 
+INFO  [main] 2023-08-13 14:49:24,880 StorageService.java:869 - Cassandra version: 4.0.7-336cdd7405ee
+INFO  [main] 2023-08-13 14:49:24,881 StorageService.java:870 - CQL version: 3.4.5
+INFO  [main] 2023-08-13 14:49:24,882 StorageService.java:871 - Native protocol supported versions: 3/v3, 4/v4, 5/v5, 6/v6-beta (default: 5/v5)
+INFO  [main] 2023-08-13 14:49:24,920 InboundConnectionInitiator.java:127 - Listening on address: (/127.0.2.1:7000), nic: lo0, encryption: unencrypted
+INFO  [main] 2023-08-13 14:49:24,939 BufferPools.java:49 - Global buffer pool limit is 2.000GiB for chunk-cache and 128.000MiB for networking
+INFO  [Messaging-EventLoop-3-3] 2023-08-13 14:49:25,179 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.0.1:51417)->/127.0.0.1:7000-URGENT_MESSAGES-1d0b0cde successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-4] 2023-08-13 14:49:25,307 InboundConnectionInitiator.java:464 - /127.0.0.1:7000(/127.0.2.1:51419)->/127.0.2.1:7000-URGENT_MESSAGES-73d2eda9 messaging connection established, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-5] 2023-08-13 14:49:27,435 InboundConnectionInitiator.java:464 - /127.0.2.2:7000(/127.0.2.1:51420)->/127.0.2.1:7000-URGENT_MESSAGES-8926d936 messaging connection established, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-8] 2023-08-13 14:49:27,460 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.2.2:51421)->/127.0.2.2:7000-URGENT_MESSAGES-8deebe68 successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [GossipStage:1] 2023-08-13 14:49:32,124 Gossiper.java:1374 - Node /127.0.2.2:7000 is now part of the cluster
+INFO  [GossipStage:1] 2023-08-13 14:49:32,131 Gossiper.java:1374 - Node /127.0.0.1:7000 is now part of the cluster
+WARN  [MigrationStage:1] 2023-08-13 14:49:32,156 MigrationCoordinator.java:682 - Can't send schema pull request: node /127.0.0.1:7000 is down.
+INFO  [GossipStage:1] 2023-08-13 14:49:32,168 TokenMetadata.java:512 - Updating topology for /127.0.0.1:7000
+INFO  [GossipStage:1] 2023-08-13 14:49:32,170 TokenMetadata.java:512 - Updating topology for /127.0.0.1:7000
+INFO  [GossipStage:1] 2023-08-13 14:49:32,174 Gossiper.java:1322 - InetAddress /127.0.2.2:7000 is now UP
+INFO  [GossipStage:1] 2023-08-13 14:49:32,175 Gossiper.java:1322 - InetAddress /127.0.0.1:7000 is now UP
+INFO  [main] 2023-08-13 14:49:32,298 StorageService.java:950 - Not joining ring as requested. Use JMX (StorageService->joinRing()) to initiate ring joining
+INFO  [main] 2023-08-13 14:49:32,299 Gossiper.java:2229 - Waiting for gossip to settle...
+INFO  [Messaging-EventLoop-3-1] 2023-08-13 14:49:32,300 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.0.1:51424)->/127.0.0.1:7000-SMALL_MESSAGES-4178fc9d successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-6] 2023-08-13 14:49:32,300 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.2.2:51425)->/127.0.2.2:7000-SMALL_MESSAGES-99f1e8a5 successfully connected, version = 100, framing = CRC, encryption = unencrypted
+WARN  [GossipTasks:1] 2023-08-13 14:49:33,124 FailureDetector.java:316 - Not marking nodes down due to local pause of 22940483875ns > 5000000000ns
+INFO  [MigrationStage:1] 2023-08-13 14:49:35,169 MigrationCoordinator.java:704 - Sending schema pull request to /127.0.0.1:7000
+INFO  [Messaging-EventLoop-3-9] 2023-08-13 14:49:35,226 InboundConnectionInitiator.java:464 - /127.0.0.1:7000(/127.0.2.1:51426)->/127.0.2.1:7000-SMALL_MESSAGES-0b56dbcd messaging connection established, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-10] 2023-08-13 14:49:38,453 InboundConnectionInitiator.java:464 - /127.0.2.2:7000(/127.0.2.1:51427)->/127.0.2.1:7000-SMALL_MESSAGES-d022c775 messaging connection established, version = 100, framing = CRC, encryption = unencrypted
+INFO  [main] 2023-08-13 14:49:40,315 Gossiper.java:2260 - No gossip backlog; proceeding
+INFO  [Messaging-EventLoop-3-1] 2023-08-13 14:49:40,541 InboundConnectionInitiator.java:464 - /127.0.2.2:7000(/127.0.2.1:51428)->/127.0.2.1:7000-LARGE_MESSAGES-d5a187e0 messaging connection established, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-7] 2023-08-13 14:49:40,591 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.2.2:51431)->/127.0.2.2:7000-LARGE_MESSAGES-16592c34 successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [main] 2023-08-13 14:49:41,475 StartupClusterConnectivityChecker.java:111 - Blocking coordination until only a single peer is DOWN in the local datacenter, timeout=10s
+INFO  [Messaging-EventLoop-3-2] 2023-08-13 14:49:41,489 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.0.1:51432)->/127.0.0.1:7000-LARGE_MESSAGES-79d6cf31 successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [main] 2023-08-13 14:49:41,490 StartupClusterConnectivityChecker.java:166 - Ensured sufficient healthy connections with [dc1] after 12 milliseconds
+INFO  [main] 2023-08-13 14:49:41,490 CassandraDaemon.java:685 - Not starting native transport as requested. Use JMX (StorageService->startNativeTransport()) or nodetool (enablebinary) to start it
+INFO  [Messaging-EventLoop-3-2] 2023-08-13 14:49:41,498 InboundConnectionInitiator.java:464 - /127.0.0.1:7000(/127.0.2.1:51433)->/127.0.2.1:7000-LARGE_MESSAGES-056d9969 messaging connection established, version = 100, framing = CRC, encryption = unencrypted
+INFO  [main] 2023-08-13 14:49:41,639 BaseActivator.java:178 - Registering persistence-dse-next as io.stargate.db.Persistence
+INFO  [main] 2023-08-13 14:49:41,646 BaseActivator.java:185 - Started persistence-dse-next
+INFO  [main] 2023-08-13 14:49:41,650 ConfigStoreActivator.java:57 - Creating Config Store YAML for config file location: /etc/stargate/stargate-config.yaml 
+INFO  [main] 2023-08-13 14:49:41,822 BaseActivator.java:178 - Registering Config Store YAML as io.stargate.config.store.api.ConfigStore
+INFO  [main] 2023-08-13 14:49:41,823 BaseActivator.java:185 - Started Config Store YAML
+INFO  [main] 2023-08-13 14:49:41,823 BaseActivator.java:178 - Registering core services as io.stargate.core.metrics.api.MetricsScraper
+INFO  [main] 2023-08-13 14:49:41,823 BaseActivator.java:178 - Registering core services as com.codahale.metrics.health.HealthCheckRegistry
+INFO  [main] 2023-08-13 14:49:41,825 BaseActivator.java:178 - Registering core services as io.stargate.core.metrics.api.HttpMetricsTagProvider
+INFO  [main] 2023-08-13 14:49:41,825 BaseActivator.java:185 - Started core services
+INFO  [main] 2023-08-13 14:49:42,200 BaseActivator.java:97 - Starting CQL ...
+INFO  [main] 2023-08-13 14:49:42,398 BaseActivator.java:97 - Starting gRPC ...
+INFO  [main] 2023-08-13 14:49:42,570 BaseActivator.java:97 - Starting healthchecker ...
+INFO  [main] 2023-08-13 14:49:42,623 BaseActivator.java:97 - Starting DB services ...
+INFO  [main] 2023-08-13 14:49:42,626 BaseActivator.java:178 - Registering DB services as io.stargate.db.Persistence
+INFO  [main] 2023-08-13 14:49:42,628 BaseActivator.java:178 - Registering DB services as io.stargate.db.datastore.DataStoreFactory
+INFO  [main] 2023-08-13 14:49:42,629 HealthCheckerActivator.java:50 - Starting healthchecker....
+INFO  [main] 2023-08-13 14:49:42,872 Version.java:21 - HV000001: Hibernate Validator null
+INFO  [main] 2023-08-13 14:49:43,044 FileUtil.java:249 - No oshi.properties file found from ClassLoader jdk.internal.loader.ClassLoaders$AppClassLoader@277050dc
+INFO  [main] 2023-08-13 14:49:43,045 FileUtil.java:249 - No oshi.properties file found from ClassLoader jdk.internal.loader.ClassLoaders$AppClassLoader@277050dc
+INFO  [main] 2023-08-13 14:49:44,108 Log.java:170 - Logging initialized @39322ms to org.eclipse.jetty.util.log.Slf4jLog
+INFO  [main] 2023-08-13 14:49:44,206 SimpleServerFactory.java:143 - Registering jersey handler with root path prefix: /
+INFO  [main] 2023-08-13 14:49:44,208 SimpleServerFactory.java:146 - Registering admin handler with root path prefix: /admin
+INFO  [main] 2023-08-13 14:49:44,225 SimpleServerFactory.java:143 - Registering jersey handler with root path prefix: /
+INFO  [main] 2023-08-13 14:49:44,225 SimpleServerFactory.java:146 - Registering admin handler with root path prefix: /admin
+INFO  [main] 2023-08-13 14:49:44,225 AbstractServerFactory.java:750 - Starting Server
+INFO  [main] 2023-08-13 14:49:44,308 SetUIDListener.java:217 - Opened Server@7ba38cce{HTTP/1.1, (http/1.1)}{127.0.2.1:8084}
+INFO  [main] 2023-08-13 14:49:44,312 Server.java:375 - jetty-9.4.51.v20230217; built: 2023-02-17T08:19:37.309Z; git: b45c405e4544384de066f814ed42ae3dceacdd49; jvm 11.0.20+0
+INFO  [main] 2023-08-13 14:49:44,328 AdminEnvironment.java:74 - tasks = 
+
+    POST    /tasks/log-level (io.dropwizard.servlets.tasks.LogConfigurationTask)
+    POST    /tasks/gc (io.dropwizard.servlets.tasks.GarbageCollectionTask)
+
+INFO  [main] 2023-08-13 14:49:44,335 ContextHandler.java:921 - Started i.d.j.MutableServletContextHandler@6272936b{/admin,null,AVAILABLE}
+INFO  [main] 2023-08-13 14:49:44,955 DropwizardResourceConfig.java:257 - The following paths were found for the configured resources:
+
+    GET     /checker/liveness (io.stargate.health.CheckerResource)
+    GET     /checker/readiness (io.stargate.health.CheckerResource)
+    GET     /metrics (io.stargate.health.PrometheusResource)
+
+INFO  [main] 2023-08-13 14:49:44,962 ContextHandler.java:921 - Started i.d.j.MutableServletContextHandler@6d6e8dfc{/,null,AVAILABLE}
+INFO  [main] 2023-08-13 14:49:44,986 AbstractConnector.java:333 - Started Server@7ba38cce{HTTP/1.1, (http/1.1)}{127.0.2.1:8084}
+INFO  [main] 2023-08-13 14:49:44,988 Server.java:415 - Started @40201ms
+INFO  [main] 2023-08-13 14:49:44,993 HealthCheckerActivator.java:69 - Started healthchecker....
+INFO  [main] 2023-08-13 14:49:44,994 BaseActivator.java:185 - Started healthchecker
+INFO  [main] 2023-08-13 14:49:45,011 AuthnTableBasedService.java:78 - Initializing keyspace data_endpoint_auth and table token for table based auth
+INFO  [main] 2023-08-13 14:49:52,768 BaseActivator.java:178 - Registering authnTableBasedService and authzTableBasedServie as io.stargate.auth.AuthenticationService
+INFO  [main] 2023-08-13 14:49:53,002 BaseActivator.java:185 - Started gRPC
+INFO  [main] 2023-08-13 14:49:53,004 BaseActivator.java:164 - The persistence-dse-next is already started. Ignoring the start request.
+INFO  [main] 2023-08-13 14:49:53,318 Version.java:21 - HV000001: Hibernate Validator null
+INFO  [main] 2023-08-13 14:49:54,178 Log.java:170 - Logging initialized @49391ms to org.eclipse.jetty.util.log.Slf4jLog
+INFO  [main] 2023-08-13 14:49:54,278 AbstractServerFactory.java:750 - Starting AuthApiServer
+INFO  [main] 2023-08-13 14:49:54,346 SetUIDListener.java:217 - Opened AuthApiServer@31809f2b{HTTP/1.1, (http/1.1)}{127.0.2.1:8081}
+INFO  [main] 2023-08-13 14:49:54,349 Server.java:375 - jetty-9.4.51.v20230217; built: 2023-02-17T08:19:37.309Z; git: b45c405e4544384de066f814ed42ae3dceacdd49; jvm 11.0.20+0
+INFO  [main] 2023-08-13 14:49:54,874 DropwizardResourceConfig.java:257 - The following paths were found for the configured resources:
+
+    GET     /swagger-ui/ (io.stargate.auth.api.swagger.SwaggerUIResource)
+    GET     /swagger-ui/{fileName} (io.stargate.auth.api.swagger.SwaggerUIResource)
+    GET     /swagger.{type:json|yaml} (io.swagger.jaxrs.listing.ApiListingResource)
+    POST    /v1/admin/auth/usernametoken (io.stargate.auth.api.resources.AuthResource)
+    POST    /v1/auth (io.stargate.auth.api.resources.AuthResource)
+    POST    /v1/auth/token/generate (io.stargate.auth.api.resources.AuthResource)
+
+INFO  [main] 2023-08-13 14:49:54,896 ContextHandler.java:921 - Started i.d.j.MutableServletContextHandler@5c447983{/,null,AVAILABLE}
+INFO  [main] 2023-08-13 14:49:54,915 AbstractConnector.java:333 - Started AuthApiServer@31809f2b{HTTP/1.1, (http/1.1)}{127.0.2.1:8081}
+INFO  [main] 2023-08-13 14:49:54,916 Server.java:415 - Started @50130ms
+INFO  [main] 2023-08-13 14:49:54,918 BaseActivator.java:185 - Started authApiServer
+INFO  [main] 2023-08-13 14:49:54,920 BaseActivator.java:178 - Registering authnTableBasedService and authzTableBasedServie as io.stargate.auth.AuthorizationService
+INFO  [main] 2023-08-13 14:49:54,921 BaseActivator.java:164 - The gRPC is already started. Ignoring the start request.
+INFO  [main] 2023-08-13 14:49:54,922 BaseActivator.java:164 - The persistence-dse-next is already started. Ignoring the start request.
+INFO  [main] 2023-08-13 14:49:54,922 BaseActivator.java:164 - The authApiServer is already started. Ignoring the start request.
+INFO  [main] 2023-08-13 14:49:55,194 BaseActivator.java:185 - Started bridge
+INFO  [main] 2023-08-13 14:49:55,195 BaseActivator.java:185 - Started authnTableBasedService and authzTableBasedServie
+INFO  [main] 2023-08-13 14:49:55,197 BaseActivator.java:178 - Registering DB services as io.stargate.db.metrics.api.ClientInfoMetricsTagProvider
+INFO  [main] 2023-08-13 14:49:55,828 CqlImpl.java:75 - Netty using Java NIO event loop
+INFO  [main] 2023-08-13 14:49:55,922 PipelineConfigurator.java:129 - Using Netty Version: []
+INFO  [main] 2023-08-13 14:49:55,923 PipelineConfigurator.java:130 - Starting listening for CQL clients on /127.0.2.1:9043 (unencrypted)...
+INFO  [main] 2023-08-13 14:49:55,958 BaseActivator.java:185 - Started CQL
+INFO  [main] 2023-08-13 14:49:55,959 BaseActivator.java:185 - Started DB services
+INFO  [main] 2023-08-13 14:49:55,979 BaseActivator.java:97 - Starting testing-services ...
+INFO  [main] 2023-08-13 14:49:55,980 BaseActivator.java:185 - Started testing-services
+WARN  [nioEventLoopGroup-2-2] 2023-08-13 14:50:00,442 NoSpamLogger.java:95 - Protocol exception with client networking: org.apache.cassandra.stargate.transport.ProtocolException: Invalid or unsupported protocol version (66); supported versions are (3/v3, 4/v4, 5/v5, 6/v6-beta)
+WARN  [nioEventLoopGroup-2-3] 2023-08-13 14:50:00,467 NoSpamLogger.java:95 - Protocol exception with client networking: org.apache.cassandra.stargate.transport.ProtocolException: Invalid or unsupported protocol version (65); supported versions are (3/v3, 4/v4, 5/v5, 6/v6-beta)
+INFO  [nioEventLoopGroup-2-4] 2023-08-13 14:50:00,678 BufferPools.java:54 - Global buffer pool limit is 0.000KiB for chunk-cache and 0.000KiB for networking
+INFO  [nioEventLoopGroup-2-4] 2023-08-13 14:50:00,703 MonotonicClock.java:202 - Scheduling approximate time conversion task with an interval of 10000 milliseconds
+INFO  [nioEventLoopGroup-2-4] 2023-08-13 14:50:00,705 MonotonicClock.java:338 - Scheduling approximate time-check task with a precision of 2 milliseconds
+INFO  [GossipStage:1] 2023-08-13 14:50:36,496 Gossiper.java:1374 - Node /127.0.2.3:7000 is now part of the cluster
+INFO  [Messaging-EventLoop-3-5] 2023-08-13 14:50:36,521 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.2.3:51467)->/127.0.2.3:7000-URGENT_MESSAGES-5aea52ad successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-6] 2023-08-13 14:50:36,536 InboundConnectionInitiator.java:464 - /127.0.2.3:7000(/127.0.2.1:51468)->/127.0.2.1:7000-URGENT_MESSAGES-893c563b messaging connection established, version = 100, framing = CRC, encryption = unencrypted
+INFO  [GossipStage:1] 2023-08-13 14:50:36,538 Gossiper.java:1322 - InetAddress /127.0.2.3:7000 is now UP
+INFO  [Messaging-EventLoop-3-7] 2023-08-13 14:50:39,831 InboundConnectionInitiator.java:464 - /127.0.2.3:7000(/127.0.2.1:51471)->/127.0.2.1:7000-SMALL_MESSAGES-552cc1d1 messaging connection established, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-3] 2023-08-13 14:50:48,196 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.2.3:51473)->/127.0.2.3:7000-SMALL_MESSAGES-7c6cf13d successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-8] 2023-08-13 14:50:48,283 InboundConnectionInitiator.java:464 - /127.0.2.3:7000(/127.0.2.1:51475)->/127.0.2.1:7000-LARGE_MESSAGES-0744425b messaging connection established, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-4] 2023-08-13 14:50:48,308 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.2.3:51479)->/127.0.2.3:7000-LARGE_MESSAGES-14aa9354 successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [StorageServiceShutdownHook] 2023-08-13 14:53:21,634 HintsService.java:226 - Paused hints dispatch
+INFO  [JettyShutdownThread] 2023-08-13 14:53:21,646 AbstractConnector.java:383 - Stopped AuthApiServer@31809f2b{HTTP/1.1, (http/1.1)}{127.0.2.1:8081}
+INFO  [JettyShutdownThread] 2023-08-13 14:53:21,635 AbstractConnector.java:383 - Stopped Server@7ba38cce{HTTP/1.1, (http/1.1)}{127.0.2.1:8084}
+INFO  [GossipStage:1] 2023-08-13 14:53:21,659 Gossiper.java:1338 - InetAddress /127.0.0.1:7000 is now DOWN
+WARN  [StorageServiceShutdownHook] 2023-08-13 14:53:21,663 Gossiper.java:2047 - No local state, state is in silent shutdown, or node hasn't joined, not announcing shutdown
+INFO  [StorageServiceShutdownHook] 2023-08-13 14:53:21,673 MessagingService.java:485 - Waiting for messaging service to quiesce
+INFO  [GossipStage:1] 2023-08-13 14:53:21,776 StorageService.java:2950 - Node /127.0.0.1:7000 state jump to shutdown
+INFO  [Messaging-EventLoop-3-3] 2023-08-13 14:53:21,833 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.0.1:51509)->/127.0.0.1:7000-URGENT_MESSAGES-a4086291 successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-2] 2023-08-13 14:53:21,836 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.0.1:51508)->/127.0.0.1:7000-LARGE_MESSAGES-39fba583 successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [Messaging-EventLoop-3-1] 2023-08-13 14:53:21,834 OutboundConnection.java:1150 - /127.0.2.1:7000(/127.0.0.1:51510)->/127.0.0.1:7000-SMALL_MESSAGES-da07d39e successfully connected, version = 100, framing = CRC, encryption = unencrypted
+INFO  [JettyShutdownThread] 2023-08-13 14:53:22,082 ContextHandler.java:1159 - Stopped i.d.j.MutableServletContextHandler@6d6e8dfc{/,null,STOPPED}
+INFO  [JettyShutdownThread] 2023-08-13 14:53:22,085 ContextHandler.java:1159 - Stopped i.d.j.MutableServletContextHandler@6272936b{/admin,null,STOPPED}
+INFO  [JettyShutdownThread] 2023-08-13 14:53:22,093 ContextHandler.java:1159 - Stopped i.d.j.MutableServletContextHandler@5c447983{/,null,STOPPED}
+WARN  [MemtableFlushWriter:4] 2023-08-13 14:53:24,252 NativeLibrary.java:326 - open(/private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86, O_RDONLY) failed, errno (2).
+WARN  [MemtableFlushWriter:3] 2023-08-13 14:53:24,252 NativeLibrary.java:326 - open(/private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca, O_RDONLY) failed, errno (2).
+ERROR [MemtableFlushWriter:3] 2023-08-13 14:53:24,258 LogReplicaSet.java:98 - Failed to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca/nc_txn_flush_d3848d91-3a23-11ee-ba59-f9f5c571a32b.log
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca
+	... 27 common frames omitted
+ERROR [MemtableFlushWriter:4] 2023-08-13 14:53:24,258 LogReplicaSet.java:98 - Failed to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86/nc_txn_flush_d3848d90-3a23-11ee-ba59-f9f5c571a32b.log
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86
+	... 27 common frames omitted
+WARN  [MemtableFlushWriter:3] 2023-08-13 14:53:24,262 DisallowedDirectories.java:109 - Disallowing /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca for writes
+WARN  [MemtableFlushWriter:4] 2023-08-13 14:53:24,262 DisallowedDirectories.java:109 - Disallowing /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86 for writes
+WARN  [MemtableFlushWriter:3] 2023-08-13 14:53:24,263 DisallowedDirectories.java:88 - Disallowing /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca for reads
+WARN  [MemtableFlushWriter:4] 2023-08-13 14:53:24,263 DisallowedDirectories.java:88 - Disallowing /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86 for reads
+ERROR [MemtableFlushWriter:4] 2023-08-13 14:53:24,273 ColumnFamilyStore.java:1376 - Flushing Memtable-size_estimates@758332333(0B serialized bytes, 1 ops, 500B (0%) on-heap, 64B (0%) off-heap) failed with error
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86
+	... 27 common frames omitted
+ERROR [MemtableFlushWriter:3] 2023-08-13 14:53:24,273 ColumnFamilyStore.java:1376 - Flushing Memtable-compaction_history@2116703795(720B serialized bytes, 3 ops, 1.652KiB (0%) on-heap, 916B (0%) off-heap) failed with error
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca
+	... 27 common frames omitted
+ERROR [MemtablePostFlush:2] 2023-08-13 14:53:24,365 CassandraDaemon.java:568 - Exception in thread Thread[MemtablePostFlush:2,5,main]
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca
+	... 27 common frames omitted
+WARN  [MemtableFlushWriter:3] 2023-08-13 14:53:24,370 NativeLibrary.java:326 - open(/private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288, O_RDONLY) failed, errno (2).
+WARN  [MemtableFlushWriter:4] 2023-08-13 14:53:24,370 NativeLibrary.java:326 - open(/private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e, O_RDONLY) failed, errno (2).
+ERROR [MemtableFlushWriter:4] 2023-08-13 14:53:24,373 LogReplicaSet.java:98 - Failed to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e/nc_txn_flush_d39c8260-3a23-11ee-ba59-f9f5c571a32b.log
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e
+	... 27 common frames omitted
+ERROR [MemtableFlushWriter:3] 2023-08-13 14:53:24,373 LogReplicaSet.java:98 - Failed to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288/nc_txn_flush_d39cd080-3a23-11ee-ba59-f9f5c571a32b.log
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288
+	... 27 common frames omitted
+WARN  [MemtableFlushWriter:4] 2023-08-13 14:53:24,373 DisallowedDirectories.java:109 - Disallowing /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e for writes
+WARN  [MemtableFlushWriter:3] 2023-08-13 14:53:24,373 DisallowedDirectories.java:109 - Disallowing /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288 for writes
+WARN  [MemtableFlushWriter:4] 2023-08-13 14:53:24,373 DisallowedDirectories.java:88 - Disallowing /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e for reads
+WARN  [MemtableFlushWriter:3] 2023-08-13 14:53:24,374 DisallowedDirectories.java:88 - Disallowing /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288 for reads
+ERROR [MemtablePostFlush:2] 2023-08-13 14:53:24,375 CassandraDaemon.java:568 - Exception in thread Thread[MemtablePostFlush:2,5,main]
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86
+	... 27 common frames omitted
+ERROR [MemtableFlushWriter:3] 2023-08-13 14:53:24,390 ColumnFamilyStore.java:1376 - Flushing Memtable-sstable_activity_v2@250371380(0B serialized bytes, 18 ops, 2.461KiB (0%) on-heap, 2.375KiB (0%) off-heap) failed with error
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288
+	... 27 common frames omitted
+ERROR [MemtableFlushWriter:4] 2023-08-13 14:53:24,390 ColumnFamilyStore.java:1376 - Flushing Memtable-table_estimates@116183166(0B serialized bytes, 1 ops, 500B (0%) on-heap, 64B (0%) off-heap) failed with error
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e
+	... 27 common frames omitted
+ERROR [MemtablePostFlush:2] 2023-08-13 14:53:24,394 CassandraDaemon.java:568 - Exception in thread Thread[MemtablePostFlush:2,5,main]
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e
+	... 27 common frames omitted
+ERROR [MemtablePostFlush:2] 2023-08-13 14:53:24,395 CassandraDaemon.java:568 - Exception in thread Thread[MemtablePostFlush:2,5,main]
+org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288
+	... 27 common frames omitted
+ERROR [StorageServiceShutdownHook] 2023-08-13 14:53:24,397 StorageService.java:5299 - Caught an exception while draining 
+java.lang.RuntimeException: java.util.concurrent.ExecutionException: FSReadError in /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca
+	at org.apache.cassandra.utils.Throwables.maybeFail(Throwables.java:89)
+	at org.apache.cassandra.utils.FBUtilities.waitOnFutures(FBUtilities.java:505)
+	at org.apache.cassandra.utils.FBUtilities.waitOnFutures(FBUtilities.java:468)
+	at org.apache.cassandra.service.StorageService.drain(StorageService.java:5257)
+	at org.apache.cassandra.service.StorageService$1.runMayThrow(StorageService.java:900)
+	at org.apache.cassandra.utils.WrappedRunnable.run(WrappedRunnable.java:28)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+Caused by: java.util.concurrent.ExecutionException: FSReadError in /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca
+	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
+	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191)
+	at org.apache.cassandra.utils.FBUtilities.waitOnFutures(FBUtilities.java:492)
+	... 6 common frames omitted
+	Suppressed: java.util.concurrent.ExecutionException: FSReadError in /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86
+		... 9 common frames omitted
+	Caused by: org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86
+		at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+		at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+		at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+		at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+		at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+		at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+		at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+		at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+		at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+		at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+		at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+		at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+		at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+		at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+		at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+		at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+		at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+		at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+		at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+		at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+		at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+		at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+		at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+		at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+		at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+		... 2 common frames omitted
+	Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/size_estimates-618f817b005f3678b8a453f3930b8e86
+		... 27 common frames omitted
+	Suppressed: java.util.concurrent.ExecutionException: FSReadError in /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e
+		... 9 common frames omitted
+	Caused by: org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e
+		at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+		at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+		at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+		at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+		at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+		at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+		at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+		at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+		at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+		at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+		at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+		at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+		at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+		at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+		at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+		at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+		at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+		at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+		at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+		at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+		at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+		at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+		at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+		at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+		at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+		... 2 common frames omitted
+	Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/table_estimates-176c39cdb93d33a5a2188eb06a56f66e
+		... 27 common frames omitted
+	Suppressed: java.util.concurrent.ExecutionException: FSReadError in /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288
+		... 9 common frames omitted
+	Caused by: org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288
+		at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+		at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+		at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+		at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+		at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+		at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+		at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+		at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+		at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+		at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+		at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+		at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+		at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+		at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+		at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+		at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+		at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+		at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+		at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+		at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+		at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+		at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+		at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+		at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+		at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+		... 2 common frames omitted
+	Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/sstable_activity_v2-62efe31f3be8310c8d298963439c1288
+		... 27 common frames omitted
+Caused by: org.apache.cassandra.io.FSReadError: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca
+	at org.apache.cassandra.db.lifecycle.LogReplica.create(LogReplica.java:61)
+	at org.apache.cassandra.db.lifecycle.LogReplicaSet.maybeCreateReplica(LogReplicaSet.java:90)
+	at org.apache.cassandra.db.lifecycle.LogFile.maybeCreateReplica(LogFile.java:352)
+	at org.apache.cassandra.db.lifecycle.LogFile.makeAddRecord(LogFile.java:333)
+	at org.apache.cassandra.db.lifecycle.LogFile.add(LogFile.java:313)
+	at org.apache.cassandra.db.lifecycle.LogTransaction.trackNew(LogTransaction.java:144)
+	at org.apache.cassandra.db.lifecycle.LifecycleTransaction.trackNew(LifecycleTransaction.java:599)
+	at org.apache.cassandra.io.sstable.format.SortedTableWriter.<init>(SortedTableWriter.java:95)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableWriter.<init>(TrieIndexSSTableWriter.java:98)
+	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexFormat$WriterFactory.open(TrieIndexFormat.java:182)
+	at org.apache.cassandra.io.sstable.format.SSTableWriter.create(SSTableWriter.java:134)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.createWriter(ShardedMultiWriter.java:109)
+	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.<init>(ShardedMultiWriter.java:98)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.createSSTableMultiWriter(UnifiedCompactionStrategy.java:342)
+	at org.apache.cassandra.db.compaction.UnifiedCompactionContainer.createSSTableMultiWriter(UnifiedCompactionContainer.java:327)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:734)
+	at org.apache.cassandra.db.ColumnFamilyStore.createSSTableMultiWriter(ColumnFamilyStore.java:729)
+	at org.apache.cassandra.db.memtable.Flushing.createFlushWriter(Flushing.java:303)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnable(Flushing.java:135)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:96)
+	at org.apache.cassandra.db.memtable.Flushing.flushRunnables(Flushing.java:73)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1355)
+	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1310)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	... 2 common frames omitted
+Caused by: java.io.IOException: Invalid folder descriptor trying to create log replica /private/var/folders/32/0w1k4v6n1hl9xqqw011y1_600000gr/T/stargate-persistence-dse-next14593132079064320544/data/system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca
+	... 27 common frames omitted

--- a/coordinator/testing/pom.xml
+++ b/coordinator/testing/pom.xml
@@ -440,41 +440,6 @@
                   <failIfNoTests>true</failIfNoTests>
                   <reportsDirectory>target/failsafe-reports/dse-next</reportsDirectory>
                   <summaryFile>target/failsafe-reports/summary-dse-next.xml</summaryFile>
-                  <excludes>
-                    <!-- TODO: Fix authentication related errors including:
-                     "CassandraRoleManager doesn't support PASSWORD"
-                     "You have to be logged in and not anonymous to perform this request" -->
-                    <exclude>io.stargate.it.bridge.BridgeAuthorizationTest</exclude>
-                    <exclude>io.stargate.it.cql.JwtAuthTest</exclude>
-                    <exclude>io.stargate.it.cql.compatibility.protocolv4.JwtAuthTest</exclude>
-                    <exclude>io.stargate.it.grpc.GrpcAuthorizationTest</exclude>
-                    <exclude>io.stargate.it.cql.AuthorizationCommandInterceptorTest</exclude>
-                    <!-- TODO: fix Timeout related issues similar to:
-                     "ConditionTimeout Condition with lambda expression ... was not fulfilled within 5 minutes"-->
-                    <exclude>io.stargate.it.cql.TokenAwareTest</exclude>
-                    <exclude>io.stargate.it.cql.compatibility.protocolv4.TokenAwareTest</exclude>
-                    <exclude>io.stargate.it.cql.SystemTablesTest</exclude>
-                    <exclude>io.stargate.it.cql.compatibility.protocolv4.SystemTablesTest</exclude>
-                    <!-- TODO: fix result matching issue:
-                     "Expecting size of: ["-9223372036854775808"] to be greater than 1 but was 1"-->
-                    <exclude>io.stargate.it.cql.SystemTablesTest</exclude>
-                    <exclude>io.stargate.it.cql.compatibility.protocolv4.SystemTablesTest</exclude>
-                    <!-- TODO: fix result matching issue:
-                     "Expecting size of: [] to be greater than 0 but was 0"-->
-                    <exclude>io.stargate.it.cql.AdditionalPortsTest</exclude>
-                    <exclude>io.stargate.it.cql.compatibility.protocolv4.AdditionalPortsTest</exclude>
-                    <!-- TODO: fix result matching issues:
-                    "Expecting ArrayList: ["127.0.2.14"] to contain: ["127.0.0.1"]..."
-                    "expected: "cc03e747-a6af-3bcb-b8be-7668acfebee5" but was: "9b0a72d6-5861-4344-8d21-cbb2296c6865""-->
-                    <exclude>io.stargate.it.cql.BatchStatementTest</exclude>
-                    <exclude>io.stargate.it.cql.compatibility.protocolv4.BatchStatementTest</exclude>
-                    <exclude>io.stargate.it.cql.BoundStatementTest</exclude>
-                    <exclude>io.stargate.it.cql.compatibility.protocolv4.BoundStatementTest</exclude>
-                    <exclude>io.stargate.it.cql.SimpleStatementTest</exclude>
-                    <exclude>io.stargate.it.cql.compatibility.protocolv4.SimpleStatementTest</exclude>
-                    <exclude>io.stargate.it.cql.HostIdTest</exclude>
-                    <exclude>io.stargate.it.cql.compatibility.protocolv4.HostIdTest</exclude>
-                  </excludes>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
Re-implement system keyspace as virtual tables, leveraging code from DSE 6.8 persistence module.

Fixes #2685 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
