### PR TITLE
DocsAPI: Debug log to log the batch size when a doc is translated 

### DIFF
--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/write/WriteBridgeService.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/write/WriteBridgeService.java
@@ -592,7 +592,9 @@ public class WriteBridgeService {
                             .setValue(queriesConfig.consistency().writes())));
     batchQueries.forEach(batch::addQueries);
     Batch batchBuilt = batch.build();
-    logger.debug("Batch payload size : {}", batchBuilt.getSerializedSize());
+    if (logger.isDebugEnabled()) {
+      logger.debug("Batch payload size : {}", batchBuilt.getSerializedSize());
+    }
     return bridge.executeBatch(batchBuilt).map(QueryOuterClass.Response::getResultSet);
   }
 

--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/write/WriteBridgeService.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/write/WriteBridgeService.java
@@ -37,25 +37,18 @@ import io.stargate.sgv2.docsapi.service.JsonShreddedRow;
 import io.stargate.sgv2.docsapi.service.json.DeadLeaf;
 import io.stargate.sgv2.docsapi.service.util.DocsApiUtils;
 import io.stargate.sgv2.docsapi.service.util.TimeSource;
-import io.stargate.sgv2.docsapi.service.write.db.AbstractDeleteQueryBuilder;
-import io.stargate.sgv2.docsapi.service.write.db.DeleteDocumentQueryBuilder;
-import io.stargate.sgv2.docsapi.service.write.db.DeleteSubDocumentArrayQueryBuilder;
-import io.stargate.sgv2.docsapi.service.write.db.DeleteSubDocumentKeysQueryBuilder;
-import io.stargate.sgv2.docsapi.service.write.db.DeleteSubDocumentPathQueryBuilder;
-import io.stargate.sgv2.docsapi.service.write.db.InsertQueryBuilder;
+import io.stargate.sgv2.docsapi.service.write.db.*;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class WriteBridgeService {
-
+  private static final Logger logger = LoggerFactory.getLogger(WriteBridgeService.class);
   // path splitter on dot
   private static final Splitter PATH_SPLITTER = Splitter.on(".");
 
@@ -599,8 +592,9 @@ public class WriteBridgeService {
                         QueryOuterClass.ConsistencyValue.newBuilder()
                             .setValue(queriesConfig.consistency().writes())));
     batchQueries.forEach(batch::addQueries);
-
-    return bridge.executeBatch(batch.build()).map(QueryOuterClass.Response::getResultSet);
+    Batch batchBuilt = batch.build();
+    logger.debug("Batch payload size : {}", batchBuilt.getSerializedSize());
+    return bridge.executeBatch(batchBuilt).map(QueryOuterClass.Response::getResultSet);
   }
 
   private Uni<ResultSet> executeSingle(

--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/write/WriteBridgeService.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/write/WriteBridgeService.java
@@ -40,11 +40,10 @@ import io.stargate.sgv2.docsapi.service.util.TimeSource;
 import io.stargate.sgv2.docsapi.service.write.db.*;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.*;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ApplicationScoped
 public class WriteBridgeService {


### PR DESCRIPTION
**What this PR does**:
Adds a debug log to log the batch size when a doc is translated by the DOCS API

**Which issue(s) this PR fixes**:
Fixes #2728 

**Checklist**
- [X] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [X] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
