### PR TITLE
'compactMapData' param added to the parameters definition

### DIFF
--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/StargateRestApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/StargateRestApi.java
@@ -90,7 +90,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                   description = "Whether to 'unwrap' results object (omit wrapper)",
                   required = false,
                   schema = @Schema(implementation = boolean.class)),
-             @Parameter(
+              @Parameter(
                   in = ParameterIn.QUERY,
                   name = RestOpenApiConstants.Parameters.COMPACT_MAP_DATA,
                   description = "Whether to return/expect the map data in compact format",

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/StargateRestApi.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/StargateRestApi.java
@@ -90,6 +90,12 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                   description = "Whether to 'unwrap' results object (omit wrapper)",
                   required = false,
                   schema = @Schema(implementation = boolean.class)),
+             @Parameter(
+                  in = ParameterIn.QUERY,
+                  name = RestOpenApiConstants.Parameters.COMPACT_MAP_DATA,
+                  description = "Whether to return/expect the map data in compact format",
+                  required = false,
+                  schema = @Schema(implementation = boolean.class)),
               @Parameter(
                   in = ParameterIn.QUERY,
                   name = RestOpenApiConstants.Parameters.SORT,


### PR DESCRIPTION
**What this PR does**:
`compactMapData` param that is supported by few of the REST APIs is not in the parameters definition and so, an error is thrown on the swagger-ui when those APIs are loaded. This PR addresses the same.

**Which issue(s) this PR fixes**:
Fixes #2733 

**Checklist**
- [X] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
