### PR TITLE
Fix #2765: update java-driver-core to latest

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -61,6 +61,8 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.2.1.Final</quarkus.platform.version>
+    <!-- Cassandra dependencies -->
+    <driver.version>4.17.0</driver.version>
     <!-- Testing -->
     <skipTests>false</skipTests>
     <skipUnitTests>${skipTests}</skipUnitTests>
@@ -114,7 +116,7 @@
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-core</artifactId>
-        <version>4.14.1</version>
+        <version>${driver.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -53,7 +53,7 @@
     <!-- Release -->
     <project.scm.id>github</project.scm.id>
     <doclint>none</doclint>
-    <driver.version>4.15.0</driver.version>
+    <driver.version>4.17.0</driver.version>
     <!-- First DropWizard version and things it directly depends on that make sense to sync -->
     <dropwizard.version>2.1.6</dropwizard.version>
     <!--
@@ -720,7 +720,7 @@
         <artifactId>java-driver-core</artifactId>
         <version>${driver.version}</version>
       </dependency>
-      <!-- 14-Jun-2022, tatu: with java-driver-core 4.14.1 this dependency is optional
+      <!-- 14-Jun-2022, tatu: with java-driver-core 4.14+ this dependency is optional
             and not brought as compile-time dependency, so needs to be explicitly added
            (see [stargate#1889] for details). But we better use consistent version
       -->


### PR DESCRIPTION
**What this PR does**:

Updates `java-driver-core` dependency to the latest available, 4.17.0

**Which issue(s) this PR fixes**:
Fixes #2765

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
