### PR TITLE
Fixes #2795: update Docker base image versions for Docs/GraphQL/REST API

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>au.com.acegi</groupId>
         <artifactId>xml-format-maven-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.2.2</version>
         <executions>
           <execution>
             <goals>

--- a/apis/sgv2-docsapi/src/main/docker/Dockerfile.jvm
+++ b/apis/sgv2-docsapi/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.15
+FROM registry.access.redhat.com/ubi8/openjdk-17:1.17
 
 ENV LANGUAGE='en_US:en'
 

--- a/apis/sgv2-docsapi/src/main/docker/Dockerfile.native
+++ b/apis/sgv2-docsapi/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8180:8180 quarkus/sgv2-docsapi
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/apis/sgv2-graphqlapi/src/main/docker/Dockerfile.jvm
+++ b/apis/sgv2-graphqlapi/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.15
+FROM registry.access.redhat.com/ubi8/openjdk-17:1.17
 
 ENV LANGUAGE='en_US:en'
 

--- a/apis/sgv2-graphqlapi/src/main/docker/Dockerfile.native
+++ b/apis/sgv2-graphqlapi/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/sgv2-graphqlapi-quarkus
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/apis/sgv2-restapi/src/main/docker/Dockerfile.jvm
+++ b/apis/sgv2-restapi/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.15
+FROM registry.access.redhat.com/ubi8/openjdk-17:1.17
 
 ENV LANGUAGE='en_US:en'
 

--- a/apis/sgv2-restapi/src/main/docker/Dockerfile.native
+++ b/apis/sgv2-restapi/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8082:8082 quarkus/sgv2-restapi
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -299,7 +299,7 @@
       <plugin>
         <groupId>au.com.acegi</groupId>
         <artifactId>xml-format-maven-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.2.2</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
**What this PR does**:

Updates base images from 5 month old to latest for `jvm` and `native` images of Docs/GraphQL/REST APIs.

**Which issue(s) this PR fixes**:
Fixes #2795

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
