### PR TITLE
Fix #2802: upgrade Quarkus dep to 3.2.6 (gRPC to 1.56.x)

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -60,7 +60,7 @@
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.3.3</quarkus.platform.version>
+    <quarkus.platform.version>3.2.6.Final</quarkus.platform.version>
     <!-- Cassandra dependencies -->
     <driver.version>4.17.0</driver.version>
     <!-- Testing -->

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -43,9 +43,9 @@
   <!-- Aggregated modules -->
   <modules>
     <module>sgv2-quarkus-common</module>
+    <module>sgv2-restapi</module>
     <module>sgv2-docsapi</module>
     <module>sgv2-graphqlapi</module>
-    <module>sgv2-restapi</module>
   </modules>
   <!-- Shared properties -->
   <properties>
@@ -60,7 +60,7 @@
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.4.1</quarkus.platform.version>
+    <quarkus.platform.version>3.3.3</quarkus.platform.version>
     <!-- Cassandra dependencies -->
     <driver.version>4.17.0</driver.version>
     <!-- Testing -->

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -60,7 +60,7 @@
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.2.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>3.4.1</quarkus.platform.version>
     <!-- Cassandra dependencies -->
     <driver.version>4.17.0</driver.version>
     <!-- Testing -->

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -72,7 +72,7 @@
     <!-- And then other 3rd party version dependencies, compile/runtime -->
     <caffeine.version>2.9.3</caffeine.version>
     <commons-io.version>2.7</commons-io.version>
-    <grpc.version>1.57.2</grpc.version>
+    <grpc.version>1.56.1</grpc.version>
     <immutables.version>2.8.8</immutables.version>
     <jackson.version>2.14.2</jackson.version>
     <javatuples.version>1.2</javatuples.version>


### PR DESCRIPTION
**What this PR does**:

Upgrades Quarkus to 3.3.3 (from 3.2.1), to upgrade transitive `grpc-core` to 1.56.1.
Also downgrade Coordinator side grpc.version to `1.56.1` to have versions align.

**Which issue(s) this PR fixes**:
Fixes #2802

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
