### PR TITLE
use openjdk runtime images

### DIFF
--- a/apis/sgv2-docsapi/src/main/docker/Dockerfile.jvm
+++ b/apis/sgv2-docsapi/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.17
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.17
 
 ENV LANGUAGE='en_US:en'
 

--- a/apis/sgv2-graphqlapi/src/main/docker/Dockerfile.jvm
+++ b/apis/sgv2-graphqlapi/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.17
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.17
 
 ENV LANGUAGE='en_US:en'
 

--- a/apis/sgv2-restapi/src/main/docker/Dockerfile.jvm
+++ b/apis/sgv2-restapi/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.17
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.17
 
 ENV LANGUAGE='en_US:en'
 


### PR DESCRIPTION
Use openjdk's runtime base images for APIs. These are smaller, omitting JDK tools. These should have fewer vulnerabilities as a result.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
