### PR TITLE
ensure JVM heap memory settings applied in API images

### DIFF
--- a/apis/sgv2-docsapi/src/main/docker/Dockerfile.jvm
+++ b/apis/sgv2-docsapi/src/main/docker/Dockerfile.jvm
@@ -90,6 +90,6 @@ COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
 USER 185
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dvertx.disableURIValidation=true"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dvertx.disableURIValidation=true"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 

--- a/apis/sgv2-graphqlapi/src/main/docker/Dockerfile.jvm
+++ b/apis/sgv2-graphqlapi/src/main/docker/Dockerfile.jvm
@@ -90,5 +90,5 @@ COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
 USER 185
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/apis/sgv2-restapi/src/main/docker/Dockerfile.jvm
+++ b/apis/sgv2-restapi/src/main/docker/Dockerfile.jvm
@@ -90,6 +90,6 @@ COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
 USER 185
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dvertx.disableURIValidation=true"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dvertx.disableURIValidation=true"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 


### PR DESCRIPTION
Upgrading the base Docker images used for APIs in #2796 caused a regression in the v2.0.20 and v2.0.21 releases where JVM settings including max heap size via `JAVA_MAX_MEM_RATIO` are no longer honored. The issue is that the Dockerfiles for our API images use the `JAVA_OPTS` environment variable, when apparently we should be using `JAVA_OPTS_APPEND`. If you set `JAVA_OPTS`, other environment variables such as `JAVA_MAX_MEM_RATIO` are ignored. 

From this issue link : https://access.redhat.com/solutions/7031183
```
It is expected that if JAVA_OPTS is used, it includes all JVM options and system properties, and any S2I properties (e.g. JAVA_MAX_MEM_RATIO) will be ignored.

If it is desired to use S2I properties (e.g. JAVA_MAX_MEM_RATIO) and/or add to some base set of JVM options and/or system properties, then JAVA_OPTS_APPEND should be used.

Some builds do not strictly adhere to this (e.g. JAVA_OPTS does not do a full replacement); however, these are regressions that should not be relied upon and are fixed in later release.
```

Apparently we are now using a new enough base image that enforcement is now tripping us up.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
