### PR TITLE
Fix Python 3.12/ccm/CI issue

### DIFF
--- a/.github/workflows/coordinator-test-v21.yml
+++ b/.github/workflows/coordinator-test-v21.yml
@@ -55,7 +55,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - uses: actions/setup-java@v3
         name: Setup Java JDK
@@ -87,7 +87,8 @@ jobs:
       #  all unit tests should run without storage
       - name: Install CCM
         run: |
-          python -m pip install --upgrade pip ccm
+          python -m pip install --upgrade pip setuptools
+          python -m pip install ccm
           ccm list
 
       - name: Run unit tests
@@ -139,7 +140,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - uses: actions/setup-java@v3
         name: Setup Java JDK
@@ -170,7 +171,8 @@ jobs:
 
       - name: Install CCM
         run: |
-          python -m pip install --upgrade pip ccm
+          python -m pip install --upgrade pip setuptools
+          python -m pip install ccm
           ccm list
 
       - name: Run Integration Tests

--- a/.github/workflows/coordinator-test.yml
+++ b/.github/workflows/coordinator-test.yml
@@ -55,7 +55,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - uses: actions/setup-java@v3
         name: Setup Java JDK
@@ -87,7 +87,8 @@ jobs:
       #  all unit tests should run without storage
       - name: Install CCM
         run: |
-          python -m pip install --upgrade pip ccm
+          python -m pip install --upgrade pip setuptools
+          python -m pip install ccm
           ccm list
 
       - name: Run unit tests
@@ -139,7 +140,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - uses: actions/setup-java@v3
         name: Setup Java JDK
@@ -170,7 +171,8 @@ jobs:
 
       - name: Install CCM
         run: |
-          python -m pip install --upgrade pip ccm
+          python -m pip install --upgrade pip setuptools
+          python -m pip install ccm
           ccm list
 
       - name: Run Integration Tests


### PR DESCRIPTION
**What this PR does**:

Due to https://github.com/python/cpython/issues/95299, Python 3.12 no longer bundles `setuptools`, leading to CI failures for 2 of our workflows that refer to Python version as `3.x`.
Solution is to explicitly install package.

PR also changes Python dependency to use `3.12` explicitly instead of `3.x` to prevent "accidental" version upgrade in future.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
