### PR TITLE
Fix #1281: update to Logback 1.3.x (from 1.2.x); slf4j-api to 2.0 (from 1.3)

### DIFF
--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -67,8 +67,8 @@
     -->
     <jetty.version>9.4.53.v20231009</jetty.version>
     <!-- Logging framework likewise in sync -->
-    <slf4j.version>1.7.36</slf4j.version>
-    <logback.version>1.2.12</logback.version>
+    <slf4j.version>2.0.9</slf4j.version>
+    <logback.version>1.3.11</logback.version>
     <!-- And then other 3rd party version dependencies, compile/runtime -->
     <caffeine.version>2.9.3</caffeine.version>
     <commons-io.version>2.7</commons-io.version>


### PR DESCRIPTION
**What this PR does**:

Updates version of `logback` logging library we use for Coordinator

**Which issue(s) this PR fixes**:
Fixes #1281

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
