### PR TITLE
Upgraded quarkus to 3.6.1 and add tenant to http request metrics

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -60,7 +60,7 @@
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.2.6.Final</quarkus.platform.version>
+    <quarkus.platform.version>3.6.1</quarkus.platform.version>
     <!-- Cassandra dependencies -->
     <driver.version>4.17.0</driver.version>
     <!-- Testing -->

--- a/apis/sgv2-docsapi/src/test/resources/application.yaml
+++ b/apis/sgv2-docsapi/src/test/resources/application.yaml
@@ -3,3 +3,12 @@
 stargate:
   data-store:
     ignore-bridge: true
+
+"%test":
+  quarkus:
+    # properties for the gRPC clients
+    grpc:
+      # all the clients' setup, only bridge
+      clients:
+        bridge:
+          port: 9001

--- a/apis/sgv2-docsapi/src/test/resources/application.yaml
+++ b/apis/sgv2-docsapi/src/test/resources/application.yaml
@@ -4,6 +4,7 @@ stargate:
   data-store:
     ignore-bridge: true
 
+# The test profile to override the port is needed because with quarkus upgrade this is defaulted to 9001
 "%test":
   quarkus:
     # properties for the gRPC clients

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/metrics/TenantRequestMetricsTagProvider.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/metrics/TenantRequestMetricsTagProvider.java
@@ -10,6 +10,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.regex.Pattern;
 
+/** Tags provider for http request metrics. It provides tenant id and user agent as tags. */
 @ApplicationScoped
 public class TenantRequestMetricsTagProvider implements HttpServerMetricsTagsContributor {
 
@@ -32,7 +33,7 @@ public class TenantRequestMetricsTagProvider implements HttpServerMetricsTagsCon
   private final Tag errorFalse;
 
   /** The tag for tenant being unknown, created only once. */
-  Tag tenantUnknown;
+  private final Tag tenantUnknown;
 
   /** Default constructor. */
   @Inject
@@ -45,6 +46,7 @@ public class TenantRequestMetricsTagProvider implements HttpServerMetricsTagsCon
     tenantUnknown = Tag.of(config.tenantTag(), UNKNOWN_VALUE);
   }
 
+  @Override
   public Tags contribute(Context context) {
     // resolve tenant
     Tag tenantTag =

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/metrics/TenantRequestMetricsTagProvider.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/metrics/TenantRequestMetricsTagProvider.java
@@ -1,0 +1,75 @@
+package io.stargate.sgv2.api.common.metrics;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.quarkus.micrometer.runtime.HttpServerMetricsTagsContributor;
+import io.stargate.sgv2.api.common.StargateRequestInfo;
+import io.stargate.sgv2.api.common.config.MetricsConfig;
+import io.vertx.core.http.HttpServerRequest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.regex.Pattern;
+
+@ApplicationScoped
+public class TenantRequestMetricsTagProvider implements HttpServerMetricsTagsContributor {
+
+  // split pattern for the user agent, extract only first part of the agent
+  private static final Pattern USER_AGENT_SPLIT = Pattern.compile("[\\s/]");
+
+  // same as V1 io.stargate.core.metrics.StargateMetricConstants#UNKNOWN
+  private static final String UNKNOWN_VALUE = "unknown";
+
+  /** The configuration for metrics. */
+  private final MetricsConfig.TenantRequestCounterConfig config;
+
+  /** The request info bean. */
+  private final StargateRequestInfo requestInfo;
+
+  /** The tag for error being true, created only once. */
+  private final Tag errorTrue;
+
+  /** The tag for error being false, created only once. */
+  private final Tag errorFalse;
+
+  /** The tag for tenant being unknown, created only once. */
+  Tag tenantUnknown;
+
+  /** Default constructor. */
+  @Inject
+  public TenantRequestMetricsTagProvider(
+      StargateRequestInfo requestInfo, MetricsConfig metricsConfig) {
+    this.requestInfo = requestInfo;
+    this.config = metricsConfig.tenantRequestCounter();
+    errorTrue = Tag.of(config.errorTag(), "true");
+    errorFalse = Tag.of(config.errorTag(), "false");
+    tenantUnknown = Tag.of(config.tenantTag(), UNKNOWN_VALUE);
+  }
+
+  public Tags contribute(Context context) {
+    // resolve tenant
+    Tag tenantTag =
+        requestInfo.getTenantId().map(id -> Tag.of(config.tenantTag(), id)).orElse(tenantUnknown);
+
+    // check if we need user agent as well
+    Tags tags = Tags.of(tenantTag);
+    if (config.userAgentTagEnabled()) {
+      String userAgentValue = getUserAgentValue(context.request());
+      tags = tags.and(Tag.of(config.userAgentTag(), userAgentValue));
+    }
+    return tags;
+  }
+
+  private String getUserAgentValue(HttpServerRequest request) {
+    String headerString = request.getHeader("user-agent");
+    if (null != headerString && !headerString.isBlank()) {
+      String[] split = USER_AGENT_SPLIT.split(headerString);
+      if (split.length > 0) {
+        return split[0];
+      } else {
+        return headerString;
+      }
+    } else {
+      return UNKNOWN_VALUE;
+    }
+  }
+}

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/metrics/TenantRequestMetricsTagProviderTest.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/api/common/metrics/TenantRequestMetricsTagProviderTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.stargate.sgv2.api.common.metrics;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.api.common.testprofiles.FixedTenantTestProfile;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(TenantRequestMetricsTagProviderTest.Profile.class)
+class TenantRequestMetricsTagProviderTest {
+
+  public static class Profile extends FixedTenantTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      Map<String, String> configOverrides = super.getConfigOverrides();
+
+      return ImmutableMap.<String, String>builder()
+          .putAll(configOverrides)
+          .put("quarkus.micrometer.export.prometheus.path", "/metrics")
+          .build();
+    }
+  }
+
+  // simple testing endpoint, helps in testing metrics
+  @Path("testingTagProvider")
+  public static class TestingResource {
+
+    @GET
+    @Produces("text/plain")
+    public String greet() {
+      return "hello";
+    }
+  }
+
+  @Test
+  public void record() {
+    // call endpoint
+    given().when().get("/testingTagProvider").then().statusCode(200);
+
+    // collect metrics
+    String result = given().when().get("/metrics").then().statusCode(200).extract().asString();
+
+    // find target metrics
+    List<String> meteredLines =
+        Arrays.stream(result.split(System.getProperty("line.separator")))
+            .filter(line -> line.startsWith("http_server_requests"))
+            .collect(Collectors.toList());
+
+    assertThat(meteredLines)
+        .anySatisfy(
+            metric ->
+                assertThat(metric).contains("tenant=\"" + FixedTenantTestProfile.TENANT_ID + "\""));
+  }
+}

--- a/apis/sgv2-quarkus-common/src/test/resources/application.yaml
+++ b/apis/sgv2-quarkus-common/src/test/resources/application.yaml
@@ -11,6 +11,8 @@ quarkus:
         host: localhost
         port: 8091
 
+# The test profile to override the port is needed because with quarkus upgrade this is defaulted to 9001
+# https://github.com/quarkusio/quarkus/issues/15934
 "%test":
   quarkus:
     # properties for the gRPC clients

--- a/apis/sgv2-quarkus-common/src/test/resources/application.yaml
+++ b/apis/sgv2-quarkus-common/src/test/resources/application.yaml
@@ -11,6 +11,15 @@ quarkus:
         host: localhost
         port: 8091
 
+"%test":
+  quarkus:
+    # properties for the gRPC clients
+    grpc:
+      # all the clients' setup, only bridge
+      clients:
+        bridge:
+          port: 9001
+
 io:
   stargate:
     sgv2:


### PR DESCRIPTION
**What this PR does**:
Added tenant to default http request metrics
Upgraded quarkus to 3.6.1

**Which issue(s) this PR fixes**:
Fixes #2843 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
