### PR TITLE
Baclport #2539 in `v1` to upgrade DSE 6.8.33 -> 6.8.34

### DIFF
--- a/coordinator/persistence-dse-6.8/README.md
+++ b/coordinator/persistence-dse-6.8/README.md
@@ -5,7 +5,7 @@ the DSE (DataStax Enterprise cassandra) `6.8.x` version.
 
 ## Cassandra version update
 
-The current Cassandra version this module depends on is `6.8.33`.
+The current Cassandra version this module depends on is `6.8.34`.
 In order to update to a newer patch version, please follow the guidelines below:
 
 * Update the `dse.version` property in the [pom.xml](pom.xml).
@@ -19,3 +19,4 @@ It's always good to validate your work against the pull requests that bumped the
 * `6.8.16` -> `6.8.20` [stargate/stargate#1652](https://github.com/stargate/stargate/pull/1652)
 * `6.8.21` -> `6.8.24` [stargate/stargate#1898](https://github.com/stargate/stargate/pull/1898)
 * `6.8.31` -> `6.8.32` [stargate/stargate#2430](https://github.com/stargate/stargate/pull/2430)
+* `6.8.32` -> `6.8.33` [stargate/stargate#2430](https://github.com/stargate/stargate/pull/2497)

--- a/coordinator/persistence-dse-6.8/pom.xml
+++ b/coordinator/persistence-dse-6.8/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>persistence-dse-6.8</artifactId>
   <name>Stargate - Coordinator - Persistence DSE 6.8</name>
   <properties>
-    <dse.version>6.8.33</dse.version>
+    <dse.version>6.8.34</dse.version>
   </properties>
   <repositories>
     <repository>
@@ -131,6 +131,11 @@
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-shaded-guava</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec</artifactId>
+      <version>4.1.86.1.dse</version>
     </dependency>
     <!-- 3rd party dependencies -->
     <dependency>

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -743,10 +743,13 @@
             and not brought as compile-time dependency, so needs to be explicitly added
            (see [stargate#1889] for details). But we better use consistent version
         -->
+      <!-- 13-Apr-2023, tatu: And now DSE-6.8.34 upgraded version to 2.2.4 (from 1.2.1)
+	     let's hope things still work
+	-->
       <dependency>
         <groupId>com.esri.geometry</groupId>
         <artifactId>esri-geometry-api</artifactId>
-        <version>1.2.1</version>
+        <version>2.2.4</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>

--- a/coordinator/testing/pom.xml
+++ b/coordinator/testing/pom.xml
@@ -441,7 +441,7 @@
                 <configuration>
                   <systemPropertyVariables>
                     <ccm.dse>true</ccm.dse>
-                    <ccm.version>6.8.33</ccm.version>
+                    <ccm.version>6.8.34</ccm.version>
                     <stargate.test.nodes>1</stargate.test.nodes>
                   </systemPropertyVariables>
                   <failIfNoTests>true</failIfNoTests>


### PR DESCRIPTION
**What this PR does**:

Upgrades v1 branch to DSE-6.8.34, similar to how #2539 updated main/v2.

Part of eventual upgrade needed for #2868

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
