### PR TITLE
Update dependencies to be compatible with DSE-6.8.41 (SG/v2)

### DIFF
--- a/coordinator/persistence-dse-6.8/pom.xml
+++ b/coordinator/persistence-dse-6.8/pom.xml
@@ -126,7 +126,8 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
-      <version>4.1.86.1.dse</version>
+      <!-- Updated on DSE 6.8.40: -->
+      <version>4.1.100.1.dse</version>
     </dependency>
     <!-- 3rd party dependencies -->
     <dependency>

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -67,14 +67,14 @@
     -->
     <jetty.version>9.4.53.v20231009</jetty.version>
     <!-- Logging framework likewise in sync -->
-    <slf4j.version>2.0.9</slf4j.version>
+    <slf4j.version>2.0.11</slf4j.version>
     <logback.version>1.3.14</logback.version>
     <!-- And then other 3rd party version dependencies, compile/runtime -->
     <caffeine.version>2.9.3</caffeine.version>
     <commons-io.version>2.7</commons-io.version>
     <grpc.version>1.56.1</grpc.version>
     <immutables.version>2.8.8</immutables.version>
-    <jackson.version>2.14.2</jackson.version>
+    <jackson.version>2.14.3</jackson.version>
     <javatuples.version>1.2</javatuples.version>
     <!-- Make sure micrometer and prometheus versions are in sync  -->
     <micrometer.version>1.8.2</micrometer.version>


### PR DESCRIPTION
**What this PR does**:

Updates dependencies for SG v2 to be compatible with latest DSE (6.8.41).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
