### PR TITLE
Fix #2956: change Docker base images for API/native (to resolve CVEs)

### DIFF
--- a/apis/sgv2-docsapi/src/main/docker/Dockerfile.native
+++ b/apis/sgv2-docsapi/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8180:8180 quarkus/sgv2-docsapi
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.17
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/apis/sgv2-graphqlapi/src/main/docker/Dockerfile.native
+++ b/apis/sgv2-graphqlapi/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/sgv2-graphqlapi-quarkus
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.17
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/apis/sgv2-restapi/src/main/docker/Dockerfile.native
+++ b/apis/sgv2-restapi/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8082:8082 quarkus/sgv2-restapi
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.17
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \


### PR DESCRIPTION
**What this PR does**:

Update Stargate v2 REST/GraphQL/DocsAPI native variants' Docker base images to ones without Snyk-reported vulnerabilities.
For some reason native images use different base: will try PR to see if use of ".jvm" images' base images just works as-is, to unify handling.

Base image change appears to work: actual image size likely grow, going from minimal to "full" base.

**Which issue(s) this PR fixes**:
Fixes #2956

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
