### PR TITLE
Fixes #2963: upgrade Quarkus from 3.6.1 to the latest (3.12.0) version to resolve CVEs

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -60,13 +60,13 @@
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.6.1</quarkus.platform.version>
+    <quarkus.platform.version>3.11.3</quarkus.platform.version>
     <!-- Cassandra dependencies -->
     <driver.version>4.17.0</driver.version>
     <!-- Testing -->
     <skipTests>false</skipTests>
     <skipUnitTests>${skipTests}</skipUnitTests>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.3.0</surefire-plugin.version>
     <!--
       Integration test properties, defaults to cassandra-40
       Please maintain default values for int-test in sync with io.stargate.sgv2.docsapi.testresource.StargateTestResource.Defaults

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -60,7 +60,7 @@
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.9.5</quarkus.platform.version>
+    <quarkus.platform.version>3.8.5</quarkus.platform.version>
     <!-- Cassandra dependencies -->
     <driver.version>4.17.0</driver.version>
     <!-- Testing -->

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -60,7 +60,7 @@
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.8.5</quarkus.platform.version>
+    <quarkus.platform.version>3.7.4</quarkus.platform.version>
     <!-- Cassandra dependencies -->
     <driver.version>4.17.0</driver.version>
     <!-- Testing -->

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -60,7 +60,7 @@
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.11.3</quarkus.platform.version>
+    <quarkus.platform.version>3.12.0</quarkus.platform.version>
     <!-- Cassandra dependencies -->
     <driver.version>4.17.0</driver.version>
     <!-- Testing -->

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -60,7 +60,7 @@
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.11.3</quarkus.platform.version>
+    <quarkus.platform.version>3.9.5</quarkus.platform.version>
     <!-- Cassandra dependencies -->
     <driver.version>4.17.0</driver.version>
     <!-- Testing -->

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -60,7 +60,7 @@
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.7.4</quarkus.platform.version>
+    <quarkus.platform.version>3.9.5</quarkus.platform.version>
     <!-- Cassandra dependencies -->
     <driver.version>4.17.0</driver.version>
     <!-- Testing -->

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -60,7 +60,7 @@
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.9.5</quarkus.platform.version>
+    <quarkus.platform.version>3.11.3</quarkus.platform.version>
     <!-- Cassandra dependencies -->
     <driver.version>4.17.0</driver.version>
     <!-- Testing -->

--- a/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/CQLResource.java
+++ b/apis/sgv2-restapi/src/main/java/io/stargate/sgv2/restapi/service/resources/CQLResource.java
@@ -36,7 +36,7 @@ import org.jboss.resteasy.reactive.RestResponse;
 @SecurityRequirement(name = RestOpenApiConstants.SecuritySchemes.TOKEN)
 @Tag(ref = RestOpenApiConstants.Tags.DATA)
 @EndpointDisabled(
-    name = "stargate.rest.cql.disabled",
+    name = "stargate.rest.cql-disabled",
     stringValue = "true",
     disableIfMissing = true)
 public class CQLResource {

--- a/apis/sgv2-restapi/src/main/resources/application.yaml
+++ b/apis/sgv2-restapi/src/main/resources/application.yaml
@@ -3,9 +3,8 @@
 
 stargate:
   rest:
-    cql:
-      # By default CQL endpoint (/v2/cql) is disabled: change to false to enable
-      disabled: true
+    # By default CQL endpoint (/v2/cql) is disabled: change to false to enable
+    cql-disabled: true
 
   # metrics properties
   # see io.stargate.sgv2.api.common.config.MetricsConfig for all config properties and options

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QCqlIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QCqlIT.java
@@ -23,7 +23,7 @@ public class RestApiV2QCqlIT extends RestApiV2QIntegrationTestBase {
   public static class Profile implements QuarkusTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
-      return Map.of("stargate.rest.cql.disabled", "false");
+      return Map.of("stargate.rest.cql-disabled", "false");
     }
   }
 


### PR DESCRIPTION
**What this PR does**:

Upgrades Quarkus used by APIs to a later version, to resolve CVEs reported against dependencies and allow use of later Jackson version by Data API.

**Which issue(s) this PR fixes**:
Fixes #2963

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
