### PR TITLE
Update DSE from 6.8.41 to 6.8.50

### DIFF
--- a/coordinator/persistence-dse-6.8/README.md
+++ b/coordinator/persistence-dse-6.8/README.md
@@ -5,7 +5,7 @@ the DSE (DataStax Enterprise cassandra) `6.8.x` version.
 
 ## Cassandra version update
 
-The current Cassandra version this module depends on is `6.8.41`.
+The current Cassandra version this module depends on is `6.8.50`.
 In order to update to a newer patch version, please follow the guidelines below:
 
 * Update the `dse.version` property in the [pom.xml](pom.xml).
@@ -19,4 +19,4 @@ It's always good to validate your work against the pull requests that bumped the
 * `6.8.16` -> `6.8.20` [stargate/stargate#1652](https://github.com/stargate/stargate/pull/1652)
 * `6.8.21` -> `6.8.24` [stargate/stargate#1898](https://github.com/stargate/stargate/pull/1898)
 * `6.8.31` -> `6.8.32` [stargate/stargate#2430](https://github.com/stargate/stargate/pull/2430)
-* `6.8.32` -> `6.8.33` [stargate/stargate#2430](https://github.com/stargate/stargate/pull/2497)
+* `6.8.34` -> `6.8.41` [stargate/stargate#2879](https://github.com/stargate/stargate/pull/2879)

--- a/coordinator/persistence-dse-6.8/pom.xml
+++ b/coordinator/persistence-dse-6.8/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>persistence-dse-6.8</artifactId>
   <name>Stargate - Coordinator - Persistence DSE 6.8</name>
   <properties>
-    <dse.version>6.8.41</dse.version>
+    <dse.version>6.8.50</dse.version>
   </properties>
   <repositories>
     <repository>

--- a/coordinator/testing/pom.xml
+++ b/coordinator/testing/pom.xml
@@ -441,7 +441,7 @@
                 <configuration>
                   <systemPropertyVariables>
                     <ccm.dse>true</ccm.dse>
-                    <ccm.version>6.8.41</ccm.version>
+                    <ccm.version>6.8.50</ccm.version>
                     <stargate.test.nodes>1</stargate.test.nodes>
                   </systemPropertyVariables>
                   <failIfNoTests>true</failIfNoTests>


### PR DESCRIPTION
**What this PR does**:

Updates DSE persistence dependency from 6.8.41 to 6.8.50

**Which issue(s) this PR fixes**:
Fixes #2970

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
