### PR TITLE
Update to Quarkus 3.13.2 (but not to new test resource annotation)

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -60,7 +60,7 @@
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.12.0</quarkus.platform.version>
+    <quarkus.platform.version>3.13.2</quarkus.platform.version>
     <!-- Cassandra dependencies -->
     <driver.version>4.17.0</driver.version>
     <!-- Testing -->

--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/JsonDocumentShredder.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/JsonDocumentShredder.java
@@ -20,7 +20,7 @@ package io.stargate.sgv2.docsapi.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCode;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCodeRuntimeException;
 import io.stargate.sgv2.docsapi.api.properties.document.DocumentProperties;

--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/json/JsonConverter.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/json/JsonConverter.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.databind.node.LongNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.stargate.sgv2.docsapi.api.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.config.constants.Constants;
 import io.stargate.sgv2.docsapi.service.common.model.RowWrapper;

--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/ReadBridgeService.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/ReadBridgeService.java
@@ -19,7 +19,7 @@ package io.stargate.sgv2.docsapi.service.query;
 
 import com.bpodgursky.jbool_expressions.Expression;
 import com.bpodgursky.jbool_expressions.Literal;
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.grpc.Values;

--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/CollectionManager.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/CollectionManager.java
@@ -17,7 +17,7 @@
 
 package io.stargate.sgv2.docsapi.service.schema;
 
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.proto.QueryOuterClass;

--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/NamespaceManager.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/NamespaceManager.java
@@ -17,7 +17,7 @@
 
 package io.stargate.sgv2.docsapi.service.schema;
 
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.proto.QueryOuterClass;

--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/write/WriteBridgeService.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/write/WriteBridgeService.java
@@ -19,7 +19,7 @@ package io.stargate.sgv2.docsapi.service.write;
 
 import com.google.common.base.Splitter;
 import io.grpc.Metadata;
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.quarkus.grpc.GrpcClientUtils;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.proto.QueryOuterClass;

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/schema/SchemaManager.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/schema/SchemaManager.java
@@ -21,7 +21,7 @@ import com.google.protobuf.BytesValue;
 import com.google.protobuf.Int32Value;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.quarkus.cache.Cache;
 import io.quarkus.cache.CacheInvalidate;
 import io.quarkus.cache.CacheKey;


### PR DESCRIPTION
**What this PR does**:

Updates Quarkus dep to latest (3.13.2) without yet updating to new test annotation, since that seems to cause breakage. Will convert test annotations as follow-up.

**Which issue(s) this PR fixes**:
Fixes #2968

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
