### PR TITLE
Merge Quarkus upgrade changes from v2 (main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+
 ## [v2.0.30](https://github.com/stargate/stargate/tree/v2.0.30) (2024-07-08)
 
 [Full Changelog](https://github.com/stargate/stargate/compare/v2.0.29...v2.0.30)

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -60,7 +60,7 @@
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.12.0</quarkus.platform.version>
+    <quarkus.platform.version>3.13.2</quarkus.platform.version>
     <!-- Cassandra dependencies -->
     <driver.version>4.17.0</driver.version>
     <!-- Testing -->

--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/JsonDocumentShredder.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/JsonDocumentShredder.java
@@ -20,7 +20,7 @@ package io.stargate.sgv2.docsapi.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCode;
 import io.stargate.sgv2.docsapi.api.exception.ErrorCodeRuntimeException;
 import io.stargate.sgv2.docsapi.api.properties.document.DocumentProperties;

--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/json/JsonConverter.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/json/JsonConverter.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.databind.node.LongNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.stargate.sgv2.docsapi.api.properties.document.DocumentProperties;
 import io.stargate.sgv2.docsapi.config.constants.Constants;
 import io.stargate.sgv2.docsapi.service.common.model.RowWrapper;

--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/ReadBridgeService.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/query/ReadBridgeService.java
@@ -19,7 +19,7 @@ package io.stargate.sgv2.docsapi.service.query;
 
 import com.bpodgursky.jbool_expressions.Expression;
 import com.bpodgursky.jbool_expressions.Literal;
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.grpc.Values;

--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/CollectionManager.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/CollectionManager.java
@@ -17,7 +17,7 @@
 
 package io.stargate.sgv2.docsapi.service.schema;
 
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.proto.QueryOuterClass;

--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/NamespaceManager.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/schema/NamespaceManager.java
@@ -17,7 +17,7 @@
 
 package io.stargate.sgv2.docsapi.service.schema;
 
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.proto.QueryOuterClass;

--- a/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/write/WriteBridgeService.java
+++ b/apis/sgv2-docsapi/src/main/java/io/stargate/sgv2/docsapi/service/write/WriteBridgeService.java
@@ -19,7 +19,7 @@ package io.stargate.sgv2.docsapi.service.write;
 
 import com.google.common.base.Splitter;
 import io.grpc.Metadata;
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.quarkus.grpc.GrpcClientUtils;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.proto.QueryOuterClass;

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/CollectionsResourceIntegrationTest.java
@@ -24,7 +24,7 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 public class CollectionsResourceIntegrationTest extends DocsApiIntegrationTest {
 
   // base path for the test

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/BuiltInFunctionResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/BuiltInFunctionResourceIntegrationTest.java
@@ -23,7 +23,7 @@ import static net.javacrumbs.jsonunit.JsonMatchers.jsonNodeAbsent;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonPartEquals;
 import static org.hamcrest.Matchers.equalTo;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 class BuiltInFunctionResourceIntegrationTest extends DocsApiIntegrationTest {
 
   public static final String BASE_PATH =

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentDeleteResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentDeleteResourceIntegrationTest.java
@@ -22,7 +22,7 @@ import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 class DocumentDeleteResourceIntegrationTest extends DocsApiIntegrationTest {
 
   public static final String BASE_PATH =

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentPatchResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentPatchResourceIntegrationTest.java
@@ -25,7 +25,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 class DocumentPatchResourceIntegrationTest extends DocsApiIntegrationTest {
 
   public static final String BASE_PATH =

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentReadResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentReadResourceIntegrationTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.nullValue;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.CharStreams;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
@@ -54,7 +54,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 class DocumentReadResourceIntegrationTest extends DocsApiIntegrationTest {
 
   public static final String BASE_PATH = "/v2/namespaces/{namespace}/collections/{collection}";

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentUpdateResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentUpdateResourceIntegrationTest.java
@@ -26,7 +26,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 import com.google.common.io.CharStreams;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
@@ -42,7 +42,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 class DocumentUpdateResourceIntegrationTest extends DocsApiIntegrationTest {
 
   public static final String BASE_PATH =

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentWriteResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/documents/DocumentWriteResourceIntegrationTest.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 class DocumentWriteResourceIntegrationTest extends DocsApiIntegrationTest {
 
   public static final String BASE_PATH = "/v2/namespaces/{namespace}/collections/{collection}";

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/jsonschema/JsonSchemaResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/namespaces/collections/jsonschema/JsonSchemaResourceIntegrationTest.java
@@ -20,7 +20,7 @@ package io.stargate.sgv2.docsapi.api.v2.namespaces.collections.jsonschema;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 public class JsonSchemaResourceIntegrationTest extends DocsApiIntegrationTest {
 
   // base path for the test

--- a/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/schemas/namespaces/NamespacesResourceIntegrationTest.java
+++ b/apis/sgv2-docsapi/src/test/java/io/stargate/sgv2/docsapi/api/v2/schemas/namespaces/NamespacesResourceIntegrationTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 class NamespacesResourceIntegrationTest {
 
   public static final String BASE_PATH = "/v2/schemas/namespaces";

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/AggregationFunctionsIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/AggregationFunctionsIntegrationTest.java
@@ -18,7 +18,7 @@ package io.stargate.sgv2.graphql.integration.cqlfirst;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.BetterBotzIntegrationTestBase;
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class AggregationFunctionsIntegrationTest extends BetterBotzIntegrationTestBase {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/ApolloIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/ApolloIntegrationTest.java
@@ -30,7 +30,7 @@ import com.example.graphql.client.betterbotz.products.InsertProductsMutation;
 import com.example.graphql.client.betterbotz.products.UpdateProductsMutation;
 import com.example.graphql.client.betterbotz.type.OrdersInput;
 import com.example.graphql.client.betterbotz.type.ProductsInput;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.ApolloIntegrationTestBase;
@@ -68,7 +68,7 @@ import org.junit.jupiter.api.TestInstance;
  * </ul>
  */
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ApolloIntegrationTest extends ApolloIntegrationTestBase {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/AsyncDirectiveIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/AsyncDirectiveIntegrationTest.java
@@ -18,7 +18,7 @@ package io.stargate.sgv2.graphql.integration.cqlfirst;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.BetterBotzIntegrationTestBase;
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class AsyncDirectiveIntegrationTest extends BetterBotzIntegrationTestBase {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/AtomicBatchIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/AtomicBatchIntegrationTest.java
@@ -18,7 +18,7 @@ package io.stargate.sgv2.graphql.integration.cqlfirst;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.CqlFirstIntegrationTest;
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class AtomicBatchIntegrationTest extends CqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/AtomicBulkInsertIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/AtomicBulkInsertIntegrationTest.java
@@ -17,7 +17,7 @@ package io.stargate.sgv2.graphql.integration.cqlfirst;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.CqlFirstIntegrationTest;
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class AtomicBulkInsertIntegrationTest extends CqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/AtomicDirectiveIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/AtomicDirectiveIntegrationTest.java
@@ -12,7 +12,7 @@ import com.example.graphql.client.betterbotz.type.MutationConsistency;
 import com.example.graphql.client.betterbotz.type.MutationOptions;
 import com.example.graphql.client.betterbotz.type.OrdersInput;
 import com.example.graphql.client.betterbotz.type.ProductsInput;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.ApolloIntegrationTestBase;
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.TestInstance;
  * ApolloIntegrationTestBase}.
  */
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class AtomicDirectiveIntegrationTest extends ApolloIntegrationTestBase {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/BulkInsertIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/BulkInsertIntegrationTest.java
@@ -11,7 +11,7 @@ import com.example.graphql.client.betterbotz.products.BulkInsertProductsMutation
 import com.example.graphql.client.betterbotz.products.GetProductsWithFilterQuery;
 import com.example.graphql.client.betterbotz.type.OrdersInput;
 import com.example.graphql.client.betterbotz.type.ProductsInput;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.ApolloIntegrationTestBase;
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.TestInstance;
  * ApolloIntegrationTestBase}.
  */
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class BulkInsertIntegrationTest extends ApolloIntegrationTestBase {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/CollectionsIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/CollectionsIntegrationTest.java
@@ -18,7 +18,7 @@ package io.stargate.sgv2.graphql.integration.cqlfirst;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.CqlFirstIntegrationTest;
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class CollectionsIntegrationTest extends CqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/CounterUpdateIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/CounterUpdateIntegrationTest.java
@@ -18,7 +18,7 @@ package io.stargate.sgv2.graphql.integration.cqlfirst;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.CqlFirstIntegrationTest;
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class CounterUpdateIntegrationTest extends CqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/GroupByIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/GroupByIntegrationTest.java
@@ -18,7 +18,7 @@ package io.stargate.sgv2.graphql.integration.cqlfirst;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.CqlFirstIntegrationTest;
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class GroupByIntegrationTest extends CqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/InsertIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/InsertIntegrationTest.java
@@ -18,7 +18,7 @@ package io.stargate.sgv2.graphql.integration.cqlfirst;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.BetterBotzIntegrationTestBase;
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class InsertIntegrationTest extends BetterBotzIntegrationTestBase {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/IntrospectionQueryIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/IntrospectionQueryIntegrationTest.java
@@ -17,7 +17,7 @@ package io.stargate.sgv2.graphql.integration.cqlfirst;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.CqlFirstIntegrationTest;
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class IntrospectionQueryIntegrationTest extends CqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/InvalidQueriesIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/InvalidQueriesIntegrationTest.java
@@ -18,7 +18,7 @@ package io.stargate.sgv2.graphql.integration.cqlfirst;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.CqlFirstIntegrationTest;
@@ -30,7 +30,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class InvalidQueriesIntegrationTest extends CqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/KeyspaceDdlIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/KeyspaceDdlIntegrationTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.CqlFirstIntegrationTest;
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class KeyspaceDdlIntegrationTest extends CqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/MetricsIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/MetricsIntegrationTest.java
@@ -18,7 +18,7 @@ package io.stargate.sgv2.graphql.integration.cqlfirst;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.CqlFirstIntegrationTest;
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class MetricsIntegrationTest extends CqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/ScalarsIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/ScalarsIntegrationTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.CqlFirstIntegrationTest;
@@ -39,7 +39,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ScalarsIntegrationTest extends CqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/SelectIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/SelectIntegrationTest.java
@@ -16,7 +16,7 @@
 package io.stargate.sgv2.graphql.integration.cqlfirst;
 
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.BetterBotzIntegrationTestBase;
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SelectIntegrationTest extends BetterBotzIntegrationTestBase {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/TableDdlIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/TableDdlIntegrationTest.java
@@ -23,7 +23,7 @@ import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
 import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.CqlFirstIntegrationTest;
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TableDdlIntegrationTest extends CqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/TuplesIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/TuplesIntegrationTest.java
@@ -18,7 +18,7 @@ package io.stargate.sgv2.graphql.integration.cqlfirst;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.CqlFirstIntegrationTest;
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TuplesIntegrationTest extends CqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/UdtsIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/cqlfirst/UdtsIntegrationTest.java
@@ -18,7 +18,7 @@ package io.stargate.sgv2.graphql.integration.cqlfirst;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.CqlFirstIntegrationTest;
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class UdtsIntegrationTest extends CqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/AtomicIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/AtomicIntegrationTest.java
@@ -18,7 +18,7 @@ package io.stargate.sgv2.graphql.integration.graphqlfirst;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class AtomicIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/BulkInsertIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/BulkInsertIntegrationTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class BulkInsertIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/BulkInsertValidationIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/BulkInsertValidationIntegrationTest.java
@@ -17,7 +17,7 @@ package io.stargate.sgv2.graphql.integration.graphqlfirst;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class BulkInsertValidationIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/CqlIncrementDirectiveValidationIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/CqlIncrementDirectiveValidationIntegrationTest.java
@@ -17,7 +17,7 @@ package io.stargate.sgv2.graphql.integration.graphqlfirst;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class CqlIncrementDirectiveValidationIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/CqlTimestampDirectiveIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/CqlTimestampDirectiveIntegrationTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class CqlTimestampDirectiveIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/CqlTimestampDirectiveValidationIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/CqlTimestampDirectiveValidationIntegrationTest.java
@@ -17,7 +17,7 @@ package io.stargate.sgv2.graphql.integration.graphqlfirst;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class CqlTimestampDirectiveValidationIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/CreateIndexIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/CreateIndexIntegrationTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.metadata.schema.IndexMetadata;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class CreateIndexIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/DataTypesIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/DataTypesIntegrationTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.jayway.jsonpath.JsonPath;
 import graphql.com.google.common.collect.ImmutableMap;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -38,7 +38,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class DataTypesIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/DeleteCustomConditionsIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/DeleteCustomConditionsIntegrationTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class DeleteCustomConditionsIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/DeleteIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/DeleteIntegrationTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class DeleteIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/FederationIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/FederationIntegrationTest.java
@@ -18,7 +18,7 @@ package io.stargate.sgv2.graphql.integration.graphqlfirst;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class FederationIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/FilesResourceIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/FilesResourceIntegrationTest.java
@@ -17,7 +17,7 @@ package io.stargate.sgv2.graphql.integration.graphqlfirst;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class FilesResourceIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/InsertIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/InsertIntegrationTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class InsertIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/SchemaDeploymentIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/SchemaDeploymentIntegrationTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SchemaDeploymentIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/SelectCustomConditionsIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/SelectCustomConditionsIntegrationTest.java
@@ -18,7 +18,7 @@ package io.stargate.sgv2.graphql.integration.graphqlfirst;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SelectCustomConditionsIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/SelectIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/SelectIntegrationTest.java
@@ -19,7 +19,7 @@ package io.stargate.sgv2.graphql.integration.graphqlfirst;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SelectIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/SelectInvalidConditionsIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/SelectInvalidConditionsIntegrationTest.java
@@ -18,7 +18,7 @@ package io.stargate.sgv2.graphql.integration.graphqlfirst;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SelectInvalidConditionsIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/TtlIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/TtlIntegrationTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.data.Offset.offset;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -37,7 +37,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TtlIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/UdtIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/UdtIntegrationTest.java
@@ -21,7 +21,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
 import com.datastax.oss.driver.api.core.type.UserDefinedType;
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class UdtIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/UpdateCustomConditionsIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/UpdateCustomConditionsIntegrationTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class UpdateCustomConditionsIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/UpdateIncrementalUpdatesIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/UpdateIncrementalUpdatesIntegrationTest.java
@@ -21,7 +21,7 @@ import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class UpdateIncrementalUpdatesIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/UpdateIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/UpdateIntegrationTest.java
@@ -18,7 +18,7 @@ package io.stargate.sgv2.graphql.integration.graphqlfirst;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jayway.jsonpath.JsonPath;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class UpdateIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/WhereAndIfDirectivesIntegrationTest.java
+++ b/apis/sgv2-graphqlapi/src/test/java/io/stargate/sgv2/graphql/integration/graphqlfirst/WhereAndIfDirectivesIntegrationTest.java
@@ -17,7 +17,7 @@ package io.stargate.sgv2.graphql.integration.graphqlfirst;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import io.stargate.sgv2.graphql.integration.util.GraphqlFirstIntegrationTest;
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(value = StargateTestResource.class, restrictToAnnotatedClass = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class WhereAndIfDirectivesIntegrationTest extends GraphqlFirstIntegrationTest {
 

--- a/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/schema/SchemaManager.java
+++ b/apis/sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/schema/SchemaManager.java
@@ -21,7 +21,7 @@ import com.google.protobuf.BytesValue;
 import com.google.protobuf.Int32Value;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.quarkus.cache.Cache;
 import io.quarkus.cache.CacheInvalidate;
 import io.quarkus.cache.CacheKey;

--- a/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
+++ b/apis/sgv2-quarkus-common/src/test/java/io/stargate/sgv2/common/testresource/StargateTestResource.java
@@ -19,8 +19,8 @@ package io.stargate.sgv2.common.testresource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.common.DevServicesContext;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.quarkus.test.common.WithTestResource;
 import io.stargate.sgv2.api.common.token.impl.FixedTokenResolver;
 import io.stargate.sgv2.common.IntegrationTestUtils;
 import java.net.URI;
@@ -43,7 +43,7 @@ import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
  * Quarkus test resource that starts Cassandra/DSE and Stargate Coordinator using test containers.
  *
  * <p>Should be used in the integration tests, that should be explicitly annotated with {@link
- * QuarkusTestResource} class: <code>@QuarkusTestResource(value = StargateTestResource.class)</code>
+ * WithTestResource} class: <code>@QuarkusTestResource(value = StargateTestResource.class)</code>
  * (and usually with {@code initArgs} property set as well).
  *
  * <p>When run from IDE, by default it uses container versions specified in {@link Defaults}. If you

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QCqlBasicIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QCqlBasicIT.java
@@ -2,7 +2,7 @@ package io.stargate.sgv2.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 /** Integration tests for CQL endpoint (at {@code /v2/cql}) when explicitly enabled. */
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(StargateTestResource.class)
 @TestProfile(RestApiV2QCqlBasicIT.Profile.class)
 public class RestApiV2QCqlBasicIT extends RestApiV2QIntegrationTestBase {
   // Since /cql endpoint is disabled by default, need to override

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QCqlDisabledIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QCqlDisabledIT.java
@@ -1,6 +1,6 @@
 package io.stargate.sgv2.it;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 /** Integration tests that verify that CQL endpoint (at {@code /v2/cql}) is disabled by default. */
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(StargateTestResource.class)
 public class RestApiV2QCqlDisabledIT extends RestApiV2QIntegrationTestBase {
   public RestApiV2QCqlDisabledIT() {
     super("cqld_ks_", "cqld_t_", KeyspaceCreation.NONE);

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QMapCompactDisabledIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QMapCompactDisabledIT.java
@@ -1,6 +1,6 @@
 package io.stargate.sgv2.it;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
@@ -9,7 +9,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(StargateTestResource.class)
 @TestProfile(RestApiV2QMapCompactDisabledIT.Profile.class)
 public class RestApiV2QMapCompactDisabledIT extends RestApiV2QIntegrationTestBase
     implements RestApiV2QMapTests {

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QMapCompactIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QMapCompactIT.java
@@ -1,12 +1,12 @@
 package io.stargate.sgv2.it;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(StargateTestResource.class)
 public class RestApiV2QMapCompactIT extends RestApiV2QIntegrationTestBase
     implements RestApiV2QMapTests {
   /**

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QPrimaryKeyIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QPrimaryKeyIT.java
@@ -2,7 +2,7 @@ package io.stargate.sgv2.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
  * that escaped slashes are not decoded prematurely.
  */
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(StargateTestResource.class)
 public class RestApiV2QPrimaryKeyIT extends RestApiV2QIntegrationTestBase {
   public RestApiV2QPrimaryKeyIT() {
     super("rowpk_ks_", "rowpk_t_", KeyspaceCreation.PER_CLASS);

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowAddIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowAddIT.java
@@ -2,7 +2,7 @@ package io.stargate.sgv2.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.exception.model.dto.ApiError;
@@ -17,7 +17,7 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(StargateTestResource.class)
 public class RestApiV2QRowAddIT extends RestApiV2QIntegrationTestBase {
   public RestApiV2QRowAddIT() {
     super("rowadd_ks_", "rowadd_t_", KeyspaceCreation.PER_CLASS);

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowDeleteIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowDeleteIT.java
@@ -2,7 +2,7 @@ package io.stargate.sgv2.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.api.common.exception.model.dto.ApiError;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
@@ -14,7 +14,7 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(StargateTestResource.class)
 public class RestApiV2QRowDeleteIT extends RestApiV2QIntegrationTestBase {
   public RestApiV2QRowDeleteIT() {
     super("rowdel_ks_", "rowdel_t_", KeyspaceCreation.PER_CLASS);

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowGetIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowGetIT.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.bridge.grpc.CqlDuration;
@@ -23,7 +23,7 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(StargateTestResource.class)
 public class RestApiV2QRowGetIT extends RestApiV2QIntegrationTestBase {
   public RestApiV2QRowGetIT() {
     super("rowget_ks_", "rowget_t_", KeyspaceCreation.PER_CLASS);

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowPatchIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowPatchIT.java
@@ -2,7 +2,7 @@ package io.stargate.sgv2.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.api.common.exception.model.dto.ApiError;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
@@ -14,7 +14,7 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(StargateTestResource.class)
 public class RestApiV2QRowPatchIT extends RestApiV2QIntegrationTestBase {
   public RestApiV2QRowPatchIT() {
     super("rowptc_ks_", "rowptc_t_", KeyspaceCreation.PER_CLASS);

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowUpdateIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QRowUpdateIT.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.api.common.exception.model.dto.ApiError;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
@@ -16,7 +16,7 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(StargateTestResource.class)
 public class RestApiV2QRowUpdateIT extends RestApiV2QIntegrationTestBase {
   public RestApiV2QRowUpdateIT() {
     super("rowupd_ks_", "rowupd_t_", KeyspaceCreation.PER_CLASS);

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaColumnsIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaColumnsIT.java
@@ -2,7 +2,7 @@ package io.stargate.sgv2.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.exception.model.dto.ApiError;
@@ -14,7 +14,7 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(StargateTestResource.class)
 public class RestApiV2QSchemaColumnsIT extends RestApiV2QIntegrationTestBase {
   public RestApiV2QSchemaColumnsIT() {
     super("col_ks_", "col_t_", KeyspaceCreation.PER_CLASS);

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaIndexesIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaIndexesIT.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.cql.builder.CollectionIndexingType;
@@ -21,7 +21,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(StargateTestResource.class)
 public class RestApiV2QSchemaIndexesIT extends RestApiV2QIntegrationTestBase {
   public RestApiV2QSchemaIndexesIT() {
     super("idx_ks_", "idx_t_", KeyspaceCreation.PER_CLASS);

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaKeyspacesIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaKeyspacesIT.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.hamcrest.Matchers.is;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.exception.model.dto.ApiError;
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 
 /** Integration tests for checking CRUD schema operations for Keyspaces. */
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(StargateTestResource.class)
 public class RestApiV2QSchemaKeyspacesIT extends RestApiV2QIntegrationTestBase {
   private static final String BASE_PATH = "/v2/schemas/keyspaces";
 

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaTablesIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaTablesIT.java
@@ -2,7 +2,7 @@ package io.stargate.sgv2.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.exception.model.dto.ApiError;
@@ -19,7 +19,7 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(StargateTestResource.class)
 public class RestApiV2QSchemaTablesIT extends RestApiV2QIntegrationTestBase {
   public RestApiV2QSchemaTablesIT() {
     super("tbl_ks_", "tbl_t_", KeyspaceCreation.PER_CLASS);

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaUserTypeIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/RestApiV2QSchemaUserTypeIT.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesRegex;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.exception.model.dto.ApiError;
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(StargateTestResource.class)
 public class RestApiV2QSchemaUserTypeIT extends RestApiV2QIntegrationTestBase {
   public RestApiV2QSchemaUserTypeIT() {
     // Need per-method due to "udtGetAll()" verifying that no UDTs exist

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/auxiliary/RestApiV2QHealthCheckerIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/auxiliary/RestApiV2QHealthCheckerIT.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import org.apache.http.HttpStatus;
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.TestClassOrder;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(StargateTestResource.class)
 @TestClassOrder(ClassOrderer.DisplayName.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class RestApiV2QHealthCheckerIT {

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/auxiliary/RestApiV2QMetricsIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/auxiliary/RestApiV2QMetricsIT.java
@@ -3,7 +3,7 @@ package io.stargate.sgv2.it.auxiliary;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
 import java.util.List;
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.TestClassOrder;
 import org.junit.jupiter.api.TestInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(StargateTestResource.class)
 @TestClassOrder(ClassOrderer.DisplayName.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class RestApiV2QMetricsIT {

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/persistence/RestApiV2QDSETests_IT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/persistence/RestApiV2QDSETests_IT.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.fasterxml.jackson.databind.JsonNode;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.api.common.cql.builder.CollectionIndexingType;
 import io.stargate.sgv2.common.IntegrationTestUtils;
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
  * <p>Converted from Stargate V1 test {@code RestApiv2DseTest}.
  */
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(StargateTestResource.class)
 public class RestApiV2QDSETests_IT extends RestApiV2QCqlEnabledTestBase {
   public RestApiV2QDSETests_IT() {
     super("dse_ks_", "dse_t_", KeyspaceCreation.PER_CLASS);

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/persistence/RestApiV2QIndexSASI_IT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/persistence/RestApiV2QIndexSASI_IT.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.IntegrationTestUtils;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  * tests since SASI not available on all backends.
  */
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(StargateTestResource.class)
 public class RestApiV2QIndexSASI_IT extends RestApiV2QIntegrationTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(RestApiV2QIndexSASI_IT.class);
 

--- a/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/persistence/RestApiV2QMaterializedViewIT.java
+++ b/apis/sgv2-restapi/src/test/java/io/stargate/sgv2/it/persistence/RestApiV2QMaterializedViewIT.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import com.datastax.oss.driver.api.core.cql.ResultSet;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.common.IntegrationTestUtils;
 import io.stargate.sgv2.common.testresource.StargateTestResource;
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * not available on all backends.
  */
 @QuarkusIntegrationTest
-@QuarkusTestResource(StargateTestResource.class)
+@WithTestResource(StargateTestResource.class)
 public class RestApiV2QMaterializedViewIT extends RestApiV2QCqlEnabledTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(RestApiV2QMaterializedViewIT.class);
 

--- a/coordinator/persistence-dse-6.8/pom.xml
+++ b/coordinator/persistence-dse-6.8/pom.xml
@@ -144,7 +144,7 @@
     <dependency>
       <groupId>dnsjava</groupId>
       <artifactId>dnsjava</artifactId>
-      <version>2.1.8</version>
+      <version>3.6.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -249,7 +249,7 @@
                 <artifactItem>
                   <groupId>dnsjava</groupId>
                   <artifactId>dnsjava</artifactId>
-                  <version>2.1.8</version>
+                  <version>3.6.0</version>
                   <outputDirectory>${project.build.directory}/dnsjava</outputDirectory>
                 </artifactItem>
               </artifactItems>


### PR DESCRIPTION
**What this PR does**:

Merges changes from main (v2.0) into `v2.1`: most importantly Quarkus upgrade to 3.13.2.
(but also `dnsjava` upgrade)

**Which issue(s) this PR fixes**:
Post #2968 merge

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
