### PR TITLE
Check header filter when sending CQL protocol events

### DIFF
--- a/coordinator/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/CqlServer.java
+++ b/coordinator/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/CqlServer.java
@@ -272,7 +272,7 @@ public class CqlServer {
               .get()
               .getVersion()
               .isSmallerThan(ProtocolVersion.V5)
-              || channel.attr(Connection.attributeKey).get().getVersion().isDse();
+          || channel.attr(Connection.attributeKey).get().getVersion().isDse();
     }
 
     private static boolean checkHeaderFilter(Channel channel, Event event) {
@@ -280,7 +280,7 @@ public class CqlServer {
 
       ProxyInfo proxyInfo = channel.attr(ProxyInfo.attributeKey).get();
       Map<String, String> headers =
-              proxyInfo != null ? proxyInfo.toHeaders() : Collections.emptyMap();
+          proxyInfo != null ? proxyInfo.toHeaders() : Collections.emptyMap();
 
       return event.headerFilter.test(headers);
     }
@@ -289,11 +289,15 @@ public class CqlServer {
       EventMessage message = new EventMessage(event);
 
       // Deliver event to pre-v5 channels
-      groups.get(event.type).writeAndFlush(message, channel -> isPreV5Channel(channel) && checkHeaderFilter(channel, event));
+      groups
+          .get(event.type)
+          .writeAndFlush(
+              message, channel -> isPreV5Channel(channel) && checkHeaderFilter(channel, event));
 
       // Deliver event to post-v5 channels
       for (Channel c : groups.get(event.type))
-        if (!isPreV5Channel(c) && checkHeaderFilter(c, event)) c.attr(Dispatcher.EVENT_DISPATCHER).get().accept(message);
+        if (!isPreV5Channel(c) && checkHeaderFilter(c, event))
+          c.attr(Dispatcher.EVENT_DISPATCHER).get().accept(message);
     }
 
     void closeAll() {


### PR DESCRIPTION
When protocol V5 was merged the header filter logic was removed.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
