### PR TITLE
CNDB-9895: Allow excluding protocol versions from supported versions advertised to the client

### DIFF
--- a/coordinator/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/CqlServer.java
+++ b/coordinator/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/CqlServer.java
@@ -105,13 +105,12 @@ public class CqlServer {
     }
     InitialConnectionHandler.setPersistence(persistence);
     pipelineConfigurator =
-        builder.pipelineConfigurator != null
-            ? builder.pipelineConfigurator
-            : new PipelineConfigurator(
-                useEpoll,
-                TransportDescriptor.getRpcKeepAlive(),
-                TransportDescriptor.useNativeTransportLegacyFlusher(),
-                builder.tlsEncryptionPolicy);
+        new PipelineConfigurator(
+            useEpoll,
+            TransportDescriptor.getRpcKeepAlive(),
+            TransportDescriptor.useNativeTransportLegacyFlusher(),
+            builder.tlsEncryptionPolicy,
+            () -> persistence.protocolFilter());
     this.persistence.registerEventListener(new EventNotifier(this));
   }
 
@@ -187,8 +186,6 @@ public class CqlServer {
     private int port = -1;
     private InetSocketAddress socket;
 
-    // Added as part of Cassandra {4.0.10} upgrade
-    private PipelineConfigurator pipelineConfigurator;
     private EncryptionOptions.TlsEncryptionPolicy tlsEncryptionPolicy =
         EncryptionOptions.TlsEncryptionPolicy.UNENCRYPTED;
 

--- a/coordinator/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/InitialConnectionHandler.java
+++ b/coordinator/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/InitialConnectionHandler.java
@@ -91,7 +91,7 @@ public class InitialConnectionHandler extends ByteToMessageDecoder {
           assert supportedOptions.containsKey(StartupMessage.CQL_VERSION);
           supportedOptions.put(StartupMessage.COMPRESSION, compressions);
           supportedOptions.put(
-              StartupMessage.PROTOCOL_VERSIONS, ProtocolVersion.supportedVersions());
+              StartupMessage.PROTOCOL_VERSIONS, decoder.supportedProtcolVersions());
           SupportedMessage supported = new SupportedMessage(supportedOptions);
           supported.setStreamId(inbound.header.streamId);
           outbound = supported.encode(inbound.header.version);

--- a/coordinator/persistence-api/src/main/java/io/stargate/db/Persistence.java
+++ b/coordinator/persistence-api/src/main/java/io/stargate/db/Persistence.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.IntPredicate;
 import org.apache.cassandra.stargate.exceptions.AuthenticationException;
 
 /**
@@ -133,6 +134,18 @@ public interface Persistence extends SchemaAgreementChecker {
   default String decorateKeyspaceName(
       String keyspaceName, Map<String, String> connectionProperties) {
     return keyspaceName;
+  }
+
+  /**
+   * Returns a client protocol filter which allows disabling certain protocol versions. By default,
+   * it accepts all supported protocols.
+   *
+   * <p>Note that the returned filter should be pure, i.e. it should not have side effects and
+   * should not depend on any external state. If the filter needs to be changed, a new instance
+   * should be returned.
+   */
+  default IntPredicate protocolFilter() {
+    return protocolVersionNum -> true;
   }
 
   /**


### PR DESCRIPTION
Adds a system property which can limit the maximum support protocol version.