### PR TITLE
Update CQL message encoder/decoder to respect frame header flags ordering as per native protocol specs

### DIFF
--- a/coordinator/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Message.java
+++ b/coordinator/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Message.java
@@ -174,7 +174,7 @@ public abstract class Message {
   protected Connection connection;
   private int streamId;
   private long sourceFrameBodySizeInBytes;
-  private Map<String, ByteBuffer> customPayload;
+  protected Map<String, ByteBuffer> customPayload;
   protected ProtocolVersion forcedProtocolVersion = null;
 
   protected Message(Type type) {
@@ -320,9 +320,9 @@ public abstract class Message {
       boolean hasWarning = frame.header.flags.contains(Frame.Header.Flag.WARNING);
 
       UUID tracingId = isRequest || !isTracing ? null : CBUtil.readUUID(frame.body);
-      List<String> warnings = isRequest || !hasWarning ? null : CBUtil.readStringList(frame.body);
       Map<String, ByteBuffer> customPayload =
           !isCustomPayload ? null : CBUtil.readBytesMap(frame.body);
+      List<String> warnings = isRequest || !hasWarning ? null : CBUtil.readStringList(frame.body);
 
       try {
         if (isCustomPayload && frame.header.version.isSmallerThan(ProtocolVersion.V4))
@@ -415,13 +415,13 @@ public abstract class Message {
             CBUtil.writeUUID(tracingId, body);
             flags.add(Frame.Header.Flag.TRACING);
           }
-          if (warnings != null) {
-            CBUtil.writeStringList(warnings, body);
-            flags.add(Frame.Header.Flag.WARNING);
-          }
           if (customPayload != null) {
             CBUtil.writeBytesMap(customPayload, body);
             flags.add(Frame.Header.Flag.CUSTOM_PAYLOAD);
+          }
+          if (warnings != null) {
+            CBUtil.writeStringList(warnings, body);
+            flags.add(Frame.Header.Flag.WARNING);
           }
         } else {
           assert message instanceof Request;

--- a/coordinator/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/ResultMessage.java
+++ b/coordinator/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/messages/ResultMessage.java
@@ -71,6 +71,7 @@ public class ResultMessage extends Message.Response {
     this.result = result;
     this.tracingId = result.getTracingId();
     this.warnings = result.getWarnings();
+    this.customPayload = result.getCustomPayload();
   }
 
   public static class VoidSubCodec implements CBCodec<Result> {

--- a/coordinator/cql/src/test/java/org/apache/cassandra/stargate/transport/internal/CQLProtocolCompatibilityTest.java
+++ b/coordinator/cql/src/test/java/org/apache/cassandra/stargate/transport/internal/CQLProtocolCompatibilityTest.java
@@ -1,0 +1,161 @@
+package org.apache.cassandra.stargate.transport.internal;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.datastax.oss.driver.internal.core.protocol.ByteBufPrimitiveCodec;
+import com.datastax.oss.protocol.internal.Compressor;
+import com.datastax.oss.protocol.internal.FrameCodec;
+import com.datastax.oss.protocol.internal.NoopCompressor;
+import com.datastax.oss.protocol.internal.PrimitiveCodec;
+import com.datastax.oss.protocol.internal.ProtocolConstants;
+import com.datastax.oss.protocol.internal.response.result.Void;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.stargate.db.Result;
+import io.stargate.db.metrics.api.ClientInfoMetricsTagProvider;
+import org.apache.cassandra.stargate.metrics.ClientMetrics;
+import org.apache.cassandra.stargate.transport.internal.messages.ResultMessage;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * The purpose of this test is to ensure that the Stargate CQL protocol codec is compatible with the native
+ * protocol codec. This is especially important when adding flags to headers as the order of encoding/decoding is significant.
+ * The tests uses <a href="https://github.com/datastax/native-protocol"/> as a reference implementation for native protocol.
+ */
+public class CQLProtocolCompatibilityTest
+{
+    private static final UUID TRACING_ID = UUID.randomUUID();
+    private static final Map<String, ByteBuffer> CUSTOM_PAYLOAD = Collections.singletonMap("test-key", ByteBuffer.wrap("test-value".getBytes()));
+    private static final List<String> WARNINGS = ImmutableList.of("warning1");
+
+    private EmbeddedChannel channel;
+
+    @BeforeAll
+    public static void initClientMetrics() {
+        ClientInfoMetricsTagProvider clientTagProvider = mock(ClientInfoMetricsTagProvider.class);
+        CqlServer server1 = mock(CqlServer.class);
+        List<CqlServer> servers = Arrays.asList(server1);
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        ClientMetrics.instance.init(servers, meterRegistry, clientTagProvider, 0d);
+    }
+
+    @BeforeEach
+    public void initChannel() {
+        channel = new EmbeddedChannel();
+    }
+
+    @AfterEach
+    public void closeChannel() {
+        channel.close();
+    }
+
+    @Test
+    public void encoderCompatibleWithNativeProtocolDecoder()
+    {
+        // Prepare a ResultMessage with custom payload, warnings and tracingId
+        ResultMessage resultMessage = new MockingResultMessage(TRACING_ID, CUSTOM_PAYLOAD, WARNINGS);
+
+        channel.pipeline().addLast(new Frame.Encoder());
+        channel.pipeline().addLast(new Frame.OutboundBodyTransformer());
+        channel.pipeline().addLast(new Message.ProtocolEncoder());
+
+        // Encode the ResultMessage via the Stargate CQL protocol encoder
+        channel.writeOutbound(resultMessage);
+        channel.finish();
+
+        ByteBuf header = channel.readOutbound();
+        ByteBuf body = channel.readOutbound();
+
+        int messageSize = header.readableBytes() + body.readableBytes();
+        ByteBuf headerAndBody = CBUtil.allocator.buffer(messageSize);
+        headerAndBody.writeBytes(header).writeBytes(body);
+
+        // Decode the encoded message by the native protocol decoder
+        Compressor<ByteBuf> compressor = new NoopCompressor<>();
+        UnpooledByteBufAllocator allocator = new UnpooledByteBufAllocator(false);
+        PrimitiveCodec<ByteBuf> primitiveCodec = new ByteBufPrimitiveCodec(allocator);
+        FrameCodec<ByteBuf> frameCodec = FrameCodec.defaultClient(primitiveCodec, compressor);
+
+        com.datastax.oss.protocol.internal.Frame decodedFrame = frameCodec.decode(headerAndBody);
+        assertThat(decodedFrame).isNotNull();
+        assertThat(decodedFrame.tracingId).isEqualTo(TRACING_ID);
+        assertThat(decodedFrame.customPayload).isEqualTo(CUSTOM_PAYLOAD);
+        assertThat(decodedFrame.warnings).isEqualTo(WARNINGS);
+        assertThat(decodedFrame.message).isInstanceOf(Void.class);
+    }
+
+    @Test
+    public void decoderCompatibleWithNativeProtocolEncoder()
+    {
+        // Prepare native protocol frame with custom payload, warnings and tracingId
+        int streamId = 1;
+        com.datastax.oss.protocol.internal.response.Result resultMessage = com.datastax.oss.protocol.internal.response.result.Void.INSTANCE;
+        Compressor<ByteBuf> compressor = new NoopCompressor<>();
+        UnpooledByteBufAllocator allocator = new UnpooledByteBufAllocator(false);
+        PrimitiveCodec<ByteBuf> primitiveCodec = new ByteBufPrimitiveCodec(allocator);
+
+        com.datastax.oss.protocol.internal.Frame frame = com.datastax.oss.protocol.internal.Frame.forResponse(
+            ProtocolConstants.Version.V4,
+            streamId,
+            TRACING_ID,
+            CUSTOM_PAYLOAD,
+            WARNINGS,
+            resultMessage);
+
+        int protocolV4 = ProtocolConstants.Version.V4; // customPayload is supported from V4
+        FrameCodec<ByteBuf> frameCodec = new FrameCodec<>(
+            primitiveCodec, compressor,
+            registry -> registry.addEncoder(new com.datastax.oss.protocol.internal.response.Result.Codec(protocolV4)));
+
+        // Encode via native protocol encoder
+        ByteBuf encodedFrame = frameCodec.encode(frame);
+
+        // Write the encoded frame to the channel, that will invoke the Stargate CQL protocol decoder
+        EmbeddedChannel channel = new EmbeddedChannel();
+        Connection.Factory connectionFactory = Mockito.mock(Connection.Factory.class);
+        channel.pipeline().addLast(new Frame.Decoder(connectionFactory));
+        channel.pipeline().addLast(new Frame.InboundBodyTransformer());
+        channel.pipeline().addLast(new Message.ProtocolDecoder());
+
+        channel.writeInbound(encodedFrame);
+        channel.finish();
+
+        ResultMessage decodedResult = channel.readInbound();
+
+        assertThat(decodedResult).isNotNull();
+        assertThat(decodedResult.tracingId).isEqualTo(TRACING_ID);
+        assertThat(decodedResult.customPayload).isEqualTo(CUSTOM_PAYLOAD);
+        assertThat(decodedResult.warnings).isEqualTo(WARNINGS);
+        assertThat(decodedResult.type).isEqualTo(Message.Type.RESULT);
+    }
+
+    public static class MockingResultMessage extends ResultMessage
+    {
+        protected MockingResultMessage(UUID tracingId, Map<String, ByteBuffer> customPayload, List<String> warnings)
+        {
+            super(new Result.Void());
+            this.tracingId = tracingId;
+            this.customPayload = customPayload;
+            this.warnings = warnings;
+        }
+    }
+}
+
+

--- a/coordinator/cql/src/test/java/org/apache/cassandra/stargate/transport/internal/CQLProtocolCompatibilityTest.java
+++ b/coordinator/cql/src/test/java/org/apache/cassandra/stargate/transport/internal/CQLProtocolCompatibilityTest.java
@@ -1,17 +1,7 @@
 package org.apache.cassandra.stargate.transport.internal;
 
-import java.nio.ByteBuffer;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import com.google.common.collect.ImmutableList;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
 
 import com.datastax.oss.driver.internal.core.protocol.ByteBufPrimitiveCodec;
 import com.datastax.oss.protocol.internal.Compressor;
@@ -20,6 +10,7 @@ import com.datastax.oss.protocol.internal.NoopCompressor;
 import com.datastax.oss.protocol.internal.PrimitiveCodec;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
 import com.datastax.oss.protocol.internal.response.result.Void;
+import com.google.common.collect.ImmutableList;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.buffer.ByteBuf;
@@ -27,91 +18,100 @@ import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.stargate.db.Result;
 import io.stargate.db.metrics.api.ClientInfoMetricsTagProvider;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import org.apache.cassandra.stargate.metrics.ClientMetrics;
 import org.apache.cassandra.stargate.transport.internal.messages.ResultMessage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.Mockito.mock;
-
 /**
- * The purpose of this test is to ensure that the Stargate CQL protocol codec is compatible with the native
- * protocol codec. This is especially important when adding flags to headers as the order of encoding/decoding is significant.
- * The tests uses <a href="https://github.com/datastax/native-protocol"/> as a reference implementation for native protocol.
+ * The purpose of this test is to ensure that the Stargate CQL protocol codec is compatible with the
+ * native protocol codec. This is especially important when adding flags to headers as the order of
+ * encoding/decoding is significant. The tests uses <a
+ * href="https://github.com/datastax/native-protocol"/>as a reference implementation for native
+ * protocol.
  */
-public class CQLProtocolCompatibilityTest
-{
-    private static final UUID TRACING_ID = UUID.randomUUID();
-    private static final Map<String, ByteBuffer> CUSTOM_PAYLOAD = Collections.singletonMap("test-key", ByteBuffer.wrap("test-value".getBytes()));
-    private static final List<String> WARNINGS = ImmutableList.of("warning1");
+public class CQLProtocolCompatibilityTest {
+  private static final UUID TRACING_ID = UUID.randomUUID();
+  private static final Map<String, ByteBuffer> CUSTOM_PAYLOAD =
+      Collections.singletonMap("test-key", ByteBuffer.wrap("test-value".getBytes()));
+  private static final List<String> WARNINGS = ImmutableList.of("warning1");
 
-    private EmbeddedChannel channel;
+  private EmbeddedChannel channel;
 
-    @BeforeAll
-    public static void initClientMetrics() {
-        ClientInfoMetricsTagProvider clientTagProvider = mock(ClientInfoMetricsTagProvider.class);
-        CqlServer server1 = mock(CqlServer.class);
-        List<CqlServer> servers = Arrays.asList(server1);
-        MeterRegistry meterRegistry = new SimpleMeterRegistry();
-        ClientMetrics.instance.init(servers, meterRegistry, clientTagProvider, 0d);
-    }
+  @BeforeAll
+  public static void initClientMetrics() {
+    ClientInfoMetricsTagProvider clientTagProvider = mock(ClientInfoMetricsTagProvider.class);
+    CqlServer server1 = mock(CqlServer.class);
+    List<CqlServer> servers = Arrays.asList(server1);
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    ClientMetrics.instance.init(servers, meterRegistry, clientTagProvider, 0d);
+  }
 
-    @BeforeEach
-    public void initChannel() {
-        channel = new EmbeddedChannel();
-    }
+  @BeforeEach
+  public void initChannel() {
+    channel = new EmbeddedChannel();
+  }
 
-    @AfterEach
-    public void closeChannel() {
-        channel.close();
-    }
+  @AfterEach
+  public void closeChannel() {
+    channel.close();
+  }
 
-    @Test
-    public void encoderCompatibleWithNativeProtocolDecoder()
-    {
-        // Prepare a ResultMessage with custom payload, warnings and tracingId
-        ResultMessage resultMessage = new MockingResultMessage(TRACING_ID, CUSTOM_PAYLOAD, WARNINGS);
+  @Test
+  public void encoderCompatibleWithNativeProtocolDecoder() {
+    // Prepare a ResultMessage with custom payload, warnings and tracingId
+    ResultMessage resultMessage = new MockingResultMessage(TRACING_ID, CUSTOM_PAYLOAD, WARNINGS);
 
-        channel.pipeline().addLast(new Frame.Encoder());
-        channel.pipeline().addLast(new Frame.OutboundBodyTransformer());
-        channel.pipeline().addLast(new Message.ProtocolEncoder());
+    channel.pipeline().addLast(new Frame.Encoder());
+    channel.pipeline().addLast(new Frame.OutboundBodyTransformer());
+    channel.pipeline().addLast(new Message.ProtocolEncoder());
 
-        // Encode the ResultMessage via the Stargate CQL protocol encoder
-        channel.writeOutbound(resultMessage);
-        channel.finish();
+    // Encode the ResultMessage via the Stargate CQL protocol encoder
+    channel.writeOutbound(resultMessage);
+    channel.finish();
 
-        ByteBuf header = channel.readOutbound();
-        ByteBuf body = channel.readOutbound();
+    ByteBuf header = channel.readOutbound();
+    ByteBuf body = channel.readOutbound();
 
-        int messageSize = header.readableBytes() + body.readableBytes();
-        ByteBuf headerAndBody = CBUtil.allocator.buffer(messageSize);
-        headerAndBody.writeBytes(header).writeBytes(body);
+    int messageSize = header.readableBytes() + body.readableBytes();
+    ByteBuf headerAndBody = CBUtil.allocator.buffer(messageSize);
+    headerAndBody.writeBytes(header).writeBytes(body);
 
-        // Decode the encoded message by the native protocol decoder
-        Compressor<ByteBuf> compressor = new NoopCompressor<>();
-        UnpooledByteBufAllocator allocator = new UnpooledByteBufAllocator(false);
-        PrimitiveCodec<ByteBuf> primitiveCodec = new ByteBufPrimitiveCodec(allocator);
-        FrameCodec<ByteBuf> frameCodec = FrameCodec.defaultClient(primitiveCodec, compressor);
+    // Decode the encoded message by the native protocol decoder
+    Compressor<ByteBuf> compressor = new NoopCompressor<>();
+    UnpooledByteBufAllocator allocator = new UnpooledByteBufAllocator(false);
+    PrimitiveCodec<ByteBuf> primitiveCodec = new ByteBufPrimitiveCodec(allocator);
+    FrameCodec<ByteBuf> frameCodec = FrameCodec.defaultClient(primitiveCodec, compressor);
 
-        com.datastax.oss.protocol.internal.Frame decodedFrame = frameCodec.decode(headerAndBody);
-        assertThat(decodedFrame).isNotNull();
-        assertThat(decodedFrame.tracingId).isEqualTo(TRACING_ID);
-        assertThat(decodedFrame.customPayload).isEqualTo(CUSTOM_PAYLOAD);
-        assertThat(decodedFrame.warnings).isEqualTo(WARNINGS);
-        assertThat(decodedFrame.message).isInstanceOf(Void.class);
-    }
+    com.datastax.oss.protocol.internal.Frame decodedFrame = frameCodec.decode(headerAndBody);
+    assertThat(decodedFrame).isNotNull();
+    assertThat(decodedFrame.tracingId).isEqualTo(TRACING_ID);
+    assertThat(decodedFrame.customPayload).isEqualTo(CUSTOM_PAYLOAD);
+    assertThat(decodedFrame.warnings).isEqualTo(WARNINGS);
+    assertThat(decodedFrame.message).isInstanceOf(Void.class);
+  }
 
-    @Test
-    public void decoderCompatibleWithNativeProtocolEncoder()
-    {
-        // Prepare native protocol frame with custom payload, warnings and tracingId
-        int streamId = 1;
-        com.datastax.oss.protocol.internal.response.Result resultMessage = com.datastax.oss.protocol.internal.response.result.Void.INSTANCE;
-        Compressor<ByteBuf> compressor = new NoopCompressor<>();
-        UnpooledByteBufAllocator allocator = new UnpooledByteBufAllocator(false);
-        PrimitiveCodec<ByteBuf> primitiveCodec = new ByteBufPrimitiveCodec(allocator);
+  @Test
+  public void decoderCompatibleWithNativeProtocolEncoder() {
+    // Prepare native protocol frame with custom payload, warnings and tracingId
+    int streamId = 1;
+    com.datastax.oss.protocol.internal.response.Result resultMessage =
+        com.datastax.oss.protocol.internal.response.result.Void.INSTANCE;
+    Compressor<ByteBuf> compressor = new NoopCompressor<>();
+    UnpooledByteBufAllocator allocator = new UnpooledByteBufAllocator(false);
+    PrimitiveCodec<ByteBuf> primitiveCodec = new ByteBufPrimitiveCodec(allocator);
 
-        com.datastax.oss.protocol.internal.Frame frame = com.datastax.oss.protocol.internal.Frame.forResponse(
+    com.datastax.oss.protocol.internal.Frame frame =
+        com.datastax.oss.protocol.internal.Frame.forResponse(
             ProtocolConstants.Version.V4,
             streamId,
             TRACING_ID,
@@ -119,43 +119,44 @@ public class CQLProtocolCompatibilityTest
             WARNINGS,
             resultMessage);
 
-        int protocolV4 = ProtocolConstants.Version.V4; // customPayload is supported from V4
-        FrameCodec<ByteBuf> frameCodec = new FrameCodec<>(
-            primitiveCodec, compressor,
-            registry -> registry.addEncoder(new com.datastax.oss.protocol.internal.response.Result.Codec(protocolV4)));
+    int protocolV4 = ProtocolConstants.Version.V4; // customPayload is supported from V4
+    FrameCodec<ByteBuf> frameCodec =
+        new FrameCodec<>(
+            primitiveCodec,
+            compressor,
+            registry ->
+                registry.addEncoder(
+                    new com.datastax.oss.protocol.internal.response.Result.Codec(protocolV4)));
 
-        // Encode via native protocol encoder
-        ByteBuf encodedFrame = frameCodec.encode(frame);
+    // Encode via native protocol encoder
+    ByteBuf encodedFrame = frameCodec.encode(frame);
 
-        // Write the encoded frame to the channel, that will invoke the Stargate CQL protocol decoder
-        EmbeddedChannel channel = new EmbeddedChannel();
-        Connection.Factory connectionFactory = Mockito.mock(Connection.Factory.class);
-        channel.pipeline().addLast(new Frame.Decoder(connectionFactory));
-        channel.pipeline().addLast(new Frame.InboundBodyTransformer());
-        channel.pipeline().addLast(new Message.ProtocolDecoder());
+    // Write the encoded frame to the channel, that will invoke the Stargate CQL protocol decoder
+    EmbeddedChannel channel = new EmbeddedChannel();
+    Connection.Factory connectionFactory = Mockito.mock(Connection.Factory.class);
+    channel.pipeline().addLast(new Frame.Decoder(connectionFactory));
+    channel.pipeline().addLast(new Frame.InboundBodyTransformer());
+    channel.pipeline().addLast(new Message.ProtocolDecoder());
 
-        channel.writeInbound(encodedFrame);
-        channel.finish();
+    channel.writeInbound(encodedFrame);
+    channel.finish();
 
-        ResultMessage decodedResult = channel.readInbound();
+    ResultMessage decodedResult = channel.readInbound();
 
-        assertThat(decodedResult).isNotNull();
-        assertThat(decodedResult.tracingId).isEqualTo(TRACING_ID);
-        assertThat(decodedResult.customPayload).isEqualTo(CUSTOM_PAYLOAD);
-        assertThat(decodedResult.warnings).isEqualTo(WARNINGS);
-        assertThat(decodedResult.type).isEqualTo(Message.Type.RESULT);
+    assertThat(decodedResult).isNotNull();
+    assertThat(decodedResult.tracingId).isEqualTo(TRACING_ID);
+    assertThat(decodedResult.customPayload).isEqualTo(CUSTOM_PAYLOAD);
+    assertThat(decodedResult.warnings).isEqualTo(WARNINGS);
+    assertThat(decodedResult.type).isEqualTo(Message.Type.RESULT);
+  }
+
+  public static class MockingResultMessage extends ResultMessage {
+    protected MockingResultMessage(
+        UUID tracingId, Map<String, ByteBuffer> customPayload, List<String> warnings) {
+      super(new Result.Void());
+      this.tracingId = tracingId;
+      this.customPayload = customPayload;
+      this.warnings = warnings;
     }
-
-    public static class MockingResultMessage extends ResultMessage
-    {
-        protected MockingResultMessage(UUID tracingId, Map<String, ByteBuffer> customPayload, List<String> warnings)
-        {
-            super(new Result.Void());
-            this.tracingId = tracingId;
-            this.customPayload = customPayload;
-            this.warnings = warnings;
-        }
-    }
+  }
 }
-
-

--- a/coordinator/persistence-api/src/main/java/io/stargate/db/Result.java
+++ b/coordinator/persistence-api/src/main/java/io/stargate/db/Result.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -52,6 +53,7 @@ public abstract class Result {
   public final Kind kind;
   private UUID tracingId;
   private @Nullable List<String> warnings;
+  private Map<String, ByteBuffer> customPayload;
 
   private Result(Kind kind) {
     this.kind = kind;
@@ -68,12 +70,21 @@ public abstract class Result {
     return this;
   }
 
+  public Result setCustomPayload(Map<String, ByteBuffer> customPayload) {
+    this.customPayload = customPayload;
+    return this;
+  }
+
   public UUID getTracingId() {
     return tracingId;
   }
 
   public @Nullable List<String> getWarnings() {
     return warnings;
+  }
+
+  public Map<String, ByteBuffer> getCustomPayload() {
+    return customPayload;
   }
 
   public static class Rows extends Result {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
* Change the order of encoding/decoding frame header flags to respect the order of native protocal specs (V4 or later) as specified [here](https://github.com/datastax/cassandra/blob/2ec96ae669ad506b30a0489acf077b615fc67870/doc/native_protocol_v4.spec#L125) 
* Also exposed `customPayload` on `ResultMesasge` to make it available for a downstream client

**Which issue(s) this PR fixes**:
Fixes #3003

**Checklist**
- [X] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
