### PR TITLE
Minor updates to deps: jacoco and shade plugins

### DIFF
--- a/coordinator/cql/pom.xml
+++ b/coordinator/cql/pom.xml
@@ -175,7 +175,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.4.1</version>
+        <version>3.6.0</version>
         <configuration>
           <createDependencyReducedPom>true</createDependencyReducedPom>
           <filters>

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -95,10 +95,7 @@
     <netty-boringssl.version>2.0.51.Final</netty-boringssl.version>
     <jacoco.version>0.8.12</jacoco.version>
     <junit.version>5.8.2</junit.version>
-    <!-- 01-Oct-2024, tatu: 5.2 last version with mockito-inline, later
-	   on embedded in mockito-core
-      -->
-    <mockito.version>5.2.0</mockito.version>
+    <mockito.version>4.11.0</mockito.version>
     <assertj.version>3.24.2</assertj.version>
     <awaitility.version>4.2.0</awaitility.version>
   </properties>

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -93,9 +93,12 @@
       -->
     <netty.version>4.1.75.Final</netty.version>
     <netty-boringssl.version>2.0.51.Final</netty-boringssl.version>
-    <jacoco.version>0.8.10</jacoco.version>
+    <jacoco.version>0.8.12</jacoco.version>
     <junit.version>5.8.2</junit.version>
-    <mockito.version>4.11.0</mockito.version>
+    <!-- 01-Oct-2024, tatu: 5.2 last version with mockito-inline, later
+	   on embedded in mockito-core
+      -->
+    <mockito.version>5.2.0</mockito.version>
     <assertj.version>3.24.2</assertj.version>
     <awaitility.version>4.2.0</awaitility.version>
   </properties>


### PR DESCRIPTION
**What this PR does**:

Updates deps to Shade and Jacoco plugins; to try to make it easier/possible to eventually upgrade Coordinator past JDK 11

(NOTE: reverted planned upgrade of Mockito due to 2 new unit test failures)

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
