### PR TITLE
Minor dep update for Jackson 2.14->2.15 (for CVE in jackson-core)

### DIFF
--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -71,7 +71,7 @@
     <logback.version>1.3.14</logback.version>
     <!-- And then other 3rd party version dependencies, compile/runtime -->
     <caffeine.version>2.9.3</caffeine.version>
-    <commons-io.version>2.7</commons-io.version>
+    <commons-io.version>2.14.0</commons-io.version>
     <grpc.version>1.56.1</grpc.version>
     <immutables.version>2.8.8</immutables.version>
     <jackson.version>2.15.4</jackson.version>

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -74,7 +74,7 @@
     <commons-io.version>2.7</commons-io.version>
     <grpc.version>1.56.1</grpc.version>
     <immutables.version>2.8.8</immutables.version>
-    <jackson.version>2.14.3</jackson.version>
+    <jackson.version>2.15.4</jackson.version>
     <javatuples.version>1.2</javatuples.version>
     <!-- Make sure micrometer and prometheus versions are in sync  -->
     <micrometer.version>1.8.2</micrometer.version>


### PR DESCRIPTION
**What this PR does**:

Upgrades Jackson version Coordinator uses from 2.14 to 2.15, to address a CVE Snyk complains wrt c2. Would upgrade further but have some concerns by downstream deps.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
