### PR TITLE
amc-844 usage of Histogram Metric to measure Reads Size with SelectStatements

### DIFF
--- a/coordinator/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/StargateQueryHandler.java
+++ b/coordinator/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/StargateQueryHandler.java
@@ -99,8 +99,8 @@ public class StargateQueryHandler implements QueryHandler {
   private final List<QueryInterceptor> interceptors = new CopyOnWriteArrayList<>();
   private AtomicReference<AuthorizationService> authorizationService;
   private final Histogram metricReadSizehistogram =
-          CassandraMetricsRegistry.actualRegistry.histogram(
-                  "org.apache.cassandra.metrics.ClientRequest.read_size.histogram");
+      CassandraMetricsRegistry.actualRegistry.histogram(
+          "org.apache.cassandra.metrics.ClientRequest.read_size.histogram");
 
   public void register(QueryInterceptor interceptor) {
     this.interceptors.add(interceptor);
@@ -174,16 +174,16 @@ public class StargateQueryHandler implements QueryHandler {
     }
 
     return QueryProcessor.instance
-            .processStatement(statement, queryState, options, customPayload, queryStartNanoTime)
-            .doOnSuccess(
-                    resultMessage -> {
-                      if (statement instanceof SelectStatement) {
-                        long encodedSize =
-                                resultMessage.kind.subcodec.encodedSize(
-                                        resultMessage, org.apache.cassandra.transport.ProtocolVersion.CURRENT);
-                        metricReadSizehistogram.update(encodedSize);
-                      }
-                    });
+        .processStatement(statement, queryState, options, customPayload, queryStartNanoTime)
+        .doOnSuccess(
+            resultMessage -> {
+              if (statement instanceof SelectStatement) {
+                long encodedSize =
+                    resultMessage.kind.subcodec.encodedSize(
+                        resultMessage, org.apache.cassandra.transport.ProtocolVersion.CURRENT);
+                metricReadSizehistogram.update(encodedSize);
+              }
+            });
   }
 
   @Override

--- a/coordinator/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/StargateQueryHandler.java
+++ b/coordinator/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/StargateQueryHandler.java
@@ -17,6 +17,7 @@
  */
 package io.stargate.db.dse.impl;
 
+import com.codahale.metrics.Histogram;
 import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import io.reactivex.Single;
 import io.stargate.auth.AuthenticationSubject;
@@ -85,6 +86,7 @@ import org.apache.cassandra.cql3.statements.schema.DropTriggerStatement;
 import org.apache.cassandra.cql3.statements.schema.DropTypeStatement;
 import org.apache.cassandra.cql3.statements.schema.DropViewStatement;
 import org.apache.cassandra.exceptions.UnauthorizedException;
+import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.transport.messages.ResultMessage;
 import org.apache.cassandra.utils.MD5Digest;
@@ -96,6 +98,9 @@ public class StargateQueryHandler implements QueryHandler {
   private static final Logger logger = LoggerFactory.getLogger(StargateQueryHandler.class);
   private final List<QueryInterceptor> interceptors = new CopyOnWriteArrayList<>();
   private AtomicReference<AuthorizationService> authorizationService;
+  private final Histogram metricReadSizehistogram =
+          CassandraMetricsRegistry.actualRegistry.histogram(
+                  "org.apache.cassandra.metrics.ClientRequest.read_size.histogram");
 
   public void register(QueryInterceptor interceptor) {
     this.interceptors.add(interceptor);
@@ -168,8 +173,17 @@ public class StargateQueryHandler implements QueryHandler {
       authorizeByToken(customPayload, statement);
     }
 
-    return QueryProcessor.instance.processStatement(
-        statement, queryState, options, customPayload, queryStartNanoTime);
+    return QueryProcessor.instance
+            .processStatement(statement, queryState, options, customPayload, queryStartNanoTime)
+            .doOnSuccess(
+                    resultMessage -> {
+                      if (statement instanceof SelectStatement) {
+                        long encodedSize =
+                                resultMessage.kind.subcodec.encodedSize(
+                                        resultMessage, org.apache.cassandra.transport.ProtocolVersion.CURRENT);
+                        metricReadSizehistogram.update(encodedSize);
+                      }
+                    });
   }
 
   @Override

--- a/coordinator/testing/src/main/java/io/stargate/it/http/MetricsTest.java
+++ b/coordinator/testing/src/main/java/io/stargate/it/http/MetricsTest.java
@@ -570,25 +570,25 @@ public class MetricsTest extends BaseIntegrationTest {
     assertThat(lines).isNotEmpty();
   }
 
-    @Test
-    public void dropwizardMetricReadSizeIsPresent() throws IOException {
+  @Test
+  public void dropwizardMetricReadSizeIsPresent() throws IOException {
 
-        assumeThat(backend.isDse())
-                .as("Disabled because this metric does not exists for Cassandra 4 backend")
-                .isTrue();
+    assumeThat(backend.isDse())
+        .as("Disabled because this metric does not exists for Cassandra 4 backend")
+        .isTrue();
 
-        String expectedMetric =
-                "persistence_dse_"
-                        + StringUtils.remove(backend.clusterVersion(), '.').substring(0, 2)
-                        + "_org_apache_cassandra_metrics_ClientRequest_read_size_histogram{";
-        String result = RestUtils.get("", String.format("%s:8084/metrics", host), HttpStatus.SC_OK);
-        List<String> lines =
-                Arrays.stream(result.split(System.getProperty("line.separator")))
-                        .filter(line -> line.startsWith(expectedMetric))
-                        .collect(Collectors.toList());
+    String expectedMetric =
+        "persistence_dse_"
+            + StringUtils.remove(backend.clusterVersion(), '.').substring(0, 2)
+            + "_org_apache_cassandra_metrics_ClientRequest_read_size_histogram{";
+    String result = RestUtils.get("", String.format("%s:8084/metrics", host), HttpStatus.SC_OK);
+    List<String> lines =
+        Arrays.stream(result.split(System.getProperty("line.separator")))
+            .filter(line -> line.startsWith(expectedMetric))
+            .collect(Collectors.toList());
 
-        assertThat(lines).isNotEmpty();
-    }
+    assertThat(lines).isNotEmpty();
+  }
 
   private int execute(OkHttpClient client, Request request) throws IOException {
     try (Response execute = client.newCall(request).execute()) {

--- a/coordinator/testing/src/main/java/io/stargate/it/http/MetricsTest.java
+++ b/coordinator/testing/src/main/java/io/stargate/it/http/MetricsTest.java
@@ -17,6 +17,7 @@
 package io.stargate.it.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.awaitility.Awaitility.await;
 
 import io.stargate.it.BaseIntegrationTest;
@@ -568,6 +569,26 @@ public class MetricsTest extends BaseIntegrationTest {
 
     assertThat(lines).isNotEmpty();
   }
+
+    @Test
+    public void dropwizardMetricReadSizeIsPresent() throws IOException {
+
+        assumeThat(backend.isDse())
+                .as("Disabled because this metric does not exists for Cassandra 4 backend")
+                .isTrue();
+
+        String expectedMetric =
+                "persistence_dse_"
+                        + StringUtils.remove(backend.clusterVersion(), '.').substring(0, 2)
+                        + "_org_apache_cassandra_metrics_ClientRequest_read_size_histogram{";
+        String result = RestUtils.get("", String.format("%s:8084/metrics", host), HttpStatus.SC_OK);
+        List<String> lines =
+                Arrays.stream(result.split(System.getProperty("line.separator")))
+                        .filter(line -> line.startsWith(expectedMetric))
+                        .collect(Collectors.toList());
+
+        assertThat(lines).isNotEmpty();
+    }
 
   private int execute(OkHttpClient client, Request request) throws IOException {
     try (Response execute = client.newCall(request).execute()) {


### PR DESCRIPTION
**What this PR does**:

This creates a new Metric persistence_dse_[clusterVersion]_org_apache_cassandra_metrics_ClientRequest_read_size_histogram exposed under xxx:8084/metrics
As this Metric is missing from Cassandra metrics, the idea is to add it on Stargate side.

This PR also contains an associated test which test the right presence of this Metric in Metrics list.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
