### PR TITLE
Remove now unnecessary (and failing) GH action step that kills "mono" process

### DIFF
--- a/.github/workflows/coordinator-test-v21.yml
+++ b/.github/workflows/coordinator-test-v21.yml
@@ -129,18 +129,6 @@ jobs:
 
     steps:
 
-      # Kill unused mono process that uses port 8084 starting on Ubuntu 20.04 GitHub runner
-      # This is brute force but other attempts did not work
-      #   see: https://github.com/actions/runner-images/issues/2821
-      #   this doesn't seem to stop the process:
-      #     sudo systemctl stop mono-xsp4.service || true
-      #   neither does uninstalling mono:
-      #     sudo apt-get purge --auto-remove ubuntu-mono mono-runtime
-      - name: Disable Mono
-        run: |
-          sudo killall mono
-          sudo lsof -iTCP -n -P | sort -k1
-
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5

--- a/.github/workflows/coordinator-test.yml
+++ b/.github/workflows/coordinator-test.yml
@@ -128,18 +128,6 @@ jobs:
 
     steps:
 
-      # Kill unused mono process that uses port 8084 starting on Ubuntu 20.04 GitHub runner
-      # This is brute force but other attempts did not work
-      #   see: https://github.com/actions/runner-images/issues/2821
-      #   this doesn't seem to stop the process:
-      #     sudo systemctl stop mono-xsp4.service || true
-      #   neither does uninstalling mono:
-      #     sudo apt-get purge --auto-remove ubuntu-mono mono-runtime
-      - name: Disable Mono
-        run: |
-          sudo killall mono
-          sudo lsof -iTCP -n -P | sort -k1
-
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5


### PR DESCRIPTION
**What this PR does**:

Removes step from CI that tries to kill "mono" process: something that was needed with Ubuntu-20. But with "ubuntu-latest" moving to Ubuntu-22 this step fails and is no longer needed.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
