### PR TITLE
Fix #3059: update to C* 4.0.17 (from 4.0.13)

### DIFF
--- a/coordinator/cql/pom.xml
+++ b/coordinator/cql/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-all</artifactId>
-      <version>4.0.13</version>
+      <version>4.0.17</version>
       <exclusions>
         <exclusion>
           <groupId>org.gridkit.jvmtool</groupId>

--- a/coordinator/persistence-api/pom.xml
+++ b/coordinator/persistence-api/pom.xml
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-all</artifactId>
-      <version>4.0.13</version>
+      <version>4.0.17</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/coordinator/persistence-cassandra-4.0/README.md
+++ b/coordinator/persistence-cassandra-4.0/README.md
@@ -4,7 +4,7 @@ This module represents the implementation of the [persistence-api](../persistenc
 
 ## Cassandra version update
 
-The current Cassandra version this module depends on is `4.0.13`.
+The current Cassandra version this module depends on is `4.0.17`.
 In order to update to a newer patch version, please follow the guidelines below:
 
 * Update the `cassandra.version` property in the [pom.xml](pom.xml).
@@ -12,7 +12,7 @@ In order to update to a newer patch version, please follow the guidelines below:
 * Check the transitive dependencies of the `org.apache.cassandra:cassandra-all` for the new version.
 Make sure that the version of the `com.datastax.cassandra:cassandra-driver-core` that `cassandra-all` depends on, is same as in the `cassandra.bundled-driver.version` property in the [pom.xml](pom.xml).
 This dependency is set as optional in the `cassandra-all`, but we need it to correctly handle UDFs.
-Note that transitive dependencies can be seen on [mvnrepository.com](https://mvnrepository.com/artifact/org.apache.cassandra/cassandra-all/4.0.13).
+Note that transitive dependencies can be seen on [mvnrepository.com](https://mvnrepository.com/artifact/org.apache.cassandra/cassandra-all/4.0.17).
 * Update the [CI Dockerfile](../ci/Dockerfile) and set the new version in the `ccm create` command related to 4.0.
 Note that this will have no effect until the docker image is rebuilt and pushed to the remote repository, thus creating an issue for that would be a good idea.
 * Create a separate PR for bumping the Cassandra 4 version in the Quarkus-based API integration tests on the `v2.0.0` branch. Test profiles are defined in the `apis/pom.xml`.
@@ -22,6 +22,7 @@ Note that this will have no effect until the docker image is rebuilt and pushed 
 
 It's always good to validate your work against the pull requests that bumped the version in the past:
 
+* `4.0.10` -> `4.0.13` [stargate/stargate#2989](https://github.com/stargate/stargate/pull/2989)
 * `4.0.9` -> `4.0.10` [stargate/stargate#2602](https://github.com/stargate/stargate/pull/2602)
 * `4.0.1` -> `4.0.3` [stargate/stargate#1647](https://github.com/stargate/stargate/pull/1647)
 * `4.0.4` -> `4.0.7` [stargate/stargate#2329](https://github.com/stargate/stargate/pull/2329)

--- a/coordinator/persistence-cassandra-4.0/pom.xml
+++ b/coordinator/persistence-cassandra-4.0/pom.xml
@@ -13,8 +13,8 @@
   <name>Stargate - Coordinator - Persistence C* 4.0</name>
   <properties>
     <!-- If you update this, make sure to keep `cassandra.bundled-driver.version` in sync -->
-    <!-- 4.0.13 depends on 3.11.x: https://mvnrepository.com/artifact/org.apache.cassandra/cassandra-all/4.0.13 -->
-    <cassandra.version>4.0.13</cassandra.version>
+    <!-- 4.0.17 depends on 3.11.x: https://mvnrepository.com/artifact/org.apache.cassandra/cassandra-all/4.0.17 -->
+    <cassandra.version>4.0.17</cassandra.version>
     <!--
       The driver used internally by cassandra-all for UDFs (must match the version declared in
       cassandra-all's POM).

--- a/coordinator/testing/pom.xml
+++ b/coordinator/testing/pom.xml
@@ -411,7 +411,7 @@
                 </goals>
                 <configuration>
                   <systemPropertyVariables>
-                    <ccm.version>4.0.13</ccm.version>
+                    <ccm.version>4.0.17</ccm.version>
                     <stargate.test.nodes>1</stargate.test.nodes>
                   </systemPropertyVariables>
                   <failIfNoTests>true</failIfNoTests>


### PR DESCRIPTION
**What this PR does**:

Updates c* 4.0 dependency by Stargate v2.0 to 4.0.17 from 4.0.13 to address 3 direct vulnerabilities (none that is applicable but tools alert).

**Which issue(s) this PR fixes**:
Fixes #3059

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
