### PR TITLE
CNDB-13534: Add RequestFailureReason.INDEX_VERSION_TOO_OLD

### DIFF
--- a/coordinator/persistence-api/src/main/java/org/apache/cassandra/stargate/exceptions/RequestFailureReason.java
+++ b/coordinator/persistence-api/src/main/java/org/apache/cassandra/stargate/exceptions/RequestFailureReason.java
@@ -113,6 +113,12 @@ public enum RequestFailureReason {
   INDEX_BUILD_IN_PROGRESS(503),
 
   /**
+   * The request queried an index using an on-disk index format version that doesn't support the
+   * query.
+   */
+  INDEX_VERSION_TOO_OLD(504),
+
+  /**
    * Used when receiving a code we do not know to indicate that it is a reason added in newer
    * version than us, but is something somewhat expected by that node from the future (it is not
    * {@link #UNKNOWN}).


### PR DESCRIPTION
Adds a new `RequestFailureReason.INDEX_VERSION_TOO_OLD`, matching the one that will be added to CC by https://github.com/riptano/cndb/pull/13687.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
