### PR TITLE
Fix dse-next IT failure on v2.1 by downgrading Ubuntu

### DIFF
--- a/.github/workflows/coordinator-test-v21.yml
+++ b/.github/workflows/coordinator-test-v21.yml
@@ -18,7 +18,7 @@ on:
       - 'coordinator/**pom.xml'
       - 'coordinator/**/src/**'
       - 'coordinator/**mvn**'
-      - '.github/workflows/coordinator-test.yml'
+      - '.github/workflows/coordinator*'
 
   pull_request:
     branches: [ "v2.1" ]

--- a/.github/workflows/coordinator-test-v21.yml
+++ b/.github/workflows/coordinator-test-v21.yml
@@ -103,7 +103,9 @@ jobs:
 
   integration-test:
     name: Integration tests
-    runs-on: ubuntu-latest
+    # 16-Apr-2025, tatu: For reasons unknown, dse-next ITs fail with 24.04; broke some time
+    #   after October 2024
+    runs-on: ubuntu-22.04
 
     # max run time 120 minutes
     timeout-minutes: 120

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <!-- Artifact props -->
+  <!-- Artifact properties -->
   <groupId>io.stargate</groupId>
   <artifactId>stargate</artifactId>
   <name>Stargate - Coordinator Parent pom</name>


### PR DESCRIPTION
**What this PR does**:

Fixes CI wrt dse-next backend on v2.1 branch; breakage somehow due to Ubuntu upgrade

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
