### PR TITLE
Disabling dse-next Coordinator tests (failing with 2h timeout)

### DIFF
--- a/.github/workflows/coordinator-test-v21.yml
+++ b/.github/workflows/coordinator-test-v21.yml
@@ -18,7 +18,7 @@ on:
       - 'coordinator/**pom.xml'
       - 'coordinator/**/src/**'
       - 'coordinator/**mvn**'
-      - '.github/workflows/coordinator-test.yml'
+      - '.github/workflows/coordinator*.yml'
 
   pull_request:
     branches: [ "v2.1" ]
@@ -26,7 +26,7 @@ on:
       - 'coordinator/**pom.xml'
       - 'coordinator/**/src/**'
       - 'coordinator/**mvn**'
-      - '.github/workflows/coordinator-test.yml'
+      - '.github/workflows/coordinator*.yml'
 
   workflow_dispatch:
 
@@ -113,7 +113,9 @@ jobs:
       # (see https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs)
       fail-fast: false
       matrix:
-        backend: [ cassandra-40, cassandra-41, dse-next, dse-68, dse-v4-68 ]
+        # 17-Apr-2025, tatu: failed to start dse-next tests, must disable
+        #backend: [ cassandra-40, cassandra-41, dse-next, dse-68, dse-v4-68 ]
+        backend: [ cassandra-40, cassandra-41, dse-68, dse-v4-68 ]
         include:
           - backend: cassandra-40
             build-profile:


### PR DESCRIPTION
**What this PR does**:

Disables "dse-next" Coordinator ITs from CI, to unblock our pipeline: this combo always fails with 2h timeout. Unable to find the root cause, ruled out possibility was caused by changes we made.
Leading candidate for root cause is Github runner change for `ubuntu-latest`, changing from 22.04 to 24.04 around Dec-2024/Jan-2025), somehow causing failure (but just for this backend).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
