### PR TITLE
Fix several issues with CQL ClientMetrics

### DIFF
--- a/coordinator/cql/src/main/java/org/apache/cassandra/stargate/metrics/ClientMetrics.java
+++ b/coordinator/cql/src/main/java/org/apache/cassandra/stargate/metrics/ClientMetrics.java
@@ -91,8 +91,8 @@ public final class ClientMetrics {
   private Counter unknownException;
   private Counter totalBytesRead;
   private Counter totalBytesWritten;
-  private DistributionSummary bytesReceivedPerFrame;
-  private DistributionSummary bytesTransmittedPerFrame;
+  private DistributionSummary bytesReceivedPerMessage;
+  private DistributionSummary bytesTransmittedPerMessage;
   private MultiGauge connectedNativeClients;
   private MultiGauge connectedNativeClientsByUser;
 
@@ -123,12 +123,12 @@ public final class ClientMetrics {
     totalBytesWritten.increment(value);
   }
 
-  public void recordBytesReceivedPerFrame(double value) {
-    bytesReceivedPerFrame.record(value);
+  public void recordBytesReceivedPerMessage(double value) {
+    bytesReceivedPerMessage.record(value);
   }
 
-  public void recordBytesTransmittedPerFrame(double value) {
-    bytesTransmittedPerFrame.record(value);
+  public void recordBytesTransmittedPerMessage(double value) {
+    bytesTransmittedPerMessage.record(value);
   }
 
   public ConnectionMetrics connectionMetrics(ClientInfo clientInfo) {
@@ -182,8 +182,8 @@ public final class ClientMetrics {
     totalBytesRead = meterRegistry.counter(metric("TotalBytesRead"));
     totalBytesWritten = meterRegistry.counter(metric("TotalBytesWritten"));
 
-    bytesReceivedPerFrame = meterRegistry.summary(metric("BytesReceivedPerFrame"));
-    bytesTransmittedPerFrame = meterRegistry.summary(metric("BytesTransmittedPerFrame"));
+    bytesReceivedPerMessage = meterRegistry.summary(metric("BytesReceivedPerMessage"));
+    bytesTransmittedPerMessage = meterRegistry.summary(metric("BytesTransmittedPerMessage"));
 
     initialized = true;
 

--- a/coordinator/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Dispatcher.java
+++ b/coordinator/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/Dispatcher.java
@@ -128,6 +128,8 @@ public class Dispatcher {
           });
       Message.logger.trace("Responding: {}, v={}", response, connection.getVersion());
     } catch (Throwable t) {
+      Message.logger.error(
+          "Exception thrown when processing request? This may leak resources... ", t);
       // Cassandra {4.0.10} Patched as per stargate
       // JVMStabilityInspector.inspectThrowable(t);
     } finally {

--- a/coordinator/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/PreV5Handlers.java
+++ b/coordinator/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/PreV5Handlers.java
@@ -151,9 +151,12 @@ public class PreV5Handlers {
         } else {
           // set backpressure on the channel, and handle the request
           endpointPayloadTracker.allocate(requestSize);
-          ctx.channel().config().setAutoRead(false);
-          ClientMetrics.instance.pauseConnection();
-          paused = true;
+          // avoid double-pausing if we read multiple requests
+          if (!paused) {
+            ctx.channel().config().setAutoRead(false);
+            ClientMetrics.instance.pauseConnection();
+            paused = true;
+          }
         }
       }
 

--- a/coordinator/cql/src/test/java/org/apache/cassandra/stargate/metrics/ClientMetricsTest.java
+++ b/coordinator/cql/src/test/java/org/apache/cassandra/stargate/metrics/ClientMetricsTest.java
@@ -276,16 +276,16 @@ class ClientMetricsTest {
   }
 
   @Nested
-  class RecordBytesReceivedPerFrame {
+  class RecordBytesReceivedPerMessage {
 
     @Test
     public void happyPath() {
-      clientMetrics.recordBytesReceivedPerFrame(11);
-      clientMetrics.recordBytesReceivedPerFrame(33);
+      clientMetrics.recordBytesReceivedPerMessage(11);
+      clientMetrics.recordBytesReceivedPerMessage(33);
 
       DistributionSummary summary =
           meterRegistry
-              .get("cql.org.apache.cassandra.metrics.Client.BytesReceivedPerFrame")
+              .get("cql.org.apache.cassandra.metrics.Client.BytesReceivedPerMessage")
               .summary();
 
       assertThat(summary.count()).isEqualTo(2);
@@ -294,16 +294,16 @@ class ClientMetricsTest {
   }
 
   @Nested
-  class RecordBytesTransmittedPerFrame {
+  class RecordBytesTransmittedPerMessage {
 
     @Test
     public void happyPath() {
-      clientMetrics.recordBytesTransmittedPerFrame(22);
-      clientMetrics.recordBytesTransmittedPerFrame(44);
+      clientMetrics.recordBytesTransmittedPerMessage(22);
+      clientMetrics.recordBytesTransmittedPerMessage(44);
 
       DistributionSummary summary =
           meterRegistry
-              .get("cql.org.apache.cassandra.metrics.Client.BytesTransmittedPerFrame")
+              .get("cql.org.apache.cassandra.metrics.Client.BytesTransmittedPerMessage")
               .summary();
 
       assertThat(summary.count()).isEqualTo(2);
@@ -464,6 +464,37 @@ class ClientMetricsTest {
                       .gauge());
 
       assertThat(throwable).isInstanceOf(MeterNotFoundException.class);
+    }
+  }
+
+  @Nested
+  class MarkProtocolException {
+
+    @Test
+    public void happyPath() {
+      clientMetrics.markProtocolException();
+      clientMetrics.markProtocolException();
+
+      Counter counter =
+          meterRegistry.get("cql.org.apache.cassandra.metrics.Client.ProtocolException").counter();
+
+      assertThat(counter.count()).isEqualTo(2d);
+    }
+  }
+
+  @Nested
+  class MarkUnknownException {
+
+    @Test
+    public void happyPath() {
+      clientMetrics.markUnknownException();
+      clientMetrics.markUnknownException();
+      clientMetrics.markUnknownException();
+
+      Counter counter =
+          meterRegistry.get("cql.org.apache.cassandra.metrics.Client.UnknownException").counter();
+
+      assertThat(counter.count()).isEqualTo(3d);
     }
   }
 

--- a/coordinator/cql/src/test/java/org/apache/cassandra/stargate/transport/internal/CQLProtocolCompatibilityTest.java
+++ b/coordinator/cql/src/test/java/org/apache/cassandra/stargate/transport/internal/CQLProtocolCompatibilityTest.java
@@ -11,6 +11,8 @@ import com.datastax.oss.protocol.internal.ProtocolConstants;
 import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
+import io.stargate.core.metrics.api.Metrics;
+import io.stargate.core.metrics.impl.MetricsImpl;
 import io.stargate.db.Result;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -18,8 +20,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.apache.cassandra.stargate.metrics.ClientMetrics;
 import org.apache.cassandra.stargate.transport.ProtocolVersion;
 import org.apache.cassandra.stargate.transport.internal.messages.ResultMessage;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -34,6 +38,12 @@ public class CQLProtocolCompatibilityTest {
   private static final Map<String, ByteBuffer> CUSTOM_PAYLOAD =
       Collections.singletonMap("test-key", ByteBuffer.wrap("test-value".getBytes()));
   private static final List<String> WARNINGS = ImmutableList.of("warning1");
+
+  @BeforeAll
+  public static void setup() {
+    Metrics metrics = new MetricsImpl();
+    ClientMetrics.instance.init(Collections.emptyList(), metrics.getMeterRegistry(), null, 0);
+  }
 
   @Test
   public void encoderCompatibleWithNativeProtocolDecoder() {

--- a/coordinator/testing/src/main/java/io/stargate/it/cql/ClientMetricsTest.java
+++ b/coordinator/testing/src/main/java/io/stargate/it/cql/ClientMetricsTest.java
@@ -145,6 +145,73 @@ public abstract class ClientMetricsTest extends BaseIntegrationTest {
             });
   }
 
+  @Test
+  public void totalBytesReadMetric(CqlSession session) throws IOException {
+    // given
+    SimpleStatement statement = SimpleStatement.newInstance("SELECT v FROM test WHERE k=?", KEY);
+    ResultSet resultSet = session.execute(statement);
+    assertThat(resultSet).hasSize(1);
+
+    // when
+    String body = RestUtils.get("", String.format("%s:8084/metrics", host), HttpStatus.SC_OK);
+
+    // then
+    String totalBytesReadMetric = "cql_org_apache_cassandra_metrics_Client_TotalBytesRead_total";
+    Optional<Double> totalBytesRead = getCqlMetric(body, totalBytesReadMetric);
+    assertThat(totalBytesRead).hasValueSatisfying(v -> assertThat(v).isGreaterThan(0d));
+  }
+
+  @Test
+  public void totalBytesWrittenMetric(CqlSession session) throws IOException {
+    // given
+    SimpleStatement statement = SimpleStatement.newInstance("SELECT v FROM test WHERE k=?", KEY);
+    ResultSet resultSet = session.execute(statement);
+    assertThat(resultSet).hasSize(1);
+
+    // when
+    String body = RestUtils.get("", String.format("%s:8084/metrics", host), HttpStatus.SC_OK);
+
+    // then
+    String totalBytesWrittenMetric =
+        "cql_org_apache_cassandra_metrics_Client_TotalBytesWritten_total";
+    Optional<Double> totalBytesWritten = getCqlMetric(body, totalBytesWrittenMetric);
+    assertThat(totalBytesWritten).hasValueSatisfying(v -> assertThat(v).isGreaterThan(0d));
+  }
+
+  @Test
+  public void bytesReceivedPerMessageMetric(CqlSession session) throws IOException {
+    // given
+    SimpleStatement statement = SimpleStatement.newInstance("SELECT v FROM test WHERE k=?", KEY);
+    ResultSet resultSet = session.execute(statement);
+    assertThat(resultSet).hasSize(1);
+
+    // when
+    String body = RestUtils.get("", String.format("%s:8084/metrics", host), HttpStatus.SC_OK);
+
+    // then
+    String bytesReceivedMetric =
+        "cql_org_apache_cassandra_metrics_Client_BytesReceivedPerMessage_count";
+    Optional<Double> bytesReceived = getCqlMetric(body, bytesReceivedMetric);
+    assertThat(bytesReceived).hasValueSatisfying(v -> assertThat(v).isGreaterThan(0d));
+  }
+
+  @Test
+  public void bytesTransmittedPerMessageMetric(CqlSession session) throws IOException {
+    // given
+    SimpleStatement statement = SimpleStatement.newInstance("SELECT v FROM test WHERE k=?", KEY);
+    ResultSet resultSet = session.execute(statement);
+    assertThat(resultSet).hasSize(1);
+
+    // when
+    String body = RestUtils.get("", String.format("%s:8084/metrics", host), HttpStatus.SC_OK);
+
+    // then
+    String bytesTransmittedMetric =
+        "cql_org_apache_cassandra_metrics_Client_BytesTransmittedPerMessage_count";
+    Optional<Double> bytesTransmitted = getCqlMetric(body, bytesTransmittedMetric);
+    assertThat(bytesTransmitted).hasValueSatisfying(v -> assertThat(v).isGreaterThan(0d));
+  }
+
   private double getOnHeapMemoryUsed(String body) {
     return getMetricValue(body, "jvm_memory_heap_used", MEMORY_HEAP_USAGE_REGEXP);
   }


### PR DESCRIPTION
**What this PR does**:
* In PreV5Handlers, avoid double-pausing connections. This prevent metric drift from the underlying number of paused connections.
* In ClientMetrics, change PerFrame metrics to PerMessage metrics. The PerFrame metrics are currently never incremented, and in V5, it makes more sense to expose these on a per-message level. In pre-V5, the protocol is frame per message.
* In pre-v5 protocol, actually increment total bytes/bytes per message metrics.
* In CQLMessageHandler, Cassandra metrics are being updated for ClientMetrics/ClientMessageSizeMetrics. Switch to Stargate metrics.
* Update tests to improve coverage for the above issues.
* Add error logging to previously silent exception path intended to be unreachable.

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
