### PR TITLE
Fix #3103: update API JDK base image

### DIFF
--- a/apis/sgv2-docsapi/src/main/docker/Dockerfile.jvm
+++ b/apis/sgv2-docsapi/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.20
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/apis/sgv2-docsapi/src/main/docker/Dockerfile.native
+++ b/apis/sgv2-docsapi/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8180:8180 quarkus/sgv2-docsapi
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.20
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.21
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/apis/sgv2-graphqlapi/src/main/docker/Dockerfile.jvm
+++ b/apis/sgv2-graphqlapi/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.20
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/apis/sgv2-graphqlapi/src/main/docker/Dockerfile.native
+++ b/apis/sgv2-graphqlapi/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/sgv2-graphqlapi-quarkus
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.20
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.21
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/apis/sgv2-restapi/src/main/docker/Dockerfile.jvm
+++ b/apis/sgv2-restapi/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.20
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/apis/sgv2-restapi/src/main/docker/Dockerfile.native
+++ b/apis/sgv2-restapi/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8082:8082 quarkus/sgv2-restapi
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.20
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.21
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \


### PR DESCRIPTION
**What this PR does**:

Fixes #3103: updates API docker base image to latest version of `ubi8/openjdk17`.

**Which issue(s) this PR fixes**:
Fixes #3103

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
