### PR TITLE
Upgrade cosign GH action version; pre-2.0 now disabled

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -444,7 +444,8 @@ jobs:
 
     env:
       # not a newest version, this reflects riptano action target version
-      COSIGN_VERSION: v1.9.0
+      # 22-Jul-2025, tatu: pre-2.0.0 no longer supported, use current latest
+      COSIGN_VERSION: v2.5.3
 
     steps:
       - name: Install Cosign

--- a/.github/workflows/release-v21.yml
+++ b/.github/workflows/release-v21.yml
@@ -444,7 +444,8 @@ jobs:
 
     env:
       # not a newest version, this reflects riptano action target version
-      COSIGN_VERSION: v1.9.0
+      # 22-Jul-2025, tatu: pre-2.0.0 no longer supported, use current latest
+      COSIGN_VERSION: v2.5.3
 
     steps:
       - name: Install Cosign


### PR DESCRIPTION
**What this PR does**:

Fixes one issue with Stargate Github release action: co-sign action was failing due to old version that is now blocked.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
