### PR TITLE
Fix Docker build failure: switch from OpenJDK11/debian to Temurin11

### DIFF
--- a/coordinator/Dockerfile
+++ b/coordinator/Dockerfile
@@ -2,7 +2,8 @@
 # Dockerfile for building coordinator node images
 #
 
-FROM adoptopenjdk/openjdk11:jre-11.0.19_7-debian as base
+# 22-Jul-2025, tatu: OpenJDK archived, switch to Temurin
+FROM eclipse-temurin:11-jre AS c2-6_8
 
 RUN apt update -qq \
     && apt install iproute2 libaio1 libjemalloc2 -y \


### PR DESCRIPTION
**What this PR does**:

Fixes Coordinator Docker image build, similar to https://github.com/riptano/c2/pull/1152.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
