### PR TITLE
CNDB-14889: add handling for `DateRangeType` (follow-up to CNDB-14199)

### DIFF
--- a/coordinator/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/ColumnUtils.java
+++ b/coordinator/cql/src/main/java/org/apache/cassandra/stargate/transport/internal/ColumnUtils.java
@@ -104,6 +104,7 @@ public class ColumnUtils {
       case Point: // Fallthrough intended
       case Polygon: // Fallthrough intended
       case Vector: // NOTE: marshalTypeName includes element type, length (dimensions)
+      case DateRange: // Fallthrough intended
         // For custom types the class name of the type follows the type ID (which is zero)
         CBUtil.writeAsciiString(type.marshalTypeName(), dest);
         break;
@@ -146,6 +147,7 @@ public class ColumnUtils {
       case Point: // Fallthrough intended
       case Polygon: // Fallthrough intended
       case Vector: // NOTE: marshalTypeName includes element type, length (dimensions)
+      case DateRange:
         size += CBUtil.sizeOfAsciiString(type.marshalTypeName());
         break;
       default: // fall though (simple types)

--- a/coordinator/persistence-api/src/main/java/io/stargate/db/schema/Column.java
+++ b/coordinator/persistence-api/src/main/java/io/stargate/db/schema/Column.java
@@ -611,7 +611,15 @@ public abstract class Column implements SchemaEntity, Comparable<Column> {
         "org.apache.cassandra.db.marshal.VectorType",
         true,
         null,
-        "Experimental vector value type");
+        "Experimental vector value type"),
+
+    DateRange(
+        0, // custom type
+        io.stargate.db.schema.DateRange.class,
+        "org.apache.cassandra.db.marshal.DateRangeType",
+        true,
+        null,
+        "Date range C* type with lower and upper bounds represented as timestamps with a millisecond precision");
 
     private final int id;
     private final String usage;

--- a/coordinator/persistence-api/src/main/java/io/stargate/db/schema/DateRange.java
+++ b/coordinator/persistence-api/src/main/java/io/stargate/db/schema/DateRange.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.stargate.db.schema;
+
+public class DateRange {
+  // Placeholder for DateRange values
+}

--- a/coordinator/testing/src/main/java/io/stargate/it/cql/DateRangeTypeTest.java
+++ b/coordinator/testing/src/main/java/io/stargate/it/cql/DateRangeTypeTest.java
@@ -27,9 +27,11 @@ import io.stargate.it.BaseIntegrationTest;
 import io.stargate.it.driver.CqlSessionExtension;
 import io.stargate.it.driver.TestKeyspace;
 import io.stargate.it.driver.WithProtocolVersion;
+import io.stargate.it.storage.ClusterConnectionInfo;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,6 +42,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 public abstract class DateRangeTypeTest extends BaseIntegrationTest {
 
   private static List<TypeSample<?>> allTypes;
+
+  @BeforeAll
+  public static void validateAssumptions(ClusterConnectionInfo backend) {
+    Assumptions.assumeTrue(backend.isDse(), "Test disabled when not running on DSE");
+  }
 
   @BeforeAll
   public static void createSchema(CqlSession session, @TestKeyspace CqlIdentifier keyspaceId)

--- a/coordinator/testing/src/main/java/io/stargate/it/cql/DateRangeTypeTest.java
+++ b/coordinator/testing/src/main/java/io/stargate/it/cql/DateRangeTypeTest.java
@@ -1,0 +1,117 @@
+package io.stargate.it.cql;
+
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.literal;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.selectFrom;
+import static com.datastax.oss.driver.api.querybuilder.SchemaBuilder.createTable;
+import static io.stargate.it.cql.TypeSample.listOf;
+import static io.stargate.it.cql.TypeSample.mapOfIntTo;
+import static io.stargate.it.cql.TypeSample.mapToIntFrom;
+import static io.stargate.it.cql.TypeSample.setOf;
+import static io.stargate.it.cql.TypeSample.typeSample;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.dse.driver.api.core.data.time.DateRange;
+import com.datastax.dse.driver.api.core.type.DseDataTypes;
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.BatchStatement;
+import com.datastax.oss.driver.api.core.cql.BatchType;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.driver.api.core.type.reflect.GenericType;
+import com.datastax.oss.driver.api.querybuilder.schema.CreateTable;
+import io.stargate.it.BaseIntegrationTest;
+import io.stargate.it.driver.CqlSessionExtension;
+import io.stargate.it.driver.TestKeyspace;
+import io.stargate.it.driver.WithProtocolVersion;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@ExtendWith(CqlSessionExtension.class)
+public abstract class DateRangeTypeTest extends BaseIntegrationTest {
+
+  private static List<TypeSample<?>> allTypes;
+
+  @BeforeAll
+  public static void createSchema(CqlSession session, @TestKeyspace CqlIdentifier keyspaceId)
+      throws ParseException {
+    allTypes = generateAllTypes(keyspaceId);
+    // Creating a new table for each type is too slow; use a single table with all possible types:
+    CreateTable createTableQuery = createTable("test").withPartitionKey("k", DataTypes.INT);
+    for (TypeSample<?> sample : allTypes) {
+      createTableQuery = createTableQuery.withColumn(sample.columnName, sample.cqlType);
+    }
+
+    session.execute(createTableQuery.asCql());
+  }
+
+  public static List<TypeSample<?>> getAllTypes() {
+    return allTypes;
+  }
+
+  @DisplayName("Should write and read DateRange type")
+  @ParameterizedTest
+  @MethodSource("getAllTypes")
+  public <JavaTypeT> void writeAndReadTest(TypeSample<JavaTypeT> sample, CqlSession session) {
+    String insertQuery =
+        insertInto("test").value("k", literal(1)).value(sample.columnName, bindMarker()).asCql();
+
+    SimpleStatement simpleStatement = SimpleStatement.newInstance(insertQuery, sample.value);
+    session.execute(simpleStatement);
+    checkValue(sample, session);
+
+    session.execute(BatchStatement.newInstance(BatchType.LOGGED).add(simpleStatement));
+    checkValue(sample, session);
+
+    session.execute(session.prepare(insertQuery).bind(sample.value));
+    checkValue(sample, session);
+  }
+
+  private static List<TypeSample<?>> generateAllTypes(CqlIdentifier keyspaceId)
+      throws ParseException {
+    List<TypeSample<?>> primitiveTypes =
+        List.of(
+            typeSample(
+                DseDataTypes.DATE_RANGE,
+                GenericType.of(DateRange.class),
+                DateRange.parse("[2000-02 TO 2000-03]")));
+
+    // Auto-generate collection variants
+    List<TypeSample<?>> allTypes = new ArrayList<>();
+    for (TypeSample<?> type : primitiveTypes) {
+      allTypes.add(type);
+      allTypes.add(listOf(type));
+      allTypes.add(setOf(type));
+      allTypes.add(mapOfIntTo(type));
+      allTypes.add(mapToIntFrom(type));
+      allTypes.add(mapOfIntTo(type));
+    }
+    return allTypes;
+  }
+
+  private <JavaTypeT> void checkValue(TypeSample<JavaTypeT> sample, CqlSession session) {
+    String selectQuery =
+        selectFrom("test").column(sample.columnName).whereColumn("k").isEqualTo(literal(1)).asCql();
+    Row row = session.execute(selectQuery).one();
+    assertThat(row).isNotNull();
+    assertThat(row.get(0, sample.javaType)).isEqualTo(sample.value);
+
+    // Clean up for the following test
+    session.execute("DELETE FROM test WHERE k = 1");
+  }
+
+  @WithProtocolVersion("V4")
+  public static class WithV4ProtocolVersionTest extends DateRangeTypeTest {}
+
+  @WithProtocolVersion("V5")
+  public static class WithV5ProtocolVersionTest extends DateRangeTypeTest {}
+}


### PR DESCRIPTION
**What this PR does**:

Adds minimal support for `DateRangeType`, to avoid crashes for table schema contain columns of that type.

**Which issue(s) this PR fixes**:
CNDB-14889

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
