### PR TITLE
Fix #3120: switch Maven publish to Central Portal

### DIFF
--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -275,8 +275,9 @@
       <id>deploy</id>
       <distributionManagement>
         <repository>
-          <id>ossrh</id>
-          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+          <id>central</id>
+          <name>Sonatype Central Portal Repository (releases)</name>
+          <url>https://central.sonatype.com/api/v1/publisher</url>
         </repository>
       </distributionManagement>
       <build>
@@ -341,6 +342,8 @@
               <outputDirectory>${project.basedir}/target</outputDirectory>
             </configuration>
           </plugin>
+          <!-- 27-Aug-2025, tatu: [stargate#3120] Migrate to Central portal -->
+          <!--
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
@@ -350,6 +353,18 @@
               <serverId>ossrh</serverId>
               <nexusUrl>https://oss.sonatype.org/</nexusUrl>
               <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+          -->
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.8.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
             </configuration>
           </plugin>
         </plugins>

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -272,6 +272,8 @@
         </configuration>
       </plugin>
       <!-- Nexus Staging Plugin -->
+      <!-- 27-Aug-2025, tatu: [stargate#3120] Migrate to Central portal -->
+      <!--
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
@@ -281,6 +283,18 @@
           <serverId>ossrh</serverId>
           <nexusUrl>https://oss.sonatype.org/</nexusUrl>
           <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+      -->
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.8.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+          <autoPublish>true</autoPublish>
+          <waitUntil>published</waitUntil>
         </configuration>
       </plugin>
       <plugin>
@@ -425,8 +439,8 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[1.8,1.9)</version>
-                  <message>Project requires JDK 8</message>
+                  <version>[8,18)</version>
+                  <message>Project requires JDK 8+</message>
                 </requireJavaVersion>
                 <requireUpperBoundDeps>
                   <!-- If specifying includes ONLY those are checked


### PR DESCRIPTION
**What this PR does**:

Switches publishing of Stargate jars from Sonatype OSSRH to the new Central Portal

**Which issue(s) this PR fixes**:
Fixes #3120

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
