### PR TITLE
ECR federated login fix to the release workflow

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -366,11 +366,10 @@ jobs:
           cd ../
 
       # repeat the same for the AWS ECR
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.ECR_SECRET_KEY }}
+          role-to-assume: ${{ secrets.ECR_FEDERATED_ROLE }}
           aws-region: us-east-1
 
       - name: Login to Amazon ECR
@@ -453,11 +452,10 @@ jobs:
         with:
           cosign-release: ${COSIGN_VERSION}
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.ECR_SECRET_KEY }}
+          role-to-assume: ${{ secrets.ECR_FEDERATED_ROLE }}
           aws-region: us-east-1
 
       - name: Login to Amazon ECR

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -17,6 +17,11 @@ on:
         required: true
         type: string
 
+# needed when a workflow wants to use OIDC (OpenID Connect) to authenticate to cloud
+permissions:
+  id-token: write
+  contents: read
+
 # global env vars, available in all jobs and steps
 env:
   ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}

--- a/.github/workflows/release-v21.yml
+++ b/.github/workflows/release-v21.yml
@@ -366,11 +366,10 @@ jobs:
           cd ../
 
       # repeat the same for the AWS ECR
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.ECR_SECRET_KEY }}
+          role-to-assume: ${{ secrets.ECR_FEDERATED_ROLE }}
           aws-region: us-east-1
 
       - name: Login to Amazon ECR
@@ -453,11 +452,10 @@ jobs:
         with:
           cosign-release: ${COSIGN_VERSION}
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.ECR_SECRET_KEY }}
+          role-to-assume: ${{ secrets.ECR_FEDERATED_ROLE }}
           aws-region: us-east-1
 
       - name: Login to Amazon ECR

--- a/.github/workflows/release-v21.yml
+++ b/.github/workflows/release-v21.yml
@@ -17,6 +17,11 @@ on:
         required: true
         type: string
 
+# needed when a workflow wants to use OIDC (OpenID Connect) to authenticate to cloud
+permissions:
+  id-token: write
+  contents: read
+
 # global env vars, available in all jobs and steps
 env:
   ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}


### PR DESCRIPTION
This is a followup fix to #3126.

Too enable OIDC, we need set the permission for the workflow.
```

It looks like you might be trying to authenticate with OIDC. Did you mean to set the `id-token` permission? If you are not trying to authenticate with OIDC and the action is working successfully, you can ignore this message.
Error: Credentials could not be loaded, please check your action inputs: Could not load credentials from any providers
```

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
