### PR TITLE
Fix #3143: update gRPC dependency to 1.70.0

### DIFF
--- a/coordinator/bridge/pom.xml
+++ b/coordinator/bridge/pom.xml
@@ -82,6 +82,13 @@
       <artifactId>logback-classic</artifactId>
     </dependency>
     <!-- Test dependencies -->
+    <!-- 16-Sep-2025, tatu: #3143 need to add new dependency
+      -->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-inprocess</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/coordinator/grpc/pom.xml
+++ b/coordinator/grpc/pom.xml
@@ -86,6 +86,12 @@
       <artifactId>logback-classic</artifactId>
     </dependency>
     <!-- Test dependencies -->
+    <!-- 16-Sep-2025, tatu: #3143 need to add new dependency -->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-inprocess</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -72,7 +72,7 @@
     <!-- And then other 3rd party version dependencies, compile/runtime -->
     <caffeine.version>2.9.3</caffeine.version>
     <commons-io.version>2.14.0</commons-io.version>
-    <grpc.version>1.56.1</grpc.version>
+    <grpc.version>1.70.0</grpc.version>
     <immutables.version>2.8.8</immutables.version>
     <jackson.version>2.15.4</jackson.version>
     <javatuples.version>1.2</javatuples.version>


### PR DESCRIPTION
**What this PR does**:

Updates `grpc.version` from 1.56.1 to 1.70.0 to align with dse-core 6.8.59

**Which issue(s) this PR fixes**:
Fixes #3143

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
