### PR TITLE
Fix #3203: update v1 DSE dep to 6.8.58

### DIFF
--- a/coordinator/persistence-dse-6.8/README.md
+++ b/coordinator/persistence-dse-6.8/README.md
@@ -5,7 +5,7 @@ the DSE (DataStax Enterprise cassandra) `6.8.x` version.
 
 ## Cassandra version update
 
-The current Cassandra version this module depends on is `6.8.50`.
+The current Cassandra version this module depends on is `6.8.58`.
 In order to update to a newer patch version, please follow the guidelines below:
 
 * Update the `dse.version` property in the [pom.xml](pom.xml).
@@ -20,3 +20,4 @@ It's always good to validate your work against the pull requests that bumped the
 * `6.8.21` -> `6.8.24` [stargate/stargate#1898](https://github.com/stargate/stargate/pull/1898)
 * `6.8.31` -> `6.8.32` [stargate/stargate#2430](https://github.com/stargate/stargate/pull/2430)
 * `6.8.34` -> `6.8.41` [stargate/stargate#2879](https://github.com/stargate/stargate/pull/2879)
+* `6.8.41` -> `6.8.50` [stargate/stargate#2974](https://github.com/stargate/stargate/pull/2974)

--- a/coordinator/persistence-dse-6.8/pom.xml
+++ b/coordinator/persistence-dse-6.8/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>persistence-dse-6.8</artifactId>
   <name>Stargate - Coordinator - Persistence DSE 6.8</name>
   <properties>
-    <dse.version>6.8.50</dse.version>
+    <dse.version>6.8.58</dse.version>
   </properties>
   <repositories>
     <repository>

--- a/coordinator/testing/pom.xml
+++ b/coordinator/testing/pom.xml
@@ -441,7 +441,7 @@
                 <configuration>
                   <systemPropertyVariables>
                     <ccm.dse>true</ccm.dse>
-                    <ccm.version>6.8.50</ccm.version>
+                    <ccm.version>6.8.58</ccm.version>
                     <stargate.test.nodes>1</stargate.test.nodes>
                   </systemPropertyVariables>
                   <failIfNoTests>true</failIfNoTests>


### PR DESCRIPTION
**What this PR does**:

Updates DSE dependency to 6.8.58 from 6.8.50

**Which issue(s) this PR fixes**:
Fixes #3203

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
